### PR TITLE
fix(types,medusa): fix query types for some store routes

### DIFF
--- a/packages/core/types/src/http/order/store/queries.ts
+++ b/packages/core/types/src/http/order/store/queries.ts
@@ -1,8 +1,9 @@
 import { BaseFilterable } from "../../../dal";
+import { OrderStatus } from "../../../order";
 import { FindParams } from "../../common";
 
 export interface StoreOrderFilters extends 
   FindParams, BaseFilterable<StoreOrderFilters> {
     id?: string | string[]
-    name?: string | string[]
+    status?: OrderStatus | OrderStatus[]
   }

--- a/packages/core/types/src/http/payment/store/queries.ts
+++ b/packages/core/types/src/http/payment/store/queries.ts
@@ -4,10 +4,9 @@ import {
   BasePaymentSessionFilters,
 } from "../common"
 
-export interface StorePaymentProviderFilters
-  extends BasePaymentProviderFilters {
-    is_enabled?: boolean
-  }
+export interface StorePaymentProviderFilters {
+  region_id: string
+}
 export interface StorePaymentCollectionFilters
   extends BasePaymentCollectionFilters {}
 export interface StorePaymentSessionFilters extends BasePaymentSessionFilters {}

--- a/packages/core/types/src/http/product-category/store/queries.ts
+++ b/packages/core/types/src/http/product-category/store/queries.ts
@@ -4,6 +4,6 @@ import {
 } from "../common"
 
 export interface StoreProductCategoryListParams
-  extends BaseProductCategoryListParams {}
+  extends Omit<BaseProductCategoryListParams, "is_internal" | "is_active"> {}
 
 export interface StoreProductCategoryParams extends BaseProductCategoryParams {}

