### PR TITLE
fix(orchestration): filter out undefined items

### DIFF
--- a/packages/core/orchestration/src/joiner/remote-joiner.ts
+++ b/packages/core/orchestration/src/joiner/remote-joiner.ts
@@ -92,7 +92,16 @@ export class RemoteJoiner {
   }
 
   private static getNestedItems(items: any[], property: string): any[] {
-    return items.flatMap((item) => item?.[property])
+    const result: unknown[] = []
+    for (const item of items) {
+      for (const value of item?.[property] ?? []) {
+        if (isDefined(value)) {
+          result.push(value)
+        }
+      }
+    }
+
+    return result
   }
 
   private static createRelatedDataMap(
@@ -377,7 +386,11 @@ export class RemoteJoiner {
     const isObj = isDefined(response.path)
     let resData = isObj ? response.data[response.path!] : response.data
 
-    resData = Array.isArray(resData) ? resData : [resData]
+    resData = isDefined(resData)
+      ? Array.isArray(resData)
+        ? resData
+        : [resData]
+      : []
 
     this.checkIfKeysExist(
       uniqueIds,

--- a/packages/core/orchestration/src/joiner/remote-joiner.ts
+++ b/packages/core/orchestration/src/joiner/remote-joiner.ts
@@ -94,7 +94,9 @@ export class RemoteJoiner {
   private static getNestedItems(items: any[], property: string): any[] {
     const result: unknown[] = []
     for (const item of items) {
-      for (const value of item?.[property] ?? []) {
+      const allValues = item?.[property] ?? []
+      const values = Array.isArray(allValues) ? allValues : [allValues]
+      for (const value of values) {
         if (isDefined(value)) {
           result.push(value)
         }


### PR DESCRIPTION
What:
* filter `undefined` values so the remote joiner stops resolving relations if there are no more items