### PR TITLE
fix: OrderDTO add first class discount_subtotal var

### DIFF
--- a/packages/core/types/src/order/common.ts
+++ b/packages/core/types/src/order/common.ts
@@ -1150,6 +1150,11 @@ export interface OrderDTO {
   tax_total: BigNumberValue
 
   /**
+   * The discount subtotal of the order.
+   */
+  discount_subtotal: BigNumberValue
+
+  /**
    * The discount total of the order.
    */
   discount_total: BigNumberValue


### PR DESCRIPTION
Include discount_subtotal as a first class var for OrderDTO

mentioned in PR #9002 