### PR TITLE
chore: fix oas errors

### DIFF
--- a/www/utils/generated/oas-output/operations/admin/post_admin_products_[id]_variants_inventory-items_batch.ts
+++ b/www/utils/generated/oas-output/operations/admin/post_admin_products_[id]_variants_inventory-items_batch.ts
@@ -25,7 +25,7 @@
  *         properties:
  *           create:
  *             type: array
- *             description: 
+ *             description: The The associations to create between product variants and inventory items.
  *             items:
  *               type: object
  *               description: The associations to create between a product variant and an inventory item.

--- a/www/utils/generated/oas-output/operations/admin/post_admin_promotions.ts
+++ b/www/utils/generated/oas-output/operations/admin/post_admin_promotions.ts
@@ -225,15 +225,15 @@
  *                           oneOf:
  *                             - type: string
  *                               title: values
-  *                              description: The attribute's value.
-  *                              example: prod_123
-  *                            - type: array
-  *                              description: The allowed attribute values.
-  *                              items:
-  *                                type: string
-  *                                title: values
-  *                                description: An attribute value.
-  *                                example: prod_123
+ *                               description: The attribute's value.
+ *                               example: prod_123
+ *                             - type: array
+ *                               description: The allowed attribute values.
+ *                               items:
+ *                                 type: string
+ *                                 title: values
+ *                                 description: An attribute value.
+ *                                 example: prod_123
  *                   buy_rules:
  *                     type: array
  *                     description: The application method's buy rules.
@@ -270,15 +270,15 @@
  *                           oneOf:
  *                             - type: string
  *                               title: values
-  *                              description: The attribute's value.
-  *                              example: prod_123
-  *                            - type: array
-  *                              description: The allowed attribute values.
-  *                              items:
-  *                                type: string
-  *                                title: values
-  *                                description: An attribute value.
-  *                                example: prod_123
+ *                               description: The attribute's value.
+ *                               example: prod_123
+ *                             - type: array
+ *                               description: The allowed attribute values.
+ *                               items:
+ *                                 type: string
+ *                                 title: values
+ *                                 description: An attribute value.
+ *                                 example: prod_123
  *                   apply_to_quantity:
  *                     type: number
  *                     title: apply_to_quantity
@@ -324,14 +324,14 @@
  *                         - type: string
  *                           title: values
  *                           description: The attribute's value.
-  *                          example: prod_123
-  *                            - type: array
-  *                              description: The allowed attribute values.
-  *                              items:
-  *                                type: string
-  *                                title: values
-  *                                description: An attribute value.
-  *                                example: prod_123
+ *                           example: prod_123
+ *                         - type: array
+ *                           description: The allowed attribute values.
+ *                           items:
+ *                             type: string
+ *                             title: values
+ *                             description: An attribute value.
+ *                             example: prod_123
  *           - type: object
  *             description: The promotion's details.
  *             properties:

--- a/www/utils/generated/oas-output/operations/admin/post_admin_shipping-options_[id].ts
+++ b/www/utils/generated/oas-output/operations/admin/post_admin_shipping-options_[id].ts
@@ -213,7 +213,6 @@
  *                     attribute:
  *                       type: string
  *                       title: attribute
- *                       description: The rule's attribute.
  *                       description: The name of a property or table that the rule applies to.
  *                       example: customer_group
  *                     value:


### PR DESCRIPTION
Fix indentation and missing values in OAS resulting in an error when generating the specs in the API reference