### PR TITLE
fix: Export all classes and types from the SDK

### DIFF
--- a/packages/core/js-sdk/src/index.ts
+++ b/packages/core/js-sdk/src/index.ts
@@ -21,4 +21,18 @@ class Medusa {
 }
 
 export default Medusa
-export { FetchError } from "./client"
+
+export { FetchError, Client } from "./client"
+export { Admin } from "./admin"
+export { Auth } from "./auth"
+export { Store } from "./store"
+export {
+  Config,
+  ClientHeaders,
+  ClientFetch,
+  FetchArgs,
+  FetchInput,
+  FetchStreamResponse,
+  Logger,
+  ServerSentEventMessage,
+} from "./types"


### PR DESCRIPTION
Extending the SDK is a common pattern, so having access to all underlying types and classes is important for creating a wrapper.