### PR TITLE
fix: remove default value for the cluster flag

### DIFF
--- a/packages/cli/medusa-cli/src/create-cli.ts
+++ b/packages/cli/medusa-cli/src/create-cli.ts
@@ -339,7 +339,6 @@ function buildLocalCommands(cli, isLocalProject) {
           })
           .option(`cluster`, {
             type: `number`,
-            default: process.env.CPUS,
             describe:
               "Start the Node.js server in cluster mode. You can specify the number of cpus to use, which defaults to (env.CPUS)",
           }),


### PR DESCRIPTION
Defining the default value applies the flag automatically and hence activates the cluster mode.