### PR TITLE
feat(notification-sendgrid): include ability to handle attachments

### DIFF
--- a/packages/core/types/src/notification/common.ts
+++ b/packages/core/types/src/notification/common.ts
@@ -4,6 +4,34 @@ import { OperatorMap } from "../dal/utils"
 /**
  * @interface
  *
+ * The structure for attachments in a notification.
+ */
+export interface Attachment {
+  /**
+   * The content of the attachment, encoded as a base64 string.
+   */
+  content: string
+  /**
+   * The filename of the attachment.
+   */
+  filename: string
+  /**
+   * The MIME type of the attachment.
+   */
+  content_type?: string
+  /**
+   * The disposition of the attachment, e.g., "inline" or "attachment".
+   */
+  disposition?: string
+  /**
+   * The ID, if the attachment is meant to be referenced within the body of the message.
+   */
+  id?: string
+}
+
+/**
+ * @interface
+ *
  * A notification's data.
  */
 export interface NotificationDTO {
@@ -15,6 +43,14 @@ export interface NotificationDTO {
    * The recipient of the notification. It can be email, phone number, or username, depending on the channel.
    */
   to: string
+  /**
+   * The sender of the notification. It can be email, phone number, or username, depending on the channel.
+   */
+  from?: string | null
+  /**
+   * Optional attachments for the notification.
+   */
+  attachments?: Attachment[] | null
   /**
    * The channel through which the notification is sent, such as 'email' or 'sms'
    */

--- a/packages/core/types/src/notification/provider.ts
+++ b/packages/core/types/src/notification/provider.ts
@@ -1,3 +1,5 @@
+import { Attachment } from "./common"
+
 /**
  * @interface
  *
@@ -8,6 +10,14 @@ export type ProviderSendNotificationDTO = {
    * The recipient of the notification. It can be email, phone number, or username, depending on the channel.
    */
   to: string
+  /**
+   * The sender of the notification. It can be email, phone number, or username, depending on the channel.
+   */
+  from?: string | null
+  /**
+   * Optional attachments for the notification.
+   */
+  attachments?: Attachment[] | null
   /**
    * The channel through which the notification is sent, such as 'email' or 'sms'
    */

--- a/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
+++ b/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
@@ -64,9 +64,15 @@ export class SendgridNotificationService extends AbstractNotificationProviderSer
         }))
       : undefined
 
