### PR TITLE
fix(utils): wrong initialization of collection

### DIFF
--- a/packages/core/utils/src/dal/mikro-orm/utils.ts
+++ b/packages/core/utils/src/dal/mikro-orm/utils.ts
@@ -105,8 +105,7 @@ async function performCascadingSoftDeletion<T>(
 
     if (isCollection) {
       if (!entityRelation.isInitialized()) {
-        entityRelation = await retrieveEntity()
-        entityRelation = entityRelation[relation.name]
+        await entityRelation.init()
       }
       relationEntities = entityRelation.getItems()
     } else {


### PR DESCRIPTION
**What**
When a collection needs to be initialized, use the classic init function instead of trying to improve a little bit this area in favor of something that we know work all the time