### PR TITLE
docs-util: fix for product type schemas

### DIFF
--- a/www/utils/packages/docs-generator/src/classes/helpers/oas-schema.ts
+++ b/www/utils/packages/docs-generator/src/classes/helpers/oas-schema.ts
@@ -272,7 +272,7 @@ class OasSchemaHelper {
     return name
       .replace("DTO", "")
       .replace(this.schemaRefPrefix, "")
-      .replace(/(?<!Type)Type$/, "")
+      .replace(/(?<!AdminProduct)Type$/, "")
   }
 
   /**


### PR DESCRIPTION
schemas related to `ProductType` were names as `Product` instead, leading to overlapping types.

This PR fixes this issue by adding a specific fix for `AdminProductType` and `StoreProductType`.

Note that the previous `Type` removal at the end of a schema name was necessary before but not anymore. However, I avoided removing the replace statement entirely as that will lead to a lot of changes in existing generated files. This change should fix th issue at the present moment.