### PR TITLE
fix(oas): support additional props, fix circular references patch, and other fixes

### DIFF
--- a/packages/cli/oas/medusa-oas-cli/redocly/redocly-config.yaml
+++ b/packages/cli/oas/medusa-oas-cli/redocly/redocly-config.yaml
@@ -16,6 +16,7 @@ decorators:
         - ProductCategoryResponse
       AdminShippingOption:
         - AdminShippingOption
+        - AdminServiceZone
       AdminProductCategory:
         - AdminProductCategory
         - AdminProduct
@@ -41,6 +42,8 @@ decorators:
       AdminTaxRegion:
         - AdminTaxRegion
         - AdminTaxRate
+      AdminInventoryLevel:
+        - AdminInventoryItem
 theme:
   openapi:
     theme:

--- a/packages/cli/oas/medusa-oas-cli/src/command-docs.ts
+++ b/packages/cli/oas/medusa-oas-cli/src/command-docs.ts
@@ -238,10 +238,13 @@ ${hint}
 `
       const redoclyConfigPath = path.join(basePath, "redocly", "redocly-config.yaml")
       const originalContent = await readYaml(redoclyConfigPath) as CircularReferenceConfig
-      originalContent.decorators["medusa/circular-patch"].schemas = Object.assign(
-        originalContent.decorators["medusa/circular-patch"].schemas, 
-        recommendation
-      )
+      Object.keys(recommendation).forEach((recKey) => {
+        originalContent.decorators["medusa/circular-patch"].schemas[recKey] = [
+          ...originalContent.decorators["medusa/circular-patch"].schemas[recKey],
+          ...recommendation[recKey]
+        ]
+      })
+
       await writeYaml(redoclyConfigPath, jsonObjectToYamlString(originalContent))
       console.log(`🟡 Added the following unhandled circular references to redocly-config.ts:` + hintMessage)
     }

--- a/www/apps/api-reference/components/Tags/Operation/Parameters/Types/Object/index.tsx
+++ b/www/apps/api-reference/components/Tags/Operation/Parameters/Types/Object/index.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import type { SchemaObject } from "@/types/openapi"
 import TagOperationParametersDefault from "../Default"
 import dynamic from "next/dynamic"
@@ -5,6 +7,7 @@ import type { TagOperationParametersProps } from "../.."
 import type { TagsOperationParametersNestedProps } from "../../Nested"
 import checkRequired from "@/utils/check-required"
 import { Loading, type DetailsProps } from "docs-ui"
+import { useMemo } from "react"
 
 const TagOperationParameters = dynamic<TagOperationParametersProps>(
   async () => import("../.."),
@@ -41,9 +44,22 @@ const TagOperationParametersObject = ({
   isRequired,
   topLevel = false,
 }: TagOperationParametersObjectProps) => {
+  const isPropertiesEmpty = useMemo(
+    () => !schema.properties || !Object.values(schema.properties).length,
+    [schema]
+  )
+  const isAdditionalPropertiesEmpty = useMemo(
+    () =>
+      !schema.additionalProperties ||
+      schema.additionalProperties.type !== "object" ||
+      !schema.additionalProperties.properties ||
+      !Object.values(schema.additionalProperties.properties).length,
+    [schema]
+  )
+
   if (
     (schema.type !== "object" && schema.type !== undefined) ||
-    (!schema.properties && !name)
+    (isPropertiesEmpty && isAdditionalPropertiesEmpty && !name)
   ) {
     return <></>
   }
@@ -65,22 +81,19 @@ const TagOperationParametersObject = ({
   }
 
   const getPropertyParameterElms = (isNested = false) => {
+    const properties = isPropertiesEmpty
+      ? schema.additionalProperties!.properties
+      : schema.properties
     // sort properties to show required fields first
-    const sortedProperties = Object.keys(schema.properties).sort(
+    const sortedProperties = Object.keys(properties).sort(
       (property1, property2) => {
-        schema.properties[property1].isRequired = checkRequired(
-          schema,
-          property1
-        )
-        schema.properties[property2].isRequired = checkRequired(
-          schema,
-          property2
-        )
+        properties[property1].isRequired = checkRequired(schema, property1)
+        properties[property2].isRequired = checkRequired(schema, property2)
 
-        return schema.properties[property1].isRequired &&
-          schema.properties[property2].isRequired
+        return properties[property1].isRequired &&
+          properties[property2].isRequired
           ? 0
-          : schema.properties[property1].isRequired
+          : properties[property1].isRequired
           ? -1
           : 1
       }
@@ -90,13 +103,12 @@ const TagOperationParametersObject = ({
         {sortedProperties.map((property, index) => (
           <TagOperationParameters
             schemaObject={{
-              ...schema.properties[property],
+              ...properties[property],
               parameterName: property,
             }}
             key={index}
             isRequired={
-              schema.properties[property].isRequired ||
-              checkRequired(schema, property)
+              properties[property].isRequired || checkRequired(schema, property)
             }
           />
         ))}
@@ -114,7 +126,7 @@ const TagOperationParametersObject = ({
     )
   }
 
-  if (!schema.properties || !Object.values(schema.properties).length) {
+  if (isPropertiesEmpty && isAdditionalPropertiesEmpty) {
     return getPropertyDescriptionElm()
   }
 

--- a/www/apps/api-reference/types/openapi.ts
+++ b/www/apps/api-reference/types/openapi.ts
@@ -72,9 +72,15 @@ export type ArraySchemaObject = Omit<
 
 export type NonArraySchemaObject = Omit<
   OpenAPIV3.NonArraySchemaObject,
-  "properties" | "anyOf" | "allOf" | "oneOf" | "examples"
+  | "properties"
+  | "anyOf"
+  | "allOf"
+  | "oneOf"
+  | "examples"
+  | "additionalProperties"
 > & {
   properties: PropertiesObject
+  additionalProperties?: SchemaObject
   anyOf?: SchemaObject[]
   allOf?: SchemaObject[]
   oneOf?: SchemaObject[]
@@ -90,6 +96,7 @@ export type SchemaObject = (ArraySchemaObject | NonArraySchemaObject) & {
   "x-featureFlag"?: string
   "x-expandable"?: string
   "x-schemaName"?: string
+  additionalProperties?: SchemaObject
 }
 
 export type PropertiesObject = {

--- a/www/utils/generated/oas-output/schemas/AdminWorkflowExecutionExecution.ts
+++ b/www/utils/generated/oas-output/schemas/AdminWorkflowExecutionExecution.ts
@@ -25,24 +25,24 @@
  *           description: The step's ID.
  *         invoke:
  *           type: object
- *           description: The step's invoke.
+ *           description: The state of the step's invokation function.
  *           x-schemaName: WorkflowExecutionFn
  *         definition:
  *           type: object
- *           description: The step's definition.
+ *           description: The step's definition details.
  *           x-schemaName: WorkflowExecutionDefinition
  *         compensate:
  *           type: object
- *           description: The step's compensate.
+ *           description: The state of the step's compensation function.
  *           x-schemaName: WorkflowExecutionFn
  *         depth:
  *           type: number
  *           title: depth
- *           description: The step's depth.
+ *           description: The step's depth in the workflow's execution.
  *         startedAt:
  *           type: number
  *           title: startedAt
- *           description: The step's startedat.
+ *           description: The timestamp the step started executing.
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminWorkflowExecutionExecution.ts
+++ b/www/utils/generated/oas-output/schemas/AdminWorkflowExecutionExecution.ts
@@ -8,7 +8,7 @@
  * properties:
  *   steps:
  *     type: object
- *     description: The execution's steps.
+ *     description: The execution's steps. Each object key is a step ID, and the value is the object whose properties are shown below.
  *     required:
  *       - id
  *       - invoke

--- a/www/utils/generated/oas-output/schemas/AdminWorkflowExecutionExecution.ts
+++ b/www/utils/generated/oas-output/schemas/AdminWorkflowExecutionExecution.ts
@@ -1,7 +1,7 @@
 /**
  * @schema AdminWorkflowExecutionExecution
  * type: object
- * description: The workflow execution's execution.
+ * description: The workflow execution's steps details.
  * x-schemaName: AdminWorkflowExecutionExecution
  * required:
  *   - steps
@@ -9,6 +9,40 @@
  *   steps:
  *     type: object
  *     description: The execution's steps.
+ *     required:
+ *       - id
+ *       - invoke
+ *       - definition
+ *       - compensate
+ *       - depth
+ *       - startedAt
+ *     additionalProperties:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           title: id
+ *           description: The step's ID.
+ *         invoke:
+ *           type: object
+ *           description: The step's invoke.
+ *           x-schemaName: WorkflowExecutionFn
+ *         definition:
+ *           type: object
+ *           description: The step's definition.
+ *           x-schemaName: WorkflowExecutionDefinition
+ *         compensate:
+ *           type: object
+ *           description: The step's compensate.
+ *           x-schemaName: WorkflowExecutionFn
+ *         depth:
+ *           type: number
+ *           title: depth
+ *           description: The step's depth.
+ *         startedAt:
+ *           type: number
+ *           title: startedAt
+ *           description: The step's startedat.
  * 
 */
 

--- a/www/utils/packages/docs-generator/src/commands/clean-oas.ts
+++ b/www/utils/packages/docs-generator/src/commands/clean-oas.ts
@@ -175,6 +175,30 @@ export default async function () {
       })
 
       // collect schemas
+      oas.parameters?.forEach((parameter) => {
+        if (oasSchemaHelper.isRefObject(parameter)) {
+          referencedSchemas.add(
+            oasSchemaHelper.normalizeSchemaName(parameter.$ref)
+          )
+
+          return
+        }
+
+        if (!parameter.schema) {
+          return
+        }
+
+        if (oasSchemaHelper.isRefObject(parameter.schema)) {
+          referencedSchemas.add(
+            oasSchemaHelper.normalizeSchemaName(parameter.schema.$ref)
+          )
+
+          return
+        }
+
+        testAndFindReferenceSchema(parameter.schema)
+      })
+
       if (oas.requestBody) {
         if (oasSchemaHelper.isRefObject(oas.requestBody)) {
           referencedSchemas.add(


### PR DESCRIPTION
## `medusa-oas-cli` package

- Fix circular patch not adding items to existing keys
- Generate the updated circular patch yaml

## docs-generator

- Fix `clean` command removing schemas references in query parameters' schemas
- Support `additionalProperties` for object types that have dynamic keys

## API reference

- Support showing `additionalProperties` similar to an object. As there is no good way of properly showing it, we have to rely on the description of a schema that has `additionalProperties` to convey that these properties are the value of the object, not the actual keys.