### PR TITLE
chore: add action to update starter dependencies + update reference actions

### DIFF
--- a/.github/workflows/generate-public-references.yml
+++ b/.github/workflows/generate-public-references.yml
@@ -6,8 +6,9 @@ on:
         description: "Reference to Generate. Use either `all` to generate all references, `api` to generate the API reference, or `ui` to generate UI reference."
         required: false
         default: "all"
-  release:
-    types: [published]
+  # Disable this action until v2 is out of RC
+  # release:
+  #   types: [published]
 
 jobs:
   api-v2:

--- a/.github/workflows/generate-rc-references.yml
+++ b/.github/workflows/generate-rc-references.yml
@@ -1,12 +1,11 @@
-name: Generate Preview Reference [Automated]
+name: Generate RC Reference [Automated]
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_call:
 jobs:
-  preview-references:
+  rc-references:
     uses: ./.github/workflows/generate-resources-reference.yml
-  preview-api:
+  rc-api:
     name: Generate OAS
     runs-on: ubuntu-latest
     steps:
@@ -65,7 +64,7 @@ jobs:
             www/utils/generated/oas-output
           branch: "docs/generate-api-ref"
           branch-suffix: "timestamp"
-  preview-dml:
+  rc-dml:
     name: Generate DML JSON files
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/generate-resources-reference.yml
+++ b/.github/workflows/generate-resources-reference.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   references:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (startsWith(github.head_ref, 'chore/generate-tsdocs') && github.event.pull_request.merged == true)
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release' || (startsWith(github.head_ref, 'chore/generate-tsdocs') && github.event.pull_request.merged == true)
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/trigger-update-starter.yml
+++ b/.github/workflows/trigger-update-starter.yml
@@ -1,16 +1,15 @@
 name: Trigger Starter Update
 
 on:
-  workflow_run:
-    workflows: [Trigger Release and Publish]
-    types:
-      - completed
+  release:
+    types: [published]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - if: ${{ contains(github.event.release.tag_name, 'rc') }}
+        run: |
           curl -X POST \
           -H "Authorization: Bearer ${{ secrets.STARTER_ACCESS_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \

--- a/.github/workflows/trigger-update-starter.yml
+++ b/.github/workflows/trigger-update-starter.yml
@@ -1,0 +1,18 @@
+name: Trigger Starter Update
+
+on:
+  workflow_run:
+    workflows: [Trigger Release and Publish]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.STARTER_ACCESS_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/medusajs/medusa-starter-default/actions/workflows/update-preview-deps.yml/dispatches \
+          -d '{"ref":"master"}'

--- a/.github/workflows/update-on-rc.yml
+++ b/.github/workflows/update-on-rc.yml
@@ -1,4 +1,4 @@
-name: Trigger Starter Update
+name: Update on RC Release
 
 on:
   release:
@@ -15,3 +15,5 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/medusajs/medusa-starter-default/actions/workflows/update-preview-deps.yml/dispatches \
           -d '{"ref":"master"}'
+  generate-references:
+    uses: ./.github/workflows/generate-preview-references.yml


### PR DESCRIPTION
- Add an action that triggers the starter's update dependencies action when a new release, whose tag includes `rc`, is out.
    - This only triggers the action to update the `feat/v2` branch. `feat/v2-ci` branch will keep updating every 3 hours similar to the preview.
- Update docs references to be generated only on rc releases (instead of once a day)