### PR TITLE
fix(types, medusa): fixes to draft order request types

### DIFF
--- a/packages/core/types/src/http/order/admin/queries.ts
+++ b/packages/core/types/src/http/order/admin/queries.ts
@@ -1,14 +1,14 @@
 import { OperatorMap } from "../../../dal"
+import { FulfillmentStatus, PaymentStatus } from "../../../order"
 import { FindParams } from "../../common"
 import { BaseOrderFilters } from "../common"
 import { BaseOrderChangesFilters } from "../common"
 
 export interface AdminOrderFilters extends FindParams, BaseOrderFilters {
   id?: string[] | string
-  name?: string[] | string
   sales_channel_id?: string[]
-  fulfillment_status?: string[]
-  payment_status?: string[]
+  fulfillment_status?: FulfillmentStatus[]
+  payment_status?: PaymentStatus[]
   region_id?: string[]
   q?: string
   created_at?: OperatorMap<string>

--- a/packages/medusa/src/api/admin/draft-orders/validators.ts
+++ b/packages/medusa/src/api/admin/draft-orders/validators.ts
@@ -16,7 +16,6 @@ export const AdminGetOrdersParams = createFindParams({
 }).merge(
   z.object({
     id: z.union([z.string(), z.array(z.string())]).optional(),
-    name: z.union([z.string(), z.array(z.string())]).optional(),
     $and: z.lazy(() => AdminGetOrdersParams.array()).optional(),
     $or: z.lazy(() => AdminGetOrdersParams.array()).optional(),
   })
@@ -28,7 +27,6 @@ enum Status {
 
 const ShippingMethod = z.object({
   shipping_method_id: z.string().nullish(),
-  order_id: z.string().nullish(),
   name: z.string(),
   shipping_option_id: z.string(),
   data: z.record(z.string(), z.unknown()).optional(),


### PR DESCRIPTION
- remove the `name` filter for orders (couldn't find any `name` property in the order data model).
- Remove the `order_id` property of a shipping method in the request body type for creating a draft order
- Update the types of `fulfillment_status` and `payment_status` in the order filters to showcase the possible status values.