### PR TITLE
docs-util: fix generated hooks example

### DIFF
--- a/www/utils/packages/typedoc-plugin-workflows/src/utils/helper.ts
+++ b/www/utils/packages/typedoc-plugin-workflows/src/utils/helper.ts
@@ -173,7 +173,7 @@ export default class Helper {
   }): string {
     let str = `import { ${workflowName} } from "@medusajs/core-flows"\n\n`
 
-    str += `${workflowName}.hooks.${hookName}(\n\tasync (({`
+    str += `${workflowName}.hooks.${hookName}(\n\t(async ({`
 
     if (
       parameter.type?.type === "reference" &&


### PR DESCRIPTION
Fix generated hook examples by the placement of `async` keyword