### PR TITLE
fix(types): fix parameter types for the order module's service

### DIFF
--- a/packages/core/types/src/order/service.ts
+++ b/packages/core/types/src/order/service.ts
@@ -48,7 +48,6 @@ import {
   CancelOrderReturnDTO,
   ConfirmOrderChangeDTO,
   CreateOrderAddressDTO,
-  CreateOrderAdjustmentDTO,
   CreateOrderChangeActionDTO,
   CreateOrderChangeDTO,
   CreateOrderClaimDTO,

--- a/packages/core/types/src/order/service.ts
+++ b/packages/core/types/src/order/service.ts
@@ -56,6 +56,7 @@ import {
   CreateOrderDTO,
   CreateOrderExchangeDTO,
   CreateOrderExchangeItemDTO,
+  CreateOrderLineItemAdjustmentDTO,
   CreateOrderLineItemDTO,
   CreateOrderLineItemTaxLineDTO,
   CreateOrderReturnDTO,
@@ -1539,7 +1540,7 @@ export interface IOrderModuleService extends IModuleService {
   /**
    * This method creates line item adjustments.
    *
-   * @param {CreateOrderAdjustmentDTO[]} data - The line item adjustments to be created.
+   * @param {CreateOrderLineItemAdjustmentDTO[]} data - The line item adjustments to be created.
    * @returns {Promise<OrderLineItemAdjustmentDTO[]>} The created line item adjustments.
    *
    * @example
@@ -1548,14 +1549,14 @@ export interface IOrderModuleService extends IModuleService {
    * }])
    */
   createOrderLineItemAdjustments(
-    data: CreateOrderAdjustmentDTO[],
+    data: CreateOrderLineItemAdjustmentDTO[],
     sharedContext?: Context
   ): Promise<OrderLineItemAdjustmentDTO[]>
 
   /**
    * This method creates a line item adjustment.
    *
-   * @param {CreateOrderAdjustmentDTO} data - The line-item adjustment to be created.
+   * @param {CreateOrderLineItemAdjustmentDTO} data - The line-item adjustment to be created.
    * @returns {Promise<OrderLineItemAdjustmentDTO[]>} The created line-item adjustment.
    *
    * @example
@@ -1564,7 +1565,7 @@ export interface IOrderModuleService extends IModuleService {
    * })
    */
   createOrderLineItemAdjustments(
-    data: CreateOrderAdjustmentDTO,
+    data: CreateOrderLineItemAdjustmentDTO,
     sharedContext?: Context
   ): Promise<OrderLineItemAdjustmentDTO[]>
 
@@ -1572,7 +1573,7 @@ export interface IOrderModuleService extends IModuleService {
    * This method creates line item adjustments for an order.
    *
    * @param {string} orderId - The order's ID.
-   * @param {CreateOrderAdjustmentDTO[]} data - The line-item adjustments to be created.
+   * @param {CreateOrderLineItemAdjustmentDTO[]} data - The line-item adjustments to be created.
    * @returns {Promise<OrderLineItemAdjustmentDTO[]>} The created line item adjustments.
    *
    * @example
@@ -1585,7 +1586,7 @@ export interface IOrderModuleService extends IModuleService {
    */
   createOrderLineItemAdjustments(
     orderId: string,
-    data: CreateOrderAdjustmentDTO[],
+    data: CreateOrderLineItemAdjustmentDTO[],
     sharedContext?: Context
   ): Promise<OrderLineItemAdjustmentDTO[]>
 


### PR DESCRIPTION
Use correct type for the `createOrderLineItemAdjustments` method. The module uses the correct type, only the service has the incorrect one.