### PR TITLE
docs: fix how api reference shows any type

### DIFF
--- a/www/apps/api-reference/components/Tags/Operation/Parameters/Description/index.tsx
+++ b/www/apps/api-reference/components/Tags/Operation/Parameters/Description/index.tsx
@@ -62,7 +62,7 @@ const TagOperationParametersDescription = ({
     default:
       typeDescription = (
         <>
-          {schema.type}
+          {!schema.type ? "any" : schema.type}
           {schema.nullable ? ` or null` : ""}
           {schema.format ? ` <${schema.format}>` : ""}
         </>


### PR DESCRIPTION
Show `any` types in the api reference