### PR TITLE
fix(medusa): use correct request type for create cart API route

### DIFF
--- a/packages/medusa/src/api/store/carts/route.ts
+++ b/packages/medusa/src/api/store/carts/route.ts
@@ -11,7 +11,7 @@ import {
 import { refetchCart } from "./helpers"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest<CreateCartWorkflowInputDTO & AdditionalData>,
+  req: AuthenticatedMedusaRequest<HttpTypes.StoreCreateCart & AdditionalData>,
   res: MedusaResponse<HttpTypes.StoreCartResponse>
 ) => {
   const workflowInput = {
@@ -20,7 +20,7 @@ export const POST = async (
   }
 
   const { result } = await createCartWorkflow(req.scope).run({
-    input: workflowInput,
+    input: workflowInput as CreateCartWorkflowInputDTO,
   })
 
   const cart = await refetchCart(


### PR DESCRIPTION
Use the `StoreCreateCart` type instead of the workflow input type for the create cart API route.