### PR TITLE
docs-util: include types in workflows.ts in generated references

### DIFF
--- a/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
@@ -123,7 +123,7 @@ const customOptions: Record<string, Partial<TypeDocOptions>> = {
     enableInternalResolve: true,
     exclude: [
       ...(baseOptions.exclude || []),
-      ...modules.map((moduleName) => `**/${moduleName}/**/*.ts`),
+      ...modules.map((moduleName) => `**/${moduleName}/**/!(workflows).ts`),
     ],
   }),
   "modules-sdk": getOptions({


### PR DESCRIPTION
Include types in `workflows.ts` files under each module's directory in the `types` package as part of the generated references.