### PR TITLE
docs: fix missing auth tag in api reference

### DIFF
--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -9,6 +9,9 @@ servers:
   - url: http://localhost:9000
   - url: https://api.medusajs.com
 tags:
+  - name: Auth
+    description: >
+      Auth API routes allow you to manage an admin user's authentication.
   - name: Api Keys
     description: |
       API keys can be used for authentication or resource-scoping.

--- a/www/apps/api-reference/specs/admin/openapi.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.yaml
@@ -9,6 +9,9 @@ servers:
   - url: http://localhost:9000
   - url: https://api.medusajs.com
 tags:
+  - name: Auth
+    description: >
+      Auth API routes allow you to manage an admin user's authentication.
   - name: Api Keys
     description: >
       API keys can be used for authentication or resource-scoping.

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -9,6 +9,9 @@ servers:
   - url: http://localhost:9000
   - url: https://api.medusajs.com
 tags:
+  - name: Auth
+    description: >
+      Auth API routes allow you to manage a customer's authentication.
   - name: Carts
     description: |
       A cart is a virtual shopping bag that customers can use to add items they want to purchase.

--- a/www/apps/api-reference/specs/store/openapi.yaml
+++ b/www/apps/api-reference/specs/store/openapi.yaml
@@ -9,6 +9,9 @@ servers:
   - url: http://localhost:9000
   - url: https://api.medusajs.com
 tags:
+  - name: Auth
+    description: >
+      Auth API routes allow you to manage a customer's authentication.
   - name: Carts
     description: >
       A cart is a virtual shopping bag that customers can use to add items they

--- a/www/utils/generated/oas-output/base/admin.oas.base.yaml
+++ b/www/utils/generated/oas-output/base/admin.oas.base.yaml
@@ -6,6 +6,9 @@ info:
     name: MIT
     url: https://github.com/medusajs/medusa/blob/develop/LICENSE
 tags:
+  - name: Auth
+    description: >
+      Auth API routes allow you to manage an admin user's authentication.
   - name: Api Keys
     description: >
       API keys can be used for authentication or resource-scoping.

--- a/www/utils/generated/oas-output/base/store.oas.base.yaml
+++ b/www/utils/generated/oas-output/base/store.oas.base.yaml
@@ -6,6 +6,9 @@ info:
     name: MIT
     url: https://github.com/medusajs/medusa/blob/master/LICENSE
 tags:
+  - name: Auth
+    description: >
+      Auth API routes allow you to manage a customer's authentication.
   - name: Carts
     description: >
       A cart is a virtual shopping bag that customers can use to add items they


### PR DESCRIPTION
The `clean` command of OAS removed the `Auth` tags manually added. This PR re-adds them.

Will open a follow-up PR that fixes the behavior in the clean command.