### PR TITLE
fix(dashboard): customer groups table fileds

### DIFF
--- a/packages/admin/dashboard/src/routes/price-lists/common/components/price-list-customer-group-rule-form/price-list-customer-group-rule-form.tsx
+++ b/packages/admin/dashboard/src/routes/price-lists/common/components/price-list-customer-group-rule-form/price-list-customer-group-rule-form.tsx
@@ -60,7 +60,7 @@ export const PriceListCustomerGroupRuleForm = ({
   })
   const { customer_groups, count, isLoading, isError, error } =
     useCustomerGroups(
-      { ...searchParams, fields: "*customers.id" },
+      { ...searchParams, fields: "id,name,customers.id" },
       {
         placeholderData: keepPreviousData,
       }

--- a/packages/admin/dashboard/src/routes/price-lists/common/components/price-list-customer-group-rule-form/price-list-customer-group-rule-form.tsx
+++ b/packages/admin/dashboard/src/routes/price-lists/common/components/price-list-customer-group-rule-form/price-list-customer-group-rule-form.tsx
@@ -60,7 +60,7 @@ export const PriceListCustomerGroupRuleForm = ({
   })
   const { customer_groups, count, isLoading, isError, error } =
     useCustomerGroups(
-      { ...searchParams, fields: "customers.id" },
+      { ...searchParams, fields: "*customers.id" },
       {
         placeholderData: keepPreviousData,
       }


### PR DESCRIPTION
**What**
- a fix pushed this morning results in customer groups also having just id returned and other fields are omitted