### PR TITLE
fix(types): fix order DTO types

### DIFF
--- a/packages/core/types/src/http/claim/common.ts
+++ b/packages/core/types/src/http/claim/common.ts
@@ -27,7 +27,7 @@ export interface BaseClaim {
   type: OrderClaimType
   order_id: string
   return_id?: string
-  display_id: string
+  display_id: number
   order_version: string
   refund_amount?: number
   created_by?: string

--- a/packages/core/types/src/order/common.ts
+++ b/packages/core/types/src/order/common.ts
@@ -1828,7 +1828,7 @@ export interface OrderClaimDTO {
   /**
    * The version of the order when the claim is applied.
    */
-  order_version: string
+  order_version: number
 
   /**
    * The claim's display ID.
@@ -1935,7 +1935,7 @@ export interface OrderExchangeDTO {
   /**
    * The version of the order when the exchange is applied.
    */
-  order_version: string
+  order_version: number
 
   /**
    * The exchange's display ID.

--- a/packages/core/types/src/order/common.ts
+++ b/packages/core/types/src/order/common.ts
@@ -3,7 +3,7 @@ import { OperatorMap } from "../dal/utils"
 import { FulfillmentDTO } from "../fulfillment"
 import { PaymentCollectionDTO } from "../payment"
 import { BigNumberInput, BigNumberRawValue, BigNumberValue } from "../totals"
-import { ClaimReason } from "./mutations"
+import { ClaimReason, OrderClaimType } from "./mutations"
 
 /**
  * The change action's type.
@@ -115,6 +115,8 @@ export type OrderSummaryDTO = {
 
   /**
    * The raw pending difference of the order.
+   * 
+   * @ignore
    */
   raw_pending_difference: BigNumberRawValue
 }
@@ -277,11 +279,15 @@ export interface OrderShippingMethodTaxLineDTO extends OrderTaxLineDTO {
 
   /**
    * The raw total tax relative to the shipping method.
+   * 
+   * @ignore
    */
   raw_total: BigNumberRawValue
 
   /**
    * The raw subtotal tax relative to the shipping method.
+   * 
+   * @ignore
    */
   raw_subtotal: BigNumberRawValue
 }
@@ -314,11 +320,15 @@ export interface OrderLineItemTaxLineDTO extends OrderTaxLineDTO {
 
   /**
    * The raw total tax relative to the item.
+   * 
+   * @ignore
    */
   raw_total: BigNumberRawValue
 
   /**
    * The raw subtotal tax relative to the item.
+   * 
+   * @ignore
    */
   raw_subtotal: BigNumberRawValue
 }
@@ -434,6 +444,8 @@ export interface OrderShippingMethodDTO {
 
   /**
    * The raw price of the shipping method.
+   * 
+   * @ignore
    */
   raw_amount: BigNumberRawValue
 
@@ -523,41 +535,57 @@ export interface OrderShippingMethodDTO {
 
   /**
    * The raw original total of the order shipping method.
+   * 
+   * @ignore
    */
   raw_original_total: BigNumberRawValue
 
   /**
    * The raw original subtotal of the order shipping method.
+   * 
+   * @ignore
    */
   raw_original_subtotal: BigNumberRawValue
 
   /**
    * The raw original tax total of the order shipping method.
+   * 
+   * @ignore
    */
   raw_original_tax_total: BigNumberRawValue
 
   /**
    * The raw total of the order shipping method.
+   * 
+   * @ignore
    */
   raw_total: BigNumberRawValue
 
   /**
    * The raw subtotal of the order shipping method.
+   * 
+   * @ignore
    */
   raw_subtotal: BigNumberRawValue
 
   /**
    * The raw tax total of the order shipping method.
+   * 
+   * @ignore
    */
   raw_tax_total: BigNumberRawValue
 
   /**
    * The raw discount total of the order shipping method.
+   * 
+   * @ignore
    */
   raw_discount_total: BigNumberRawValue
 
   /**
    * The raw discount tax total of the order shipping method.
+   * 
+   * @ignore
    */
   raw_discount_tax_total: BigNumberRawValue
 }
@@ -633,66 +661,92 @@ export interface OrderLineItemTotalsDTO {
 
   /**
    * The raw original total of the order line item.
+   * 
+   * @ignore
    */
   raw_original_total: BigNumberRawValue
 
   /**
    * The raw original subtotal of the order line item.
+   * 
+   * @ignore
    */
   raw_original_subtotal: BigNumberRawValue
 
   /**
    * The raw original tax total of the order line item.
+   * 
+   * @ignore
    */
   raw_original_tax_total: BigNumberRawValue
 
   /**
    * The raw item total of the order line item.
+   * 
+   * @ignore
    */
   raw_item_total: BigNumberRawValue
 
   /**
    * The raw item subtotal of the order line item.
+   * 
+   * @ignore
    */
   raw_item_subtotal: BigNumberRawValue
 
   /**
    * The raw item tax total of the order line item.
+   * 
+   * @ignore
    */
   raw_item_tax_total: BigNumberRawValue
 
   /**
    * The raw total of the order line item.
+   * 
+   * @ignore
    */
   raw_total: BigNumberRawValue
 
   /**
    * The raw subtotal of the order line item.
+   * 
+   * @ignore
    */
   raw_subtotal: BigNumberRawValue
 
   /**
    * The raw tax total of the order line item.
+   * 
+   * @ignore
    */
   raw_tax_total: BigNumberRawValue
 
   /**
    * The raw discount total of the order line item.
+   * 
+   * @ignore
    */
   raw_discount_total: BigNumberRawValue
 
   /**
    * The raw discount tax total of the order line item.
+   * 
+   * @ignore
    */
   raw_discount_tax_total: BigNumberRawValue
 
   /**
    * The raw refundable total of the order line item..
+   * 
+   * @ignore
    */
   raw_refundable_total: BigNumberRawValue
 
   /**
    * The raw  refundable total per unit of the order line item.
+   * 
+   * @ignore
    */
   raw_refundable_total_per_unit: BigNumberRawValue
 }
@@ -803,6 +857,8 @@ export interface OrderLineItemDTO extends OrderLineItemTotalsDTO {
 
   /**
    * The raw compare at unit price of the line item.
+   * 
+   * @ignore
    */
   raw_compare_at_unit_price?: BigNumberRawValue
 
@@ -813,6 +869,8 @@ export interface OrderLineItemDTO extends OrderLineItemTotalsDTO {
 
   /**
    * The raw unit price of the line item.
+   * 
+   * @ignore
    */
   raw_unit_price: BigNumberRawValue
 
@@ -823,6 +881,8 @@ export interface OrderLineItemDTO extends OrderLineItemTotalsDTO {
 
   /**
    * The raw quantity of the line item.
+   * 
+   * @ignore
    */
   raw_quantity: BigNumberRawValue
 
@@ -889,6 +949,8 @@ export interface OrderItemDTO {
 
   /**
    * The raw quantity of the order line item.
+   * 
+   * @ignore
    */
   raw_quantity: BigNumberRawValue
 
@@ -899,6 +961,8 @@ export interface OrderItemDTO {
 
   /**
    * The raw fulfilled quantity of the order line item.
+   * 
+   * @ignore
    */
   raw_fulfilled_quantity: BigNumberRawValue
 
@@ -909,6 +973,8 @@ export interface OrderItemDTO {
 
   /**
    * The raw delivered quantity of the order line item.
+   * 
+   * @ignore
    */
   raw_delivered_quantity: BigNumberRawValue
 
@@ -919,6 +985,8 @@ export interface OrderItemDTO {
 
   /**
    * The raw shipped quantity of the order line item.
+   * 
+   * @ignore
    */
   raw_shipped_quantity: BigNumberRawValue
 
@@ -929,6 +997,8 @@ export interface OrderItemDTO {
 
   /**
    * The raw quantity of return requested for the order line item.
+   * 
+   * @ignore
    */
   raw_return_requested_quantity: BigNumberRawValue
 
@@ -939,6 +1009,8 @@ export interface OrderItemDTO {
 
   /**
    * The raw quantity of return received for the order line item.
+   * 
+   * @ignore
    */
   raw_return_received_quantity: BigNumberRawValue
 
@@ -949,6 +1021,8 @@ export interface OrderItemDTO {
 
   /**
    * The raw quantity of return dismissed for the order line item.
+   * 
+   * @ignore
    */
   raw_return_dismissed_quantity: BigNumberRawValue
 
@@ -959,6 +1033,8 @@ export interface OrderItemDTO {
 
   /**
    * The raw quantity of written off for the order line item.
+   * 
+   * @ignore
    */
   raw_written_off_quantity: BigNumberRawValue
 
@@ -1219,111 +1295,155 @@ export interface OrderDTO {
 
   /**
    * The raw original item total of the order.
+   * 
+   * @ignore
    */
   raw_original_item_total: BigNumberRawValue
 
   /**
    * The raw original item subtotal of the order.
+   * 
+   * @ignore
    */
   raw_original_item_subtotal: BigNumberRawValue
 
   /**
    * The raw original item tax total of the order.
+   * 
+   * @ignore
    */
   raw_original_item_tax_total: BigNumberRawValue
 
   /**
    * The raw item total of the order.
+   * 
+   * @ignore
    */
   raw_item_total: BigNumberRawValue
 
   /**
    * The raw item subtotal of the order.
+   * 
+   * @ignore
    */
   raw_item_subtotal: BigNumberRawValue
 
   /**
    * The raw item tax total of the order.
+   * 
+   * @ignore
    */
   raw_item_tax_total: BigNumberRawValue
 
   /**
    * The raw original total of the order.
+   * 
+   * @ignore
    */
   raw_original_total: BigNumberRawValue
 
   /**
    * The raw original subtotal of the order.
+   * 
+   * @ignore
    */
   raw_original_subtotal: BigNumberRawValue
 
   /**
    * The raw original tax total of the order.
+   * 
+   * @ignore
    */
   raw_original_tax_total: BigNumberRawValue
 
   /**
    * The raw total of the order.
+   * 
+   * @ignore
    */
   raw_total: BigNumberRawValue
 
   /**
    * The raw subtotal of the order. (Excluding taxes)
+   * 
+   * @ignore
    */
   raw_subtotal: BigNumberRawValue
 
   /**
    * The raw tax total of the order.
+   * 
+   * @ignore
    */
   raw_tax_total: BigNumberRawValue
 
   /**
    * The raw discount total of the order.
+   * 
+   * @ignore
    */
   raw_discount_total: BigNumberRawValue
 
   /**
    * The raw discount tax total of the order.
+   * 
+   * @ignore
    */
   raw_discount_tax_total: BigNumberRawValue
 
   /**
    * The raw gift card total of the order.
+   * 
+   * @ignore
    */
   raw_gift_card_total: BigNumberRawValue
 
   /**
    * The raw gift card tax total of the order.
+   * 
+   * @ignore
    */
   raw_gift_card_tax_total: BigNumberRawValue
 
   /**
    * The raw shipping total of the order.
+   * 
+   * @ignore
    */
   raw_shipping_total: BigNumberRawValue
 
   /**
    * The raw shipping subtotal of the order.
+   * 
+   * @ignore
    */
   raw_shipping_subtotal: BigNumberRawValue
 
   /**
    * The raw shipping tax total of the order.
+   * 
+   * @ignore
    */
   raw_shipping_tax_total: BigNumberRawValue
 
   /**
    * The raw original shipping total of the order.
+   * 
+   * @ignore
    */
   raw_original_shipping_total: BigNumberRawValue
 
   /**
    * The raw original shipping subtotal of the order.
+   * 
+   * @ignore
    */
   raw_original_shipping_subtotal: BigNumberRawValue
 
   /**
    * The raw original shipping tax total of the order.
+   * 
+   * @ignore
    */
   raw_original_shipping_tax_total: BigNumberRawValue
 }
@@ -1336,8 +1456,7 @@ type ReturnStatus = "requested" | "received" | "partially_received" | "canceled"
 /**
  * The return details.
  */
-export interface ReturnDTO
-  extends Omit<OrderDTO, "status" | "version" | "items"> {
+export interface ReturnDTO {
   /**
    * The ID of the return.
    */
@@ -1354,14 +1473,110 @@ export interface ReturnDTO
   refund_amount?: BigNumberValue
 
   /**
+   * The raw refund amount of the return.
+   */
+  raw_refund_amount?: BigNumberValue
+
+  /**
    * The associated order's ID.
    */
   order_id: string
 
   /**
+   * The associated order.
+   */
+  order?: OrderDTO
+
+  /**
    * The items of the return
    */
   items: OrderReturnItemDTO[]
+
+  /**
+   * The associated exchange's ID.
+   */
+  exchange_id?: string
+
+  /**
+   * The associated exchange.
+   */
+  exchange?: OrderExchangeDTO
+
+  /**
+   * The associated claim's ID.
+   */
+  claim_id?: string
+
+  /**
+   * The associated claim.
+   */
+  claim?: OrderClaimDTO
+
+  /**
+   * The return's display ID.
+   */
+  display_id: number
+
+  /**
+   * The ID of the location to return the items to.
+   */
+  location_id?: string
+
+  /**
+   * Whether the customer should receive notifications related
+   * to updates on the return.
+   */
+  no_notification?: boolean
+
+  /**
+   * The id of the user that created the return
+   */
+  created_by?: string | null
+
+  /**
+   * The shipping methods used to receive the returned items.
+   */
+  shipping_methods?: OrderShippingMethodDTO[]
+
+  /**
+   * The return's transactions if refund is required.
+   */
+  transactions?: OrderTransactionDTO[]
+
+  /**
+   * Holds custom data in key-value pairs.
+   */
+  metadata: Record<string, unknown> | null
+
+  /**
+   * The creation date of the return.
+   */
+  created_at?: Date | string
+
+  /**
+   * The update date of the return.
+   */
+  updated_at?: Date | string
+
+  /**
+   * The deletion date of the return.
+   */
+  deleted_at?: Date | string
+
+  /**
+   * The cancelation date of the return.
+   */
+  canceled_at?: Date | string
+
+  /**
+   * The request date of the return.
+   */
+  requested_at?: Date | string
+
+  /**
+   * The receival date of the return.
+   */
+  received_at?: Date | string
 }
 
 /**
@@ -1400,6 +1615,8 @@ export interface OrderReturnItemDTO {
 
   /**
    * The raw quantity of the item to return.
+   * 
+   * @ignore
    */
   raw_quantity: BigNumberRawValue
 
@@ -1410,6 +1627,8 @@ export interface OrderReturnItemDTO {
 
   /**
    * The raw received quantity of the return item.
+   * 
+   * @ignore
    */
   raw_received_quantity?: BigNumberRawValue
 
@@ -1454,6 +1673,11 @@ export interface OrderClaimItemDTO {
   item_id: string
 
   /**
+   * The associated item.
+   */
+  item: OrderLineItemDTO
+
+  /**
    * The quantity of the order claim item
    */
   quantity: number
@@ -1465,6 +1689,8 @@ export interface OrderClaimItemDTO {
 
   /**
    * The raw quantity of the order claim item
+   * 
+   * @ignore
    */
   raw_quantity: BigNumberRawValue
 
@@ -1544,12 +1770,19 @@ export interface OrderExchangeItemDTO {
   item_id: string
 
   /**
+   * The associated item.
+   */
+  item: OrderLineItemDTO
+
+  /**
    * The quantity of the order exchange item
    */
   quantity: number
 
   /**
    * The raw quantity of the order exchange item
+   * 
+   * @ignore
    */
   raw_quantity: BigNumberRawValue
 
@@ -1572,16 +1805,38 @@ export interface OrderExchangeItemDTO {
 /**
  * The claim details.
  */
-export interface OrderClaimDTO
-  extends Omit<OrderDTO, "status" | "version" | "items"> {
+export interface OrderClaimDTO {
+  /**
+   * The claim's ID.
+   */
+  id: string
+
+  /**
+   * The claim's type.
+   */
+  type: OrderClaimType
   /**
    * The ID of the associated order.
    */
   order_id: string
 
   /**
-   * The items to be received from the customer
-   * if the claim's type is `replace`.
+   * The associated order.
+   */
+  order?: OrderDTO
+
+  /**
+   * The version of the order when the claim is applied.
+   */
+  order_version: string
+
+  /**
+   * The claim's display ID.
+   */
+  display_id: number
+
+  /**
+   * The items to be received from the customer.
    */
   claim_items: any[]
 
@@ -1613,25 +1868,79 @@ export interface OrderClaimDTO
   refund_amount?: BigNumberValue
 
   /**
-   * The id of the user that creates the order claim
+   * The raw refund amount of the claim.
+   */
+  raw_refund_amount?: BigNumberValue
+
+  /**
+   * The id of the user that created the order claim
    */
   created_by?: string | null
+
+  /**
+   * The shipping methods used to send the additional items.
+   */
+  shipping_methods?: OrderShippingMethodDTO[]
+
+  /**
+   * The claim's transactions if additional payment is required.
+   */
+  transactions?: OrderTransactionDTO[]
+
+  /**
+   * Holds custom data in key-value pairs.
+   */
+  metadata: Record<string, unknown> | null
+
+  /**
+   * The creation date of the claim.
+   */
+  created_at?: Date | string
+
+  /**
+   * The update date of the claim.
+   */
+  updated_at?: Date | string
+
+  /**
+   * The deletion date of the claim.
+   */
+  deleted_at?: Date | string
+
+  /**
+   * The cancelation date of the claim.
+   */
+  canceled_at?: Date | string
 }
 
 /**
  * The exchange details.
  */
-export interface OrderExchangeDTO
-  extends Omit<OrderDTO, "status" | "version" | "items"> {
+export interface OrderExchangeDTO {
+  /**
+   * The exchange's ID.
+   */
+  id: string
+
   /**
    * The associated order's ID.
    */
   order_id: string
 
   /**
-   * The items to be returned from the customer.
+   * The associated order.
    */
-  return_items: any[]
+  order?: OrderDTO
+
+  /**
+   * The version of the order when the exchange is applied.
+   */
+  order_version: string
+
+  /**
+   * The exchange's display ID.
+   */
+  display_id: number
 
   /**
    * The items to be sent to the customer.
@@ -1654,6 +1963,20 @@ export interface OrderExchangeDTO
   difference_due?: BigNumberValue
 
   /**
+   * The raw difference due of the order exchange.
+   *
+   * - If less than `0`, the merchant owes the customer this amount.
+   * - If greater than `0`, the customer owes the merchange this amount.
+   * - If equal to `0`, no payment is required by either sides.
+   */
+  raw_difference_due?: BigNumberValue
+
+  /**
+   * Whether the variants that are out of stock can be added to the exchange.
+   */
+  allow_backorder?: boolean
+
+  /**
    * The associated return.
    */
   return?: ReturnDTO
@@ -1664,9 +1987,44 @@ export interface OrderExchangeDTO
   return_id?: string
 
   /**
-   * The id of the user that creates the order exchange
+   * The id of the user that created the order exchange
    */
   created_by?: string | null
+
+  /**
+   * The shipping methods used to send the additional items.
+   */
+  shipping_methods?: OrderShippingMethodDTO[]
+
+  /**
+   * The exchange's transactions if additional payment is required.
+   */
+  transactions?: OrderTransactionDTO[]
+
+  /**
+   * Holds custom data in key-value pairs.
+   */
+  metadata: Record<string, unknown> | null
+
+  /**
+   * The creation date of the exchange.
+   */
+  created_at?: Date | string
+
+  /**
+   * The update date of the exchange.
+   */
+  updated_at?: Date | string
+
+  /**
+   * The deletion date of the exchange.
+   */
+  deleted_at?: Date | string
+
+  /**
+   * The cancelation date of the exchange.
+   */
+  canceled_at?: Date | string
 }
 
 /**
@@ -1978,6 +2336,8 @@ export interface OrderTransactionDTO {
 
   /**
    * The raw amount of the transaction
+   * 
+   * @ignore
    */
   raw_amount: BigNumberRawValue
 
@@ -2035,6 +2395,8 @@ export interface OrderTransactionDTO {
 
   /**
    * The raw amount of the transaction
+   * 
+   * @ignore
    */
   raw_amount: BigNumberRawValue
 


### PR DESCRIPTION
- Fix claim / exchange / return extending an order (we previously addressed this in the http types)
- add `@ignore` for all `raw_*` fields to hide them from references.