### PR TITLE
fix(core-flows): fixes case where inventory attempts delete when input is empty

### DIFF
--- a/integration-tests/http/__tests__/inventory/admin/inventory.spec.ts
+++ b/integration-tests/http/__tests__/inventory/admin/inventory.spec.ts
@@ -175,6 +175,38 @@ medusaIntegrationTestRunner({
             message: `Cannot remove Inventory Levels for ${stockLocation1.id} because there are stocked or reserved items at the locations`,
           })
         })
+
+        it("should successfully add an inventory location", async () => {
+          await api.post(
+            `/admin/inventory-items/${inventoryItem1.id}/location-levels/${stockLocation1.id}`,
+            { stocked_quantity: 10 },
+            adminHeaders
+          )
+
+          await api.post(
+            `/admin/inventory-items/${inventoryItem1.id}/location-levels/batch`,
+            { create: [{ location_id: stockLocation2.id }] },
+            adminHeaders
+          )
+
+          const {
+            data: { inventory_levels: inventoryLevels },
+          } = await api.get(
+            `/admin/inventory-items/${inventoryItem1.id}/location-levels`,
+            adminHeaders
+          )
+
+          expect(inventoryLevels).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                location_id: stockLocation1.id,
+              }),
+              expect.objectContaining({
+                location_id: stockLocation2.id,
+              }),
+            ])
+          )
+        })
       })
 
       describe("DELETE /admin/inventory-items/:id/location-levels/:id", () => {


### PR DESCRIPTION
what:

- when an empty array is passed to the workflow, it attempts to delete all inventory locations. This PR adds a conditional to prevent it from happening.

RESOLVES CC-477

Fixes https://github.com/medusajs/medusa/issues/9154