### PR TITLE
docs: added a section on middlewares and trailing backslashes

### DIFF
--- a/www/apps/book/app/advanced-development/api-routes/middlewares/page.mdx
+++ b/www/apps/book/app/advanced-development/api-routes/middlewares/page.mdx
@@ -55,6 +55,48 @@ In the example above, you define a middleware that logs the message `Received a 
 
 ---
 
+## Request URLs with Trailing Backslashes
+
+A middleware whose `matcher` pattern doesn't end with a backslash won't be applied for requests to URLs with a trailing backslash.
+
+For example, consider you have the following middleware:
+
+```ts
+import { defineMiddlewares } from "@medusajs/medusa"
+import type { 
+  MedusaNextFunction, 
+  MedusaRequest, 
+  MedusaResponse, 
+} from "@medusajs/medusa"
+
+export default defineMiddlewares({
+  routes: [
+    {
+      matcher: "/custom",
+      middlewares: [
+        (
+          req: MedusaRequest, 
+          res: MedusaResponse, 
+          next: MedusaNextFunction
+        ) => {
+          console.log("Received a request!")
+
+          next()
+        },
+      ],
+    },
+  ],
+})
+```
+
+If you send a request to `http://localhost:9000/custom`, the middleware will run.
+
+However, if you send a request to `http://localhost:9000/custom/`, the middleware won't run.
+
+In general, avoid adding trailing backslashes when sending requests to API routes.
+
+---
+
 ## Test the Middleware
 
 To test the middleware:

--- a/www/apps/book/generated/edit-dates.mjs
+++ b/www/apps/book/generated/edit-dates.mjs
@@ -61,7 +61,7 @@ export const generatedEditDates = {
   "app/advanced-development/admin/tips/page.mdx": "2024-08-05T13:20:34+03:00",
   "app/advanced-development/api-routes/cors/page.mdx": "2024-07-25T17:14:06+02:00",
   "app/advanced-development/admin/ui-routes/page.mdx": "2024-08-06T09:44:22+02:00",
-  "app/advanced-development/api-routes/middlewares/page.mdx": "2024-07-25T17:14:06+02:00",
+  "app/advanced-development/api-routes/middlewares/page.mdx": "2024-09-02T13:52:00.236Z",
   "app/advanced-development/modules/isolation/page.mdx": "2024-07-04T17:26:03+03:00",
   "app/advanced-development/data-models/configure-properties/page.mdx": "2024-07-04T17:26:03+03:00",
   "app/advanced-development/data-models/index/page.mdx": "2024-07-04T17:26:03+03:00",

--- a/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
+++ b/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
@@ -512,6 +512,12 @@ This route is available because you created the `vendor` actor type previously.
 
 3. Send a request to the `/vendors` API route, passing the token retrieved from the previous response in the request header:
 
+<Note>
+
+Don't include a trailing slash at the end of the URL. Learn more [here](!docs!/advanced-development/api-routes/middlewares).
+
+</Note>
+
 ```bash
 curl -X POST 'http://localhost:9000/vendors' \
 -H 'Content-Type: application/json' \

--- a/www/apps/resources/generated/edit-dates.mjs
+++ b/www/apps/resources/generated/edit-dates.mjs
@@ -145,7 +145,7 @@ export const generatedEditDates = {
   "app/recipes/digital-products/page.mdx": "2024-08-02T13:02:06+00:00",
   "app/recipes/ecommerce/page.mdx": "2024-06-09T15:18:43+02:00",
   "app/recipes/integrate-ecommerce-stack/page.mdx": "2024-08-05T07:24:27+00:00",
-  "app/recipes/marketplace/examples/vendors/page.mdx": "2024-07-31T17:01:33+03:00",
+  "app/recipes/marketplace/examples/vendors/page.mdx": "2024-09-02T14:06:37.189Z",
   "app/recipes/marketplace/page.mdx": "2024-07-11T15:56:41+00:00",
   "app/recipes/multi-region-store/page.mdx": "2024-07-01T10:21:19+03:00",
   "app/recipes/omnichannel/page.mdx": "2024-06-09T15:18:43+02:00",


### PR DESCRIPTION
- Added a section on how middlewares match request URLs with trailing backslashes
- Add a note in marketplace recipe to warn from adding a trailing backslash.

Closes #8920
Closes DOCS-941