### PR TITLE
feat(types,medusa): add acknowledgement typing

### DIFF
--- a/packages/core/types/src/http/workflow-execution/admin/responses.ts
+++ b/packages/core/types/src/http/workflow-execution/admin/responses.ts
@@ -1,3 +1,4 @@
+import { Acknowledgement } from "../../../workflows-sdk"
 import { PaginatedResponse } from "../../common/response"
 import { AdminWorkflowExecution } from "./entities"
 
@@ -8,3 +9,7 @@ export interface AdminWorkflowExecutionResponse {
 export type AdminWorkflowExecutionListResponse = PaginatedResponse<{
   workflow_executions: AdminWorkflowExecution[]
 }>
+
+export type AdminWorkflowRunResponse = {
+  acknowledgement: Acknowledgement
+}

--- a/packages/core/types/src/workflows-sdk/service.ts
+++ b/packages/core/types/src/workflows-sdk/service.ts
@@ -15,6 +15,11 @@ type FlowRunOptions<TData = unknown> = {
   events?: Record<string, Function>
 }
 
+export type Acknowledgement = {
+  workflowId: string
+  transactionId: string
+}
+
 export interface WorkflowOrchestratorRunDTO<T = unknown>
   extends FlowRunOptions<T> {
   transactionId?: string
@@ -59,7 +64,7 @@ export interface IWorkflowEngineService extends IModuleService {
     errors: Error[]
     transaction: object
     result: any
-    acknowledgement: object
+    acknowledgement: Acknowledgement
   }>
 
   getRunningTransaction(

--- a/packages/medusa/src/api/admin/workflows-executions/[workflow_id]/run/route.ts
+++ b/packages/medusa/src/api/admin/workflows-executions/[workflow_id]/run/route.ts
@@ -1,4 +1,5 @@
 import {
+  HttpTypes,
   IWorkflowEngineService,
   WorkflowOrchestratorRunDTO,
 } from "@medusajs/types"
@@ -11,7 +12,7 @@ import { AdminCreateWorkflowsRunType } from "../../validators"
 
 export const POST = async (
   req: AuthenticatedMedusaRequest<AdminCreateWorkflowsRunType>,
-  res: MedusaResponse<{ acknowledgement: object }>
+  res: MedusaResponse<HttpTypes.AdminWorkflowRunResponse>
 ) => {
   const workflowEngineService: IWorkflowEngineService = req.scope.resolve(
     ModuleRegistrationName.WORKFLOW_ENGINE


### PR DESCRIPTION
- Add acknowledgement typing based on the returned type by the redis and in-memory workflow engines
- Add a new http type for the `/admin/workflows-executions/:workflow_id/run` API route, which returns the acknowledgement.