### PR TITLE
fix(types): fix referenes between store / admin types, change bigNumberValue in cart types

### DIFF
--- a/packages/core/types/src/http/cart/common.ts
+++ b/packages/core/types/src/http/cart/common.ts
@@ -1,4 +1,3 @@
-import { BigNumberValue } from "../../totals"
 import { BasePaymentCollection } from "../payment/common"
 import { BaseProduct, BaseProductVariant } from "../product/common"
 import { BaseRegion } from "../region/common"
@@ -94,112 +93,112 @@ export interface BaseCart {
   /**
    * The original item total of the cart.
    */
-  original_item_total: BigNumberValue
+  original_item_total: number
 
   /**
    * The original item subtotal of the cart.
    */
-  original_item_subtotal: BigNumberValue
+  original_item_subtotal: number
 
   /**
    * The original item tax total of the cart.
    */
-  original_item_tax_total: BigNumberValue
+  original_item_tax_total: number
 
   /**
    * The item total of the cart.
    */
-  item_total: BigNumberValue
+  item_total: number
 
   /**
    * The item subtotal of the cart.
    */
-  item_subtotal: BigNumberValue
+  item_subtotal: number
 
   /**
    * The item tax total of the cart.
    */
-  item_tax_total: BigNumberValue
+  item_tax_total: number
 
   /**
    * The original total of the cart.
    */
-  original_total: BigNumberValue
+  original_total: number
 
   /**
    * The original subtotal of the cart.
    */
-  original_subtotal: BigNumberValue
+  original_subtotal: number
 
   /**
    * The original tax total of the cart.
    */
-  original_tax_total: BigNumberValue
+  original_tax_total: number
 
   /**
    * The total of the cart.
    */
-  total: BigNumberValue
+  total: number
 
   /**
    * The subtotal of the cart. (Excluding taxes)
    */
-  subtotal: BigNumberValue
+  subtotal: number
 
   /**
    * The tax total of the cart.
    */
-  tax_total: BigNumberValue
+  tax_total: number
 
   /**
    * The discount total of the cart.
    */
-  discount_total: BigNumberValue
+  discount_total: number
 
   /**
    * The discount tax total of the cart.
    */
-  discount_tax_total: BigNumberValue
+  discount_tax_total: number
 
   /**
    * The gift card total of the cart.
    */
-  gift_card_total: BigNumberValue
+  gift_card_total: number
 
   /**
    * The gift card tax total of the cart.
    */
-  gift_card_tax_total: BigNumberValue
+  gift_card_tax_total: number
 
   /**
    * The shipping total of the cart.
    */
-  shipping_total: BigNumberValue
+  shipping_total: number
 
   /**
    * The shipping subtotal of the cart.
    */
-  shipping_subtotal: BigNumberValue
+  shipping_subtotal: number
 
   /**
    * The shipping tax total of the cart.
    */
-  shipping_tax_total: BigNumberValue
+  shipping_tax_total: number
 
   /**
    * The original shipping total of the cart.
    */
-  original_shipping_total: BigNumberValue
+  original_shipping_total: number
 
   /**
    * The original shipping subtotal of the cart.
    */
-  original_shipping_subtotal: BigNumberValue
+  original_shipping_subtotal: number
 
   /**
    * The original shipping tax total of the cart.
    */
-  original_shipping_tax_total: BigNumberValue
+  original_shipping_tax_total: number
 }
 
 export interface BaseCartAddress {
@@ -306,7 +305,7 @@ export interface BaseCartShippingMethod {
   /**
    * The price of the shipping method.
    */
-  amount: BigNumberValue
+  amount: number
 
   /**
    * Whether the shipping method price is tax inclusive.
@@ -355,42 +354,42 @@ export interface BaseCartShippingMethod {
   /**
    * The original total of the cart shipping method.
    */
-  original_total: BigNumberValue
+  original_total: number
 
   /**
    * The original subtotal of the cart shipping method.
    */
-  original_subtotal: BigNumberValue
+  original_subtotal: number
 
   /**
    * The original tax total of the cart shipping method.
    */
-  original_tax_total: BigNumberValue
+  original_tax_total: number
 
   /**
    * The total of the cart shipping method.
    */
-  total: BigNumberValue
+  total: number
 
   /**
    * The subtotal of the cart shipping method.
    */
-  subtotal: BigNumberValue
+  subtotal: number
 
   /**
    * The tax total of the cart shipping method.
    */
-  tax_total: BigNumberValue
+  tax_total: number
 
   /**
    * The discount total of the cart shipping method.
    */
-  discount_total: BigNumberValue
+  discount_total: number
 
   /**
    * The discount tax total of the cart shipping method.
    */
-  discount_tax_total: BigNumberValue
+  discount_tax_total: number
 }
 
 /**
@@ -420,7 +419,7 @@ export interface BaseCartLineItem extends BaseCartLineItemTotals {
   /**
    * The line item's quantity in the cart.
    */
-  quantity: BigNumberValue
+  quantity: number
 
   /**
    * The associated product with the line item.
@@ -514,12 +513,12 @@ export interface BaseCartLineItem extends BaseCartLineItemTotals {
   /**
    * The calculated price of the line item.
    */
-  compare_at_unit_price?: BigNumberValue
+  compare_at_unit_price?: number
 
   /**
    * The unit price of the item.
    */
-  unit_price: BigNumberValue
+  unit_price: number
 
   /**
    * The associated tax lines.
@@ -575,57 +574,57 @@ export interface BaseCartLineItemTotals {
   /**
    * The original total of the cart line item.
    */
-  original_total: BigNumberValue
+  original_total: number
 
   /**
    * The original subtotal of the cart line item.
    */
-  original_subtotal: BigNumberValue
+  original_subtotal: number
 
   /**
    * The original tax total of the cart line item.
    */
-  original_tax_total: BigNumberValue
+  original_tax_total: number
 
   /**
    * The item total of the cart line item.
    */
-  item_total: BigNumberValue
+  item_total: number
 
   /**
    * The item subtotal of the cart line item.
    */
-  item_subtotal: BigNumberValue
+  item_subtotal: number
 
   /**
    * The item tax total of the cart line item.
    */
-  item_tax_total: BigNumberValue
+  item_tax_total: number
 
   /**
    * The total of the cart line item.
    */
-  total: BigNumberValue
+  total: number
 
   /**
    * The subtotal of the cart line item.
    */
-  subtotal: BigNumberValue
+  subtotal: number
 
   /**
    * The tax total of the cart line item.
    */
-  tax_total: BigNumberValue
+  tax_total: number
 
   /**
    * The discount total of the cart line item.
    */
-  discount_total: BigNumberValue
+  discount_total: number
 
   /**
    * The discount tax total of the cart line item.
    */
-  discount_tax_total: BigNumberValue
+  discount_tax_total: number
 }
 
 /**
@@ -646,7 +645,7 @@ export interface BaseAdjustmentLine {
   /**
    * The amount to adjust the original amount with.
    */
