### PR TITLE
docs: replace usages of migrations and links commands

### DIFF
--- a/www/apps/book/app/advanced-development/data-models/write-migration/page.mdx
+++ b/www/apps/book/app/advanced-development/data-models/write-migration/page.mdx
@@ -17,7 +17,7 @@ A migration is a class created in a TypeScript or JavaScript file under a module
 
 ## How to Write a Migration?
 
-The Medusa CLI tool provides a [migrations generate](!resources!/medusa-cli#migrations-generate) command to generate a migration for the specified modules' data models.
+The Medusa CLI tool provides a [db:generate](!resources!/medusa-cli/commands/db#dbgenerate) command to generate a migration for the specified modules' data models.
 
 Alternatively, you can manually create a migration file under the `migrations` directory of your module.
 
@@ -51,8 +51,14 @@ In the example above, the `up` method creates the table `my_custom`, and the `do
 
 To run your migration, run the following command:
 
+<Note>
+
+This command also syncs module links. If you don't want that, use the `--skip-links` option.
+
+</Note>
+
 ```bash
-npx medusa migrations run
+npx medusa db:migrate
 ```
 
 This reflects the changes in the database as implemented in the migration's `up` method.

--- a/www/apps/book/app/advanced-development/modules/module-links/page.mdx
+++ b/www/apps/book/app/advanced-development/modules/module-links/page.mdx
@@ -58,13 +58,19 @@ In this example, you define a module link between the `hello` module's `MyCustom
 
 ### 2. Sync Links
 
-Medusa stores links as pivot tables in the database. So, to reflect your link in the database, run the `links sync` command:
+Medusa stores links as pivot tables in the database. So, to reflect your link in the database, run the `db:sync-links` command:
 
 ```bash
-npx medusa links sync
+npx medusa db:sync-links
 ```
 
 Use this command whenever you make changes to your links. For example, run this command if you remove your link definition file.
+
+<Note title="Tip">
+
+You can also use the `db:migrate` command, which both runs the migrations and syncs the links.
+
+</Note>
 
 ---
 

--- a/www/apps/book/app/basics/data-models/page.mdx
+++ b/www/apps/book/app/basics/data-models/page.mdx
@@ -51,10 +51,10 @@ A migration defines changes to be made in the database, such as create or update
 To generate a migration for the data models in your module, run the following command:
 
 ```bash
-npx medusa migrations generate helloModuleService
+npx medusa db:generate helloModuleService
 ```
 
-The `migrations generate` command of the Medusa CLI accepts one or more module names (for example, `helloModuleService`) to generate the migration for.
+The `db:generate` command of the Medusa CLI accepts one or more module names (for example, `helloModuleService`) to generate the migration for.
 
 The above command creates a migration file at the directory `src/modules/hello/migrations` similar to the following:
 
@@ -81,7 +81,7 @@ In the migration class, the `up` method creates the table `my_custom` and define
 To reflect the changes in the generated migration file, run the `migration` command:
 
 ```bash
-npx medusa migrations run
+npx medusa db:migrate
 ```
 
 If ran successfully, the `my_custom` table will be created in the database.

--- a/www/apps/resources/app/deployment/medusa-application/railway/page.mdx
+++ b/www/apps/resources/app/deployment/medusa-application/railway/page.mdx
@@ -111,7 +111,7 @@ So, add the following script in `package.json`:
 ```json
 "scripts": {
   // ...
-  "predeploy": "medusa migrations run && medusa links sync"
+  "predeploy": "medusa db:migrate"
 },
 ```
 

--- a/www/apps/resources/app/recipes/b2b/page.mdx
+++ b/www/apps/resources/app/recipes/b2b/page.mdx
@@ -283,7 +283,7 @@ You can create a B2B module that adds necessary data models to represent a B2B c
   You can now run migrations with the following commands:
 
   ```bash npm2yarn
-  npx medusa migrations run
+  npx medusa db:migrate
   ```
 
   ### Add Create Company API Route

--- a/www/apps/resources/app/recipes/commerce-automation/page.mdx
+++ b/www/apps/resources/app/recipes/commerce-automation/page.mdx
@@ -166,10 +166,10 @@ export const restockModelHighlights = [
   })
   ```
 
-  You can now run the module's migrations with the following command:
+  You can now run the migrations with the following command:
 
   ```bash npm2yarn
-  npx medusa migrations run
+  npx medusa db:migrate
   ```
 
   ### Create Restock Notification API Route

--- a/www/apps/resources/app/recipes/digital-products/examples/standard/page.mdx
+++ b/www/apps/resources/app/recipes/digital-products/examples/standard/page.mdx
@@ -264,21 +264,15 @@ This defines a link between `DigitalProductOrder` and the Order Module’s `Orde
 To create tables for the digital product data models in the database, start by generating the migrations for the Digital Product Module with the following command:
 
 ```bash
-npx medusa migrations generate digitalProductModuleService
+npx medusa db:generate digitalProductModuleService
 ```
 
 This generates a migration in the `src/modules/digital-product/migrations` directory.
 
-Then, reflect the migrations in the database with the following command:
+Then, reflect the migrations and links in the database with the following command:
 
 ```bash
-npx medusa migrations run
-```
-
-Next, to reflect your links in the database, run the `links sync` command:
-
-```bash
-npx medusa links sync
+npx medusa db:migrate
 ```
 
 ---

--- a/www/apps/resources/app/recipes/marketplace/examples/restaurant-delivery/page.mdx
+++ b/www/apps/resources/app/recipes/marketplace/examples/restaurant-delivery/page.mdx
@@ -409,22 +409,16 @@ This defines a link between the Delivery Module’s `delivery` data model and th
 To create tables for the above data models in the database, start by generating the migrations for the Restaurant and Delivery Modules with the following commands:
 
 ```bash
-npx medusa migrations generate restaurantModuleService
-npx medusa migrations generate deliveryModuleService
+npx medusa db:generate restaurantModuleService
+npx medusa db:generate deliveryModuleService
 ```
 
 This generates migrations in the `src/modules/restaurant/migrations` and `src/modules/delivery/migrations` directories.
 
-Then, to reflect the migration in the database, run the following command:
+Then, to reflect the migration and links in the database, run the following command:
 
 ```bash
-npx medusa migrations run
-```
-
-Next, to reflect your links in the database, run the `links sync` command:
-
-```bash
-npx medusa links sync
+npx medusa db:migrate
 ```
 
 ---

--- a/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
+++ b/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
@@ -213,21 +213,15 @@ This adds a list link between the `Vendor` and `Order` data models, indicating t
 To create tables for the marketplace data models in the database, start by generating the migrations for the Marketplace Module with the following command:
 
 ```bash
-npx medusa migrations generate marketplaceModuleService
+npx medusa db:generate marketplaceModuleService
 ```
 
 This generates a migration in the `src/modules/marketeplace/migrations` directory.
 
-Then, to reflect the migration in the database, run the following command:
+Then, to reflect the migration and links in the database, run the following command:
 
 ```bash
-npx medusa migrations run
-```
-
-Next, to reflect your links in the database, run the `links sync` command:
-
-```bash
-npx medusa links sync
+npx medusa db:migrate
 ```
 
 ---

--- a/www/apps/resources/app/recipes/subscriptions/examples/standard/page.mdx
+++ b/www/apps/resources/app/recipes/subscriptions/examples/standard/page.mdx
@@ -252,21 +252,15 @@ This defines a list link to the `Order` data model since a subscription has mult
 To create a table for the `Subscription` data model in the database, start by generating the migrations for the Subscription Module with the following command:
 
 ```bash
-npx medusa migrations generate subscriptionModuleService
+npx medusa db:generate subscriptionModuleService
 ```
 
 This generates a migration in the `src/modules/subscriptions/migrations` directory.
 
-Then, to reflect the migration in the database, run the following command:
+Then, to reflect the migration and links in the database, run the following command:
 
 ```bash
-npx medusa migrations run
-```
-
-Next, to reflect your links in the database, run the `links sync` command:
-
-```bash
-npx medusa links sync
+npx medusa db:migrate
 ```
 
 ---

--- a/www/apps/resources/app/troubleshooting/_sections/create-medusa-app-errors/eagain-error.mdx
+++ b/www/apps/resources/app/troubleshooting/_sections/create-medusa-app-errors/eagain-error.mdx
@@ -17,7 +17,7 @@ npm run build
 3. Run migrations:
 
 ```bash
-npx medusa migrations run
+npx medusa db:migrate
 ```
 
 4. Create an admin user:

--- a/www/apps/resources/app/troubleshooting/errors-after-upgrading/page.mdx
+++ b/www/apps/resources/app/troubleshooting/errors-after-upgrading/page.mdx
@@ -6,10 +6,10 @@ export const metadata = {
 
 If you run into errors after updating Medusa and its dependencies, it's highly recommended to check the Upgrade Guides if there is a specific guide for your version. These guides include steps required to perform after upgrading Medusa.
 
-If there's no upgrade guide for your version, make sure that you ran the `migrations` command in the root directory of your Medusa application:
+If there's no upgrade guide for your version, make sure that you ran the `db:migrate` command in the root directory of your Medusa application:
 
 ```bash
-npx medusa migrations run
+npx medusa db:migrate
 ```
 
 This ensures your application has the latest database structure required. Then, try running your Medusa application again and check whether the same error occurs.


### PR DESCRIPTION
Replace usages of migrations and links commands with db commands