### PR TITLE
fix(utils): Mikro orm joined selection issue when select-in strategy

### DIFF
--- a/packages/core/types/src/dal/index.ts
+++ b/packages/core/types/src/dal/index.ts
@@ -51,6 +51,10 @@ export interface OptionsQuery<T, P extends string = never> {
    * Filters to apply on the retrieved items.
    */
   filters?: Dictionary<boolean | Dictionary> | string[] | boolean
+  /**
+   * Load strategy (e.g for mikro orm it accept select-in or joined)
+   */
+  strategy?: 'select-in' | 'joined' | string & {}
 }
 
 /**

--- a/packages/core/utils/src/dal/mikro-orm/mikro-orm-repository.ts
+++ b/packages/core/utils/src/dal/mikro-orm/mikro-orm-repository.ts
@@ -121,7 +121,7 @@ export class MikroOrmBaseRepository<T extends object = object>
   static compensateRelationFieldsSelectionFromLoadStrategy({
     findOptions,
   }: {
-    findOptions: DAL.FindOptions<any>
+    findOptions: DAL.FindOptions
   }) {
     const loadStrategy = findOptions?.options?.strategy
 
@@ -349,7 +349,10 @@ export function mikroOrmBaseRepositoryFactory<T extends object = object>(
       await manager.nativeDelete<T>(entity as EntityName<T>, filters as any)
     }
 
-    async find(options?: DAL.FindOptions<T>, context?: Context): Promise<T[]> {
+    async find(
+      options: DAL.FindOptions<T> = { where: {} },
+      context?: Context
+    ): Promise<T[]> {
       const manager = this.getActiveManager<EntityManager>(context)
 
       const findOptions_ = { ...options }


### PR DESCRIPTION
**What**
When in `select-in` strategy selection with mikro orm, the behaviour is different than using the `joined` strategy in the sense that with the joined strategy if a relation is populated then it will be returned entirely. But in `select-in `strategy if a relation is populated but no fields are selected from it then it wont be returned at all.