### PR TITLE
docs: update providers to use ModuleProvider

### DIFF
--- a/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
@@ -62,7 +62,7 @@ const customOptions: Record<string, Partial<TypeDocOptions>> = {
     ],
   }),
   "medusa-config": getOptions({
-    entryPointPath: "packages/frameworksrc/config/types.ts",
+    entryPointPath: "packages/framework/src/config/types.ts",
     tsConfigName: "framework.json",
     name: "medusa-config",
   }),

--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/auth-provider.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/auth-provider.ts
@@ -39,10 +39,14 @@ Create the file \`src/modules/my-auth/index.ts\` with the following content:
 
 \`\`\`ts title="src/modules/my-auth/index.ts"
 import MyAuthProviderService from "./service"
+import { 
+  ModuleProvider, 
+  Modules
+} from "@medusajs/framework/utils"
 
-export default {
+export default ModuleProvider(Modules.AUTH, {
   services: [MyAuthProviderService],
-}
+})
 \`\`\`
 
 This exports the module's definition, indicating that the \`MyAuthProviderService\` is the module's service.`,

--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/file.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/file.ts
@@ -39,10 +39,14 @@ Create the file \`src/modules/my-file/index.ts\` with the following content:
 
 \`\`\`ts title="src/modules/my-file/index.ts"
 import MyFileProviderService from "./service"
+import { 
+  ModuleProvider, 
+  Modules
+} from "@medusajs/framework/utils"
 
-export default {
+export default ModuleProvider(Modules.FILE, {
   services: [MyFileProviderService],
-}
+})
 \`\`\`
 
 This exports the module's definition, indicating that the \`MyFileProviderService\` is the module's service.`,

--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/fulfillment-provider.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/fulfillment-provider.ts
@@ -39,10 +39,14 @@ Create the file \`src/modules/my-fulfillment/index.ts\` with the following conte
 
 \`\`\`ts title="src/modules/my-fulfillment/index.ts"
 import MyFulfillmentProviderService from "./service"
+import { 
+  ModuleProvider, 
+  Modules
+} from "@medusajs/framework/utils"
 
-export default {
+export default ModuleProvider(Modules.FULFILLMENT, {
   services: [MyFulfillmentProviderService],
-}
+})
 \`\`\`
 
 This exports the module's definition, indicating that the \`MyFulfillmentProviderService\` is the module's service.`,

--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/notification.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/notification.ts
@@ -43,10 +43,14 @@ Create the file \`src/modules/my-notification/index.ts\` with the following cont
 
 \`\`\`ts title="src/modules/my-notification/index.ts"
 import MyNotificationProviderService from "./service"
+import { 
+  ModuleProvider, 
+  Modules
+} from "@medusajs/framework/utils"
 
-export default {
+export default ModuleProvider(Modules.NOTIFICATION, {
   services: [MyNotificationProviderService],
-}
+})
 \`\`\`
 
 This exports the module's definition, indicating that the \`MyNotificationProviderService\` is the module's service.`,

--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/payment-provider.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/payment-provider.ts
@@ -48,10 +48,14 @@ Create the file \`src/modules/my-payment/index.ts\` with the following content:
 
 \`\`\`ts title="src/modules/my-payment/index.ts"
 import MyPaymentProviderService from "./service"
+import { 
+  ModuleProvider, 
+  Modules
+} from "@medusajs/framework/utils"
 
-export default {
+export default ModuleProvider(Modules.PAYMENT, {
   services: [MyPaymentProviderService],
-}
+})
 \`\`\`
 
 This exports the module's definition, indicating that the \`MyPaymentProviderService\` is the module's service.`,


### PR DESCRIPTION
Document change introduced by #9544

> Note: fine to merge now as it requires generating references, which will only happen after the next release.