### PR TITLE
chore: re-add oas tests for generated OAS

### DIFF
--- a/.github/workflows/oas-test.yml
+++ b/.github/workflows/oas-test.yml
@@ -1,39 +1,41 @@
-#name: OAS Comments Format Validation
-#on:
-#  pull_request:
-#
-#jobs:
-#  docs-test:
-#    runs-on: ubuntu-latest
-#    env:
-#      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-#      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-#    steps:
-#      - name: Cancel Previous Runs
-#        uses: styfle/cancel-workflow-action@0.11.0
-#        with:
-#          access_token: ${{ github.token }}
-#
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#        with:
-#          fetch-depth: 0
-#
-#      - name: Setup Node.js environment
-#        uses: actions/setup-node@v3
-#        with:
-#          node-version: "16.10.0"
-#          cache: "yarn"
-#
-#      - name: Install dependencies
-#        uses: ./.github/actions/cache-deps
-#        with:
-#          extension: oas
-#
-#      - name: Build Packages
-#        run: yarn build
-#
-#      - name: Build OAS
-#        run: |
-#          yarn openapi:generate --dry-run
+name: OAS Comments Format Validation
+on:
+ pull_request:
+  paths:
+    - www/utils/generated/oas-output/**
+
+jobs:
+ docs-test:
+   runs-on: ubuntu-latest
+   env:
+     TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+     TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+   steps:
+     - name: Cancel Previous Runs
+       uses: styfle/cancel-workflow-action@0.11.0
+       with:
+         access_token: ${{ github.token }}
+
+     - name: Checkout
+       uses: actions/checkout@v3
+       with:
+         fetch-depth: 0
+
+     - name: Setup Node.js environment
+       uses: actions/setup-node@v3
+       with:
+         node-version: "16.10.0"
+         cache: "yarn"
+
+     - name: Install dependencies
+       uses: ./.github/actions/cache-deps
+       with:
+         extension: oas
+
+     - name: Build Packages
+       run: yarn build
+
+     - name: Build OAS
+       run: |
+         yarn openapi:generate --dry-run
 #

--- a/packages/cli/oas/medusa-oas-cli/src/__tests__/command-docs.test.ts
+++ b/packages/cli/oas/medusa-oas-cli/src/__tests__/command-docs.test.ts
@@ -208,7 +208,7 @@ describe("command docs", () => {
       configFile = path.resolve(outDir, "redocly-config.json")
       await writeJson(configFile, config)
       configYamlFile = path.resolve(outDir, "redocly-config.yaml")
-      await writeYaml(configYamlFile, config)
+      await writeYaml(configYamlFile, JSON.stringify(config))
     })
 
     it("should fail with unhandled circular reference", async () => {


### PR DESCRIPTION
- Re-add the test used previously to validate OAS comments, but this time only run it when there are changes in `www/utils/generated/oas-output/**`
- Fix the OAS CLI using dry run to allow modifying the redocly configurations, then reverting the change