--- a/packages/core/types/src/http/product/store/queries.ts
+++ b/packages/core/types/src/http/product/store/queries.ts
@@ -6,7 +6,8 @@ import {
 
 export interface StoreProductOptionParams extends BaseProductOptionParams {}
 export interface StoreProductVariantParams extends BaseProductVariantParams {}
-export interface StoreProductParams extends BaseProductListParams {
+export interface StoreProductParams extends Omit<BaseProductListParams, "tags" | "status" | "categories"> {
+  tag_id?: string | string[]
   // The region ID and currency_code are not params, but are used for the pricing context. Maybe move to separate type definition.
   region_id?: string
   currency_code?: string

--- a/packages/core/types/src/http/region/admin/queries.ts
+++ b/packages/core/types/src/http/region/admin/queries.ts
@@ -5,10 +5,10 @@ import {
   BaseRegionFilters,
 } from "../common"
 
-export interface AdminRegionFilters extends FindParams, BaseFilterable<BaseRegionFilters> {
+export interface AdminRegionFilters extends FindParams, BaseFilterable<AdminRegionFilters> {
   q?: string
   id?: string | string[]
-  code?: string | string[]
+  currency_code?: string | string[]
   name?: string | string[]
   created_at?: OperatorMap<string>
   updated_at?: OperatorMap<string>

--- a/packages/core/types/src/http/region/common.ts
+++ b/packages/core/types/src/http/region/common.ts
@@ -26,7 +26,7 @@ export interface BaseRegionFilters extends BaseFilterable<BaseRegionFilters> {
   q?: string
   id?: string[] | string | OperatorMap<string | string[]>
   name?: string | string[]
-  code?: string | string[]
+  currency_code?: string | string[]
   created_at?: OperatorMap<string>
   updated_at?: OperatorMap<string>
 }

--- a/packages/core/types/src/http/region/store/queries.ts
+++ b/packages/core/types/src/http/region/store/queries.ts
@@ -3,5 +3,5 @@ import {
   BaseRegionFilters,
 } from "../common"
 
-export interface StoreRegionFilters extends BaseRegionFilters {}
+export interface StoreRegionFilters extends Omit<BaseRegionFilters, "created_at" | "updated_at"> {}
 export interface StoreRegionCountryFilters extends BaseRegionCountryFilters {}

--- a/packages/core/types/src/order/common.ts
+++ b/packages/core/types/src/order/common.ts
@@ -968,7 +968,7 @@ export interface OrderItemDTO {
 /**
  * The order's status.
  */
-type OrderStatus =
+export type OrderStatus =
   | "pending"
   | "completed"
   | "draft"

--- a/packages/medusa/src/api/admin/regions/validators.ts
+++ b/packages/medusa/src/api/admin/regions/validators.ts
@@ -16,7 +16,7 @@ export const AdminGetRegionsParams = createFindParams({
   z.object({
     q: z.string().optional(),
     id: z.union([z.string(), z.array(z.string())]).optional(),
-    code: z.union([z.string(), z.array(z.string())]).optional(),
+    currency_code: z.union([z.string(), z.array(z.string())]).optional(),
     name: z.union([z.string(), z.array(z.string())]).optional(),
     created_at: createOperatorMap().optional(),
     updated_at: createOperatorMap().optional(),

--- a/packages/medusa/src/api/store/customers/validators.ts
+++ b/packages/medusa/src/api/store/customers/validators.ts
@@ -50,7 +50,7 @@ export type StoreGetCustomerAddressParamsType = z.infer<
   typeof StoreGetCustomerAddressParams
 >
 export type StoreGetCustomerAddressesParamsType = z.infer<
-  typeof StoreCreateCustomerAddress
+  typeof StoreGetCustomerAddressesParams
 >
 export type StoreCreateCustomerAddressType = z.infer<
   typeof StoreCreateCustomerAddress

--- a/packages/medusa/src/api/store/orders/[id]/route.ts
+++ b/packages/medusa/src/api/store/orders/[id]/route.ts
@@ -1,11 +1,10 @@
 import { HttpTypes } from "@medusajs/types"
 import { MedusaRequest, MedusaResponse } from "../../../../types/routing"
 import { refetchOrder } from "../helpers"
-import { StoreGetOrdersParamsType } from "../validators"
 
 // TODO: Do we want to apply some sort of authentication here? My suggestion is that we do
 export const GET = async (
-  req: MedusaRequest<StoreGetOrdersParamsType>,
+  req: MedusaRequest,
   res: MedusaResponse<HttpTypes.StoreOrderResponse>
 ) => {
   const order = await refetchOrder(

--- a/packages/medusa/src/api/store/payment-providers/validators.ts
+++ b/packages/medusa/src/api/store/payment-providers/validators.ts
@@ -1,5 +1,4 @@
 import { z } from "zod"
-import { booleanString } from "../../utils/common-validators"
 import { createFindParams } from "../../utils/validators"
 
 export type StoreGetPaymentProvidersParamsType = z.infer<
@@ -11,9 +10,5 @@ export const StoreGetPaymentProvidersParams = createFindParams({
 }).merge(
   z.object({
     region_id: z.string(),
-    id: z.union([z.string(), z.array(z.string())]).optional(),
-    is_enabled: booleanString().optional(),
-    $and: z.lazy(() => StoreGetPaymentProvidersParams.array()).optional(),
-    $or: z.lazy(() => StoreGetPaymentProvidersParams.array()).optional(),
   })
 )

--- a/packages/medusa/src/api/store/product-categories/[id]/route.ts
+++ b/packages/medusa/src/api/store/product-categories/[id]/route.ts
@@ -13,7 +13,7 @@ export const GET = async (
 ) => {
   const category = await refetchEntity(
     "product_category",
-    req.params.id,
+    { id: req.params.id, ...req.filterableFields },
     req.scope,
     req.remoteQueryConfig.fields
   )

--- a/packages/medusa/src/api/store/product-categories/validators.ts
+++ b/packages/medusa/src/api/store/product-categories/validators.ts
@@ -26,6 +26,7 @@ export const StoreProductCategoriesParams = createFindParams({
   z.object({
     q: z.string().optional(),
     id: z.union([z.string(), z.array(z.string())]).optional(),
+    name: z.union([z.string(), z.array(z.string())]).optional(),
     description: z.union([z.string(), z.array(z.string())]).optional(),
     handle: z.union([z.string(), z.array(z.string())]).optional(),
     parent_category_id: z.union([z.string(), z.array(z.string())]).optional(),

--- a/packages/medusa/src/api/store/regions/validators.ts
+++ b/packages/medusa/src/api/store/regions/validators.ts
@@ -12,7 +12,7 @@ export const StoreGetRegionsParams = createFindParams({
   z.object({
     q: z.string().optional(),
     id: z.union([z.string(), z.array(z.string())]).optional(),
-    code: z.union([z.string(), z.array(z.string())]).optional(),
+    currency_code: z.union([z.string(), z.array(z.string())]).optional(),
     name: z.union([z.string(), z.array(z.string())]).optional(),
     $and: z.lazy(() => StoreGetRegionsParams.array()).optional(),
     $or: z.lazy(() => StoreGetRegionsParams.array()).optional(),


### PR DESCRIPTION
- Match address filters to validator
- Move query type from `/store/orders/:id` to `/store/orders`.
- Fix `/store/payment-providers` filters to only allow region_id (since that's the only filter used in the route).
- Pass query parameters of `/store/product-categories/:id` to the refetchEntity
- Match category filters between type and validator.
- Match the product's filter type to validator
- Remove region filters that don't match the validator
- Rename the `code` filter to `currency_code` in region filter types / validators in store and admin routes