### PR TITLE
feat(core-flows,dashboard,types,medusa): delete shipping methods when all inbound/outbound items are deleted

### DIFF
--- a/integration-tests/http/__tests__/claims/claims.spec.ts
+++ b/integration-tests/http/__tests__/claims/claims.spec.ts
@@ -838,6 +838,8 @@ medusaIntegrationTestRunner({
       })
 
       describe("with only outbound items", () => {
+        let orderResult
+
         beforeEach(async () => {
           await api.post(
             `/admin/orders/${order.id}/fulfillments`,
@@ -906,7 +908,7 @@ medusaIntegrationTestRunner({
             adminHeaders
           )
 
-          await api.post(
+          const { data } = await api.post(
             `/admin/claims/${claimId}/outbound/items`,
             {
               items: [
@@ -965,7 +967,7 @@ medusaIntegrationTestRunner({
             adminHeaders
           )
 
-          let orderResult = (
+          orderResult = (
             await api.get(`/admin/orders/${order.id}`, adminHeaders)
           ).data.order
 
@@ -1040,9 +1042,55 @@ medusaIntegrationTestRunner({
 
           expect(orderResult.fulfillment_status).toEqual("shipped")
         })
+
+        it("should remove outbound shipping method when outbound items are completely removed", async () => {
+          orderResult = (
+            await api.get(`/admin/orders/${order.id}/preview`, adminHeaders)
+          ).data.order
+
+          const claimItems = orderResult.items.filter(
+            (item) =>
+              !!item.actions?.find((action) => action.action === "ITEM_ADD")
+          )
+
+          const claimShippingMethods = orderResult.shipping_methods.filter(
+            (item) =>
+              !!item.actions?.find((action) => action.action === "SHIPPING_ADD")
+          )
+
+          expect(claimItems).toHaveLength(1)
+          expect(claimShippingMethods).toHaveLength(1)
+
+          await api.delete(
+            `/admin/claims/${claimId}/outbound/items/${claimItems[0].actions[0].id}`,
+            adminHeaders
+          )
+
+          orderResult = (
+            await api.get(`/admin/orders/${order.id}/preview`, adminHeaders)
+          ).data.order
+
+          const updatedClaimItems = orderResult.items.filter(
+            (item) =>
+              !!item.actions?.find((action) => action.action === "ITEM_ADD")
+          )
+
+          const updatedClaimShippingMethods =
+            orderResult.shipping_methods.filter(
+              (item) =>
+                !!item.actions?.find(
+                  (action) => action.action === "SHIPPING_ADD"
+                )
+            )
+
+          expect(updatedClaimItems).toHaveLength(0)
+          expect(updatedClaimShippingMethods).toHaveLength(0)
+        })
       })
 
       describe("with only inbound items", () => {
+        let orderResult
+
         beforeEach(async () => {
           await api.post(
             `/admin/orders/${order.id}/fulfillments`,
@@ -1072,7 +1120,7 @@ medusaIntegrationTestRunner({
           claimId = baseClaim.id
           item = order.items[0]
 
-          let result = await api.post(
+          await api.post(
             `/admin/claims/${claimId}/inbound/items`,
             {
               items: [
@@ -1091,7 +1139,9 @@ medusaIntegrationTestRunner({
             { shipping_option_id: returnShippingOption.id },
             adminHeaders
           )
+        })
 
+        it("test inbound only", async () => {
           // Claim Items
           await api.post(
             `/admin/claims/${claimId}/claim-items`,
@@ -1109,20 +1159,18 @@ medusaIntegrationTestRunner({
 
           await api.post(`/admin/claims/${claimId}/request`, {}, adminHeaders)
 
-          result = (
+          const claims = (
             await api.get(
               `/admin/claims?fields=*claim_items,*additional_items`,
               adminHeaders
             )
           ).data.claims
 
-          expect(result).toHaveLength(1)
-          expect(result[0].additional_items).toHaveLength(0)
-          expect(result[0].claim_items).toHaveLength(1)
-          expect(result[0].canceled_at).toBeNull()
-        })
+          expect(claims).toHaveLength(1)
+          expect(claims[0].additional_items).toHaveLength(0)
+          expect(claims[0].claim_items).toHaveLength(1)
+          expect(claims[0].canceled_at).toBeNull()
 
-        it("test inbound only", async () => {
           const orderCheck = (
             await api.get(`/admin/orders/${order.id}`, adminHeaders)
           ).data.order
@@ -1136,6 +1184,49 @@ medusaIntegrationTestRunner({
           )
 
           expect(true).toBe(true)
+        })
+
+        it("should remove inbound shipping method when inbound items are completely removed", async () => {
+          orderResult = (
+            await api.get(`/admin/orders/${order.id}/preview`, adminHeaders)
+          ).data.order
+
+          const returnItems = orderResult.items.filter(
+            (item) =>
+              !!item.actions?.find((action) => action.action === "RETURN_ITEM")
+          )
+          const returnShippingMethods = orderResult.shipping_methods.filter(
+            (item) =>
+              !!item.actions?.find((action) => action.action === "SHIPPING_ADD")
+          )
+
+          expect(returnItems).toHaveLength(1)
+          expect(returnShippingMethods).toHaveLength(1)
+
+          await api.delete(
+            `/admin/claims/${claimId}/inbound/items/${returnItems[0].actions[0].id}`,
+            adminHeaders
+          )
+
+          orderResult = (
+            await api.get(`/admin/orders/${order.id}/preview`, adminHeaders)
+          ).data.order
+
+          const updatedReturnItems = orderResult.items.filter(
+            (item) =>
+              !!item.actions?.find((action) => action.action === "RETURN_ITEM")
+          )
+
+          const updatedReturnShippingMethods =
+            orderResult.shipping_methods.filter(
+              (item) =>
+                !!item.actions?.find(
+                  (action) => action.action === "SHIPPING_ADD"
+                )
+            )
+
+          expect(updatedReturnItems).toHaveLength(0)
+          expect(updatedReturnShippingMethods).toHaveLength(0)
         })
       })
     })

--- a/packages/admin/dashboard/src/hooks/api/claims.tsx
+++ b/packages/admin/dashboard/src/hooks/api/claims.tsx
@@ -1,5 +1,5 @@
-import { HttpTypes } from "@medusajs/types"
 import { FetchError } from "@medusajs/js-sdk"
+import { HttpTypes } from "@medusajs/types"
 import {
   QueryKey,
   useMutation,
@@ -305,6 +305,10 @@ export const useRemoveClaimInboundItem = (
 
       queryClient.invalidateQueries({
         queryKey: ordersQueryKeys.preview(orderId),
+      })
+
+      queryClient.invalidateQueries({
+        queryKey: returnsQueryKeys.details(),
       })
 
       options?.onSuccess?.(data, variables, context)

--- a/packages/admin/dashboard/src/hooks/api/exchanges.tsx
+++ b/packages/admin/dashboard/src/hooks/api/exchanges.tsx
@@ -1,3 +1,4 @@
+import { FetchError } from "@medusajs/js-sdk"
 import { HttpTypes } from "@medusajs/types"
 import {
   QueryKey,
@@ -6,7 +7,6 @@ import {
   useQuery,
   UseQueryOptions,
 } from "@tanstack/react-query"
-import { FetchError } from "@medusajs/js-sdk"
 import { sdk } from "../../lib/client"
 import { queryClient } from "../../lib/query-client"
 import { queryKeysFactory } from "../../lib/query-key-factory"
@@ -281,10 +281,15 @@ export const useRemoveExchangeInboundItem = (
       sdk.admin.exchange.removeInboundItem(id, actionId),
     onSuccess: (data: any, variables: any, context: any) => {
       queryClient.invalidateQueries({
+        queryKey: ordersQueryKeys.details(),
+      })
+
+      queryClient.invalidateQueries({
         queryKey: ordersQueryKeys.preview(orderId),
       })
+
       queryClient.invalidateQueries({
-        queryKey: ordersQueryKeys.details(),
+        queryKey: returnsQueryKeys.details(),
       })
 
       options?.onSuccess?.(data, variables, context)
@@ -356,6 +361,7 @@ export const useDeleteExchangeInboundShipping = (
       queryClient.invalidateQueries({
         queryKey: ordersQueryKeys.preview(orderId),
       })
+
       options?.onSuccess?.(data, variables, context)
     },
     ...options,
@@ -424,8 +430,13 @@ export const useRemoveExchangeOutboundItem = (
       sdk.admin.exchange.removeOutboundItem(id, actionId),
     onSuccess: (data: any, variables: any, context: any) => {
       queryClient.invalidateQueries({
+        queryKey: ordersQueryKeys.details(),
+      })
+
+      queryClient.invalidateQueries({
         queryKey: ordersQueryKeys.preview(orderId),
       })
+
       options?.onSuccess?.(data, variables, context)
     },
     ...options,

--- a/packages/admin/dashboard/src/hooks/api/returns.tsx
+++ b/packages/admin/dashboard/src/hooks/api/returns.tsx
@@ -7,11 +7,11 @@ import {
   UseQueryOptions,
 } from "@tanstack/react-query"
 
+import { FetchError } from "@medusajs/js-sdk"
 import { sdk } from "../../lib/client"
 import { queryClient } from "../../lib/query-client"
 import { queryKeysFactory } from "../../lib/query-key-factory"
 import { ordersQueryKeys } from "./orders"
-import { FetchError } from "@medusajs/js-sdk"
 
 const RETURNS_QUERY_KEY = "returns" as const
 export const returnsQueryKeys = queryKeysFactory(RETURNS_QUERY_KEY)
@@ -169,9 +169,11 @@ export const useCancelReturnRequest = (
       queryClient.invalidateQueries({
         queryKey: returnsQueryKeys.details(),
       })
+
       queryClient.invalidateQueries({
         queryKey: returnsQueryKeys.lists(),
       })
+
       options?.onSuccess?.(data, variables, context)
     },
     ...options,
@@ -255,6 +257,10 @@ export const useRemoveReturnItem = (
 
       queryClient.invalidateQueries({
         queryKey: ordersQueryKeys.preview(orderId),
+      })
+
+      queryClient.invalidateQueries({
+        queryKey: returnsQueryKeys.details(),
       })
 
       options?.onSuccess?.(data, variables, context)
@@ -367,6 +373,10 @@ export const useDeleteReturnShipping = (
 
       queryClient.invalidateQueries({
         queryKey: ordersQueryKeys.preview(orderId),
+      })
+
+      queryClient.invalidateQueries({
+        queryKey: returnsQueryKeys.details(),
       })
 
       options?.onSuccess?.(data, variables, context)

--- a/packages/admin/dashboard/src/routes/orders/order-create-claim/components/claim-create-form/claim-create-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-claim/components/claim-create-form/claim-create-form.tsx
@@ -323,22 +323,26 @@ export const ClaimCreateForm = ({
   }, [previewItems])
 
   useEffect(() => {
-    let method = preview.shipping_methods.find(
+    const inboundShipping = preview.shipping_methods.find(
       (s) =>
         !!s.actions?.find((a) => a.action === "SHIPPING_ADD" && !!a.return_id)
     )
 
-    if (method) {
-      form.setValue("inbound_option_id", method.shipping_option_id)
+    if (inboundShipping) {
+      form.setValue("inbound_option_id", inboundShipping.shipping_option_id)
+    } else {
+      form.setValue("inbound_option_id", null)
     }
 
-    method = preview.shipping_methods.find(
+    const outboundShipping = preview.shipping_methods.find(
       (s) =>
         !!s.actions?.find((a) => a.action === "SHIPPING_ADD" && !a.return_id)
     )
 
-    if (method) {
-      form.setValue("outbound_option_id", method.shipping_option_id)
+    if (outboundShipping) {
+      form.setValue("outbound_option_id", outboundShipping.shipping_option_id)
+    } else {
+      form.setValue("outbound_option_id", null)
     }
   }, [preview.shipping_methods])
 
@@ -420,10 +424,25 @@ export const ClaimCreateForm = ({
   }
 
   const onShippingOptionChange = async (selectedOptionId: string) => {
-    const promises = preview.shipping_methods
-      .map((s) => s.actions?.find((a) => a.action === "SHIPPING_ADD")?.id)
+    const inboundShippingMethods = preview.shipping_methods.filter((s) => {
+      const action = s.actions?.find(
+        (a) => a.action === "SHIPPING_ADD" && !!a.return_id
+      )
+
+      return action && !!!action?.return_id
+    })
+
+    const promises = inboundShippingMethods
       .filter(Boolean)
-      .map(deleteInboundShipping)
+      .map((inboundShippingMethod) => {
+        const action = inboundShippingMethod.actions?.find(
+          (a) => a.action === "SHIPPING_ADD" && !!a.return_id
+        )
+
+        if (action) {
+          return deleteInboundShipping(action.id)
+        }
+      })
 
     await Promise.all(promises)
 

--- a/packages/admin/dashboard/src/routes/orders/order-create-claim/components/claim-create-form/claim-outbound-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-claim/components/claim-create-form/claim-outbound-section.tsx
@@ -191,20 +191,22 @@ export const ClaimOutboundSection = ({
 
   const onShippingOptionChange = async (selectedOptionId: string) => {
     const outboundShippingMethods = preview.shipping_methods.filter((s) => {
-      const action = s.actions?.find((a) => a.action === "SHIPPING_ADD")
+      const action = s.actions?.find(
+        (a) => a.action === "SHIPPING_ADD" && !a.return_id
+      )
 
-      return action && !!!action?.return?.id
+      return action && !!!action?.return_id
     })
 
     const promises = outboundShippingMethods
       .filter(Boolean)
       .map((outboundShippingMethod) => {
         const action = outboundShippingMethod.actions?.find(
-          (a) => a.action === "SHIPPING_ADD"
+          (a) => a.action === "SHIPPING_ADD" && !a.return_id
         )
 
         if (action) {
-          deleteOutboundShipping(action.id)
+          return deleteOutboundShipping(action.id)
         }
       })
 

--- a/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-inbound-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-inbound-section.tsx
@@ -188,17 +188,17 @@ export const ExchangeInboundSection = ({
   }, [previewInboundItems])
 
   useEffect(() => {
-    const inboundShippingMethod = preview.shipping_methods.find((s) => {
-      const action = s.actions?.find((a) => a.action === "SHIPPING_ADD")
-
-      return !!action?.return?.id
-    })
+    const inboundShippingMethod = preview.shipping_methods.find((s) =>
+      s.actions?.find((a) => a.action === "SHIPPING_ADD" && !!a.return_id)
+    )
 
     if (inboundShippingMethod) {
       form.setValue(
         "inbound_option_id",
         inboundShippingMethod.shipping_option_id
       )
+    } else {
+      form.setValue("inbound_option_id", null)
     }
   }, [preview.shipping_methods])
 
@@ -246,21 +246,19 @@ export const ExchangeInboundSection = ({
   }
 
   const onShippingOptionChange = async (selectedOptionId: string) => {
-    const inboundShippingMethods = preview.shipping_methods.filter((s) => {
-      const action = s.actions?.find((a) => a.action === "SHIPPING_ADD")
-
-      return action && !!action?.return?.id
-    })
+    const inboundShippingMethods = preview.shipping_methods.filter((s) =>
+      s.actions?.find((a) => a.action === "SHIPPING_ADD" && !!a.return_id)
+    )
 
     const promises = inboundShippingMethods
       .filter(Boolean)
       .map((inboundShippingMethod) => {
         const action = inboundShippingMethod.actions?.find(
-          (a) => a.action === "SHIPPING_ADD"
+          (a) => a.action === "SHIPPING_ADD" && !!a.return_id
         )
 
         if (action) {
-          deleteInboundShipping(action.id)
+          return deleteInboundShipping(action.id)
         }
       })
 

--- a/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-outbound-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-outbound-section.tsx
@@ -188,22 +188,34 @@ export const ExchangeOutboundSection = ({
     setIsOpen("outbound-items", false)
   }
 
-  const onShippingOptionChange = async (selectedOptionId: string) => {
-    const outboundShippingMethods = preview.shipping_methods.filter((s) => {
-      const action = s.actions?.find((a) => a.action === "SHIPPING_ADD")
+  useEffect(() => {
+    const outboundShipping = preview.shipping_methods.find(
+      (s) =>
+        !!s.actions?.find((a) => a.action === "SHIPPING_ADD" && !a.return_id)
+    )
 
-      return !action?.return_id
-    })
+    if (outboundShipping) {
+      form.setValue("outbound_option_id", outboundShipping.shipping_option_id)
+    } else {
+      form.setValue("outbound_option_id", null)
+    }
+  }, [preview.shipping_methods])
+
+  const onShippingOptionChange = async (selectedOptionId: string) => {
+    const outboundShippingMethods = preview.shipping_methods.filter(
+      (s) =>
+        !!s.actions?.find((a) => a.action === "SHIPPING_ADD" && !a.return_id)
+    )
 
     const promises = outboundShippingMethods
       .filter(Boolean)
       .map((outboundShippingMethod) => {
         const action = outboundShippingMethod.actions?.find(
-          (a) => a.action === "SHIPPING_ADD"
+          (a) => a.action === "SHIPPING_ADD" && !a.return_id
         )
 
         if (action) {
-          deleteOutboundShipping(action.id)
+          return deleteOutboundShipping(action.id)
         }
       })
 

--- a/packages/core/core-flows/src/order/workflows/claim/remove-claim-add-item-action.ts
+++ b/packages/core/core-flows/src/order/workflows/claim/remove-claim-add-item-action.ts
@@ -8,10 +8,12 @@ import {
 } from "@medusajs/types"
 import { ChangeActionType, OrderChangeStatus } from "@medusajs/utils"
 import {
-  WorkflowData,
-  WorkflowResponse,
   createStep,
   createWorkflow,
+  transform,
+  when,
+  WorkflowData,
+  WorkflowResponse,
 } from "@medusajs/workflows-sdk"
 import { useRemoteQueryStep } from "../../../common"
 import {
@@ -22,6 +24,7 @@ import {
   throwIfIsCancelled,
   throwIfOrderChangeIsNotActive,
 } from "../../utils/order-validation"
+import { removeClaimShippingMethodWorkflow } from "./remove-claim-shipping-method"
 
 /**
  * This step validates that new items can be removed from a claim.
@@ -103,6 +106,62 @@ export const removeAddItemClaimActionWorkflow = createWorkflow(
     })
 
     deleteOrderChangeActionsStep({ ids: [input.action_id] })
+
+    const updatedOrderChange: OrderChangeDTO = useRemoteQueryStep({
+      entry_point: "order_change",
+      fields: [
+        "actions.action",
+        "actions.claim_id",
+        "actions.id",
+        "actions.return_id",
+      ],
+      variables: {
+        filters: {
+          order_id: orderClaim.order_id,
+          claim_id: orderClaim.id,
+          status: [OrderChangeStatus.PENDING, OrderChangeStatus.REQUESTED],
+        },
+      },
+      list: false,
+    }).config({ name: "updated-order-change-query" })
+
+    const actionIdToDelete = transform(
+      { updatedOrderChange, orderClaim },
+      ({
+        updatedOrderChange: { actions = [] },
+        orderClaim: { id: orderClaimId },
+      }) => {
+        const itemActions = actions.filter((c) => c.action === "ITEM_ADD")
+
+        if (itemActions.length) {
+          return null
+        }
+
+        const shippingAction = actions.find(
+          (c) =>
+            c.action === "SHIPPING_ADD" &&
+            c.claim_id === orderClaimId &&
+            !c.return_id
+        )
+
+        if (!shippingAction) {
+          return null
+        }
+
+        return shippingAction.id
+      }
+    )
+
+    when({ actionIdToDelete }, ({ actionIdToDelete }) => {
+      return !!actionIdToDelete
+    }).then(() => {
+      removeClaimShippingMethodWorkflow.runAsStep({
+        input: {
+          claim_id: orderClaim.id!,
+          action_id: actionIdToDelete,
+        },
+      })
+    })
 
     return new WorkflowResponse(previewOrderChangeStep(order.id))
   }

--- a/packages/core/types/src/order/mutations.ts
+++ b/packages/core/types/src/order/mutations.ts
@@ -1566,7 +1566,7 @@ export interface UpdateReturnDTO {
   /**
    * The ID of the location to return the items to.
    */
-  location_id?: string
+  location_id?: string | null
 
   /**
    * The refund amount of the return.

--- a/packages/core/types/src/workflow/order/update-return.ts
+++ b/packages/core/types/src/workflow/order/update-return.ts
@@ -1,6 +1,6 @@
 export interface UpdateReturnWorkflowInput {
   return_id: string
-  location_id?: string
+  location_id?: string | null
   no_notification?: boolean
   metadata?: Record<string, any> | null
 }

--- a/packages/medusa/src/api/admin/claims/[id]/outbound/items/[action_id]/route.ts
+++ b/packages/medusa/src/api/admin/claims/[id]/outbound/items/[action_id]/route.ts
@@ -2,6 +2,7 @@ import {
   removeAddItemClaimActionWorkflow,
   updateClaimAddItemWorkflow,
 } from "@medusajs/core-flows"
+import { HttpTypes } from "@medusajs/types"
 import {
   ContainerRegistrationKeys,
   remoteQueryObjectFromString,
@@ -11,7 +12,6 @@ import {
   MedusaResponse,
 } from "../../../../../../../types/routing"
 import { AdminPostClaimsItemsActionReqSchemaType } from "../../../../validators"
-import { HttpTypes } from "@medusajs/types"
 
 export const POST = async (
   req: AuthenticatedMedusaRequest<AdminPostClaimsItemsActionReqSchemaType>,
@@ -55,7 +55,6 @@ export const DELETE = async (
   const remoteQuery = req.scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
 
   const { id, action_id } = req.params
-
   const { result: orderPreview } = await removeAddItemClaimActionWorkflow(
     req.scope
   ).run({

--- a/packages/medusa/src/api/admin/exchanges/[id]/inbound/items/[action_id]/route.ts
+++ b/packages/medusa/src/api/admin/exchanges/[id]/inbound/items/[action_id]/route.ts
@@ -86,12 +86,10 @@ export const DELETE = async (
     entryPoint: "return",
     variables: {
       id: exchange.return_id,
-      filters: {
-        ...req.filterableFields,
-      },
     },
-    fields: req.remoteQueryConfig.fields,
+    fields: defaultAdminDetailsReturnFields,
   })
+
   const [orderReturn] = await remoteQuery(queryObject)
 
   res.json({


### PR DESCRIPTION
what:

- delete shipping methods when all inbound/outbound items are deleted
  - claims / exchanges / returns
- updates frontend to update the forms when ^ happens
- resolved a couple of bugs + types along the way

RESOLVES CC-439