### PR TITLE
fix: assign scheduled job worker to JobSchedulerService class

### DIFF
--- a/packages/medusa/src/services/job-scheduler.ts
+++ b/packages/medusa/src/services/job-scheduler.ts
@@ -22,6 +22,7 @@ export default class JobSchedulerService {
   protected readonly handlers_: Map<string | symbol, ScheduledJobHandler[]> =
     new Map()
   protected readonly queue_: Queue
+  protected readonly worker_: Worker
 
   constructor(
     { logger }: InjectedDependencies,
@@ -50,10 +51,14 @@ export default class JobSchedulerService {
       })
 
       // Register scheduled job worker
-      new Worker("scheduled-jobs:queue", this.scheduledJobsWorker, {
-        connection,
-        prefix,
-      })
+      this.worker_ = new Worker(
+        "scheduled-jobs:queue",
+        this.scheduledJobsWorker,
+        {
+          connection,
+          prefix,
+        }
+      )
     }
   }
 


### PR DESCRIPTION
**What** - Enhance the `JobSchedulerService` by making the scheduler jobs worker available for proper shutdown procedures.
**Why** - Currently, when the Medusa server is shut down, workers are not properly closed, increasing the risk of jobs being marked as stalled. If a worker is terminated without completing its jobs, these jobs are automatically marked as stalled and will be reprocessed when new workers come online, typically after a delay of about 30 seconds. To minimize the occurrence of stalled jobs, it is crucial to gracefully close workers during server shutdown, as recommended by the [BullMQ documentation](https://docs.bullmq.io/guide/going-to-production#gracefully-shut-down-workers).
**How** - The worker is currently created but not assigned to the `JobSchedulerService` class. This update ensures that the worker is properly attached to the `JobSchedulerService`, allowing for a graceful shutdown process.
**Test** - The changes were tested by linking the package to an existing Medusa project. The worker shutdown process was verified by adding `jobSchedulerService.worker_.close();` to the function handling `SIGTERM` and `SIGINT` signals, then starting and stopping the server process to confirm proper worker closure.
 