### PR TITLE
fix: add metadata to collection resp

### DIFF
--- a/integration-tests/http/__tests__/collection/admin/colllection.spec.ts
+++ b/integration-tests/http/__tests__/collection/admin/colllection.spec.ts
@@ -77,17 +77,16 @@ medusaIntegrationTestRunner({
         )
 
         expect(response.status).toEqual(200)
-        expect(response.data).toEqual(
-          expect.objectContaining({
-            collection: expect.objectContaining({
-              id: expect.stringMatching(/^pcol_*/),
-              title: "New collection",
-              handle: "test-new-collection",
-              created_at: expect.any(String),
-              updated_at: expect.any(String),
-            }),
-          })
-        )
+        expect(response.data).toEqual({
+          collection: {
+            id: expect.stringMatching(/^pcol_*/),
+            title: "New collection",
+            handle: "test-new-collection",
+            created_at: expect.any(String),
+            updated_at: expect.any(String),
+            metadata: null,
+          },
+        })
       })
 
       it("lists collections", async () => {
@@ -96,22 +95,33 @@ medusaIntegrationTestRunner({
         expect(response.data).toEqual(
           expect.objectContaining({
             count: 3,
+            limit: 10,
+            offset: 0,
             collections: expect.arrayContaining([
-              expect.objectContaining({
-                id: baseCollection2.id,
-                created_at: expect.any(String),
-                updated_at: expect.any(String),
-              }),
-              expect.objectContaining({
-                id: baseCollection1.id,
-                created_at: expect.any(String),
-                updated_at: expect.any(String),
-              }),
-              expect.objectContaining({
+              {
                 id: baseCollection.id,
                 created_at: expect.any(String),
                 updated_at: expect.any(String),
-              }),
+                handle: "test-collection",
+                metadata: null,
+                title: "test-collection",
+              },
+              {
+                id: baseCollection1.id,
+                created_at: expect.any(String),
+                updated_at: expect.any(String),
+                handle: "test-collection1",
+                metadata: null,
+                title: "test-collection1",
+              },
+              {
+                id: baseCollection2.id,
+                created_at: expect.any(String),
+                updated_at: expect.any(String),
+                handle: "test-collection2",
+                metadata: null,
+                title: "test-collection2",
+              },
             ]),
           })
         )
@@ -127,11 +137,14 @@ medusaIntegrationTestRunner({
           expect.objectContaining({
             count: 1,
             collections: expect.arrayContaining([
-              expect.objectContaining({
+              {
                 id: baseCollection.id,
                 created_at: expect.any(String),
                 updated_at: expect.any(String),
-              }),
+                handle: "test-collection",
+                metadata: null,
+                title: "test-collection",
+              },
             ]),
           })
         )
@@ -154,13 +167,14 @@ medusaIntegrationTestRunner({
         expect(response.status).toEqual(200)
         expect(response.data).toEqual(
           expect.objectContaining({
-            collection: expect.objectContaining({
+            collection: {
               id: expect.stringMatching(/^pcol_*/),
               title: "test collection creation",
               handle: "test-handle-creation",
               created_at: expect.any(String),
               updated_at: expect.any(String),
-            }),
+              metadata: null,
+            },
           })
         )
       })

--- a/packages/medusa/src/api/admin/collections/query-config.ts
+++ b/packages/medusa/src/api/admin/collections/query-config.ts
@@ -4,6 +4,7 @@ export const defaultAdminCollectionFields = [
   "handle",
   "created_at",
   "updated_at",
+  "metadata",
 ]
 
 export const retrieveTransformQueryConfig = {


### PR DESCRIPTION
**What**
- Adds `metadata` to the default response for `/admin/collection` endpoints.
- Fixes tests to expect correct shape and not use objectContaining.

Fixes CC-551