### PR TITLE
docs-util: fix clean script removing Auth tags

### DIFF
--- a/www/utils/packages/docs-generator/src/classes/helpers/schema-factory.ts
+++ b/www/utils/packages/docs-generator/src/classes/helpers/schema-factory.ts
@@ -76,7 +76,11 @@ class SchemaFactory {
     let schema = Object.assign({}, schemasFactory[key])
 
     if (additionalData) {
-      schema = Object.assign(schema, additionalData)
+      schema = Object.assign(schema, {
+        ...additionalData,
+        // keep the description
+        description: schema.description || additionalData.description
+      })
     }
 
     return schema

--- a/www/utils/packages/docs-generator/src/commands/clean-oas.ts
+++ b/www/utils/packages/docs-generator/src/commands/clean-oas.ts
@@ -26,6 +26,11 @@ const ignoreSchemas = [
   "AuthStoreSessionResponse",
 ]
 
+const ignoreTags = {
+  admin: ["Auth"],
+  store: ["Auth"]
+}
+
 export default async function () {
   const oasOutputBasePath = getOasOutputBasePath()
   const oasOperationsPath = path.join(oasOutputBasePath, "operations")
@@ -225,7 +230,7 @@ export default async function () {
     const lengthBefore = parsedBaseYaml.tags?.length || 0
 
     parsedBaseYaml.tags = parsedBaseYaml.tags?.filter((tag) =>
-      areaTags.has(tag.name)
+      areaTags.has(tag.name) || ignoreTags[area].includes(tag.name)
     )
 
     if (lengthBefore !== (parsedBaseYaml.tags?.length || 0)) {


### PR DESCRIPTION
- Fix the `clean:oas` command removing the Auth tags
- Other: give priority to description by schema factory
- Other: fix removal of response types in OAS other than JSON (such as stream data)