### PR TITLE
feat(create-medusa-app): add publishable API key environment variable to Next.js storefront

### DIFF
--- a/packages/cli/create-medusa-app/src/utils/prepare-project.ts
+++ b/packages/cli/create-medusa-app/src/utils/prepare-project.ts
@@ -241,14 +241,10 @@ export default async ({
       `SELECT * FROM "api_key" WHERE type = 'publishable'`
     )
 
-    console.log(apiKeys)
-
     if (apiKeys.rowCount) {
       const nextjsEnvPath = path.join(nextjsDirectory, fs.existsSync(path.join(nextjsDirectory, ".env.local")) ? ".env.local" : ".env.template")
 
       const originalContent = fs.readFileSync(nextjsEnvPath, "utf-8")
-
-      console.log(originalContent, originalContent.replace("NEXT_PUBLIC_PUBLISHABLE_KEY=", `NEXT_PUBLIC_PUBLISHABLE_KEY=${apiKeys.rows[0].token}`))
 
       fs.appendFileSync(nextjsEnvPath, originalContent.replace("NEXT_PUBLIC_PUBLISHABLE_KEY=", `NEXT_PUBLIC_PUBLISHABLE_KEY=${apiKeys.rows[0].token}`))
     }

--- a/packages/cli/create-medusa-app/src/utils/prepare-project.ts
+++ b/packages/cli/create-medusa-app/src/utils/prepare-project.ts
@@ -234,6 +234,26 @@ export default async ({
     })
   }
 
+  // if installation includes Next.js, retrieve the publishable API key
+  // from the backend and add it as an enviornment variable
+  if (nextjsDirectory && client) {
+    const apiKeys = await client.query(
+      `SELECT * FROM "api_key" WHERE type = 'publishable'`
+    )
+
+    console.log(apiKeys)
+
+    if (apiKeys.rowCount) {
+      const nextjsEnvPath = path.join(nextjsDirectory, fs.existsSync(path.join(nextjsDirectory, ".env.local")) ? ".env.local" : ".env.template")
+
+      const originalContent = fs.readFileSync(nextjsEnvPath, "utf-8")
+
+      console.log(originalContent, originalContent.replace("NEXT_PUBLIC_PUBLISHABLE_KEY=", `NEXT_PUBLIC_PUBLISHABLE_KEY=${apiKeys.rows[0].token}`))
+
+      fs.appendFileSync(nextjsEnvPath, originalContent.replace("NEXT_PUBLIC_PUBLISHABLE_KEY=", `NEXT_PUBLIC_PUBLISHABLE_KEY=${apiKeys.rows[0].token}`))
+    }
+  }
+
   displayFactBox({ ...factBoxOptions, message: "Finished Preparation" })
 
   return inviteToken


### PR DESCRIPTION
When installing with Next.js starter, retrieve the publishable API key seeded and add it to the environment variable in the `.env.local` or `.env.template` file