### PR TITLE
Fix minio.ts conditional logic within validation method

### DIFF
--- a/packages/medusa-file-minio/src/services/minio.ts
+++ b/packages/medusa-file-minio/src/services/minio.ts
@@ -179,10 +179,7 @@ class MinioService extends AbstractFileService implements IFileService {
   }
 
   validatePrivateBucketConfiguration_(usePrivateBucket: boolean) {
-    if (
-      usePrivateBucket &&
-      (!this.private_access_key_id_ || !this.private_bucket_)
-    ) {
+    if (usePrivateBucket && !this.private_bucket_) {
       throw new MedusaError(
         MedusaError.Types.UNEXPECTED_STATE,
         "Private bucket is not configured"


### PR DESCRIPTION
### What

Condition in validation method is changed to validate regardless of the key configured for access.

### Why
Fixes the following issue: #6718 

### How
Condition is updated to only check if a private bucket is configured without checking if a private access key is configured.

### Testing
Reviewer can test the feature by setting up a MinIO private bucket with no private access and secret keys configured and then exporting products from the Medusa backend admin UI. Should properly export the products and allow for download without throwing an error saying "Private bucket is not configured".