### PR TITLE
feat: Add github authentication provider

### DIFF
--- a/.changeset/pink-dolls-kiss.md
+++ b/.changeset/pink-dolls-kiss.md
@@ -1,0 +1,8 @@
+---
+"@medusajs/auth-github": patch
+"@medusajs/auth-google": patch
+"@medusajs/auth": patch
+"@medusajs/types": patch
+---
+
+Add github auth provider

--- a/packages/core/types/src/auth/common/provider.ts
+++ b/packages/core/types/src/auth/common/provider.ts
@@ -33,15 +33,6 @@ export type AuthenticationResponse = {
    * specified location.
    */
   location?: string
-
-  /**
-   * Some authentication providers support redirecting to a specified URL on
-   * success. In those cases, the URL to redirect to is set in this field.
-   *
-   * So, if `success` is true, there's no `location` set, and this field
-   * is set, you can redirect to this URL.
-   */
-  successRedirectUrl?: string
 }
 
 /**

--- a/packages/core/types/src/auth/provider.ts
+++ b/packages/core/types/src/auth/provider.ts
@@ -13,6 +13,13 @@ export interface AuthIdentityProviderService {
     provider_metadata?: Record<string, unknown>
     user_metadata?: Record<string, unknown>
   }) => Promise<AuthIdentityDTO>
+  update: (
+    entity_id: string,
+    data: {
+      provider_metadata?: Record<string, unknown>
+      user_metadata?: Record<string, unknown>
+    }
+  ) => Promise<AuthIdentityDTO>
 }
 
 /**

--- a/packages/core/types/src/auth/providers/github.ts
+++ b/packages/core/types/src/auth/providers/github.ts
@@ -2,5 +2,4 @@ export interface GithubAuthProviderOptions {
   clientId: string
   clientSecret: string
   callbackUrl: string
-  successRedirectUrl?: string
 }

--- a/packages/core/types/src/auth/providers/github.ts
+++ b/packages/core/types/src/auth/providers/github.ts
@@ -1,4 +1,4 @@
-export interface GoogleAuthProviderOptions {
+export interface GithubAuthProviderOptions {
   clientId: string
   clientSecret: string
   callbackUrl: string

--- a/packages/core/types/src/auth/providers/google.ts
+++ b/packages/core/types/src/auth/providers/google.ts
@@ -2,5 +2,4 @@ export interface GoogleAuthProviderOptions {
   clientId: string
   clientSecret: string
   callbackUrl: string
-  successRedirectUrl?: string
 }

--- a/packages/core/types/src/auth/providers/index.ts
+++ b/packages/core/types/src/auth/providers/index.ts
@@ -1,2 +1,3 @@
 export * from "./emailpass"
 export * from "./google"
+export * from "./github"

--- a/packages/core/types/src/auth/service.ts
+++ b/packages/core/types/src/auth/service.ts
@@ -46,12 +46,12 @@ export interface IAuthModuleService extends IModuleService {
    */
   authenticate(
     provider: string,
-    providerData: AuthenticationInput,
+    providerData: AuthenticationInput
   ): Promise<AuthenticationResponse>
 
   register(
     provider: string,
-    providerData: AuthenticationInput,
+    providerData: AuthenticationInput
   ): Promise<AuthenticationResponse>
 
   /**
@@ -76,7 +76,7 @@ export interface IAuthModuleService extends IModuleService {
    * `req` is an instance of the `MedusaRequest` object:
    *
    * ```ts
-   * const { success, authIdentity, error, successRedirectUrl } =
+   * const { success, authIdentity, error } =
    *   await authModuleService.validateCallback("google", {
    *     url: req.url,
    *     headers: req.headers,

--- a/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/callback/route.ts
+++ b/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/callback/route.ts
@@ -41,8 +41,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     protocol: req.protocol,
   } as AuthenticationInput
 
-  const { success, error, authIdentity, successRedirectUrl } =
-    await service.validateCallback(auth_provider, authData)
+  const { success, error, authIdentity } = await service.validateCallback(
+    auth_provider,
+    authData
+  )
 
   const entityIdKey = `${actor_type}_id`
   const entityId = authIdentity?.app_metadata?.[entityIdKey] as
@@ -70,13 +72,6 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         expiresIn: jwtExpiresIn,
       }
     )
-
-    if (successRedirectUrl) {
-      const url = new URL(successRedirectUrl!)
-      url.searchParams.append("access_token", token)
-
-      return res.redirect(url.toString())
-    }
 
     return res.json({ token })
   }

--- a/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/route.ts
+++ b/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/route.ts
@@ -47,8 +47,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   )
 
   if (location) {
-    res.redirect(location)
-    return
+    return res.status(200).json({ location })
   }
 
   if (success) {

--- a/packages/modules/providers/auth-github/README.md
+++ b/packages/modules/providers/auth-github/README.md
@@ -2,10 +2,10 @@
 
 In order to manually test the flow, you can do the following:
 
-1. Register an app in `https://console.cloud.google.com/apis/credentials/consent`
-2. Generate clientId and clientSecret credentials in the console
+1. Register a Github App - https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app
+2. Go to the app, fetch the clientId and create a new clientSecret
 3. Replace the values in the test with your credentials
 4. Remove the `server.listen()` call
 5. Run the tests, get the `location` value from the `authenticate` test, open the browser
 6. Once redirected, copy the `code` param from the URL, and add it in one of the `callback` success tests
-7. Once you run the tests, you should get back an access token, id token, and so on.
+7. Once you run the tests, you should get back an access token and so on.

--- a/packages/modules/providers/auth-github/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/auth-github/integration-tests/__tests__/services.spec.ts
@@ -81,7 +81,6 @@ describe("Github auth provider", () => {
       {
         clientId: "test",
         clientSecret: "test",
-        successRedirectUrl: baseUrl,
         callbackUrl: `${baseUrl}/auth/github/callback`,
       }
     )
@@ -179,7 +178,6 @@ describe("Github auth provider", () => {
 
     expect(res).toEqual({
       success: true,
-      successRedirectUrl: baseUrl,
       authIdentity: {
         provider_identities: [
           {
@@ -232,7 +230,6 @@ describe("Github auth provider", () => {
 
     expect(res).toEqual({
       success: true,
-      successRedirectUrl: baseUrl,
       authIdentity: {
         provider_identities: [
           {

--- a/packages/modules/providers/auth-github/jest.config.js
+++ b/packages/modules/providers/auth-github/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  transform: { "^.+\\.[jt]s?$": "@swc/jest" },
+  testEnvironment: `node`,
+  moduleFileExtensions: [`js`, `jsx`, `ts`, `tsx`, `json`],
+}

--- a/packages/modules/providers/auth-github/package.json
+++ b/packages/modules/providers/auth-github/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@medusajs/auth-github",
+  "version": "0.0.1",
+  "description": "Github OAuth authentication provider for Medusa",
+  "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/medusajs/medusa",
+    "directory": "packages/modules/providers/auth-github"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "author": "Medusa",
+  "license": "MIT",
+  "scripts": {
+    "test": "jest --passWithNoTests src",
+    "test:integration": "jest --forceExit -- integration-tests/**/__tests__/**/*.spec.ts",
+    "build": "rimraf dist && tsc --build",
+    "watch": "tsc --watch"
+  },
+  "devDependencies": {
+    "@medusajs/types": "^1.11.16",
+    "@types/simple-oauth2": "^5.0.7",
+    "cross-env": "^5.2.1",
+    "jest": "^29.7.0",
+    "msw": "^2.3.0",
+    "rimraf": "^5.0.1",
+    "typescript": "^5.1.6"
+  },
+  "dependencies": {
+    "@medusajs/utils": "^1.11.9"
+  },
+  "keywords": [
+    "medusa-provider",
+    "medusa-provider-auth-github"
+  ]
+}

