### PR TITLE
fix(dashboard): Hide note input on orders

### DIFF
--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-activity-section/order-activity-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-activity-section/order-activity-section.tsx
@@ -1,7 +1,6 @@
 import { AdminOrder } from "@medusajs/types"
 import { Container, Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
-import { OrderNoteForm } from "./order-note-form"
 import { OrderTimeline } from "./order-timeline"
 
 type OrderActivityProps = {
@@ -17,7 +16,8 @@ export const OrderActivitySection = ({ order }: OrderActivityProps) => {
         <div className="flex items-center justify-between">
           <Heading level="h2">{t("orders.activity.header")}</Heading>
         </div>
-        <OrderNoteForm order={order} />
+        {/* TODO: Re-add when we have support for notes */}
+        {/* <OrderNoteForm order={order} /> */}
       </div>
       <OrderTimeline order={order} />
     </Container>


### PR DESCRIPTION
**What**
- Hides the input for notes on the order details page.
- Should be re-added once we have support, so I have just commented out the component.