### PR TITLE
feat(cli): DB params project name admin email 

### DIFF
--- a/packages/create-medusa-app/src/commands/create.ts
+++ b/packages/create-medusa-app/src/commands/create.ts
@@ -41,6 +41,10 @@ export type CreateOptions = {
   browser?: boolean
   migrations?: boolean
   directoryPath?: string
+  projectName?: string
+  adminEmail?: string
+  postgresPassword?: string
+  postgresUsername?: string
   withNextjsStarter?: boolean
   verbose?: boolean
   v2?: boolean
@@ -55,6 +59,10 @@ export default async ({
   browser,
   migrations,
   directoryPath,
+  projectName,
+  adminEmail,
+  postgresPassword,
+  postgresUsername,
   withNextjsStarter = false,
   verbose = false,
   v2 = false,
@@ -78,6 +86,14 @@ export default async ({
   let printedMessage = false
   let nextjsDirectory = ""
 
+  if (!projectName) {
+    projectName = await askForProjectName(directoryPath)
+  }
+
+  if (!adminEmail && !skipDb && migrations) {
+    adminEmail = await askForAdminEmail(seed, boilerplate)
+  }
+
   processManager.onTerminated(async () => {
     spinner.stop()
     // prevent an error from occurring if
@@ -96,19 +112,19 @@ export default async ({
     return
   })
 
-  const projectName = await askForProjectName(directoryPath)
   const projectPath = getProjectPath(projectName, directoryPath)
-  const adminEmail =
-    !skipDb && migrations ? await askForAdminEmail(seed, boilerplate) : ""
   const installNextjs = withNextjsStarter || (await askForNextjsStarter())
 
   let { client, dbConnectionString } = !skipDb
     ? await getDbClientAndCredentials({
         dbName,
         dbUrl,
+        postgresUsername,
+        postgresPassword,
         verbose,
       })
     : { client: null, dbConnectionString: "" }
+
   isDbInitialized = true
 
   track("CMA_OPTIONS", {
@@ -182,7 +198,7 @@ export default async ({
       directory: projectPath,
       dbConnectionString,
       admin: {
-        email: adminEmail,
+        email: adminEmail || "",
       },
       seed,
       boilerplate,
@@ -320,7 +336,17 @@ function showSuccessMessage(
     message: boxen(
       chalk.green(
         // eslint-disable-next-line prettier/prettier
-        `Change to the \`${projectName}\` directory to explore your Medusa project.${EOL}${EOL}Start your Medusa app again with the following command:${EOL}${EOL}npx @medusajs/medusa-cli develop${EOL}${EOL}${inviteToken ? `After you start the Medusa app, you can set a password for your admin user with the URL ${getInviteUrl(inviteToken)}${EOL}${EOL}` : ""}${nextjsDirectory?.length ? `The Next.js Starter storefront was installed in the \`${nextjsDirectory}\` directory. Change to that directory and start it with the following command:${EOL}${EOL}npm run dev${EOL}${EOL}` : ""}Check out the Medusa documentation to start your development:${EOL}${EOL}https://docs.medusajs.com/${EOL}${EOL}Star us on GitHub if you like what we're building:${EOL}${EOL}https://github.com/medusajs/medusa/stargazers`
+        `Change to the \`${projectName}\` directory to explore your Medusa project.${EOL}${EOL}Start your Medusa app again with the following command:${EOL}${EOL}npx @medusajs/medusa-cli develop${EOL}${EOL}${
+          inviteToken
+            ? `After you start the Medusa app, you can set a password for your admin user with the URL ${getInviteUrl(
+                inviteToken
+              )}${EOL}${EOL}`
+            : ""
+        }${
+          nextjsDirectory?.length
+            ? `The Next.js Starter storefront was installed in the \`${nextjsDirectory}\` directory. Change to that directory and start it with the following command:${EOL}${EOL}npm run dev${EOL}${EOL}`
+            : ""
+        }Check out the Medusa documentation to start your development:${EOL}${EOL}https://docs.medusajs.com/${EOL}${EOL}Star us on GitHub if you like what we're building:${EOL}${EOL}https://github.com/medusajs/medusa/stargazers`
       ),
       {
         titleAlignment: "center",

--- a/packages/create-medusa-app/src/index.ts
+++ b/packages/create-medusa-app/src/index.ts
@@ -34,6 +34,22 @@ program
     "Specify the directory path to install the project in."
   )
   .option(
+    "--projectName <string>",
+    "Specify the project name."
+  )
+  .option(
+    "--adminEmail <string>",
+    "Specify the admin email."
+  )
+  .option(
+    "--postgresUsername <string>",
+    "Specify the postgres username."
+  )
+  .option(
+    "--postgresPassword <string>",
+    "Specify the postgres password."
+  )
+  .option(
     "--with-nextjs-starter",
     "Install the Next.js starter along with the Medusa backend",
     false

--- a/packages/create-medusa-app/src/utils/create-db.ts
+++ b/packages/create-medusa-app/src/utils/create-db.ts
@@ -54,17 +54,19 @@ export async function runCreateDb({
 
 async function getForDbName({
   dbName,
+  postgresUsername,
+  postgresPassword,
   verbose = false,
 }: {
   dbName: string
+  postgresUsername: string,
+  postgresPassword: string,
   verbose?: boolean
 }): Promise<{
   client: pg.Client
   dbConnectionString: string
 }> {
   let client!: pg.Client
-  let postgresUsername = "postgres"
-  let postgresPassword = ""
 
   try {
     client = await postgresClient({
@@ -164,7 +166,10 @@ async function getForDbUrl({
 export async function getDbClientAndCredentials({
   dbName = "",
   dbUrl = "",
+  postgresUsername = "",
+  postgresPassword = "",
   verbose = false,
+
 }): Promise<{
   client: pg.Client
   dbConnectionString: string
@@ -173,6 +178,8 @@ export async function getDbClientAndCredentials({
   if (dbName) {
     return await getForDbName({
       dbName,
+      postgresUsername,
+      postgresPassword,
       verbose,
     })
   } else {

--- a/packages/create-medusa-app/src/utils/nextjs-utils.ts
+++ b/packages/create-medusa-app/src/utils/nextjs-utils.ts
@@ -43,6 +43,10 @@ export async function installNextjsStarter({
 
   let nextjsDirectory = `${directoryName}-storefront`
 
+  if (directoryName === ".") {
+    nextjsDirectory = nextjsDirectory.slice(2, nextjsDirectory.length)
+  }
+
   if (
     fs.existsSync(nextjsDirectory) &&
     fs.lstatSync(nextjsDirectory).isDirectory()


### PR DESCRIPTION
Adds in fields that allows to create project fully without manual inputs such as `inquirer`:

```
projectName?: string
adminEmail?: string
postgresPassword?: string
postgresUsername?: string
```

```
npx create-medusa-app@latest --projectName . --postgresUsername postgres --postgresPassword postgres --adminEmail test@email.com
```

@riqwan - rebased on v1 - follow up of - needs approval https://github.com/medusajs/medusa/pull/7994, https://github.com/medusajs/medusa/pull/7353