### PR TITLE
fix: Allow specifying PORT for tests through environment

### DIFF
--- a/packages/core/medusa-test-utils/src/medusa-test-runner-utils/bootstrap-app.ts
+++ b/packages/core/medusa-test-utils/src/medusa-test-runner-utils/bootstrap-app.ts
@@ -19,7 +19,7 @@ async function bootstrapApp({
     expressApp: app,
   })
 
-  const PORT = await getPort()
+  const PORT = process.env.PORT ? parseInt(process.env.PORT) : await getPort()
 
   return {
     shutdown,


### PR DESCRIPTION
This is useful when you want to use something else other than axios/api function. In my case, I want to use EventSource, so I need to know the port of the server.

