### PR TITLE
docs: generate sitemaps + change search filters

### DIFF
--- a/www/apps/book/app/sitemap.ts
+++ b/www/apps/book/app/sitemap.ts
@@ -1,0 +1,13 @@
+import { retrieveMdxPages } from "build-scripts"
+import type { MetadataRoute } from "next"
+import path from "path"
+import { config } from "../config"
+import { basePathUrl } from "../utils/base-path-url"
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return retrieveMdxPages({
+    basePath: path.resolve("app"),
+  }).map((filePath) => ({
+    url: `${config.baseUrl}${basePathUrl(filePath)}`,
+  }))
+}

--- a/www/apps/book/providers/search.tsx
+++ b/www/apps/book/providers/search.tsx
@@ -74,7 +74,7 @@ const SearchProvider = ({ children }: SearchProviderProps) => {
           },
         },
       ]}
-      initialDefaultFilters={["book"]}
+      initialDefaultFilters={["guides"]}
     >
       {children}
     </UiSearchProvider>

--- a/www/apps/resources/app/sitemap.ts
+++ b/www/apps/resources/app/sitemap.ts
@@ -1,0 +1,13 @@
+import { retrieveMdxPages } from "build-scripts"
+import type { MetadataRoute } from "next"
+import path from "path"
+import { config } from "../config"
+import { basePathUrl } from "../utils/base-path-url"
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return retrieveMdxPages({
+    basePath: path.resolve("app"),
+  }).map((filePath) => ({
+    url: `${config.baseUrl}${basePathUrl(filePath)}`,
+  }))
+}

--- a/www/apps/resources/providers/search.tsx
+++ b/www/apps/resources/providers/search.tsx
@@ -63,7 +63,7 @@ const SearchProvider = ({ children }: SearchProviderProps) => {
           },
         },
       ]}
-      initialDefaultFilters={["resources"]}
+      initialDefaultFilters={["guides"]}
     >
       {children}
     </UiSearchProvider>

--- a/www/packages/build-scripts/src/index.ts
+++ b/www/packages/build-scripts/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./generate-edited-dates.js"
 export * from "./generate-sidebar.js"
+export * from "./retrieve-mdx-pages.js"
 
 export * from "./utils/find-metadata-title.js"
 export * from "./utils/find-page-heading.js"

--- a/www/packages/build-scripts/src/retrieve-mdx-pages.ts
+++ b/www/packages/build-scripts/src/retrieve-mdx-pages.ts
@@ -1,0 +1,35 @@
+import { readdirSync } from "fs"
+import path from "path"
+
+type Options = {
+  basePath: string
+}
+
+export function retrieveMdxPages({ basePath }: Options): string[] {
+  function retrieveMdxFilesInPath(dir: string): string[] {
+    const urls = []
+    const files = readdirSync(dir, {
+      withFileTypes: true,
+    })
+
+    for (const file of files) {
+      const filePath = path.join(dir, file.name)
+      if (file.isDirectory()) {
+        if (!file.name.startsWith("_")) {
+          urls.push(...retrieveMdxFilesInPath(filePath))
+        }
+        continue
+      } else if (file.name !== "page.mdx") {
+        continue
+      }
+
+      urls.push(
+        filePath.replace(basePath, "").replace(file.name, "").replace(/\/$/, "")
+      )
+    }
+
+    return urls
+  }
+
+  return retrieveMdxFilesInPath(basePath)
+}

--- a/www/packages/build-scripts/src/retrieve-mdx-pages.ts
+++ b/www/packages/build-scripts/src/retrieve-mdx-pages.ts
@@ -1,5 +1,6 @@
 import { readdirSync } from "fs"
 import path from "path"
+import { getFileSlugSyncUtil } from "remark-rehype-plugins"
 
 type Options = {
   basePath: string
@@ -23,8 +24,14 @@ export function retrieveMdxPages({ basePath }: Options): string[] {
         continue
       }
 
+      const slug = getFileSlugSyncUtil(filePath)
+
       urls.push(
-        filePath.replace(basePath, "").replace(file.name, "").replace(/\/$/, "")
+        slug ||
+          filePath
+            .replace(basePath, "")
+            .replace(file.name, "")
+            .replace(/\/$/, "")
       )
     }
 

--- a/www/packages/build-scripts/src/utils/get-core-flows-ref-sidebar-children.ts
+++ b/www/packages/build-scripts/src/utils/get-core-flows-ref-sidebar-children.ts
@@ -1,6 +1,6 @@
-import { getSidebarItemLink, ItemsToAdd } from "build-scripts"
 import { existsSync, readdirSync } from "fs"
 import path from "path"
+import { getSidebarItemLink, ItemsToAdd } from "../index.js"
 
 export default async function getCoreFlowsRefSidebarChildren(): Promise<
   ItemsToAdd[]

--- a/www/packages/docs-ui/src/constants.tsx
+++ b/www/packages/docs-ui/src/constants.tsx
@@ -188,7 +188,7 @@ export const searchFiltersV2: OptionType[] = [
     label: "Guides",
   },
   {
-    value: "references",
+    value: "references-v2",
     label: "References",
   },
   {

--- a/www/packages/docs-ui/src/constants.tsx
+++ b/www/packages/docs-ui/src/constants.tsx
@@ -184,12 +184,12 @@ export const mobileSidebarItemsV2: SidebarItem[] = [
 
 export const searchFiltersV2: OptionType[] = [
   {
-    value: "book",
-    label: "Docs v2",
+    value: "guides",
+    label: "Guides",
   },
   {
-    value: "resources",
-    label: "Learning Resources",
+    value: "references",
+    label: "References",
   },
   {
     value: "admin-v2",


### PR DESCRIPTION
- Generate sitemaps for `book` and `resources` projects (in attempt to resolve some pages not being picked up by the crawler)
- Change the v2 search filters

> Note: will require changes to algolia's crawler + a recrawl once merged