### PR TITLE
chore(framework): add a note for admin path configuration + add troubleshooting guide

### DIFF
--- a/packages/framework/framework/src/config/types.ts
+++ b/packages/framework/framework/src/config/types.ts
@@ -37,6 +37,13 @@ export type AdminOptions = {
    * - `/auth`
    * - `/`
    * 
+   * :::note
+   * 
+   * When using Docker, make sure that the root path of the Docker image doesn't path the admin's `path`. For example, if the Docker image's root path is `/app`, change
+   * the value of the `path` configuration, as it's `/app` by default.
+   * 
+   * :::
+   * 
    * @example
    * ```js title="medusa-config.js"
    * module.exports = defineConfig({

--- a/www/apps/resources/app/troubleshooting/medusa-admin/no-widget-route/page.mdx
+++ b/www/apps/resources/app/troubleshooting/medusa-admin/no-widget-route/page.mdx
@@ -35,3 +35,20 @@ export const config = defineWidgetConfig({
 Any other usage leads to the widget not being shown.
 
 Refer to the [Admin Development Constraints](!docs!/advanced-development/admin/constraints) documentation for more details.
+
+---
+
+## Errors in Docker
+
+If you're using a Docker image to host your Medusa application, make sure that the image's root path is different than the Medusa Admin's `path` configuration.
+
+For example, if your Docker image's root path is `/app`, make sure to change the `path` configuration in `medusa-config.js`, as it's `/app` by default:
+
+```js title="medusa-config.js"
+module.exports = defineConfig({
+  admin: {
+    path: `/dashboard`,
+  },
+  // ...
+})
+```


### PR DESCRIPTION
- add a note in the `path` configuration regarding same path as docker image
- Add a section in the troubleshooting guide for the same reason