### PR TITLE
fix(dashboard): location details loader

### DIFF
--- a/packages/admin/dashboard/src/routes/locations/location-detail/loader.ts
+++ b/packages/admin/dashboard/src/routes/locations/location-detail/loader.ts
@@ -8,7 +8,9 @@ import { queryClient } from "../../../lib/query-client"
 import { detailsFields } from "./const"
 
 const locationQuery = (id: string) => ({
-  queryKey: stockLocationsQueryKeys.detail(id),
+  queryKey: stockLocationsQueryKeys.detail(id, {
+    fields: detailsFields,
+  }),
   queryFn: async () => {
     return await sdk.admin.stockLocation
       .retrieve(id, {


### PR DESCRIPTION
**What**
- fix location loader returning stale data if SL details are fetched with another field params

**Why**
- if we visit the order details page and visit location details afterwards, delivery and pickup will appear disabled because a new query with `fulfillment_sets` is not fetched