### PR TITLE
fix(user): check if user account with email already exist on invite create

### DIFF
--- a/packages/modules/user/integration-tests/__tests__/invite.spec.ts
+++ b/packages/modules/user/integration-tests/__tests__/invite.spec.ts
@@ -223,6 +223,29 @@ moduleIntegrationTestRunner<IUserModuleService>({
           )
         })
 
+        it("should throw if there is an existing user with the invite email", async () => {
+          let error
+          await service.createUsers([
+            {
+              email: "existing@email.com",
+            },
+          ])
+
+          try {
+            await service.createInvites([
+              {
+                email: "existing@email.com",
+              },
+            ])
+          } catch (e) {
+            error = e
+          }
+
+          expect(error.message).toBe(
+            `User account for following email(s) already exist: existing@email.com`
+          )
+        })
+
         it("should emit invite created events", async () => {
           const eventBusSpy = jest.spyOn(MockEventBusService.prototype, "emit")
           await service.createInvites(defaultInviteData)

--- a/packages/modules/user/src/services/user-module.ts
+++ b/packages/modules/user/src/services/user-module.ts
@@ -298,6 +298,19 @@ export default class UserModuleService
     data: UserTypes.CreateInviteDTO[],
     @MedusaContext() sharedContext: Context = {}
   ): Promise<Invite[]> {
+    const alreadyExistingUsers = await this.listUsers({
+      email: data.map((d) => d.email),
+    })
+
+    if (alreadyExistingUsers.length) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `User account for following email(s) already exist: ${alreadyExistingUsers
+          .map((u) => u.email)
+          .join(", ")}`
+      )
+    }
+
     const toCreate = data.map((invite) => {
       return {
         ...invite,


### PR DESCRIPTION
**What**
- when creating an invite, validate that provided email is not already used for existing user account

---

FIXES CC-513