### PR TITLE
fix: ignore metadata when computing relationships from payload

### DIFF
--- a/packages/core/utils/src/common/__tests__/get-selects-and-relations-from-object-array.spec.ts
+++ b/packages/core/utils/src/common/__tests__/get-selects-and-relations-from-object-array.spec.ts
@@ -16,6 +16,12 @@ describe("getSelectsAndRelationsFromObjectArray", function () {
               attr_null: null,
               attr_undefined: undefined,
             },
+            metadata: {
+              is_test: true,
+              nested_object: {
+                deeply_nested: true,
+              },
+            },
             attr_array: [
               {
                 attr_object: {
@@ -43,6 +49,8 @@ describe("getSelectsAndRelationsFromObjectArray", function () {
             "attr_object.attr_boolean",
             "attr_object.attr_null",
             "attr_object.attr_undefined",
+            "metadata.is_test",
+            "metadata.nested_object.deeply_nested",
             "attr_array.attr_object.attr_string",
             "attr_array.attr_object.attr_boolean",
             "attr_array.attr_object.attr_null",

--- a/packages/core/utils/src/common/get-selects-and-relations-from-object-array.ts
+++ b/packages/core/utils/src/common/get-selects-and-relations-from-object-array.ts
@@ -1,6 +1,8 @@
 import { deduplicate } from "./deduplicate"
 import { isObject } from "./is-object"
 
+const KEYS_THAT_ARE_NOT_RELATIONS = ["metadata"]
+
 export function getSelectsAndRelationsFromObjectArray(
   dataArray: object[],
   options: { objectFields: string[] } = {
@@ -17,23 +19,29 @@ export function getSelectsAndRelationsFromObjectArray(
   for (const data of dataArray) {
     for (const [key, value] of Object.entries(data)) {
       if (isObject(value) && !options.objectFields.includes(key)) {
-        relations.push(setKey(key, prefix))
         const res = getSelectsAndRelationsFromObjectArray(
           [value],
           options,
           setKey(key, prefix)
         )
         selects.push(...res.selects)
-        relations.push(...res.relations)
+
+        if (!KEYS_THAT_ARE_NOT_RELATIONS.includes(key)) {
+          relations.push(setKey(key, prefix))
+          relations.push(...res.relations)
+        }
       } else if (Array.isArray(value)) {
-        relations.push(setKey(key, prefix))
         const res = getSelectsAndRelationsFromObjectArray(
           value,
           options,
           setKey(key, prefix)
         )
         selects.push(...res.selects)
-        relations.push(...res.relations)
+
+        if (!KEYS_THAT_ARE_NOT_RELATIONS.includes(key)) {
+          relations.push(setKey(key, prefix))
+          relations.push(...res.relations)
+        }
       } else {
         selects.push(setKey(key, prefix))
       }


### PR DESCRIPTION
Fixes: FRMW-2584

This PR updates the `getSelectsAndRelationsFromObjectArray` utility which is used by the workflow steps to find the fields and the relationships being updated. The util ignores `metadata` property from leaking into relationships array.