### PR TITLE
fix: wrap ModuleImplementations so that all methods are async

### DIFF
--- a/packages/core/types/src/common/common.ts
+++ b/packages/core/types/src/common/common.ts
@@ -312,3 +312,9 @@ export type QueryConfig<TEntity extends BaseEntity> = {
   defaultLimit?: number
   isList?: boolean
 }
+
+export type TransformObjectMethodToAsync<T extends object> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? (...args: A) => Promise<Awaited<R>>
+    : T[K] extends object ? TransformObjectMethodToAsync<T[K]> : T[K];
+}

--- a/packages/framework/framework/src/container.ts
+++ b/packages/framework/framework/src/container.ts
@@ -1,5 +1,6 @@
 import { createMedusaContainer } from "@medusajs/utils"
 import { AwilixContainer, ResolveOptions } from "awilix"
+import { TransformObjectMethodToAsync } from "@medusajs/types";
 
 /**
  * The following interface acts as a bucket that other modules or the
@@ -11,7 +12,7 @@ export interface ModuleImplementations {}
  * The Medusa Container extends [Awilix](https://github.com/jeffijoe/awilix) to
  * provide dependency injection functionalities.
  */
-export type MedusaContainer<Cradle extends object = ModuleImplementations> =
+export type MedusaContainer<Cradle extends object = TransformObjectMethodToAsync<ModuleImplementations>> =
   Omit<AwilixContainer, "resolve"> & {
     resolve<K extends keyof Cradle>(
       key: K,


### PR DESCRIPTION
As discussed on slack: modules are wrapped in a proxy which makes all of its methods async. Currently if you try to do declaration merging on th `ModuleImplementations` type, then you can end up getting the wrong types, since non-async methods will not be converted to async on a type level.

This PR fixes that by wrapping `ModuleImplementations` in a type that makes all non-async methods async.

CLOSES: FRMW-2687