### PR TITLE
fix(oas): handle new keys in circular reference patch

### DIFF
--- a/packages/cli/oas/medusa-oas-cli/src/command-docs.ts
+++ b/packages/cli/oas/medusa-oas-cli/src/command-docs.ts
@@ -240,7 +240,7 @@ ${hint}
       const originalContent = await readYaml(redoclyConfigPath) as CircularReferenceConfig
       Object.keys(recommendation).forEach((recKey) => {
         originalContent.decorators["medusa/circular-patch"].schemas[recKey] = [
-          ...(originalContent.decorators["medusa/circular-patch"].schemas[recKey] || {}),
+          ...(originalContent.decorators["medusa/circular-patch"].schemas[recKey] || []),
           ...recommendation[recKey]
         ]
       })

--- a/packages/cli/oas/medusa-oas-cli/src/command-docs.ts
+++ b/packages/cli/oas/medusa-oas-cli/src/command-docs.ts
@@ -240,7 +240,7 @@ ${hint}
       const originalContent = await readYaml(redoclyConfigPath) as CircularReferenceConfig
       Object.keys(recommendation).forEach((recKey) => {
         originalContent.decorators["medusa/circular-patch"].schemas[recKey] = [
-          ...originalContent.decorators["medusa/circular-patch"].schemas[recKey],
+          ...(originalContent.decorators["medusa/circular-patch"].schemas[recKey] || {}),
           ...recommendation[recKey]
         ]
       })


### PR DESCRIPTION
Handle new keys in the circular references patch leading to undefined not being iterable error.