### PR TITLE
feat: Add support for refreshing JWT tokens

### DIFF
--- a/integration-tests/helpers/create-admin-user.ts
+++ b/integration-tests/helpers/create-admin-user.ts
@@ -47,7 +47,10 @@ export const createAdminUser = async (
       actor_type: "user",
       auth_identity_id: authIdentity.id,
     },
-    "test"
+    "test",
+    {
+      expiresIn: "1d",
+    }
   )
 
   adminHeaders.headers["authorization"] = `Bearer ${token}`

--- a/packages/core/utils/src/auth/token.ts
+++ b/packages/core/utils/src/auth/token.ts
@@ -1,12 +1,20 @@
 import jwt from "jsonwebtoken"
+import { MedusaError } from "../common"
 
 export const generateJwtToken = (
   tokenPayload: Record<string, unknown>,
   jwtConfig: {
-    secret: string
-    expiresIn: string
+    secret: string | undefined
+    expiresIn: string | undefined
   }
 ) => {
+  if (!jwtConfig.secret || !jwtConfig.expiresIn) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_ARGUMENT,
+      "JWT secret and expiresIn must be provided when generating a token"
+    )
+  }
+
   return jwt.sign(tokenPayload, jwtConfig.secret, {
     expiresIn: jwtConfig.expiresIn,
   })

--- a/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/callback/route.ts
+++ b/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/callback/route.ts
@@ -1,4 +1,8 @@
-import { AuthenticationInput, IAuthModuleService } from "@medusajs/types"
+import {
+  AuthenticationInput,
+  ConfigModule,
+  IAuthModuleService,
+} from "@medusajs/types"
 import {
   ContainerRegistrationKeys,
   MedusaError,
@@ -10,6 +14,9 @@ import { generateJwtTokenForAuthIdentity } from "../../../utils/generate-jwt-tok
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { actor_type, auth_provider } = req.params
 
+  const config: ConfigModule = req.scope.resolve(
+    ContainerRegistrationKeys.CONFIG_MODULE
+  )
   const service: IAuthModuleService = req.scope.resolve(
     ModuleRegistrationName.AUTH
   )

--- a/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/register/route.ts
+++ b/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/register/route.ts
@@ -34,7 +34,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     authData
   )
 
-  if (success) {
+  if (success && authIdentity) {
     const { http } = config.projectConfig
 
     const token = generateJwtTokenForAuthIdentity(

--- a/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/route.ts
+++ b/packages/medusa/src/api/auth/[actor_type]/[auth_provider]/route.ts
@@ -38,7 +38,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     return res.status(200).json({ location })
   }
 
-  if (success) {
+  if (success && authIdentity) {
     const { http } = config.projectConfig
 
     const token = generateJwtTokenForAuthIdentity(

--- a/packages/medusa/src/api/auth/middlewares.ts
+++ b/packages/medusa/src/api/auth/middlewares.ts
@@ -16,6 +16,11 @@ export const authRoutesMiddlewares: MiddlewareRoute[] = [
   },
   {
     method: ["POST"],
+    matcher: "/auth/token/refresh",
+    middlewares: [authenticate("*", "bearer", { allowUnregistered: true })],
+  },
+  {
+    method: ["POST"],
     matcher: "/auth/:actor_type/:auth_provider/callback",
     middlewares: [validateScopeProviderAssociation()],
   },

--- a/packages/medusa/src/api/auth/token/refresh/route.ts
+++ b/packages/medusa/src/api/auth/token/refresh/route.ts
@@ -1,0 +1,40 @@
+import { IAuthModuleService } from "@medusajs/types"
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "../../../../types/routing"
+import {
+  ContainerRegistrationKeys,
+  ModuleRegistrationName,
+} from "@medusajs/utils"
+import { generateJwtTokenForAuthIdentity } from "../../utils/generate-jwt-token"
+
+// Retrieve a newly generated JWT token. All checks that the existing token is valid already happen in the auth middleware.
+// The token will include the actor ID, even if the token used to refresh didn't have one.
+// Note: We probably want to disallow refreshes if the password changes, and require reauth.
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const service: IAuthModuleService = req.scope.resolve(
+    ModuleRegistrationName.AUTH
+  )
+
+  const authIdentity = await service.retrieveAuthIdentity(
+    req.auth_context.auth_identity_id
+  )
+
+  const { http } = req.scope.resolve(
+    ContainerRegistrationKeys.CONFIG_MODULE
+  ).projectConfig
+
+  const token = generateJwtTokenForAuthIdentity(
+    { authIdentity, actorType: req.auth_context.actor_type },
+    {
+      secret: http.jwtSecret,
+      expiresIn: http.jwtExpiresIn,
+    }
+  )
+
+  return res.json({ token })
+}

--- a/packages/medusa/src/api/auth/utils/generate-jwt-token.ts
+++ b/packages/medusa/src/api/auth/utils/generate-jwt-token.ts
@@ -1,8 +1,15 @@
+import { AuthIdentityDTO } from "@medusajs/types"
 import { generateJwtToken } from "@medusajs/utils"
 
 export function generateJwtTokenForAuthIdentity(
-  { authIdentity, actorType },
-  { secret, expiresIn }
+  {
+    authIdentity,
+    actorType,
+  }: { authIdentity: AuthIdentityDTO; actorType: string },
+  {
+    secret,
+    expiresIn,
+  }: { secret: string | undefined; expiresIn: string | undefined }
 ) {
   const entityIdKey = `${actorType}_id`
   const entityId = authIdentity?.app_metadata?.[entityIdKey] as


### PR DESCRIPTION
This is useful in few scenarios, namely:
1. When doing oauth, after creating a user, we want to immediately refresh the JWT token so it has the actor ID populated
2. You don't want people to have to re-login every day, so you can implement a token refresh eg. every time your site is visited, as long as the `expiresIn` hasn't passed.

CLOSES CC-425