### PR TITLE
fix: invalid mutation for product media gallery

### DIFF
--- a/packages/admin/dashboard/src/routes/products/product-media/components/product-media-gallery/product-media-gallery.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-media/components/product-media-gallery/product-media-gallery.tsx
@@ -89,7 +89,7 @@ export const ProductMediaGallery = ({ product }: ProductMediaGalleryProps) => {
 
     const mediaToKeep = product.images
       .filter((i) => i.id !== current.id)
-      .map((i) => i.url)
+      .map((i) => ({ url: i.url }))
 
     if (curr === media.length - 1) {
       setCurr((prev) => prev - 1)


### PR DESCRIPTION
On Version 2, the admin dashboard has an error

This PR fixes the following error on the product media gallery:

```json
{type: "invalid_data",…}
message
: 
"Invalid request: Expected type: 'object' for field 'images, 0', got: 'string'"
type
: 
"invalid_data"
```

Steps to reproduce: 

1. use the preview
2. navigate to a product with multiple images
3. don't click on edit. just click on an image
3. click on the trash icon
4. see error in terminal and browser console/network tab