-  amount: BigNumberValue
+  amount: number
 
   /**
    * The ID of the associated cart.
@@ -773,12 +772,12 @@ export interface BaseShippingMethodTaxLine extends BaseTaxLine {
   /**
    * The total tax relative to the shipping method.
    */
-  total: BigNumberValue
+  total: number
 
   /**
    * The subtotal tax relative to the shipping method.
    */
-  subtotal: BigNumberValue
+  subtotal: number
 }
 
 /**
@@ -798,10 +797,10 @@ export interface BaseLineItemTaxLine extends BaseTaxLine {
   /**
    * The total tax relative to the item.
    */
-  total: BigNumberValue
+  total: number
 
   /**
    * The subtotal tax relative to the item.
    */
-  subtotal: BigNumberValue
+  subtotal: number
 }

--- a/packages/core/types/src/http/cart/store/entities.ts
+++ b/packages/core/types/src/http/cart/store/entities.ts
@@ -1,3 +1,4 @@
+import { StoreProduct } from "../../product"
 import {
   BaseCart,
   BaseCartAddress,
@@ -5,7 +6,14 @@ import {
   BaseCartShippingMethod,
 } from "../common"
 
-export interface StoreCart extends BaseCart {}
-export interface StoreCartLineItem extends BaseCartLineItem {}
+export interface StoreCart extends BaseCart {
+  billing_address?: StoreCartAddress
+  shipping_address?: StoreCartAddress
+  items?: StoreCartLineItem[]
+}
+export interface StoreCartLineItem extends BaseCartLineItem {
+  product?: StoreProduct
+  cart: StoreCart
+}
 export interface StoreCartAddress extends BaseCartAddress {}
 export interface StoreCartShippingMethod extends BaseCartShippingMethod {}

--- a/packages/core/types/src/http/customer-group/admin/entities.ts
+++ b/packages/core/types/src/http/customer-group/admin/entities.ts
@@ -1,3 +1,6 @@
+import { AdminCustomer } from "../../customer/admin"
 import { BaseCustomerGroup } from "../common"
 
-export interface AdminCustomerGroup extends BaseCustomerGroup {}
+export interface AdminCustomerGroup extends BaseCustomerGroup {
+  customers: AdminCustomer[]
+}

--- a/packages/core/types/src/http/customer/admin/entities.ts
+++ b/packages/core/types/src/http/customer/admin/entities.ts
@@ -4,5 +4,6 @@ import { BaseCustomer, BaseCustomerAddress } from "../common"
 export interface AdminCustomer extends BaseCustomer {
   has_account: boolean
   groups?: AdminCustomerGroup[]
+  addresses: AdminCustomerAddress[]
 }
 export interface AdminCustomerAddress extends BaseCustomerAddress {}

--- a/packages/core/types/src/http/customer/store/entities.ts
+++ b/packages/core/types/src/http/customer/store/entities.ts
@@ -3,5 +3,7 @@ import {
   BaseCustomerAddress,
 } from "../common"
 
-export interface StoreCustomer extends BaseCustomer {}
+export interface StoreCustomer extends BaseCustomer {
+  addresses: StoreCustomerAddress[]
+}
 export interface StoreCustomerAddress extends BaseCustomerAddress {}

--- a/packages/core/types/src/http/order/admin/entities.ts
+++ b/packages/core/types/src/http/order/admin/entities.ts
@@ -1,6 +1,6 @@
 import { AdminCustomer } from "../../customer"
 import { AdminPaymentCollection } from "../../payment/admin"
-import { AdminProductVariant } from "../../product"
+import { AdminProduct, AdminProductVariant } from "../../product"
 import { AdminRegionCountry } from "../../region"
 import { AdminSalesChannel } from "../../sales-channel"
 import {
@@ -22,8 +22,9 @@ export interface AdminOrder extends BaseOrder {
   billing_address?: AdminOrderAddress | null
 }
 
-export interface AdminOrderLineItem extends BaseOrderLineItem {
+export interface AdminOrderLineItem extends Omit<BaseOrderLineItem, "variant" | "product"> {
   variant?: AdminProductVariant
+  product?: AdminProduct
 }
 export interface AdminOrderChange extends BaseOrderChange {}
 
@@ -41,8 +42,8 @@ export interface AdminOrderPreview
   extends Omit<AdminOrder, "items" | "shipping_methods"> {
   return_requested_total: number
   order_change: BaseOrderChange
-  items: (BaseOrderLineItem & { actions?: BaseOrderChangeAction[] })[]
-  shipping_methods: (BaseOrderShippingMethod & {
+  items: (AdminOrderLineItem & { actions?: BaseOrderChangeAction[] })[]
+  shipping_methods: (AdminOrderShippingMethod & {
     actions?: BaseOrderChangeAction[]
   })[]
 }

--- a/packages/core/types/src/http/product/admin/entitites.ts
+++ b/packages/core/types/src/http/product/admin/entitites.ts
@@ -13,10 +13,13 @@ import {
   ProductStatus,
 } from "../common"
 
-export interface AdminProductVariant extends BaseProductVariant {
+export interface AdminProductVariant extends Omit<BaseProductVariant, "product"> {
   prices: AdminPrice[] | null
+  product?: AdminProduct | null
 }
-export interface AdminProductOption extends BaseProductOption {}
+export interface AdminProductOption extends Omit<BaseProductOption, "product"> {
+  product?: AdminProduct
+}
 export interface AdminProductImage extends BaseProductImage {}
 export interface AdminProductOptionValue extends BaseProductOptionValue {}
 export interface AdminProduct

--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -30,7 +30,7 @@ export interface BaseProduct {
   type?: BaseProductType | null
   type_id: string | null
   tags?: BaseProductTag[] | null
-  variants: BaseProductVariant[] | null
+  variants?: BaseProductVariant[] | null
   options: BaseProductOption[] | null
   images: BaseProductImage[] | null
   discountable: boolean

--- a/packages/core/types/src/http/product/store/entitites.ts
+++ b/packages/core/types/src/http/product/store/entitites.ts
@@ -1,3 +1,4 @@
+import { StoreCollection } from "../../collection"
 import { StoreProductCategory } from "../../product-category"
 import { StoreProductType } from "../../product-type"
 import {
@@ -12,6 +13,7 @@ import {
 export interface StoreProduct extends Omit<BaseProduct, "categories"> {
   categories?: StoreProductCategory[] | null
   type?: StoreProductType | null
+  collection?: StoreCollection | null
 }
 export interface StoreProductVariant extends BaseProductVariant {}
 export interface StoreProductOption extends BaseProductOption {}


### PR DESCRIPTION
- Fix types referencing base entities rather than store / admin entities (mainly useful for OAS to not generate duplicate types unnecessarily, but also technically more correct)
- Use `number` type instead of `BigNumberValue` for cart's HTTP types.

> Q: Should we change usages of all `BigNumberValue` to `number` across HTTP types? From an http layer's perspective, a big number type doesn't hold a real meaning to it.