### PR TITLE
fix: add metadata to product type resp

### DIFF
--- a/integration-tests/http/__tests__/product-type/admin/product-type.spec.ts
+++ b/integration-tests/http/__tests__/product-type/admin/product-type.spec.ts
@@ -44,12 +44,20 @@ medusaIntegrationTestRunner({
         expect(res.status).toEqual(200)
         expect(res.data.product_types).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({
+            {
+              id: expect.stringMatching(/ptyp_.{24}/),
               value: "test1",
-            }),
-            expect.objectContaining({
+              created_at: expect.any(String),
+              updated_at: expect.any(String),
+              metadata: null,
+            },
+            {
+              id: expect.stringMatching(/ptyp_.{24}/),
               value: "test2",
-            }),
+              created_at: expect.any(String),
+              updated_at: expect.any(String),
+              metadata: null,
+            },
           ])
         )
       })
@@ -61,13 +69,35 @@ medusaIntegrationTestRunner({
 
         // The value of the type should match the search param
         expect(res.data.product_types).toEqual([
-          expect.objectContaining({
+          {
+            id: expect.stringMatching(/ptyp_.{24}/),
             value: "test1",
-          }),
+            created_at: expect.any(String),
+            updated_at: expect.any(String),
+            metadata: null,
+          },
         ])
       })
 
       // BREAKING: Removed a test around filtering based on discount condition id, which is no longer supported
+    })
+
+    describe("/admin/product-types/:id", () => {
+      it("returns a product type", async () => {
+        const res = await api.get(
+          `/admin/product-types/${type1.id}`,
+          adminHeaders
+        )
+
+        expect(res.status).toEqual(200)
+        expect(res.data.product_type).toEqual({
+          id: expect.stringMatching(/ptyp_.{24}/),
+          value: "test1",
+          created_at: expect.any(String),
+          updated_at: expect.any(String),
+          metadata: null,
+        })
+      })
     })
   },
 })

--- a/packages/medusa/src/api/admin/product-types/query-config.ts
+++ b/packages/medusa/src/api/admin/product-types/query-config.ts
@@ -3,6 +3,7 @@ export const defaultAdminProductTypeFields = [
   "value",
   "created_at",
   "updated_at",
+  "metadata",
 ]
 
 export const retrieveProductTypeTransformQueryConfig = {


### PR DESCRIPTION
**What**
- Adds metadata to the default response for `/admin/product-types` endpoints.
- Fixes tests to expect correct shape and not use `objectContaining`.

Fixes CC-552