### PR TITLE
fix: Renamed the `JobSchedulerService` queue's name

### DIFF
--- a/packages/medusa/src/services/__tests__/job-scheduler.js
+++ b/packages/medusa/src/services/__tests__/job-scheduler.js
@@ -32,7 +32,7 @@ describe("JobSchedulerService", () => {
 
     it("creates bull queue", () => {
       expect(Queue).toHaveBeenCalledTimes(1)
-      expect(Queue).toHaveBeenCalledWith("scheduled-jobs:queue", {
+      expect(Queue).toHaveBeenCalledWith("scheduled-jobs-queue", {
         connection: expect.any(Object),
         prefix: "JobSchedulerService",
       })

--- a/packages/medusa/src/services/job-scheduler.ts
+++ b/packages/medusa/src/services/job-scheduler.ts
@@ -45,14 +45,14 @@ export default class JobSchedulerService {
         ...(config.projectConfig.redis_options ?? {}),
       })
 
-      this.queue_ = new Queue(`scheduled-jobs:queue`, {
+      this.queue_ = new Queue(`scheduled-jobs-queue`, {
         connection,
         prefix,
       })
 
       // Register scheduled job worker
       this.worker_ = new Worker(
-        "scheduled-jobs:queue",
+        "scheduled-jobs-queue",
         this.scheduledJobsWorker,
         {
           connection,


### PR DESCRIPTION
- Renamed from `scheduled-jobs:queue` to `scheduled-jobs-queue`, this is due to the BullMQ [v5.12.12](https://github.com/taskforcesh/bullmq/compare/v5.12.11...v5.12.12) update that throws an error whenever a Queue has a semicolon in its name

This is a fix to the issue https://github.com/medusajs/medusa/issues/8888