### PR TITLE
fix(medusa): fix complete order API route to remove duplicate params

### DIFF
--- a/packages/medusa/src/api/admin/orders/[id]/complete/route.ts
+++ b/packages/medusa/src/api/admin/orders/[id]/complete/route.ts
@@ -8,10 +8,9 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "../../../../../types/routing"
-import { AdminCompleteOrderType } from "../../validators"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest<AdminCompleteOrderType & AdditionalData>,
+  req: AuthenticatedMedusaRequest<AdditionalData>,
   res: MedusaResponse<HttpTypes.AdminOrderResponse>
 ) => {
   const remoteQuery = req.scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
@@ -19,7 +18,7 @@ export const POST = async (
 
   await completeOrderWorkflow(req.scope).run({
     input: {
-      orderIds: [req.validatedBody.order_id],
+      orderIds: [id],
       additional_data: req.validatedBody.additional_data,
     },
   })

--- a/packages/medusa/src/api/admin/orders/validators.ts
+++ b/packages/medusa/src/api/admin/orders/validators.ts
@@ -52,11 +52,7 @@ export const AdminArchiveOrder = z.object({
 })
 export type AdminArchiveOrderType = z.infer<typeof AdminArchiveOrder>
 
-export type AdminCompleteOrderType = z.infer<typeof CompleteOrder>
-export const CompleteOrder = z.object({
-  order_id: z.string(),
-})
-export const AdminCompleteOrder = WithAdditionalData(CompleteOrder)
+export const AdminCompleteOrder = WithAdditionalData(z.object({}))
 
 const Item = z.object({
   id: z.string(),


### PR DESCRIPTION
Remove the `order_id` request body param from the complete order API route and use the `id` path parameter instead.