### PR TITLE
feat(product): Allow URL-Encoded special characters in product handle

### DIFF
--- a/packages/core/utils/src/common/validate-handle.ts
+++ b/packages/core/utils/src/common/validate-handle.ts
@@ -3,5 +3,5 @@
  * friendly.
  */
 export const isValidHandle = (value: string): boolean => {
-  return /^[a-z0-9]+(?:-[a-z0-9]+|(?:-%[0-9A-Fa-f]{2})*(?:%[0-9A-Fa-f]{2})*(?:-[a-z0-9])?)+(?:[a-z0-9])*$/.test(value)
+  return /^(?:%[0-9A-Fa-f]{2}|[a-z0-9]+)(?:-[a-z0-9]+|(?:-%[0-9A-Fa-f]{2})*(?:%[0-9A-Fa-f]{2})*(?:-[a-z0-9])?)+(?:[a-z0-9])*$/.test(value)
 }

--- a/packages/core/utils/src/common/validate-handle.ts
+++ b/packages/core/utils/src/common/validate-handle.ts
@@ -3,5 +3,5 @@
  * friendly.
  */
 export const isValidHandle = (value: string): boolean => {
-  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)
+  return /^[a-z0-9]+(?:-[a-z0-9]+|(?:-%[0-9A-Fa-f]{2})*(?:%[0-9A-Fa-f]{2})*(?:-[a-z0-9])?)+(?:[a-z0-9])*$/.test(value)
 }


### PR DESCRIPTION
Changed the regex of the validation function, which checks if the product handle is valid.
It now allows for URL encoded special characters (e.g. ★ => %E2%98%85)

Best practice is to use the `encodeURIComponent()` function to encode the handle that shall be created.

It allows for handles like this:
`some-handle-%E2%98%85`
`some-%E2%98%85-handle`
`some%E2%98%85handle`
`%E2%98%85-handle`
`%E2%98%85handle`