### PR TITLE
docs: Fix link to the correct AuthIdentity model's page

### DIFF
--- a/www/apps/resources/app/commerce-modules/auth/auth-identity-and-actor-types/page.mdx
+++ b/www/apps/resources/app/commerce-modules/auth/auth-identity-and-actor-types/page.mdx
@@ -8,7 +8,7 @@ In this document, you’ll learn about concepts related to identity and actors i
 
 ## What is an Auth Identity?
 
-The [AuthIdentity data model](/references/auth/model/AuthIdentity) represents a registered user.
+The [AuthIdentity data model](/references/auth/models/AuthIdentity) represents a registered user.
 
 When a user is registered, a record of `AuthIdentity` is created. This record is used to validate the user’s authentication in future requests.
 


### PR DESCRIPTION
I think there is a bug on the link to the `AuthIdentity ` model's page. The page containing the issue can be found [here](https://docs.medusajs.com/v2/resources/commerce-modules/auth/auth-identity-and-actor-types#what-is-an-auth-identity)