### PR TITLE
fix(core-flows): use unit price of item in create cart and add to cart flows

### DIFF
--- a/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
@@ -67,7 +67,8 @@ export const addToCartWorkflow = createWorkflow(
 
         return prepareLineItemData({
           variant: variant,
-          unitPrice: variant.calculated_price.calculated_amount,
+          unitPrice: item.unit_price || 
+            variant.calculated_price.calculated_amount,
           isTaxInclusive:
             variant.calculated_price.is_calculated_price_tax_inclusive,
           quantity: item.quantity,

--- a/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
@@ -69,7 +69,7 @@ export const addToCartWorkflow = createWorkflow(
           variant: variant,
           unitPrice: item.unit_price || 
             variant.calculated_price.calculated_amount,
-          isTaxInclusive:
+          isTaxInclusive: item.is_tax_inclusive || 
             variant.calculated_price.is_calculated_price_tax_inclusive,
           quantity: item.quantity,
           metadata: item?.metadata ?? {},

--- a/packages/core/core-flows/src/cart/workflows/create-carts.ts
+++ b/packages/core/core-flows/src/cart/workflows/create-carts.ts
@@ -126,7 +126,8 @@ export const createCartWorkflow = createWorkflow(
 
         return prepareLineItemData({
           variant: variant,
-          unitPrice: data.priceSets[item.variant_id].calculated_amount,
+          unitPrice: item.unit_price || 
+            data.priceSets[item.variant_id].calculated_amount,
           isTaxInclusive:
             data.priceSets[item.variant_id].is_calculated_price_tax_inclusive,
           quantity: item.quantity,

--- a/packages/core/core-flows/src/cart/workflows/create-carts.ts
+++ b/packages/core/core-flows/src/cart/workflows/create-carts.ts
@@ -128,7 +128,7 @@ export const createCartWorkflow = createWorkflow(
           variant: variant,
           unitPrice: item.unit_price || 
             data.priceSets[item.variant_id].calculated_amount,
-          isTaxInclusive:
+          isTaxInclusive: item.is_tax_inclusive ||
             data.priceSets[item.variant_id].is_calculated_price_tax_inclusive,
           quantity: item.quantity,
           metadata: item?.metadata ?? {},

--- a/packages/core/types/src/cart/workflows.ts
+++ b/packages/core/types/src/cart/workflows.ts
@@ -34,6 +34,7 @@ export interface CreateCartCreateLineItemDTO {
   is_giftcard?: boolean
 
   compare_at_unit_price?: BigNumberInput
+  unit_price?: BigNumberInput
 
   metadata?: Record<string, unknown> | null
 }

--- a/packages/core/types/src/cart/workflows.ts
+++ b/packages/core/types/src/cart/workflows.ts
@@ -34,7 +34,6 @@ export interface CreateCartCreateLineItemDTO {
   is_giftcard?: boolean
 
   compare_at_unit_price?: BigNumberInput
-  unit_price?: BigNumberInput
 
   metadata?: Record<string, unknown> | null
 }


### PR DESCRIPTION
Use the `unit_price` property of an item in the `addToCart` and `createCart` workflows.