### PR TITLE
fix(pricing): calculate pricing repository query

### DIFF
--- a/packages/modules/pricing/src/repositories/pricing.ts
+++ b/packages/modules/pricing/src/repositories/pricing.ts
@@ -141,7 +141,7 @@ export class PricingRepository
             this.orWhere("pl.rules_count", "=", 0)
           })
 
-          this.orWhere(function () {
+          this.andWhere(function () {
             this.andWhere(function () {
               for (const [key, value] of Object.entries(context)) {
                 this.orWhere({


### PR DESCRIPTION
**What**
- fix wrong parentheses nesting when generating calculate pricing query
- filter out deleted price lists
- use built in DB values for time comparison

---

![Screenshot 2024-09-23 at 22 18 25](https://github.com/user-attachments/assets/f2fa3891-9dab-4646-947a-50d9a8f937c6)
![Screenshot 2024-09-23 at 22 05 23](https://github.com/user-attachments/assets/7b58b671-6587-4882-800b-275cfcbf369e)

---

TODO:
- [x] check after price list start/end_date is modified, PL prices are not retrieved properly anymore

---

FIXES CC-518