### PR TITLE
fix(dashboard): don't prefil invite email while onboarding

### DIFF
--- a/packages/admin/dashboard/src/routes/invite/invite.tsx
+++ b/packages/admin/dashboard/src/routes/invite/invite.tsx
@@ -175,10 +175,13 @@ const CreateView = ({
   const { t } = useTranslation()
   const [invalid, setInvalid] = useState(false)
 
+  const [params] = useSearchParams()
+  const isFirstRun = params.get("first_run") === "true" // true when the invite page is open during a "create medusa app" run
+
   const form = useForm<z.infer<typeof CreateAccountSchema>>({
     resolver: zodResolver(CreateAccountSchema),
     defaultValues: {
-      email: invite.email || "",
+      email: isFirstRun ? "" : invite.email || "",
       first_name: "",
       last_name: "",
       password: "",


### PR DESCRIPTION
**What**
- don't prefil invite email on when invite flow is started as a part of "create medusa app" flow

---

CLOSES CC-434