### PR TITLE
fix(dashboard): manage inventory flags

### DIFF
--- a/packages/admin/dashboard/src/routes/products/product-create/utils.ts
+++ b/packages/admin/dashboard/src/routes/products/product-create/utils.ts
@@ -57,8 +57,8 @@ export const normalizeVariants = (
       variant.custom_title || Object.values(variant.options || {}).join(" / "),
     options: variant.options,
     sku: variant.sku || undefined,
-    manage_inventory: variant.manage_inventory || undefined,
-    allow_backorder: variant.allow_backorder || undefined,
+    manage_inventory: !!variant.manage_inventory,
+    allow_backorder: !!variant.allow_backorder,
     inventory_items: variant
       .inventory!.map((i) => {
         const quantity = castNumber(i.required_quantity)


### PR DESCRIPTION
**What**
- allow to create a variant without managed inventory (we need to explicitly pass `false` now since the default on the model is `true` for `manage_inventory`)

---

FIXES CC-575