### PR TITLE
docs: uppercase HTTP methods in api reference

### DIFF
--- a/www/apps/api-reference/components/MethodLabel/index.tsx
+++ b/www/apps/api-reference/components/MethodLabel/index.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx"
 import { Badge, capitalize } from "docs-ui"
 
 export type MethodLabelProps = {
@@ -9,7 +10,7 @@ const MethodLabel = ({ method, className }: MethodLabelProps) => {
   return (
     <Badge
       variant={method === "get" ? "green" : method === "post" ? "blue" : "red"}
-      className={className}
+      className={clsx(className, "uppercase")}
     >
       {method === "delete" ? "Del" : capitalize(method)}
     </Badge>


### PR DESCRIPTION
Closes DOCS-867