### PR TITLE
fix(product): fix product variant update price with min_quantity and max_quantity

### DIFF
--- a/integration-tests/api/__tests__/admin/product.js
+++ b/integration-tests/api/__tests__/admin/product.js
@@ -2072,6 +2072,50 @@ medusaIntegrationTestRunner({
           )
         })
 
+        it("successfully updates a variant's default prices by changing an existing price (currency_code) with min_quantity and max_quantity", async () => {
+          const data = {
+            prices: [
+              {
+                currency_code: "usd",
+                amount: 1500,
+                min_quantity: 1,
+                max_quantity: 5,
+              },
+            ],
+          }
+
+          const response = await api.post(
+            `/admin/products/${baseProduct.id}/variants/${baseProduct.variants[0].id}`,
+            data,
+            adminHeaders
+          )
+
+          expect(
+            baseProduct.variants[0].prices.find(
+              (p) => p.currency_code === "usd"
+            ).amount
+          ).toEqual(100)
+          expect(response.status).toEqual(200)
+          expect(response.data).toEqual({
+            product: expect.objectContaining({
+              id: baseProduct.id,
+              variants: expect.arrayContaining([
+                expect.objectContaining({
+                  id: baseProduct.variants[0].id,
+                  prices: expect.arrayContaining([
+                    expect.objectContaining({
+                      amount: 1500,
+                      currency_code: "usd",
+                      min_quantity: 1,
+                      max_quantity: 5,
+                    }),
+                  ]),
+                }),
+              ]),
+            }),
+          })
+        })
+
         it("successfully updates a variant's prices by adding a new price", async () => {
           const usdPrice = baseProduct.variants[0].prices.find(
             (p) => p.currency_code === "usd"

--- a/packages/medusa/src/api/routes/admin/products/__tests__/update-variant.js
+++ b/packages/medusa/src/api/routes/admin/products/__tests__/update-variant.js
@@ -64,4 +64,58 @@ describe("POST /admin/products/:id/variants/:variantId", () => {
       expect(subject.body.product.id).toEqual(IdMap.getId("productWithOptions"))
     })
   })
+
+  describe("successful updates variant prices with min_quantity and max_quantity", () => {
+    let subject
+
+    beforeAll(async () => {
+      jest.clearAllMocks()
+      subject = await request(
+        "POST",
+        `/admin/products/${IdMap.getId(
+          "productWithOptions"
+        )}/variants/${IdMap.getId("variant1")}`,
+        {
+          payload: {
+            title: "hi",
+            prices: [
+              {
+                currency_code: "DKK",
+                amount: 100,
+                min_quantity: 1,
+                max_quantity: 5,
+              },
+            ],
+          },
+          adminSession: {
+            jwt: {
+              userId: IdMap.getId("admin_user"),
+            },
+          },
+        }
+      )
+    })
+
+    it("returns 200", () => {
+      expect(subject.status).toEqual(200)
+    })
+
+    it("filters prices", () => {
+      expect(ProductVariantServiceMock.update).toHaveBeenCalledTimes(1)
+      expect(ProductVariantServiceMock.update).toHaveBeenCalledWith(
+        IdMap.getId("variant1"),
+        expect.objectContaining({
+          title: "hi",
+          prices: [
+            {
+              currency_code: "DKK",
+              amount: 100,
+              min_quantity: 1,
+              max_quantity: 5,
+            },
+          ],
+        })
+      )
+    })
+  })
 })

--- a/packages/medusa/src/services/__tests__/product-variant.js
+++ b/packages/medusa/src/services/__tests__/product-variant.js
@@ -811,6 +811,7 @@ describe("ProductVariantService", () => {
         { id: IdMap.getId("dkk") },
         {
           amount: 850,
+          currency_code: "dkk",
         }
       )
     })

--- a/packages/medusa/src/services/product-variant.ts
+++ b/packages/medusa/src/services/product-variant.ts
@@ -658,6 +658,7 @@ class ProductVariantService extends TransactionBaseService {
           // No need to update if the amount is the same
           if (moneyAmount.amount !== price.amount) {
             dataToUpdate.push({
+              ...price,
               id: moneyAmount.id,
               amount: price.amount,
             })


### PR DESCRIPTION
## What : 
The issue is updating the variant price with min_quantity and max_quantity  always returned null for both these attributes. Which is not the expected behaviour based on the admin api reference. https://docs.medusajs.com/api/admin#products_postproductsproductvariantsvariant


## How : 
Make sure to include all the attributes when updating the variant price.

## Testing: 
Update variant price through api including min_quantity and max_quantity. 