### PR TITLE
docs-util: fix removal of manually-added schemas in clean script

### DIFF
--- a/www/utils/packages/docs-generator/src/commands/clean-oas.ts
+++ b/www/utils/packages/docs-generator/src/commands/clean-oas.ts
@@ -20,6 +20,12 @@ import parseOas from "../utils/parse-oas.js"
 
 const OAS_PREFIX_REGEX = /@oas \[(?<method>(get|post|delete))\] (?<path>.+)/
 
+const ignoreSchemas = [
+  "AuthResponse",
+  "AuthAdminSessionResponse",
+  "AuthStoreSessionResponse",
+]
+
 export default async function () {
   const oasOutputBasePath = getOasOutputBasePath()
   const oasOperationsPath = path.join(oasOutputBasePath, "operations")
@@ -274,7 +280,10 @@ export default async function () {
 
   // clean up schemas
   allSchemas.forEach((schemaName) => {
-    if (referencedSchemas.has(schemaName)) {
+    if (
+      referencedSchemas.has(schemaName) ||
+      ignoreSchemas.includes(schemaName)
+    ) {
       return
     }
 


### PR DESCRIPTION
Fix removal of manually added schemas by adding a list of schema names to be ignored.