### PR TITLE
fix(dashboard): Align product organization badges with design

### DIFF
--- a/packages/admin-next/dashboard/src/routes/products/product-detail/components/product-organization-section/product-organization-section.tsx
+++ b/packages/admin-next/dashboard/src/routes/products/product-detail/components/product-organization-section/product-organization-section.tsx
@@ -1,10 +1,10 @@
 import { PencilSquare } from "@medusajs/icons"
+import { HttpTypes } from "@medusajs/types"
 import { Badge, Container, Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import { ActionMenu } from "../../../../../components/common/action-menu"
 import { SectionRow } from "../../../../../components/common/section"
-import { HttpTypes } from "@medusajs/types"
 
 type ProductOrganizationSectionProps = {
   product: HttpTypes.AdminProduct
@@ -63,7 +63,7 @@ export const ProductOrganizationSection = ({
         title={t("fields.collection")}
         value={
           product.collection ? (
-            <Badge size="2xsmall" color="blue" className="w-fit" asChild>
+            <Badge size="2xsmall" className="w-fit" asChild>
               <Link to={`/collections/${product.collection.id}`}>
                 {product.collection.title}
               </Link>
@@ -77,13 +77,7 @@ export const ProductOrganizationSection = ({
         value={
           product.categories?.length
             ? product.categories.map((pcat) => (
-                <Badge
-                  key={pcat.id}
-                  className="w-fit"
-                  color="purple"
-                  size="2xsmall"
-                  asChild
-                >
+                <Badge key={pcat.id} className="w-fit" size="2xsmall" asChild>
                   <Link to={`/categories/${pcat.id}`}>{pcat.name}</Link>
                 </Badge>
               ))


### PR DESCRIPTION
**What**
- Aligns implementation with design, all badges in the Organization card should be grey.