### PR TITLE
fix: migrate old links tables before performing a sync

### DIFF
--- a/packages/modules/link-modules/src/migration/index.ts
+++ b/packages/modules/link-modules/src/migration/index.ts
@@ -125,7 +125,7 @@ export class MigrationsExecutionPlanner implements ILinkMigrationsPlanner {
     `
         )
     )
-      .map(({ table_name }) => table_name.toLowerCase())
+      .map(({ table_name }) => table_name)
       .filter((tableName) =>
         this.#linksEntities.some(
           ({ entity }) => entity.meta.collection === tableName
@@ -212,7 +212,10 @@ export class MigrationsExecutionPlanner implements ILinkMigrationsPlanner {
   protected async getTrackedLinksTables(
     orm: MikroORM<PostgreSqlDriver>
   ): Promise<
-    { table_name: string; link_descriptor: PlannerActionLinkDescriptor }[]
+    {
+      table_name: string
+      link_descriptor: PlannerActionLinkDescriptor
+    }[]
   > {
     const results = await orm.em.getDriver().getConnection().execute<
       {
@@ -224,7 +227,7 @@ export class MigrationsExecutionPlanner implements ILinkMigrationsPlanner {
     `)
 
     return results.map((tuple) => ({
-      table_name: tuple.table_name.toLowerCase(),
+      table_name: tuple.table_name,
       link_descriptor: tuple.link_descriptor,
     }))
   }
@@ -237,7 +240,7 @@ export class MigrationsExecutionPlanner implements ILinkMigrationsPlanner {
     entity: EntitySchema,
     trackedLinksTables: string[]
   ): Promise<LinkMigrationsPlannerAction> {
-    const tableName = entity.meta.collection.toLowerCase()
+    const tableName = entity.meta.collection
     const orm = await this.createORM([entity])
 
     try {
@@ -310,6 +313,72 @@ export class MigrationsExecutionPlanner implements ILinkMigrationsPlanner {
   }
 
   /**
+   * This method loops over the tables we have fetched from the
+   * "link_module_migrations" tables and checks if their new
+   * name is different from the tracked name and in that
+   * case it will rename the actual table and also the
+   * tracked entry.
+   */
+  protected async migrateOldTables(
+    orm: MikroORM<PostgreSqlDriver>,
+    trackedTables: {
+      table_name: string
+      link_descriptor: PlannerActionLinkDescriptor
+    }[]
+  ) {
+    const migratedTables: {
+      table_name: string
+      link_descriptor: PlannerActionLinkDescriptor
+    }[] = []
+
+    for (let trackedTable of trackedTables) {
+      const newTableName = this.#linksEntities.find((entity) => {
+        return (
+          entity.linkDescriptor.fromModel ===
+            trackedTable.link_descriptor.fromModel &&
+          entity.linkDescriptor.toModel ===
+            trackedTable.link_descriptor.toModel &&
+          entity.linkDescriptor.fromModule ===
+            trackedTable.link_descriptor.fromModule &&
+          entity.linkDescriptor.toModule ===
+            trackedTable.link_descriptor.toModule
+        )
+      })?.entity.meta.collection
+
+      /**
+       * Perform rename
+       */
+      if (newTableName && trackedTable.table_name !== newTableName) {
+        await this.renameOldTable(orm, trackedTable.table_name, newTableName)
+        migratedTables.push({
+          ...trackedTable,
+          table_name: newTableName,
+        })
+      } else {
+        migratedTables.push({
+          ...trackedTable,
+        })
+      }
+    }
+
+    return migratedTables
+  }
+
+  /**
+   * Renames existing table and also its tracked entry
+   */
+  protected async renameOldTable(
+    orm: MikroORM<PostgreSqlDriver>,
+    oldName: string,
+    newName: string
+  ) {
+    await orm.em.getDriver().getConnection().execute(`
+      ALTER TABLE "${oldName}" RENAME TO "${newName}";
+      UPDATE "${this.tableName}" SET table_name = '${newName}' WHERE table_name = '${oldName}';
+    `)
+  }
+
+  /**
    * Creates a plan to executed in order to keep the database state in
    * sync with the user-defined links.
    *
@@ -326,7 +395,10 @@ export class MigrationsExecutionPlanner implements ILinkMigrationsPlanner {
 
       await this.ensureMigrationsTableUpToDate(orm)
 
-      const trackedTables = await this.getTrackedLinksTables(orm)
+      const trackedTables = await this.migrateOldTables(
+        orm,
+        await this.getTrackedLinksTables(orm)
+      )
       const trackedTablesNames = trackedTables.map(
         ({ table_name }) => table_name
       )


### PR DESCRIPTION
This PR addresses the issue as follows.

- Do not convert table names to lowercase in the code. Instead rely on `entity.meta.collection` to provide the name with correct casing.
- Migrate old tables, which had different name before #9151 to the new name.