### PR TITLE
fix(dashboard): Adds routes for handling tax overrides for provinces

### DIFF
--- a/packages/admin/dashboard/src/index.css
+++ b/packages/admin/dashboard/src/index.css
@@ -30,7 +30,6 @@
   :root {
     @apply bg-ui-bg-subtle text-ui-fg-base antialiased;
     text-rendering: optimizeLegibility;
-    color-scheme: light dark;
   }
 }
 

--- a/packages/admin/dashboard/src/providers/router-provider/route-map.tsx
+++ b/packages/admin/dashboard/src/providers/router-provider/route-map.tsx
@@ -1347,6 +1347,20 @@ export const RouteMap: RouteObject[] = [
                             "../../routes/tax-regions/tax-region-tax-rate-edit"
                           ),
                       },
+                      {
+                        path: "overrides/create",
+                        lazy: () =>
+                          import(
+                            "../../routes/tax-regions/tax-region-tax-override-create"
+                          ),
+                      },
+                      {
+                        path: "overrides/:tax_rate_id/edit",
+                        lazy: () =>
+                          import(
+                            "../../routes/tax-regions/tax-region-tax-override-edit"
+                          ),
+                      },
                     ],
                   },
                 ],

--- a/packages/admin/dashboard/src/providers/theme-provider/theme-provider.tsx
+++ b/packages/admin/dashboard/src/providers/theme-provider/theme-provider.tsx
@@ -64,6 +64,8 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
 
       html.classList.remove(value === "light" ? "dark" : "light")
       html.classList.add(value)
+      // Ensures that native elements respect the theme, e.g. the scrollbar.
+      html.style.colorScheme = value
 
       /**
        * Re-enable transitions after the theme has been set,

--- a/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-create/tax-region-tax-override-create.tsx
+++ b/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-create/tax-region-tax-override-create.tsx
@@ -4,9 +4,11 @@ import { useTaxRegion } from "../../../hooks/api/tax-regions"
 import { TaxRegionCreateTaxOverrideForm } from "./components/tax-region-override-create-form"
 
 export const TaxRegionCreateTaxOverride = () => {
-  const { id } = useParams()
+  const { id, province_id } = useParams()
 
-  const { tax_region, isPending, isError, error } = useTaxRegion(id!)
+  const { tax_region, isPending, isError, error } = useTaxRegion(
+    province_id || id!
+  )
 
   const ready = !isPending && !!tax_region
 


### PR DESCRIPTION
**What**
- Adds routes for creating and editing tax overrides for provinces.
- Fixes an issue where color-schema, was locked to the users OS settings. E.g. if the users OS was in light mode, but the admin in darkmode, then the scrollbars would be light mode.

Resolves CC-548