### PR TITLE
fix(js-sdk): fix invite resend request being sent as GET instead of POST

### DIFF
--- a/packages/core/js-sdk/src/admin/invite.ts
+++ b/packages/core/js-sdk/src/admin/invite.ts
@@ -69,6 +69,7 @@ export class Invite {
     return await this.client.fetch<{ invite: HttpTypes.AdminInviteResponse }>(
       `/admin/invites/${id}/resend`,
       {
+        method: "POST",
         headers,
       }
     )


### PR DESCRIPTION
`/admin/invites/:id/resend` is a POST API route, but the JS SDK's `resend` method was sending a GET request.