### PR TITLE
chore(): Handle medusa service base methods events

### DIFF
--- a/packages/core/utils/src/event-bus/message-aggregator.ts
+++ b/packages/core/utils/src/event-bus/message-aggregator.ts
@@ -15,6 +15,10 @@ export class MessageAggregator implements IMessageAggregator {
     this.messages = []
   }
 
+  count(): number {
+    return this.messages.length
+  }
+
   save(msg: Message | Message[]): void {
     if (!msg || (Array.isArray(msg) && msg.length === 0)) {
       return

--- a/packages/core/utils/src/event-bus/utils.ts
+++ b/packages/core/utils/src/event-bus/utils.ts
@@ -29,6 +29,25 @@ type ReturnType<TNames extends string[]> = {
 }
 
 /**
+ * Build a conventional event name from the object name and the action and the prefix if provided
+ * @param prefix
+ * @param objectName
+ * @param action
+ */
+export function buildEventNameFromObjectName({
+  prefix,
+  objectName,
+  action,
+}: {
+  prefix?: string
+  objectName: string
+  action: string
+}): string {
+  const kebabCaseName = lowerCaseFirst(kebabCase(objectName))
+  return `${prefix ? `${prefix}.` : ""}${kebabCaseName}.${action}`
+}
+
+/**
  * From the given strings it will produce the event names accordingly.
  * the result will look like:
  * input: 'serviceZone'
@@ -57,9 +76,12 @@ export function buildEventNamesFromEntityName<TNames extends string[]>(
 
     for (const event of Object.values(CommonEvents) as string[]) {
       const upperCasedEvent = event.toUpperCase()
-      events[`${snakedCaseName}_${upperCasedEvent}`] = `${
-        prefix ? prefix + "." : ""
-      }${kebabCaseName}.${event}` as `${KebabCase<typeof name>}.${typeof event}`
+      events[`${snakedCaseName}_${upperCasedEvent}`] =
+        buildEventNameFromObjectName({
+          prefix,
+          objectName: name,
+          action: event,
+        }) as `${KebabCase<typeof name>}.${typeof event}`
     }
   }
 

--- a/packages/core/utils/src/event-bus/utils.ts
+++ b/packages/core/utils/src/event-bus/utils.ts
@@ -34,7 +34,7 @@ type ReturnType<TNames extends string[]> = {
  * @param objectName
  * @param action
  */
-export function buildEventNameFromObjectName({
+export function buildModuleResourceEventName({
   prefix,
   objectName,
   action,
@@ -62,6 +62,7 @@ export function buildEventNameFromObjectName({
  * }
  *
  * @param names
+ * @param prefix
  */
 export function buildEventNamesFromEntityName<TNames extends string[]>(
   names: TNames,
@@ -72,12 +73,11 @@ export function buildEventNamesFromEntityName<TNames extends string[]>(
   for (let i = 0; i < names.length; i++) {
     const name = names[i]
     const snakedCaseName = camelToSnakeCase(name).toUpperCase()
-    const kebabCaseName = lowerCaseFirst(kebabCase(name))
 
     for (const event of Object.values(CommonEvents) as string[]) {
       const upperCasedEvent = event.toUpperCase()
       events[`${snakedCaseName}_${upperCasedEvent}`] =
-        buildEventNameFromObjectName({
+        buildModuleResourceEventName({
           prefix,
           objectName: name,
           action: event,

--- a/packages/core/utils/src/modules-sdk/__tests__/medusa-service.spec.ts
+++ b/packages/core/utils/src/modules-sdk/__tests__/medusa-service.spec.ts
@@ -1,5 +1,6 @@
 import { MedusaService } from "../medusa-service"
 import { model } from "../../dml"
+import { MessageAggregator } from "../../event-bus"
 
 const baseRepoMock = {
   serialize: jest.fn().mockImplementation((item) => item),
@@ -11,6 +12,7 @@ const defaultContext = { __type: "MedusaContext", manager: baseRepoMock }
 const defaultTransactionContext = {
   __type: "MedusaContext",
   manager: baseRepoMock,
+  messageAggregator: new MessageAggregator(),
 }
 
 describe("Abstract Module Service Factory", () => {

--- a/packages/core/utils/src/modules-sdk/__tests__/medusa-service.spec.ts
+++ b/packages/core/utils/src/modules-sdk/__tests__/medusa-service.spec.ts
@@ -1,6 +1,7 @@
 import { MedusaService } from "../medusa-service"
 import { model } from "../../dml"
 import { MessageAggregator } from "../../event-bus"
+import { ModuleJoinerConfig } from "@medusajs/types"
 
 const baseRepoMock = {
   serialize: jest.fn().mockImplementation((item) => item),
@@ -64,6 +65,9 @@ describe("Abstract Module Service Factory", () => {
     beforeEach(() => {
       jest.clearAllMocks()
       instance = new medusaService(containerMock)
+      ;(instance as any).__joinerConfig = {
+        serviceName: "serviceName",
+      } as ModuleJoinerConfig
     })
 
     it("should have retrieve method", async () => {
@@ -126,6 +130,9 @@ describe("Abstract Module Service Factory", () => {
     beforeEach(() => {
       jest.clearAllMocks()
       instance = new medusaService(containerMock)
+      ;(instance as any).__joinerConfig = {
+        serviceName: "serviceName",
+      }
     })
 
     it("should have retrieve method for other models", async () => {

--- a/packages/core/utils/src/modules-sdk/__tests__/medusa-service.spec.ts
+++ b/packages/core/utils/src/modules-sdk/__tests__/medusa-service.spec.ts
@@ -8,7 +8,11 @@ const baseRepoMock = {
   getFreshManager: jest.fn().mockReturnThis(),
 }
 
-const defaultContext = { __type: "MedusaContext", manager: baseRepoMock }
+const defaultContext = {
+  __type: "MedusaContext",
+  manager: baseRepoMock,
+  messageAggregator: new MessageAggregator(),
+}
 const defaultTransactionContext = {
   __type: "MedusaContext",
   manager: baseRepoMock,

--- a/packages/core/utils/src/modules-sdk/decorators/emit-events.ts
+++ b/packages/core/utils/src/modules-sdk/decorators/emit-events.ts
@@ -36,9 +36,12 @@ export function EmitEvents(
 
       const argIndex = target.MedusaContextIndex_[propertyKey]
       const aggregator = args[argIndex].messageAggregator as MessageAggregator
-      await target.emitEvents_.apply(this, [aggregator.getMessages(options)])
 
-      aggregator.clearMessages()
+      if (aggregator.count() > 0) {
+        await target.emitEvents_.apply(this, [aggregator.getMessages(options)])
+        aggregator.clearMessages()
+      }
+
       return result
     }
   }

--- a/packages/core/utils/src/modules-sdk/decorators/inject-manager.ts
+++ b/packages/core/utils/src/modules-sdk/decorators/inject-manager.ts
@@ -13,6 +13,8 @@ export function InjectManager(managerProperty?: string): MethodDecorator {
       )
     }
 
+    managerProperty ??= "baseRepository_"
+
     const originalMethod = descriptor.value
     const argIndex = target.MedusaContextIndex_[propertyKey]
 

--- a/packages/core/utils/src/modules-sdk/event-builder-factory.ts
+++ b/packages/core/utils/src/modules-sdk/event-builder-factory.ts
@@ -1,14 +1,14 @@
 import { Context, EventBusTypes } from "@medusajs/types"
-import { buildEventNameFromObjectName } from "../event-bus"
+import { buildModuleResourceEventName } from "../event-bus"
 
-// TODO should that move closer to the event bus? and maybe be rename to moduleEventBuilderFactory
+// TODO should that move closer to the event bus? and maybe be rename to modulemoduleEventBuilderFactory
 
 /**
  *
  * Factory function to create event builders for different entities
  *
  * @example
- * const createdFulfillment = eventBuilderFactory({
+ * const createdFulfillment = moduleEventBuilderFactory({
  *   source: Modules.FULFILLMENT,
  *   action: CommonEvents.CREATED,
  *   object: "fulfillment",
@@ -25,7 +25,7 @@ import { buildEventNameFromObjectName } from "../event-bus"
  * @param eventsEnum
  * @param service
  */
-export function eventBuilderFactory({
+export function moduleEventBuilderFactory({
   action,
   object,
   eventsEnum,
@@ -64,7 +64,7 @@ export function eventBuilderFactory({
       : eventName
 
     if (!eventName_) {
-      eventName_ = buildEventNameFromObjectName({
+      eventName_ = buildModuleResourceEventName({
         prefix: source,
         objectName: object,
         action,

--- a/packages/core/utils/src/modules-sdk/medusa-service.ts
+++ b/packages/core/utils/src/modules-sdk/medusa-service.ts
@@ -193,7 +193,7 @@ export function MedusaService<
           const models = await service.create(serviceData, sharedContext)
           const response = Array.isArray(data) ? models : models[0]
 
-          klassPrototype.aggregatedEvents.bind(klassPrototype)({
+          klassPrototype.aggregatedEvents.bind(this)({
             action: CommonEvents.CREATED,
             object: camelToSnakeCase(modelName).toLowerCase(),
             data: response,
@@ -279,7 +279,7 @@ export function MedusaService<
           )
 
           primaryKeyValues_.map((primaryKeyValue) =>
-            klassPrototype.aggregatedEvents.bind(klassPrototype)({
+            klassPrototype.aggregatedEvents.bind(this)({
               action: CommonEvents.DELETED,
               object: camelToSnakeCase(modelName).toLowerCase(),
               data: isString(primaryKeyValue)
@@ -330,7 +330,7 @@ export function MedusaService<
                 if (entity) {
                   const linkableKeyEntity =
                     camelToSnakeCase(entity).toLowerCase()
-                  klassPrototype.aggregatedEvents.bind(klassPrototype)({
+                  klassPrototype.aggregatedEvents.bind(this)({
                     action: CommonEvents.DELETED,
                     object: linkableKeyEntity,
                     data: { id: ids },
@@ -385,7 +385,7 @@ export function MedusaService<
                 if (entity) {
                   const linkableKeyEntity =
                     camelToSnakeCase(entity).toLowerCase()
-                  klassPrototype.aggregatedEvents.bind(klassPrototype)({
+                  klassPrototype.aggregatedEvents.bind(this)({
                     action: CommonEvents.CREATED,
                     object: linkableKeyEntity,
                     data: { id: ids },

--- a/packages/core/utils/src/modules-sdk/medusa-service.ts
+++ b/packages/core/utils/src/modules-sdk/medusa-service.ts
@@ -33,7 +33,7 @@ import {
   ModelsConfigTemplate,
 } from "./types/medusa-service"
 import { CommonEvents } from "../event-bus"
-import { eventBuilderFactory } from "./event-builder-factory"
+import { moduleEventBuilderFactory } from "./event-builder-factory"
 
 const readMethods = ["retrieve", "list", "listAndCount"] as BaseMethods[]
 const writeMethods = [
@@ -441,7 +441,7 @@ export function MedusaService<
           : this.__joinerConfig
       ) as ModuleJoinerConfig
 
-      const eventBuilder = eventBuilderFactory({
+      const eventBuilder = moduleEventBuilderFactory({
         action,
         object,
         source: source || __joinerConfig.serviceName!,

--- a/packages/core/utils/src/modules-sdk/medusa-service.ts
+++ b/packages/core/utils/src/modules-sdk/medusa-service.ts
@@ -153,15 +153,10 @@ export function MedusaService<
         value: klassPrototype[methodName],
       }
 
+      // The order of the decorators is important, do not change it
       MedusaContext()(klassPrototype, methodName, contextIndex)
-
-      InjectManager("baseRepository_")(
-        klassPrototype,
-        methodName,
-        descriptorMockRef
-      )
-
       EmitEvents()(klassPrototype, methodName, descriptorMockRef)
+      InjectManager()(klassPrototype, methodName, descriptorMockRef)
 
       klassPrototype[methodName] = descriptorMockRef.value
     }
@@ -271,6 +266,7 @@ export function MedusaService<
           const primaryKeyValues_ = Array.isArray(primaryKeyValues)
             ? primaryKeyValues
             : [primaryKeyValues]
+
           await this.__container__[serviceRegistrationName].delete(
             primaryKeyValues_,
             sharedContext

--- a/packages/core/utils/src/modules-sdk/medusa-service.ts
+++ b/packages/core/utils/src/modules-sdk/medusa-service.ts
@@ -217,7 +217,7 @@ export function MedusaService<
           const models = await service.update(serviceData, sharedContext)
           const response = Array.isArray(data) ? models : models[0]
 
-          klassPrototype.aggregatedEvents.bind(klassPrototype)({
+          klassPrototype.aggregatedEvents.bind(this)({
             action: CommonEvents.UPDATED,
             object: camelToSnakeCase(modelName).toLowerCase(),
             data: response,
@@ -324,12 +324,14 @@ export function MedusaService<
                 ? this.__joinerConfig()
                 : this.__joinerConfig
             ) as ModuleJoinerConfig
+
             Object.entries(mappedCascadedModelsMap).forEach(
               ([linkableKey, ids]) => {
                 const entity = joinerConfig.linkableKeys?.[linkableKey]!
                 if (entity) {
                   const linkableKeyEntity =
                     camelToSnakeCase(entity).toLowerCase()
+
                   klassPrototype.aggregatedEvents.bind(this)({
                     action: CommonEvents.DELETED,
                     object: linkableKeyEntity,
@@ -379,6 +381,7 @@ export function MedusaService<
                 ? this.__joinerConfig()
                 : this.__joinerConfig
             ) as ModuleJoinerConfig
+
             Object.entries(mappedCascadedModelsMap).forEach(
               ([linkableKey, ids]) => {
                 const entity = joinerConfig.linkableKeys?.[linkableKey]!

--- a/packages/core/utils/src/modules-sdk/types/medusa-service.ts
+++ b/packages/core/utils/src/modules-sdk/types/medusa-service.ts
@@ -265,4 +265,29 @@ export type MedusaServiceReturnType<ModelsConfig extends Record<string, any>> =
   {
     new (...args: any[]): AbstractModuleService<ModelsConfig>
     $modelObjects: InferModelFromConfig<ModelsConfig>
+    /**
+     * helper function to aggregate events. Will format the message properly and store in
+     * the message aggregator in the context
+     * @param action
+     * @param object
+     * @param eventName optional, can be inferred from the module joiner config + action + object
+     * @param source optional, can be inferred from the module joiner config
+     * @param data
+     * @param context
+     */
+    aggregatedEvents({
+      action,
+      object,
+      eventName,
+      source,
+      data,
+      context,
+    }: {
+      action: string
+      object: string
+      eventName: string
+      source?: string
+      data: { id: any } | { id: any }[]
+      context: Context
+    }): void
   }

--- a/packages/modules/fulfillment/src/utils/events.ts
+++ b/packages/modules/fulfillment/src/utils/events.ts
@@ -10,157 +10,157 @@ import {
 import { Context } from "@medusajs/types"
 import {
   CommonEvents,
-  eventBuilderFactory,
   FulfillmentEvents,
+  moduleEventBuilderFactory,
   Modules,
 } from "@medusajs/utils"
 
 export const eventBuilders = {
-  createdFulfillment: eventBuilderFactory({
+  createdFulfillment: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "fulfillment",
     eventsEnum: FulfillmentEvents,
   }),
-  updatedFulfillment: eventBuilderFactory({
+  updatedFulfillment: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.UPDATED,
     object: "fulfillment",
     eventsEnum: FulfillmentEvents,
   }),
-  createdFulfillmentAddress: eventBuilderFactory({
+  createdFulfillmentAddress: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "fulfillment_address",
     eventsEnum: FulfillmentEvents,
   }),
-  createdFulfillmentItem: eventBuilderFactory({
+  createdFulfillmentItem: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "fulfillment_item",
     eventsEnum: FulfillmentEvents,
   }),
-  createdFulfillmentLabel: eventBuilderFactory({
+  createdFulfillmentLabel: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "fulfillment_label",
     eventsEnum: FulfillmentEvents,
   }),
-  updatedFulfillmentLabel: eventBuilderFactory({
+  updatedFulfillmentLabel: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.UPDATED,
     object: "fulfillment_label",
     eventsEnum: FulfillmentEvents,
   }),
-  deletedFulfillmentLabel: eventBuilderFactory({
+  deletedFulfillmentLabel: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.DELETED,
     object: "fulfillment_label",
     eventsEnum: FulfillmentEvents,
   }),
-  createdShippingProfile: eventBuilderFactory({
+  createdShippingProfile: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "shipping_profile",
     eventsEnum: FulfillmentEvents,
   }),
-  createdShippingOptionType: eventBuilderFactory({
+  createdShippingOptionType: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "shipping_option_type",
     eventsEnum: FulfillmentEvents,
   }),
-  updatedShippingOptionType: eventBuilderFactory({
+  updatedShippingOptionType: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.UPDATED,
     object: "shipping_option_type",
     eventsEnum: FulfillmentEvents,
   }),
-  deletedShippingOptionType: eventBuilderFactory({
+  deletedShippingOptionType: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.DELETED,
     object: "shipping_option_type",
     eventsEnum: FulfillmentEvents,
   }),
-  createdShippingOptionRule: eventBuilderFactory({
+  createdShippingOptionRule: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "shipping_option_rule",
     eventsEnum: FulfillmentEvents,
   }),
-  updatedShippingOptionRule: eventBuilderFactory({
+  updatedShippingOptionRule: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.UPDATED,
     object: "shipping_option_rule",
     eventsEnum: FulfillmentEvents,
   }),
-  deletedShippingOptionRule: eventBuilderFactory({
+  deletedShippingOptionRule: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.DELETED,
     object: "shipping_option_rule",
     eventsEnum: FulfillmentEvents,
   }),
-  createdShippingOption: eventBuilderFactory({
+  createdShippingOption: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "shipping_option",
     eventsEnum: FulfillmentEvents,
   }),
-  updatedShippingOption: eventBuilderFactory({
+  updatedShippingOption: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.UPDATED,
     object: "shipping_option",
     eventsEnum: FulfillmentEvents,
   }),
-  createdFulfillmentSet: eventBuilderFactory({
+  createdFulfillmentSet: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "fulfillment_set",
     eventsEnum: FulfillmentEvents,
   }),
-  updatedFulfillmentSet: eventBuilderFactory({
+  updatedFulfillmentSet: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.UPDATED,
     object: "fulfillment_set",
     eventsEnum: FulfillmentEvents,
   }),
-  deletedFulfillmentSet: eventBuilderFactory({
+  deletedFulfillmentSet: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.DELETED,
     object: "fulfillment_set",
     eventsEnum: FulfillmentEvents,
   }),
-  createdServiceZone: eventBuilderFactory({
+  createdServiceZone: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "service_zone",
     eventsEnum: FulfillmentEvents,
   }),
-  updatedServiceZone: eventBuilderFactory({
+  updatedServiceZone: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.UPDATED,
     object: "service_zone",
     eventsEnum: FulfillmentEvents,
   }),
-  deletedServiceZone: eventBuilderFactory({
+  deletedServiceZone: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.DELETED,
     object: "service_zone",
     eventsEnum: FulfillmentEvents,
   }),
-  createdGeoZone: eventBuilderFactory({
+  createdGeoZone: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.CREATED,
     object: "geo_zone",
     eventsEnum: FulfillmentEvents,
   }),
-  updatedGeoZone: eventBuilderFactory({
+  updatedGeoZone: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.UPDATED,
     object: "geo_zone",
     eventsEnum: FulfillmentEvents,
   }),
-  deletedGeoZone: eventBuilderFactory({
+  deletedGeoZone: moduleEventBuilderFactory({
     source: Modules.FULFILLMENT,
     action: CommonEvents.DELETED,
     object: "geo_zone",

--- a/packages/modules/notification/src/utils/events.ts
+++ b/packages/modules/notification/src/utils/events.ts
@@ -1,12 +1,12 @@
 import {
   CommonEvents,
-  eventBuilderFactory,
+  moduleEventBuilderFactory,
   Modules,
   NotificationEvents,
 } from "@medusajs/utils"
 
 export const eventBuilders = {
-  createdNotification: eventBuilderFactory({
+  createdNotification: moduleEventBuilderFactory({
     source: Modules.NOTIFICATION,
     action: CommonEvents.CREATED,
     object: "notification",

--- a/packages/modules/pricing/src/utils/events.ts
+++ b/packages/modules/pricing/src/utils/events.ts
@@ -1,6 +1,6 @@
 import {
   CommonEvents,
-  eventBuilderFactory,
+  moduleEventBuilderFactory,
   Modules,
   PricingEvents,
 } from "@medusajs/utils"

--- a/packages/modules/pricing/src/utils/events.ts
+++ b/packages/modules/pricing/src/utils/events.ts
@@ -6,61 +6,61 @@ import {
 } from "@medusajs/utils"
 
 export const eventBuilders = {
-  createdPriceSet: eventBuilderFactory({
+  createdPriceSet: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.CREATED,
     object: "price_set",
     eventsEnum: PricingEvents,
   }),
-  createdPrice: eventBuilderFactory({
+  createdPrice: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.CREATED,
     object: "price",
     eventsEnum: PricingEvents,
   }),
-  createdPriceRule: eventBuilderFactory({
+  createdPriceRule: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.CREATED,
     object: "price_rule",
     eventsEnum: PricingEvents,
   }),
-  createdPriceList: eventBuilderFactory({
+  createdPriceList: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.CREATED,
     object: "price_list",
     eventsEnum: PricingEvents,
   }),
-  createdPriceListRule: eventBuilderFactory({
+  createdPriceListRule: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.CREATED,
     object: "price_list_rule",
     eventsEnum: PricingEvents,
   }),
-  attachedPriceListRule: eventBuilderFactory({
+  attachedPriceListRule: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.ATTACHED,
     object: "price_list_rule",
     eventsEnum: PricingEvents,
   }),
-  updatedPrice: eventBuilderFactory({
+  updatedPrice: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.UPDATED,
     object: "price",
     eventsEnum: PricingEvents,
   }),
-  updatedPriceRule: eventBuilderFactory({
+  updatedPriceRule: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.UPDATED,
     object: "price_rule",
     eventsEnum: PricingEvents,
   }),
-  deletedPrice: eventBuilderFactory({
+  deletedPrice: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.DELETED,
     object: "price",
     eventsEnum: PricingEvents,
   }),
-  deletedPriceRule: eventBuilderFactory({
+  deletedPriceRule: moduleEventBuilderFactory({
     source: Modules.PRICING,
     action: CommonEvents.DELETED,
     object: "price_rule",

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/product-categories.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/product-categories.spec.ts
@@ -692,11 +692,11 @@ moduleIntegrationTestRunner<IProductModuleService>({
             [
               expect.objectContaining({
                 data: { id: productCategoryOne.id },
-                name: "product-category.deleted",
+                name: "Product.product-category.deleted",
                 metadata: {
-                  action: "",
-                  object: "",
-                  source: "",
+                  action: CommonEvents.DELETED,
+                  object: "product_category",
+                  source: Modules.PRODUCT,
                 },
               }),
             ],

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/product-collections.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/product-collections.spec.ts
@@ -1,5 +1,5 @@
 import { IProductModuleService } from "@medusajs/types"
-import { Modules, ProductStatus } from "@medusajs/utils"
+import { CommonEvents, Modules, ProductStatus } from "@medusajs/utils"
 import { Product, ProductCollection } from "@models"
 import {
   MockEventBusService,
@@ -281,12 +281,12 @@ moduleIntegrationTestRunner<IProductModuleService>({
           expect(eventBusSpy).toHaveBeenCalledWith(
             [
               {
-                name: "product-collection.deleted",
+                name: "Product.product-collection.deleted",
                 data: { id: collectionId },
                 metadata: {
-                  action: "",
-                  object: "",
-                  source: "",
+                  action: CommonEvents.DELETED,
+                  object: "product_collection",
+                  source: Modules.PRODUCT,
                 },
               },
             ],

--- a/packages/modules/product/src/utils/events.ts
+++ b/packages/modules/product/src/utils/events.ts
@@ -1,114 +1,114 @@
 import {
   CommonEvents,
-  eventBuilderFactory,
+  moduleEventBuilderFactory,
   Modules,
   ProductEvents,
 } from "@medusajs/utils"
 
 export const eventBuilders = {
-  createdProduct: eventBuilderFactory({
+  createdProduct: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.CREATED,
     object: "product",
     eventsEnum: ProductEvents,
   }),
-  updatedProduct: eventBuilderFactory({
+  updatedProduct: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.UPDATED,
     object: "product",
     eventsEnum: ProductEvents,
   }),
-  deletedProduct: eventBuilderFactory({
+  deletedProduct: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.DELETED,
     object: "product",
     eventsEnum: ProductEvents,
   }),
-  createdProductVariant: eventBuilderFactory({
+  createdProductVariant: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.CREATED,
     object: "product_variant",
     eventsEnum: ProductEvents,
   }),
-  updatedProductVariant: eventBuilderFactory({
+  updatedProductVariant: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.UPDATED,
     object: "product_variant",
     eventsEnum: ProductEvents,
   }),
-  deletedProductVariant: eventBuilderFactory({
+  deletedProductVariant: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.DELETED,
     object: "product_variant",
     eventsEnum: ProductEvents,
   }),
-  createdProductOption: eventBuilderFactory({
+  createdProductOption: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.CREATED,
     object: "product_option",
     eventsEnum: ProductEvents,
   }),
-  updatedProductOption: eventBuilderFactory({
+  updatedProductOption: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.UPDATED,
     object: "product_option",
     eventsEnum: ProductEvents,
   }),
-  deletedProductOption: eventBuilderFactory({
+  deletedProductOption: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.DELETED,
     object: "product_option",
     eventsEnum: ProductEvents,
   }),
-  createdProductType: eventBuilderFactory({
+  createdProductType: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.CREATED,
     object: "product_type",
     eventsEnum: ProductEvents,
   }),
-  updatedProductType: eventBuilderFactory({
+  updatedProductType: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.UPDATED,
     object: "product_type",
     eventsEnum: ProductEvents,
   }),
-  deletedProductType: eventBuilderFactory({
+  deletedProductType: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.DELETED,
     object: "product_type",
     eventsEnum: ProductEvents,
   }),
-  createdProductTag: eventBuilderFactory({
+  createdProductTag: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.CREATED,
     object: "product_tag",
     eventsEnum: ProductEvents,
   }),
-  updatedProductTag: eventBuilderFactory({
+  updatedProductTag: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.UPDATED,
     object: "product_tag",
     eventsEnum: ProductEvents,
   }),
-  deletedProductTag: eventBuilderFactory({
+  deletedProductTag: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.DELETED,
     object: "product_tag",
     eventsEnum: ProductEvents,
   }),
-  createdProductCategory: eventBuilderFactory({
+  createdProductCategory: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.CREATED,
     object: "product_category",
     eventsEnum: ProductEvents,
   }),
-  updatedProductCategory: eventBuilderFactory({
+  updatedProductCategory: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.UPDATED,
     object: "product_category",
     eventsEnum: ProductEvents,
   }),
-  deletedProductCategory: eventBuilderFactory({
+  deletedProductCategory: moduleEventBuilderFactory({
     source: Modules.PRODUCT,
     action: CommonEvents.DELETED,
     object: "product_category",


### PR DESCRIPTION
**What**
Properly handle medusa service event for non overridden methods. Also, provide useful utils to centralise event name building as well as message aggregation with inference from the medusa service itself. Accessible from derived service.