### PR TITLE
feature: allow using typescript path aliases when using ts-node

### DIFF
--- a/packages/cli/medusa-cli/cli.js
+++ b/packages/cli/medusa-cli/cli.js
@@ -2,6 +2,7 @@
 
 try {
   require("ts-node").register({})
+  require("tsconfig-paths").register({})
 } catch {}
 require("dotenv").config()
 require("./dist/index.js")


### PR DESCRIPTION
Fixes: FRMW-2734
Closes: #9351

Optionally registering the `tsconfig-paths` package to allow using TypeScript path aliases when using `ts-node`. 

The `tsconfig-paths` package must be installed within the starter for everything to work.