### PR TITLE
fix: plugin resolution from node_modules

### DIFF
--- a/packages/medusa/src/loaders/helpers/resolve-plugins.ts
+++ b/packages/medusa/src/loaders/helpers/resolve-plugins.ts
@@ -101,6 +101,17 @@ function resolvePlugin(pluginName: string): {
       })
     }
 
+    // Find the plugin in the node_modules folder
+    resolvedPath = path.resolve(`./node_modules/${pluginName}`)
+    const doesExistsInNodeModules = existsSync(resolvedPath)
+
+    if (doesExistsInNodeModules) {
+      return loadPluginDetails({
+        pluginName,
+        resolvedPath
+      })
+    }
+
     throw new Error(`Unable to find the plugin "${pluginName}".`)
   }
 


### PR DESCRIPTION
I'm developing a new project with version 2 and encountered the `Error: Unable to find the plugin "@medusajs/file-s3".` error after installing `@medusajs/file-s3` and configuring it based on the new config (wasn't in the docs but found the updated `s3_url`->`file_url` inside the codebase.

```js
module.exports = defineConfig({
  projectConfig: {
    ...
  }
  plugins: [
    {
      resolve: `@medusajs/file-s3`,
      options: {
        file_url: process.env.S3_URL,
        access_key_id: process.env.S3_ACCESS_KEY_ID,
        secret_access_key: process.env.S3_SECRET_ACCESS_KEY,
        region: process.env.S3_REGION,
        bucket: process.env.S3_BUCKET,                    
        prefix: process.env.S3_PREFIX,
      },
    }
  ],
  modules: {
    ...
  }
}
```
