### PR TITLE
Chores: Do not disable foreign keys by default

### DIFF
--- a/.changeset/nice-hounds-accept.md
+++ b/.changeset/nice-hounds-accept.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+Chores: Do not disable foreign keys by default

--- a/packages/utils/src/dal/mikro-orm/mikro-orm-create-connection.ts
+++ b/packages/utils/src/dal/mikro-orm/mikro-orm-create-connection.ts
@@ -110,6 +110,7 @@ export async function mikroOrmCreateConnection(
     type: "postgresql",
     filters: database.filters ?? {},
     migrations: {
+      disableForeignKeys: false,
       path: pathToMigrations,
       generator: TSMigrationGenerator,
       silent: !(
@@ -117,6 +118,9 @@ export async function mikroOrmCreateConnection(
         process.env.NODE_ENV?.startsWith("dev") ??
         false
       ),
+    },
+    schemaGenerator: {
+      disableForeignKeys: false
     },
     pool: database.pool as any,
   })


### PR DESCRIPTION
**What**
By default, the migrations are run with the option as true (default value), which can create issue when working in a shared env and not having the root user rights