### PR TITLE
chore: Processing filters deeply looking at the current joiner first

### DIFF
--- a/packages/core/modules-sdk/src/remote-query/__fixtures__/parse-filters.ts
+++ b/packages/core/modules-sdk/src/remote-query/__fixtures__/parse-filters.ts
@@ -2,6 +2,27 @@ import { defineJoinerConfig } from "@medusajs/utils"
 import { MedusaModule } from "../../medusa-module"
 import { ModuleJoinerConfig } from "@medusajs/types"
 
+const customModuleJoinerConfig = defineJoinerConfig("custom_user", {
+  schema: `
+    type CustomProduct {
+      id: ID
+      title: String
+      product: Product
+    }
+    
+    type Product {
+      id: ID
+      title: String
+    }
+  `,
+  alias: [
+    {
+      name: ["custom_products", "custom_product"],
+      entity: "CustomProduct",
+    },
+  ],
+})
+
 const productJoinerConfig = defineJoinerConfig("product", {
   schema: `
     type Product {
@@ -154,6 +175,7 @@ const linkProductVariantPriceSet = {
 
 MedusaModule.setJoinerConfig("product", productJoinerConfig)
 MedusaModule.setJoinerConfig("pricing", pricingJoinerConfig)
+MedusaModule.setJoinerConfig("customProduct", customModuleJoinerConfig)
 MedusaModule.setJoinerConfig(
   "link-product-variant-price-set",
   linkProductVariantPriceSet

--- a/packages/core/modules-sdk/src/remote-query/__tests__/parse-filters.spec.ts
+++ b/packages/core/modules-sdk/src/remote-query/__tests__/parse-filters.spec.ts
@@ -11,6 +11,44 @@ const entitiesMap = getEntitiesMap(
 
 describe("parse-filters", () => {
   describe("Without operator map usage", () => {
+    it(`should parse filter for a single level module with ambiguous entity`, () => {
+      const filters = {
+        id: "string",
+        product: {
+          title: "test",
+        },
+      }
+
+      const remoteQueryObject = {
+        custom_product: {
+          fields: ["id", "product.*"],
+        },
+      }
+
+      parseAndAssignFilters(
+        {
+          remoteQueryObject,
+          entryPoint: "custom_product",
+          filters,
+        },
+        entitiesMap
+      )
+
+      expect(remoteQueryObject).toEqual({
+        custom_product: {
+          fields: ["id", "product.*"],
+          __args: {
+            filters: {
+              id: "string",
+              product: {
+                title: "test",
+              },
+            },
+          },
+        },
+      })
+    })
+
     it("should parse filter for a single level module", () => {
       const filters = {
         id: "string",

--- a/packages/core/modules-sdk/src/remote-query/parse-filters.ts
+++ b/packages/core/modules-sdk/src/remote-query/parse-filters.ts
@@ -44,13 +44,14 @@ export function parseAndAssignFilters(
     entryAlias = alias
     entryJoinerConfig = joinerConfig
 
-    const entryEntity = entitiesMap[entryAlias.entity!]
-    console.log(entryAlias.entity, entryEntity, entryEntity._fields)
+    // TODO: This check is not used further than to validate the entity is part of the graphql schema
+    // This can't be used right now as we have not migrated the entire code base to DML from which the graphql schema is generated
+    /*const entryEntity = entitiesMap[entryAlias.entity!]
     if (!entryEntity) {
       throw new Error(
         `Entity ${entryAlias.entity} not found in the public schema of the joiner config from ${entryJoinerConfig.serviceName}`
       )
-    }
+    }*/
 
     if (isObject(filterValue)) {
       for (const [nestedFilterKey, nestedFilterValue] of Object.entries(

--- a/packages/core/modules-sdk/src/remote-query/parse-filters.ts
+++ b/packages/core/modules-sdk/src/remote-query/parse-filters.ts
@@ -1,8 +1,4 @@
-import {
-  JoinerServiceConfig,
-  JoinerServiceConfigAlias,
-  ModuleJoinerConfig,
-} from "@medusajs/types"
+import { JoinerServiceConfig, ModuleJoinerConfig } from "@medusajs/types"
 import { isObject, isString } from "@medusajs/utils"
 import { MedusaModule } from "../medusa-module"
 
@@ -33,15 +29,15 @@ export function parseAndAssignFilters(
   const joinerConfigs = MedusaModule.getAllJoinerConfigs()
 
   for (const [filterKey, filterValue] of Object.entries(filters)) {
-    let entryAlias!: JoinerServiceConfigAlias
+    /*let entryAlias!: JoinerServiceConfigAlias*/
     let entryJoinerConfig!: JoinerServiceConfig
 
-    const { joinerConfig, alias } = retrieveJoinerConfigFromPropertyName({
+    const { joinerConfig /*alias*/ } = retrieveJoinerConfigFromPropertyName({
       entryPoint: entryPoint,
       joinerConfigs,
     })
 
-    entryAlias = alias
+    /*JoinerServiceConfigentryAlias = alias!*/
     entryJoinerConfig = joinerConfig
 
     // TODO: This check is not used further than to validate the entity is part of the graphql schema
@@ -134,9 +130,11 @@ function retrieveJoinerConfigFromPropertyName({
   }
 
   for (const joinerConfig of joinerConfigs) {
-    const aliases = Array.isArray(joinerConfig.alias)
-      ? joinerConfig.alias
-      : [joinerConfig.alias]
+    const joinerConfigAlias = joinerConfig.alias ?? []
+    const aliases = Array.isArray(joinerConfigAlias)
+      ? joinerConfigAlias
+      : [joinerConfigAlias]
+
     const entryPointAlias = aliases.find((alias) => {
       const aliasNames = Array.isArray(alias.name) ? alias.name : [alias.name]
       return aliasNames.some((alias) => alias === entryPoint)
@@ -162,9 +160,11 @@ function findAliasFromJoinerConfig({
   joinerConfig: ModuleJoinerConfig
   entryPoint: string
 }) {
-  const aliases = Array.isArray(joinerConfig.alias)
-    ? joinerConfig.alias
-    : [joinerConfig.alias]
+  const joinerConfigAlias = joinerConfig.alias ?? []
+  const aliases = Array.isArray(joinerConfigAlias)
+    ? joinerConfigAlias
+    : [joinerConfigAlias]
+
   const entryPointAlias = aliases.find((alias) => {
     const aliasNames = Array.isArray(alias.name) ? alias.name : [alias.name]
     return aliasNames.some((alias) => alias === entryPoint)
@@ -178,6 +178,8 @@ function findAliasFromJoinerConfig({
 
     return { joinerConfig, alias: entryPointAlias }
   }
+
+  return
 }
 
 function assignRemoteQueryObject({


### PR DESCRIPTION
**What**
- for deep filter first look at the parent filter joiner config before searching to any other joiner config to limit the risk of ambiguity
- Temporarely remove check on entities map until we have graph for everything