### PR TITLE
fix(types): add inventory_quantity to http variant type

### DIFF
--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -50,6 +50,7 @@ export interface BaseProductVariant {
   upc: string | null
   allow_backorder: boolean | null
   manage_inventory: boolean | null
+  inventory_quantity?: number
   hs_code: string | null
   origin_country: string | null
   mid_code: string | null


### PR DESCRIPTION
The inventory quantity of a product in a location / sales channel can be retrieved by passing in the API route in fields `+variants.inventory_quantity`

This adds the field to the HTTP type.