### PR TITLE
fix(core-flows, dashboard): inventory kit reservations

### DIFF
--- a/packages/admin/dashboard/src/hooks/api/order-edits.tsx
+++ b/packages/admin/dashboard/src/hooks/api/order-edits.tsx
@@ -6,6 +6,8 @@ import { sdk } from "../../lib/client"
 import { queryClient } from "../../lib/query-client"
 import { ordersQueryKeys } from "./orders"
 import { FetchError } from "@medusajs/js-sdk"
+import { reservationItemsQueryKeys } from "./reservations"
+import { inventoryItemsQueryKeys } from "./inventory.tsx"
 
 export const useCreateOrderEdit = (
   orderId: string,
@@ -82,6 +84,19 @@ export const useConfirmOrderEdit = (
       queryClient.invalidateQueries({
         queryKey: ordersQueryKeys.changes(id),
       })
+
+      queryClient.invalidateQueries({
+        queryKey: reservationItemsQueryKeys.lists(),
+      })
+
+      queryClient.invalidateQueries({
+        queryKey: inventoryItemsQueryKeys.lists(),
+      })
+
+      queryClient.invalidateQueries({
+        queryKey: inventoryItemsQueryKeys.details(),
+      })
+
       options?.onSuccess?.(data, variables, context)
     },
     ...options,

--- a/packages/core/core-flows/src/cart/steps/confirm-inventory.ts
+++ b/packages/core/core-flows/src/cart/steps/confirm-inventory.ts
@@ -1,4 +1,4 @@
-import { IInventoryService } from "@medusajs/framework/types"
+import { BigNumberInput, IInventoryService } from "@medusajs/framework/types"
 import {
   MathBN,
   MedusaError,
@@ -12,7 +12,7 @@ export interface ConfirmVariantInventoryStepInput {
     inventory_item_id: string
     required_quantity: number
     allow_backorder: boolean
-    quantity: number
+    quantity: BigNumberInput
     location_ids: string[]
   }[]
 }

--- a/packages/core/core-flows/src/cart/steps/reserve-inventory.ts
+++ b/packages/core/core-flows/src/cart/steps/reserve-inventory.ts
@@ -1,6 +1,7 @@
 import { IInventoryService } from "@medusajs/framework/types"
 import { MathBN, Modules } from "@medusajs/framework/utils"
 import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
+import { BigNumberInput } from "@medusajs/types"
 
 export interface ReserveVariantInventoryStepInput {
   items: {
@@ -8,7 +9,7 @@ export interface ReserveVariantInventoryStepInput {
     inventory_item_id: string
     required_quantity: number
     allow_backorder: boolean
-    quantity: number
+    quantity: BigNumberInput
     location_ids: string[]
   }[]
 }

--- a/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
+++ b/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
@@ -28,7 +28,7 @@ interface ConfirmInventoryItem {
   inventory_item_id: string
   required_quantity: number
   allow_backorder: boolean
-  quantity: number
+  quantity: BigNumberInput
   location_ids: string[]
 }
 
@@ -160,7 +160,7 @@ const formatInventoryInput = ({
         inventory_item_id: variantInventoryItem.inventory_item_id,
         required_quantity: variantInventoryItem.required_quantity,
         allow_backorder: !!variant.allow_backorder,
-        quantity: item.quantity as number, // TODO: update type to BigNumberInput
+        quantity: item.quantity,
         location_ids: location_ids,
       })
     )

--- a/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
+++ b/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
@@ -143,25 +143,27 @@ const formatInventoryInput = ({
       return
     }
 
-    const variantInventoryItem = product_variant_inventory_items.find(
+    const variantInventoryItems = product_variant_inventory_items.filter(
       (i) => i.variant_id === item.variant_id
     )
 
-    if (!variantInventoryItem) {
+    if (!variantInventoryItems.length) {
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
         `Variant ${item.variant_id} does not have any inventory items associated with it.`
       )
     }
 
-    itemsToConfirm.push({
-      id: item.id,
-      inventory_item_id: variantInventoryItem.inventory_item_id,
-      required_quantity: variantInventoryItem.required_quantity,
-      allow_backorder: !!variant.allow_backorder,
-      quantity: item.quantity as number, // TODO: update type to BigNumberInput
-      location_ids: location_ids,
-    })
+    variantInventoryItems.forEach((variantInventoryItem) =>
+      itemsToConfirm.push({
+        id: item.id,
+        inventory_item_id: variantInventoryItem.inventory_item_id,
+        required_quantity: variantInventoryItem.required_quantity,
+        allow_backorder: !!variant.allow_backorder,
+        quantity: item.quantity as number, // TODO: update type to BigNumberInput
+        location_ids: location_ids,
+      })
+    )
   })
 
   return itemsToConfirm

--- a/packages/core/core-flows/src/cart/workflows/confirm-variant-inventory.ts
+++ b/packages/core/core-flows/src/cart/workflows/confirm-variant-inventory.ts
@@ -5,6 +5,7 @@ import {
   createWorkflow,
   transform,
 } from "@medusajs/framework/workflows-sdk"
+import { BigNumberInput } from "@medusajs/types"
 import { confirmInventoryStep } from "../steps"
 import { prepareConfirmInventoryInput } from "../utils/prepare-confirm-inventory-input"
 
@@ -14,7 +15,7 @@ export interface ConfirmVariantInventoryWorkflowOutput {
     inventory_item_id: string
     required_quantity: number
     allow_backorder: boolean
-    quantity: number
+    quantity: BigNumberInput
     location_ids: string[]
   }[]
 }

--- a/packages/core/core-flows/src/order/workflows/order-edit/confirm-order-edit-request.ts
+++ b/packages/core/core-flows/src/order/workflows/order-edit/confirm-order-edit-request.ts
@@ -137,7 +137,9 @@ export const confirmOrderEditRequestWorkflow = createWorkflow(
       { orderItems, previousOrderItems: order.items },
 
       (data) => {
-        const previousItemIds = data.previousOrderItems!.map(({ id }) => id) // items that have been removed with the change
+        const previousItemIds = (data.previousOrderItems || []).map(
+          ({ id }) => id
+        ) // items that have been removed with the change
         const newItemIds = data.orderItems.items.map(({ id }) => id)
         return [...new Set([...previousItemIds, newItemIds])]
       }


### PR DESCRIPTION
**What**
- fix `prepareConfirmInventory` to account for inventory kit items
  - _note: this step is reused in the complete cart and all RMA flows_ 
- properly remove reservations for items that are removed from the order edit
- invalidate inventory/reservations cache when order edit is confirmed

---

https://github.com/user-attachments/assets/f12e9198-0718-4c08-bd81-efc536eca146

---

FIXES CC-565