### PR TITLE
Fixed misleading LinkDefinition import from the wrong package

### DIFF
--- a/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
+++ b/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
@@ -878,13 +878,13 @@ import {
 import { 
   CartLineItemDTO, 
   OrderDTO,
+  LinkDefinition
 } from "@medusajs/types"
 import { Modules } from "@medusajs/utils"
 import { 
   createOrdersWorkflow,
   cancelOrderWorkflow,
 } from "@medusajs/core-flows"
-import { LinkDefinition } from "@medusajs/modules-sdk"
 import MarketplaceModuleService from "../../../../modules/marketplace/service"
 import { MARKETPLACE_MODULE } from "../../../../modules/marketplace"
 import { VendorData } from "../../../../modules/marketplace/types"


### PR DESCRIPTION
It appears that `LinkDefinition` was imported from the incorrect package. From my understanding, `remote-link.d.ts` imports it from the correct location, but the tutorial does not.

```typescript
import { ILinkModule, LinkDefinition, LoadedModule, ModuleJoinerRelationship } from "@medusajs/types";
```

Additionally, I am seeking expert assistance with Medusa's architecture. If someone could reach out to me, I would greatly appreciate any guidance or direction on developing specific components for a complex multi-vendor shipping and shopping platform. My goal is to effectively utilize the Medusa architecture and contribute back to the community as much as possible.

Thank you to the entire Medusa team. I hope my contributions have been helpful to new developers enhancing their experience with Medusa.

email: erickirt582@gmail.com