### PR TITLE
docs: add prerequisites link for test guides

### DIFF
--- a/www/apps/book/app/debugging-and-testing/testing-tools/integration-tests/api-routes/page.mdx
+++ b/www/apps/book/app/debugging-and-testing/testing-tools/integration-tests/api-routes/page.mdx
@@ -1,3 +1,5 @@
+import { Prerequisites } from "docs-ui"
+
 export const metadata = {
   title: `${pageNumber} Example: Write Integration Tests for API Routes`,
 }
@@ -5,6 +7,15 @@ export const metadata = {
 # {metadata.title}
 
 In this chapter, you'll learn how to write integration tests for API routes using the [medusaIntegrationTestRunner utility function](../page.mdx).
+
+<Prerequisites
+  items={[
+    {
+      text: "Testing Tools Setup",
+      link: "/debugging-and-testing/testing-tools"
+    }
+  ]}
+/>
 
 ## Test a GET API Route
 
@@ -73,7 +84,7 @@ If you don't have a `test:integration` script in `package.json`, refer to the [M
 
 </Note>
 
-This runs your Medusa application and runs the tests available under the `src/integrations` directory.
+This runs your Medusa application and runs the tests available under the `src/integrations/http` directory.
 
 ---
 

--- a/www/apps/book/app/debugging-and-testing/testing-tools/integration-tests/page.mdx
+++ b/www/apps/book/app/debugging-and-testing/testing-tools/integration-tests/page.mdx
@@ -1,3 +1,5 @@
+import { Prerequisites } from "docs-ui"
+
 export const metadata = {
   title: `${pageNumber} Write Integration Tests`,
 }
@@ -5,6 +7,15 @@ export const metadata = {
 # {metadata.title}
 
 In this chapter, you'll learn about the `medusaIntegrationTestRunner` utility function used to write integration tests.
+
+<Prerequisites
+  items={[
+    {
+      text: "Testing Tools Setup",
+      link: "/debugging-and-testing/testing-tools"
+    }
+  ]}
+/>
 
 ## medusaIntegrationTestRunner Utility
 
@@ -39,7 +50,27 @@ The `medusaIntegrationTestRunner` function accepts an object as a parameter. The
 
 The tests in the `testSuite` function are written using [Jest](https://jestjs.io/).
 
-### Other Options and Inputs
+---
+
+### Run Tests
+
+Run the following command to run your tests:
+
+```bash npm2yarn
+npm run test:integration
+```
+
+<Note title="Tip">
+
+If you don't have a `test:integration` script in `package.json`, refer to the [Medusa Testing Tools chapter](../page.mdx#add-test-commands).
+
+</Note>
+
+This runs your Medusa application and runs the tests available under the `src/integrations/http` directory.
+
+---
+
+## Other Options and Inputs
 
 Refer to [this reference in the Learning Resources documentation](!resources!/test-tools-reference/medusaIntegrationTestRunner) for other available parameter options and inputs of the `testSuite` function.
 

--- a/www/apps/book/app/debugging-and-testing/testing-tools/integration-tests/workflows/page.mdx
+++ b/www/apps/book/app/debugging-and-testing/testing-tools/integration-tests/workflows/page.mdx
@@ -1,3 +1,5 @@
+import { Prerequisites } from "docs-ui"
+
 export const metadata = {
   title: `${pageNumber} Example: Write Integration Tests for Workflows`,
 }
@@ -5,6 +7,15 @@ export const metadata = {
 # {metadata.title}
 
 In this chapter, you'll learn how to write integration tests for workflows using the [medusaIntegrationTestRunner utility function](../page.mdx).
+
+<Prerequisites
+  items={[
+    {
+      text: "Testing Tools Setup",
+      link: "/debugging-and-testing/testing-tools"
+    }
+  ]}
+/>
 
 ## Write Integration Test for Workflow
 

--- a/www/apps/book/app/debugging-and-testing/testing-tools/modules-tests/module-example/page.mdx
+++ b/www/apps/book/app/debugging-and-testing/testing-tools/modules-tests/module-example/page.mdx
@@ -1,3 +1,5 @@
+import { Prerequisites } from "docs-ui"
+
 export const metadata = {
   title: `${pageNumber} Example: Integration Tests for a Module`,
 }
@@ -5,6 +7,15 @@ export const metadata = {
 # {metadata.title}
 
 In this chapter, find an example of writing an integration test for a module using the [moduleIntegrationTestRunner utility function](../page.mdx).
+
+<Prerequisites
+  items={[
+    {
+      text: "Testing Tools Setup",
+      link: "/debugging-and-testing/testing-tools"
+    }
+  ]}
+/>
 
 ## Write Integration Test for Module
 
@@ -67,4 +78,4 @@ If you don't have a `test:modules` script in `package.json`, refer to the [Medus
 
 </Note>
 
-This runs your Medusa application and runs the tests available in any `__tests__` directory under the `src` directory.
+This runs your Medusa application and runs the tests available in any `__tests__` directory under the `src/modules` directory.

--- a/www/apps/book/app/debugging-and-testing/testing-tools/modules-tests/page.mdx
+++ b/www/apps/book/app/debugging-and-testing/testing-tools/modules-tests/page.mdx
@@ -1,3 +1,5 @@
+import { Prerequisites } from "docs-ui"
+
 export const metadata = {
   title: `${pageNumber} Write Tests for Modules`,
 }
@@ -5,6 +7,15 @@ export const metadata = {
 # {metadata.title}
 
 In this chapter, you'll learn about the `moduleIntegrationTestRunner` utility function and how to use it to write integration tests for a module's main service.
+
+<Prerequisites
+  items={[
+    {
+      text: "Testing Tools Setup",
+      link: "/debugging-and-testing/testing-tools"
+    }
+  ]}
+/>
 
 ## moduleIntegrationTestRunner Utility
 
@@ -44,6 +55,24 @@ The type argument provided to the `moduleIntegrationTestRunner` function is used
 </Note>
 
 The tests in the `testSuite` function are written using [Jest](https://jestjs.io/).
+
+---
+
+## Run Tests
+
+Run the following command to run your module integration tests:
+
+```bash npm2yarn
+npm run test:modules
+```
+
+<Note title="Tip">
+
+If you don't have a `test:modules` script in `package.json`, refer to the [Medusa Testing Tools chapter](../page.mdx#add-test-commands).
+
+</Note>
+
+This runs your Medusa application and runs the tests available in any `__tests__` directory under the `src/modules` directory.
 
 ---
 


### PR DESCRIPTION
- Add a prerequisites link to test guides pointing to how to setup the testing tools
- Add in the main http / module integration guides the command to run the tests