### PR TITLE
fix(dashboard): Show progress on tabs in create form

### DIFF
--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -1803,6 +1803,7 @@
         "title": "Status"
       },
       "method": {
+        "label": "Method",
         "code": {
           "title": "Promotion code",
           "description": "Customers must enter this code at checkout"

--- a/packages/admin/dashboard/src/routes/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
@@ -82,7 +82,7 @@ export const EditPromotionDetailsForm = ({
               render={({ field }) => {
                 return (
                   <Form.Item>
-                    <Form.Label>Method</Form.Label>
+                    <Form.Label>{t("promotions.form.method.label")}</Form.Label>
                     <Form.Control>
                       <RadioGroup
                         className="flex-col gap-y-3"


### PR DESCRIPTION
**What**
- Shows progress on tabs in create promotion form. This is a bit of a band-aid fix, the promotion form and domain needs some proper cleanup, but this will work for now.
- Adds missing translation of "Method" field.

Resolves CC-113