### PR TITLE
docs: fix overflowing card description hidden

### DIFF
--- a/www/packages/docs-ui/src/components/Card/Layout/Default/index.tsx
+++ b/www/packages/docs-ui/src/components/Card/Layout/Default/index.tsx
@@ -49,7 +49,9 @@ export const CardDefaultLayout = ({
           icon={image}
         />
       )}
-      <div className={clsx("flex flex-col flex-1 truncate", contentClassName)}>
+      <div
+        className={clsx("flex flex-col flex-1 overflow-auto", contentClassName)}
+      >
         {title && (
           <div className="text-compact-small-plus text-medusa-fg-base truncate">
             {title}


### PR DESCRIPTION
Only the title of a card should be truncated, if too long. The description text should be shown as-is.