--- a/packages/modules/providers/auth-github/src/index.ts
+++ b/packages/modules/providers/auth-github/src/index.ts
@@ -1,0 +1,10 @@
+import { ModuleProviderExports } from "@medusajs/types"
+import { GithubAuthService } from "./services/github"
+
+const services = [GithubAuthService]
+
+const providerExport: ModuleProviderExports = {
+  services,
+}
+
+export default providerExport

--- a/packages/modules/providers/auth-github/src/services/github.ts
+++ b/packages/modules/providers/auth-github/src/services/github.ts
@@ -2,42 +2,41 @@ import {
   AuthenticationInput,
   AuthenticationResponse,
   AuthIdentityProviderService,
-  GoogleAuthProviderOptions,
+  GithubAuthProviderOptions,
   Logger,
 } from "@medusajs/types"
 import { AbstractAuthModuleProvider, MedusaError } from "@medusajs/utils"
-import jwt, { JwtPayload } from "jsonwebtoken"
 
 type InjectedDependencies = {
   logger: Logger
 }
 
-interface LocalServiceConfig extends GoogleAuthProviderOptions {}
+interface LocalServiceConfig extends GithubAuthProviderOptions {}
 
 // TODO: Add state param that is stored in Redis, to prevent CSRF attacks
-export class GoogleAuthService extends AbstractAuthModuleProvider {
+export class GithubAuthService extends AbstractAuthModuleProvider {
   protected config_: LocalServiceConfig
   protected logger_: Logger
 
-  static validateOptions(options: GoogleAuthProviderOptions) {
+  static validateOptions(options: GithubAuthProviderOptions) {
     if (!options.clientId) {
-      throw new Error("Google clientId is required")
+      throw new Error("Github clientId is required")
     }
 
     if (!options.clientSecret) {
-      throw new Error("Google clientSecret is required")
+      throw new Error("Github clientSecret is required")
     }
 
     if (!options.callbackUrl) {
-      throw new Error("Google callbackUrl is required")
+      throw new Error("Github callbackUrl is required")
     }
   }
 
   constructor(
     { logger }: InjectedDependencies,
-    options: GoogleAuthProviderOptions
+    options: GithubAuthProviderOptions
   ) {
-    super({}, { provider: "google", displayName: "Google Authentication" })
+    super({}, { provider: "github", displayName: "Github Authentication" })
     this.config_ = options
     this.logger_ = logger
   }
@@ -45,7 +44,7 @@ export class GoogleAuthService extends AbstractAuthModuleProvider {
   async register(_): Promise<AuthenticationResponse> {
     throw new MedusaError(
       MedusaError.Types.NOT_ALLOWED,
-      "Google does not support registration. Use method `authenticate` instead."
+      "Github does not support registration. Use method `authenticate` instead."
     )
   }
 
@@ -80,16 +79,18 @@ export class GoogleAuthService extends AbstractAuthModuleProvider {
 
     const params = `client_id=${this.config_.clientId}&client_secret=${
       this.config_.clientSecret
-    }&code=${code}&redirect_uri=${encodeURIComponent(
-      this.config_.callbackUrl
-    )}&grant_type=authorization_code`
+    }&code=${code}&redirect_uri=${encodeURIComponent(this.config_.callbackUrl)}`
+
     const exchangeTokenUrl = new URL(
-      `https://oauth2.googleapis.com/token?${params}`
+      `https://github.com/login/oauth/access_token?${params}`
     )
 
     try {
       const response = await fetch(exchangeTokenUrl.toString(), {
         method: "POST",
+        headers: {
+          Accept: "application/json",
+        },
       }).then((r) => {
         if (!r.ok) {
           throw new MedusaError(
@@ -101,61 +102,76 @@ export class GoogleAuthService extends AbstractAuthModuleProvider {
         return r.json()
       })
 
-      const { authIdentity, success } = await this.verify_(
-        response.id_token as string,
+      const providerMetadata = {
+        access_token: response.access_token,
+        refresh_token: response.refresh_token,
+        // The response is in seconds
+        access_token_expires_at: new Date(
+          Date.now() + response.expires_in * 1000
+        ).toISOString(),
+        refresh_token_expires_at: new Date(
+          Date.now() + response.refresh_token_expires_in * 1000
+        ).toISOString(),
+      }
+
+      const { authIdentity, success } = await this.upsert_(
+        providerMetadata,
         authIdentityService
       )
 
       return {
         success,
         authIdentity,
-        successRedirectUrl: this.config_.successRedirectUrl,
       }
     } catch (error) {
       return { success: false, error: error.message }
     }
   }
 
-  async verify_(
-    idToken: string | undefined,
+  async upsert_(
+    providerMetadata: {
+      access_token: string
+      refresh_token: string
+      access_token_expires_at: string
+      refresh_token_expires_at: string
+    },
     authIdentityService: AuthIdentityProviderService
   ) {
-    if (!idToken) {
-      return { success: false, error: "No ID found" }
+    if (!providerMetadata?.access_token) {
+      return { success: false, error: "No access token found" }
     }
 
-    const jwtData = jwt.decode(idToken, {
-      complete: true,
-    }) as JwtPayload
-    const payload = jwtData.payload
+    const user = await fetch("https://api.github.com/user", {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${providerMetadata.access_token}`,
+      },
+    }).then((r) => r.json())
 
-    if (!payload.email_verified) {
-      throw new MedusaError(
-        MedusaError.Types.INVALID_DATA,
-        "Email not verified, cannot proceed with authentication"
-      )
-    }
-
-    // TODO: We should probably use something else than email here, like the `sub` field (which is more constant than the email)
-    const entity_id = payload.email
+    const entity_id = user.id
     const userMetadata = {
-      name: payload.name,
-      picture: payload.picture,
-      given_name: payload.given_name,
-      family_name: payload.family_name,
+      profile_url: user.url,
+      avatar: user.avatar_url,
+      email: user.email,
+      name: user.name,
+      company: user.company,
+      two_factor_authentication: user.two_factor_authentication ?? false,
     }
 
     let authIdentity
 
     try {
-      authIdentity = await authIdentityService.retrieve({
-        entity_id,
+      // Update throws if auth identity not found
+      authIdentity = await authIdentityService.update(entity_id, {
+        provider_metadata: providerMetadata,
+        user_metadata: userMetadata,
       })
     } catch (error) {
       if (error.type === MedusaError.Types.NOT_FOUND) {
         const createdAuthIdentity = await authIdentityService.create({
           entity_id,
           user_metadata: userMetadata,
+          provider_metadata: providerMetadata,
         })
         authIdentity = createdAuthIdentity
       } else {
@@ -173,14 +189,12 @@ export class GoogleAuthService extends AbstractAuthModuleProvider {
     const redirectUrlParam = `redirect_uri=${encodeURIComponent(callbackUrl)}`
     const clientIdParam = `client_id=${clientId}`
     const responseTypeParam = "response_type=code"
-    const scopeParam = "scope=email+profile+openid"
 
     const authUrl = new URL(
-      `https://accounts.google.com/o/oauth2/v2/auth?${[
+      `https://github.com/login/oauth/authorize?${[
         redirectUrlParam,
         clientIdParam,
         responseTypeParam,
-        scopeParam,
       ].join("&")}`
     )
 

--- a/packages/modules/providers/auth-github/tsconfig.json
+++ b/packages/modules/providers/auth-github/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "lib": ["es2021"],
+    "target": "es2021",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "declarationMap": true,
+    "declaration": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "noImplicitReturns": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noImplicitThis": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "inlineSourceMap": true /* Emit a single file with source maps instead of having a separate file. */
+  },
+  "include": ["src"],
+  "exclude": [
+    "dist",
+    "build",
+    "src/**/__tests__",
+    "src/**/__mocks__",
+    "src/**/__fixtures__",
+    "node_modules",
+    ".eslintrc.js"
+  ]
+}

--- a/packages/modules/providers/auth-google/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/auth-google/integration-tests/__tests__/services.spec.ts
@@ -80,7 +80,6 @@ describe("Google auth provider", () => {
       {
         clientId: "test",
         clientSecret: "test",
-        successRedirectUrl: baseUrl,
         callbackUrl: `${baseUrl}/auth/google/callback`,
       }
     )
@@ -178,7 +177,6 @@ describe("Google auth provider", () => {
 
     expect(res).toEqual({
       success: true,
-      successRedirectUrl: baseUrl,
       authIdentity: {
         provider_identities: [
           {
@@ -221,7 +219,6 @@ describe("Google auth provider", () => {
 
     expect(res).toEqual({
       success: true,
-      successRedirectUrl: baseUrl,
       authIdentity: {
         provider_identities: [
           {

--- a/packages/modules/providers/auth-google/src/services/google.ts
+++ b/packages/modules/providers/auth-google/src/services/google.ts
@@ -109,7 +109,6 @@ export class GoogleAuthService extends AbstractAuthModuleProvider {
       return {
         success,
         authIdentity,
-        successRedirectUrl: this.config_.successRedirectUrl,
       }
     } catch (error) {
       return { success: false, error: error.message }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4364,6 +4364,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@medusajs/auth-github@workspace:packages/modules/providers/auth-github":
+  version: 0.0.0-use.local
+  resolution: "@medusajs/auth-github@workspace:packages/modules/providers/auth-github"
+  dependencies:
+    "@medusajs/types": ^1.11.16
+    "@medusajs/utils": ^1.11.9
+    "@types/simple-oauth2": ^5.0.7
+    cross-env: ^5.2.1
+    jest: ^29.7.0
+    msw: ^2.3.0
+    rimraf: ^5.0.1
+    typescript: ^5.1.6
+  languageName: unknown
+  linkType: soft
+
 "@medusajs/auth-google@workspace:packages/modules/providers/auth-google":
   version: 0.0.0-use.local
   resolution: "@medusajs/auth-google@workspace:packages/modules/providers/auth-google"


### PR DESCRIPTION
There is few breaking changes in this PR, namely:

1. The Google options got renamed to be more consistent (`clientID` -> `clientId`, `callbackURL` -> `callbackUrl`)
2. The `successRedirectUrl` option was removed from google provider
3. The auth callback handling changed - It used to redirect to `successRedirectUrl` with the `access_token` as a query parameter, and the `callbackUrl` would point to the backend. The flow now would be to set `callbackUrl` to a FE path, and within that path call `sdk.auth.callback()` to login similarly to how emailpass login works.