-    const message = {
+    const data = notification.data || {}
+    const from =
+      typeof data.from === "string" && data.from.trim() !== ""
+        ? data.from
+        : this.config_.from
+
+    const message: sendgrid.MailDataRequired = {
       to: notification.to,
-      from: this.config_.from,
+      from: from,
       templateId: notification.template,
       dynamicTemplateData: notification.data as
         | { [key: string]: any }

--- a/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
+++ b/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
@@ -18,14 +18,6 @@ interface SendgridServiceConfig {
   from: string
 }
 
-interface Attachment {
-  content: string
-  filename: string
-  type?: string
-  disposition?: string
-  content_id?: string
-}
-
 export class SendgridNotificationService extends AbstractNotificationProviderService {
   protected config_: SendgridServiceConfig
   protected logger_: Logger
@@ -54,21 +46,17 @@ export class SendgridNotificationService extends AbstractNotificationProviderSer
       )
     }
 
-    const attachments = Array.isArray(notification.data?.attachments)
-      ? (notification.data.attachments as Attachment[]).map((attachment) => ({
+    const attachments = Array.isArray(notification.attachments)
+      ? notification.attachments.map((attachment) => ({
           content: attachment.content, // Base64 encoded string of the file
           filename: attachment.filename,
-          type: attachment.type, // MIME type (e.g., 'application/pdf')
+          content_type: attachment.content_type, // MIME type (e.g., 'application/pdf')
           disposition: attachment.disposition ?? "attachment", // Default to 'attachment'
-          content_id: attachment.content_id ?? undefined, // Optional: unique identifier for inline attachments
+          id: attachment.id ?? undefined, // Optional: unique identifier for inline attachments
         }))
       : undefined
 
-    const data = notification.data || {}
-    const from =
-      typeof data.from === "string" && data.from.trim() !== ""
-        ? data.from
-        : this.config_.from
+    const from = notification.from?.trim() || this.config_.from
 
     const message: sendgrid.MailDataRequired = {
       to: notification.to,

--- a/www/apps/resources/app/architectural-modules/notification/sendgrid/page.mdx
+++ b/www/apps/resources/app/architectural-modules/notification/sendgrid/page.mdx
@@ -185,7 +185,7 @@ In this subscriber:
 - The `template` property of the `create` method's parameter specifies the ID of the template defined in SendGrid.
 - The `data` property allows you to pass data to the template in SendGrid.
 - The `attachments` optional property allows you to pass attachments to the template in SendGrid.
-- The `from` optional property allows you to pass a single sender verified email, default is `SENDGRID_FROM` env variable.
+- The `from` optional property allows you to pass a single sender-verified email. If not provided, the value of the `from` configuration of the module is used.
 
 Then, start the Medusa application:
 

--- a/www/apps/resources/app/architectural-modules/notification/sendgrid/page.mdx
+++ b/www/apps/resources/app/architectural-modules/notification/sendgrid/page.mdx
@@ -156,21 +156,19 @@ export default async function productCreateHandler({
 
   await notificationModuleService.createNotifications({
     to: "test@gmail.com",
+    from: "test@medusajs.com", // Optional var, verified sender required
     channel: "email",
     template: "product-created",
-    data: {
-        // optional settings
-        from: "verified@sender.com",
-        attachments: [
-          {
-            content: base64,
-            type: MIME type,
-            filename: filename.ext,
-            disposition: "attachment or inline attachment",
-            content_id: "id", // only needed for inline attachment
-          },
-        ]
-    }
+    data,
+    attachments: [ // optional var
+      {
+        content: base64,
+        content_type: MIME type,
+        filename: filename.ext,
+        disposition: "attachment or inline attachment",
+        id: "id", // only needed for inline attachment
+      },
+    ]
   })
 }
 
@@ -186,7 +184,7 @@ In this subscriber:
 - By specifying the `email` channel, the SendGrid Notification Module Provider is used to send the notification.
 - The `template` property of the `create` method's parameter specifies the ID of the template defined in SendGrid.
 - The `data` property allows you to pass data to the template in SendGrid.
-- The `data.attachments` optional property allows you to pass attachments to the template in SendGrid.
+- The `attachments` optional property allows you to pass attachments to the template in SendGrid.
 - The `from` optional property allows you to pass a single sender verified email, default is `SENDGRID_FROM` env variable.
 
 Then, start the Medusa application:

--- a/www/apps/resources/app/architectural-modules/notification/sendgrid/page.mdx
+++ b/www/apps/resources/app/architectural-modules/notification/sendgrid/page.mdx
@@ -156,7 +156,18 @@ export default async function productCreateHandler({
     to: "test@gmail.com",
     channel: "email",
     template: "product-created",
-    data,
+    data: {
+        // optional attachments
+        attachments: [
+          {
+            content: base64,
+            type: MIME type,
+            filename: filename.ext,
+            disposition: "attachment or inline attachment",
+            content_id: "id", // only needed for inline attachment
+          },
+        ]
+    }
   })
 }
 
@@ -172,6 +183,7 @@ In this subscriber:
 - By specifying the `email` channel, the SendGrid Notification Module Provider is used to send the notification.
 - The `template` property of the `create` method's parameter specifies the ID of the template defined in SendGrid.
 - The `data` property allows you to pass data to the template in SendGrid.
+- The `data.attachments` optional property allows you to pass attachments to the template in SendGrid.
 
 Then, start the Medusa application:
 

--- a/www/apps/resources/app/architectural-modules/notification/sendgrid/page.mdx
+++ b/www/apps/resources/app/architectural-modules/notification/sendgrid/page.mdx
@@ -12,20 +12,22 @@ The SendGrid Notification Module Provider integrates [SendGrid](https://sendgrid
 
 ## Install the SendGrid Notification Module
 
-<Prerequisites items={[
-  {
-    text: "SendGrid account",
-    link: "https://signup.sendgrid.com"
-  },
-  {
-    text: "Setup SendGrid single sender",
-    link: "https://docs.sendgrid.com/ui/sending-email/sender-verification"
-  },
-  {
-    text: "SendGrid API Key",
-    link: "https://docs.sendgrid.com/ui/account-and-settings/api-keys"
-  }
-]} />
+<Prerequisites
+  items={[
+    {
+      text: "SendGrid account",
+      link: "https://signup.sendgrid.com",
+    },
+    {
+      text: "Setup SendGrid single sender",
+      link: "https://docs.sendgrid.com/ui/sending-email/sender-verification",
+    },
+    {
+      text: "SendGrid API Key",
+      link: "https://docs.sendgrid.com/ui/account-and-settings/api-keys",
+    },
+  ]}
+/>
 
 To install the SendGrid Notification Module Provider, run the following command in the directory of your Medusa application:
 
@@ -157,7 +159,8 @@ export default async function productCreateHandler({
     channel: "email",
     template: "product-created",
     data: {
-        // optional attachments
+        // optional settings
+        from: "verified@sender.com",
         attachments: [
           {
             content: base64,
@@ -184,6 +187,7 @@ In this subscriber:
 - The `template` property of the `create` method's parameter specifies the ID of the template defined in SendGrid.
 - The `data` property allows you to pass data to the template in SendGrid.
 - The `data.attachments` optional property allows you to pass attachments to the template in SendGrid.
+- The `from` optional property allows you to pass a single sender verified email, default is `SENDGRID_FROM` env variable.
 
 Then, start the Medusa application:
 


### PR DESCRIPTION
feat(notification-sendgrid): include ability to handle attachments array if passed to dynamicTemplateData.attachments

attachments array objects must contain the following: 

```ts
interface Attachment {
  content: string
  filename: string
  type?: string
  disposition?: string
  content_id?: string
}```