### PR TITLE
fix(types): fixes to HTTP types

### DIFF
--- a/packages/core/types/src/http/promotion/common.ts
+++ b/packages/core/types/src/http/promotion/common.ts
@@ -50,9 +50,22 @@ export interface BaseRuleAttributeOptions {
   id: string
   value: string
   label: string
+  /**
+   * @ignore
+   */
   field_type: string
+  /**
+   * @ignore
+   */
   required: boolean
-  disguised: boolean
+  /**
+   * @ignore
+   */
+  disguised?: boolean
+  /**
+   * @ignore
+   */
+  hydrate?: boolean
   operators: BaseRuleOperatorOptions[]
 }
 
@@ -63,7 +76,6 @@ export interface BaseRuleOperatorOptions {
 }
 
 export interface BaseRuleValueOptions {
-  id: string
   value: string
   label: string
 }

--- a/packages/core/types/src/http/region/admin/entities.ts
+++ b/packages/core/types/src/http/region/admin/entities.ts
@@ -3,5 +3,7 @@ import {
   BaseRegionCountry,
 } from "../common"
 
-export interface AdminRegion extends BaseRegion {}
+export interface AdminRegion extends Omit<BaseRegion, "countries"> {
+  countries?: AdminRegionCountry[]
+}
 export interface AdminRegionCountry extends BaseRegionCountry {}

--- a/packages/core/types/src/http/reservation/admin/entities.ts
+++ b/packages/core/types/src/http/reservation/admin/entities.ts
@@ -1,3 +1,5 @@
+import { AdminInventoryItem } from "../../inventory"
+
 export interface AdminReservation {
   id: string
   line_item_id: string | null
@@ -6,7 +8,7 @@ export interface AdminReservation {
   external_id: string | null
   description: string | null
   inventory_item_id: string
-  inventory_item: Record<string, unknown> // TODO: add InventoryItemResponse
+  inventory_item?: AdminInventoryItem
   metadata?: Record<string, unknown>
   created_by?: string | null
   deleted_at?: Date | string | null

--- a/packages/core/types/src/http/return/common.ts
+++ b/packages/core/types/src/http/return/common.ts
@@ -1,3 +1,5 @@
+import { ReturnStatus } from "../../order"
+
 export interface BaseReturnItem {
   id: string
   quantity: number
@@ -13,7 +15,7 @@ export interface BaseReturnItem {
 export interface BaseReturn {
   id: string
   order_id: string
-  status?: string
+  status?: ReturnStatus
   exchange_id?: string
   location_id?: string
   claim_id?: string

--- a/packages/core/types/src/http/shipping-option/admin/entities.ts
+++ b/packages/core/types/src/http/shipping-option/admin/entities.ts
@@ -1,3 +1,4 @@
+import { RuleOperatorType } from "../../../common"
 import { ShippingOptionPriceType } from "../../../fulfillment"
 import { AdminFulfillmentProvider } from "../../fulfillment-provider"
 import { AdminServiceZone } from "../../fulfillment-set"
@@ -18,7 +19,7 @@ export interface AdminShippingOptionType {
 export interface AdminShippingOptionRule {
   id: string
   attribute: string
-  operator: string
+  operator: RuleOperatorType
   value: string | string[] | null
   shipping_option_id: string
   created_at: string

--- a/packages/core/types/src/http/tax-region/admin/entities.ts
+++ b/packages/core/types/src/http/tax-region/admin/entities.ts
@@ -2,15 +2,9 @@ import { AdminTaxRate } from "../../tax-rate"
 
 export interface AdminTaxRegion {
   id: string
-  rate: number | null
-  code: string | null
   country_code: string | null
   province_code: string | null
-  name: string
   metadata: Record<string, unknown> | null
-  tax_region_id: string
-  is_combinable: boolean
-  is_default: boolean
   parent_id: string | null
   created_at: string
   updated_at: string


### PR DESCRIPTION
- Change `countries` in `AdminRegion` to be of type `AdminRegionCountry`
- Change `inventory_item`'s type in `AdminReturn` to `AdminInventoryItem`
- Use `ReturnStatus` enum as type of `status` in `BaseReturn`.
- Add `@ignore` tsdocs to FE-related fields in the `BaseRuleAttributeOptions` type since we don't want to show it in the API reference
- Change the `operator` type in `AdminShippingOptionRule`
- Remove `id` from `BaseRuleValueOptions` because the API route doesn't return it
- Remove incorrect properties of a tax region