### PR TITLE
fix(create-medusa-app): fix publishable api key not saving in .env.local

### DIFF
--- a/packages/cli/create-medusa-app/src/utils/prepare-project.ts
+++ b/packages/cli/create-medusa-app/src/utils/prepare-project.ts
@@ -246,7 +246,13 @@ export default async ({
 
       const originalContent = fs.readFileSync(nextjsEnvPath, "utf-8")
 
-      fs.appendFileSync(nextjsEnvPath, originalContent.replace("NEXT_PUBLIC_PUBLISHABLE_KEY=", `NEXT_PUBLIC_PUBLISHABLE_KEY=${apiKeys.rows[0].token}`))
+      fs.writeFileSync(
+        nextjsEnvPath, 
+        originalContent.replace(
+          "NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test", 
+          `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=${apiKeys.rows[0].token}`
+        )
+      )
     }
   }
 


### PR DESCRIPTION
Fix publishable API key not saving in .env following the rename of the env variable + fix content appending instead of replacing

Closes DOCS-951