### PR TITLE
fix(core-flows, types, medusa): fix batch delete types in workflows and routes

### DIFF
--- a/packages/core/core-flows/src/fulfillment/steps/delete-shipping-option-rules.ts
+++ b/packages/core/core-flows/src/fulfillment/steps/delete-shipping-option-rules.ts
@@ -34,7 +34,7 @@ export const deleteShippingOptionRulesStep = createStep(
     await fulfillmentModule.deleteShippingOptionRules(ids)
 
     return new StepResponse({
-      ids: ids ?? [],
+      ids,
       object: "shipping_option_rule",
       deleted: true,
     }, shippingOptionRules)

--- a/packages/core/core-flows/src/fulfillment/steps/delete-shipping-option-rules.ts
+++ b/packages/core/core-flows/src/fulfillment/steps/delete-shipping-option-rules.ts
@@ -33,11 +33,7 @@ export const deleteShippingOptionRulesStep = createStep(
 
     await fulfillmentModule.deleteShippingOptionRules(ids)
 
-    return new StepResponse({
-      ids,
-      object: "shipping_option_rule",
-      deleted: true,
-    }, shippingOptionRules)
+    return new StepResponse(ids, shippingOptionRules)
   },
   async (shippingOptionRules, { container }) => {
     if (!shippingOptionRules?.length) {

--- a/packages/core/core-flows/src/fulfillment/steps/delete-shipping-option-rules.ts
+++ b/packages/core/core-flows/src/fulfillment/steps/delete-shipping-option-rules.ts
@@ -33,7 +33,11 @@ export const deleteShippingOptionRulesStep = createStep(
 
     await fulfillmentModule.deleteShippingOptionRules(ids)
 
-    return new StepResponse(null, shippingOptionRules)
+    return new StepResponse({
+      ids: ids ?? [],
+      object: "shipping_option_rule",
+      deleted: true,
+    }, shippingOptionRules)
   },
   async (shippingOptionRules, { container }) => {
     if (!shippingOptionRules?.length) {

--- a/packages/core/core-flows/src/product/workflows/batch-product-variants.ts
+++ b/packages/core/core-flows/src/product/workflows/batch-product-variants.ts
@@ -54,11 +54,7 @@ export const batchProductVariantsWorkflow = createWorkflow(
       return {
         created: data.res[0],
         updated: data.res[1],
-        deleted: {
-          ids: data.input.delete ?? [],
-          object: "product_variant",
-          deleted: true,
-        },
+        deleted: data.input.delete ?? [],
       }
     })
 

--- a/packages/core/core-flows/src/product/workflows/batch-products.ts
+++ b/packages/core/core-flows/src/product/workflows/batch-products.ts
@@ -47,11 +47,7 @@ export const batchProductsWorkflow = createWorkflow(
         return {
           created: data.res[0],
           updated: data.res[1],
-          deleted: {
-            ids: data.input.delete ?? [],
-            object: "product",
-            deleted: true,
-          },
+          deleted: data.input.delete ?? [],
         }
       })
     )

--- a/packages/core/core-flows/src/promotion/steps/delete-promotion-rules-workflow.ts
+++ b/packages/core/core-flows/src/promotion/steps/delete-promotion-rules-workflow.ts
@@ -24,8 +24,6 @@ export const deletePromotionRulesWorkflowStep = createStep(
     return new StepResponse(
       {
         ids: data.data.rule_ids ?? [],
-        object: "promotion-rule",
-        deleted: true,
       },
       transaction
     )

--- a/packages/core/core-flows/src/promotion/steps/delete-promotion-rules-workflow.ts
+++ b/packages/core/core-flows/src/promotion/steps/delete-promotion-rules-workflow.ts
@@ -22,9 +22,7 @@ export const deletePromotionRulesWorkflowStep = createStep(
     }
 
     return new StepResponse(
-      {
-        ids: data.data.rule_ids ?? [],
-      },
+      data.data.rule_ids ?? [],
       transaction
     )
   },

--- a/packages/core/types/src/common/batch.ts
+++ b/packages/core/types/src/common/batch.ts
@@ -18,11 +18,7 @@ export type BatchMethodRequest<TCreate, TUpdate, TDelete = string> = {
 export type BatchMethodResponse<T> = {
   created: T[]
   updated: T[]
-  deleted: {
-    ids: string[]
-    object: string
-    deleted: boolean
-  }
+  deleted: string[]
 }
 
 export type BatchWorkflowInput<

--- a/packages/core/types/src/http/common/response.ts
+++ b/packages/core/types/src/http/common/response.ts
@@ -29,3 +29,13 @@ export type PaginatedResponse<T> = {
   offset: number
   count: number
 } & T
+
+export type BatchResponse<T> = {
+  created: T[]
+  updated: T[]
+  deleted: {
+    ids: string[]
+    object: string
+    deleted: boolean
+  }
+}

--- a/packages/core/types/src/http/product/admin/responses.ts
+++ b/packages/core/types/src/http/product/admin/responses.ts
@@ -1,5 +1,4 @@
-import { BatchMethodResponse } from "../../../common"
-import { DeleteResponse, DeleteResponseWithParent, PaginatedResponse } from "../../common"
+import { BatchResponse, DeleteResponse, DeleteResponseWithParent, PaginatedResponse } from "../../common"
 import {
   AdminProduct,
   AdminProductOption,
@@ -19,7 +18,7 @@ export type AdminProductListResponse = PaginatedResponse<{
 export interface AdminProductDeleteResponse extends DeleteResponse<"product"> {}
 
 export interface AdminBatchProductResponse
-  extends BatchMethodResponse<AdminProduct> {}
+  extends BatchResponse<AdminProduct> {}
 
 export interface AdminProductVariantResponse {
   variant: AdminProductVariant
@@ -45,10 +44,10 @@ export interface AdminImportProductResponse {
 }
 
 export interface AdminBatchProductVariantResponse
-  extends BatchMethodResponse<AdminProductVariant> {}
+  extends BatchResponse<AdminProductVariant> {}
 
 export interface AdminBatchProductVariantInventoryItemResponse
-  extends BatchMethodResponse<AdminInventoryItem> {}
+  extends BatchResponse<AdminInventoryItem> {}
 
 export interface AdminProductOptionResponse {
   product_option: AdminProductOption

--- a/packages/core/types/src/http/promotion/admin/responses.ts
+++ b/packages/core/types/src/http/promotion/admin/responses.ts
@@ -1,5 +1,4 @@
-import { BatchMethodResponse } from "../../../common";
-import { DeleteResponse, PaginatedResponse } from "../../common";
+import { BatchResponse, DeleteResponse, PaginatedResponse } from "../../common";
 import { 
   AdminPromotion, 
   AdminPromotionRule, 
@@ -54,6 +53,6 @@ export type AdminRuleValueOptionsListResponse = {
   values: AdminRuleValueOption[]
 }
 
-export type AdminPromotionRuleBatchResponse = BatchMethodResponse<AdminPromotionRule>
+export type AdminPromotionRuleBatchResponse = BatchResponse<AdminPromotionRule>
 
 export type AdminPromotionDeleteResponse = DeleteResponse<"promotion">

--- a/packages/core/types/src/http/shipping-option/admin/responses.ts
+++ b/packages/core/types/src/http/shipping-option/admin/responses.ts
@@ -1,5 +1,4 @@
-import { BatchMethodResponse } from "../../../common"
-import { DeleteResponse, PaginatedResponse } from "../../common"
+import { BatchResponse, DeleteResponse, PaginatedResponse } from "../../common"
 import { AdminShippingOption, AdminShippingOptionRule } from "./entities"
 
 export interface AdminShippingOptionResponse {
@@ -13,4 +12,4 @@ export type AdminShippingOptionListResponse = PaginatedResponse<{
 export interface AdminShippingOptionDeleteResponse
   extends DeleteResponse<"shipping_option"> {}
 
-export type AdminUpdateShippingOptionRulesResponse = BatchMethodResponse<AdminShippingOptionRule>
+export type AdminUpdateShippingOptionRulesResponse = BatchResponse<AdminShippingOptionRule>

--- a/packages/medusa/src/api/admin/products/helpers.ts
+++ b/packages/medusa/src/api/admin/products/helpers.ts
@@ -1,5 +1,6 @@
 import {
   BatchMethodResponse,
+  BatchResponse,
   HttpTypes,
   LinkDefinition,
   MedusaContainer,
@@ -125,7 +126,7 @@ export const refetchBatchProducts = async (
   batchResult: BatchMethodResponse<ProductDTO>,
   scope: MedusaContainer,
   fields: string[]
-) => {
+): Promise<BatchResponse<ProductDTO>> => {
   const remoteQuery = scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
   let created = Promise.resolve<ProductDTO[]>([])
   let updated = Promise.resolve<ProductDTO[]>([])
@@ -160,7 +161,11 @@ export const refetchBatchProducts = async (
   return {
     created: createdRes,
     updated: updatedRes,
-    deleted: batchResult.deleted,
+    deleted: {
+      ids: batchResult.deleted,
+      object: "product",
+      deleted: true,
+    },
   }
 }
 
@@ -168,7 +173,7 @@ export const refetchBatchVariants = async (
   batchResult: BatchMethodResponse<ProductVariantDTO>,
   scope: MedusaContainer,
   fields: string[]
-) => {
+): Promise<BatchResponse<ProductVariantDTO>> => {
   const remoteQuery = scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
   let created = Promise.resolve<ProductVariantDTO[]>([])
   let updated = Promise.resolve<ProductVariantDTO[]>([])
@@ -203,7 +208,11 @@ export const refetchBatchVariants = async (
   return {
     created: createdRes,
     updated: updatedRes,
-    deleted: batchResult.deleted,
+    deleted: {
+      ids: batchResult.deleted,
+      object: "variant",
+      deleted: true,
+    },
   }
 }
 

--- a/packages/medusa/src/api/admin/promotions/helpers.ts
+++ b/packages/medusa/src/api/admin/promotions/helpers.ts
@@ -1,4 +1,4 @@
-import { BatchMethodResponse } from "@medusajs/types"
+import { BatchMethodResponse, BatchResponse } from "@medusajs/types"
 import { PromotionRuleDTO, MedusaContainer } from "@medusajs/types"
 import {
   promiseAll,
@@ -28,7 +28,7 @@ export const refetchBatchRules = async (
   batchResult: BatchMethodResponse<PromotionRuleDTO>,
   scope: MedusaContainer,
   fields: string[]
-) => {
+): Promise<BatchResponse<PromotionRuleDTO>> => {
   const remoteQuery = scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
   let created = Promise.resolve<PromotionRuleDTO[]>([])
   let updated = Promise.resolve<PromotionRuleDTO[]>([])
@@ -63,6 +63,10 @@ export const refetchBatchRules = async (
   return {
     created: createdRes,
     updated: updatedRes,
-    deleted: batchResult.deleted,
+    deleted: {
+      ids: batchResult.deleted,
+      object: "promotion_rules",
+      deleted: true,
+    },
   }
 }

--- a/packages/medusa/src/api/admin/promotions/helpers.ts
+++ b/packages/medusa/src/api/admin/promotions/helpers.ts
@@ -65,7 +65,7 @@ export const refetchBatchRules = async (
     updated: updatedRes,
     deleted: {
       ids: batchResult.deleted,
-      object: "promotion_rules",
+      object: "promotion-rule",
       deleted: true,
     },
   }

--- a/packages/medusa/src/api/admin/shipping-options/helpers.ts
+++ b/packages/medusa/src/api/admin/shipping-options/helpers.ts
@@ -66,6 +66,10 @@ export const refetchBatchRules = async (
   return {
     created: createdRes,
     updated: updatedRes,
-    deleted: batchResult.deleted,
+    deleted: {
+      ids: batchResult.deleted,
+      object: "shipping_option_rule",
+      deleted: true,
+    },
   }
 }


### PR DESCRIPTION
- Fix the returned data of batch delete steps / workflows for deleted records to just be the array of IDs.
- Add a new type `BatchResponse` for API routes to have a different shape for deleted records
- Update batch delete helpers to return the expected shape for API routes