### PR TITLE
docs(v1.x): fix incorrect display of route path

### DIFF
--- a/www/apps/api-reference/utils/get-paths-of-tag.ts
+++ b/www/apps/api-reference/utils/get-paths-of-tag.ts
@@ -29,7 +29,7 @@ export default async function getPathsOfTag(
       return {
         ...fileContent,
         operationPath: `/${file
-          .replaceAll("_", "/")
+          .replaceAll(/(?<!\{[^}]*)_(?![^{]*\})/g, "/")
           .replace(/\.[A-Za-z]+$/, "")}`,
       }
     })

--- a/www/apps/docs/content/development/entities/repositories.md
+++ b/www/apps/docs/content/development/entities/repositories.md
@@ -326,13 +326,13 @@ To update a record of an entity, use the `save` method of the repository:
 
 ```ts
 const data = {
-  title: 'some_title'
+  title: "some_title",
 }
 
 const post = await postRepository.findOne({
   where: {
-    id: '1'
-  }
+    id: "1",
+  },
 })
 
 Object.assign(post, data)

--- a/www/apps/docs/content/plugins/search/meilisearch.md
+++ b/www/apps/docs/content/plugins/search/meilisearch.md
@@ -134,7 +134,11 @@ const plugins = [
       settings: {
         products: {
           indexSettings: {
-            searchableAttributes: ["title", "description", "variant_sku"],
+            searchableAttributes: [
+              "title", 
+              "description", 
+              "variant_sku"
+            ],
             displayedAttributes: [
               "title",
               "description",


### PR DESCRIPTION
Fix for route paths, such as `/store/shipping-options/{cart_id}` where displayed as `/store/shipping-options/{cart\_id}`.

(Fix copied from `develop` branch)

Closes #9374