### PR TITLE
Docs: Fixed broken link

### DIFF
--- a/docs/content/advanced/backend/payment/overview.md
+++ b/docs/content/advanced/backend/payment/overview.md
@@ -127,4 +127,4 @@ This prevents any payment issues from occurring with the customers and allows fo
 ## What’s Next 🚀
 
 - [Check out how the checkout flow is implemented on the frontend.](./frontend-payment-flow-in-checkout.md)
-- Check out payment plugins like [Stripe](../../../add-plugins/stripe.md), [Paypal](./../../../add-plugins/paypal.md), and [Klarna](../../../add-plugins/klarna.md).
+- Check out payment plugins like [Stripe](../../../add-plugins/stripe.md), [Paypal](/add-plugins/paypal), and [Klarna](../../../add-plugins/klarna.md).

--- a/docs/content/advanced/backend/payment/overview.md
+++ b/docs/content/advanced/backend/payment/overview.md
@@ -127,4 +127,4 @@ This prevents any payment issues from occurring with the customers and allows fo
 ## What’s Next 🚀
 
 - [Check out how the checkout flow is implemented on the frontend.](./frontend-payment-flow-in-checkout.md)
-- Check out payment plugins like [Stripe](../../../add-plugins/stripe.md), [Paypal](../../../add-plugins/paypal.md), and [Klarna](../../../add-plugins/klarna.md).
+- Check out payment plugins like [Stripe](../../../add-plugins/stripe.md), [Paypal](./../../../add-plugins/paypal.md), and [Klarna](../../../add-plugins/klarna.md).


### PR DESCRIPTION
The link was originally correct, but there seems to be a weird issue that is leading Docusaurus to append `.md` to the path for PayPal which was leading to a 404 error. This error is not occurring with other pages like Stripe and Klarna, so it's not clear what the issue is exactly.

For now, I replaced it with a relative path respective to the documentation.