### PR TITLE
chore(medusa): default endpoints size limit

### DIFF
--- a/packages/medusa/src/api/admin/inventory-items/middlewares.ts
+++ b/packages/medusa/src/api/admin/inventory-items/middlewares.ts
@@ -1,9 +1,11 @@
-import * as QueryConfig from "./query-config"
-import { MiddlewareRoute, unlessPath } from "@medusajs/framework/http"
 import {
   validateAndTransformBody,
   validateAndTransformQuery,
 } from "@medusajs/framework"
+import { MiddlewareRoute, unlessPath } from "@medusajs/framework/http"
+import { DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT } from "../../../utils/middlewares"
+import { createBatchBody } from "../../utils/validators"
+import * as QueryConfig from "./query-config"
 import {
   AdminCreateInventoryItem,
   AdminCreateInventoryLocationLevel,
@@ -14,7 +16,6 @@ import {
   AdminUpdateInventoryItem,
   AdminUpdateInventoryLocationLevel,
 } from "./validators"
-import { createBatchBody } from "../../utils/validators"
 
 export const adminInventoryRoutesMiddlewares: MiddlewareRoute[] = [
   {
@@ -83,6 +84,9 @@ export const adminInventoryRoutesMiddlewares: MiddlewareRoute[] = [
   {
     method: ["POST"],
     matcher: "/admin/inventory-items/:id/location-levels/batch",
+    bodyParser: {
+      sizeLimit: DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT,
+    },
     middlewares: [
       validateAndTransformBody(
         createBatchBody(

--- a/packages/medusa/src/api/admin/price-lists/middlewares.ts
+++ b/packages/medusa/src/api/admin/price-lists/middlewares.ts
@@ -1,8 +1,9 @@
-import { MiddlewareRoute } from "@medusajs/framework/http"
 import {
   validateAndTransformBody,
   validateAndTransformQuery,
 } from "@medusajs/framework"
+import { MiddlewareRoute } from "@medusajs/framework/http"
+import { DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT } from "../../../utils/middlewares"
 import { createBatchBody } from "../../utils/validators"
 import * as QueryConfig from "./query-config"
 import {
@@ -73,6 +74,9 @@ export const adminPriceListsRoutesMiddlewares: MiddlewareRoute[] = [
   {
     method: ["POST"],
     matcher: "/admin/price-lists/:id/prices/batch",
+    bodyParser: {
+      sizeLimit: DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT,
+    },
     middlewares: [
       validateAndTransformBody(
         createBatchBody(AdminCreatePriceListPrice, AdminUpdatePriceListPrice)

--- a/packages/medusa/src/api/admin/products/middlewares.ts
+++ b/packages/medusa/src/api/admin/products/middlewares.ts
@@ -1,12 +1,14 @@
 import {
+  validateAndTransformBody,
+  validateAndTransformQuery,
+} from "@medusajs/framework"
+import {
   maybeApplyLinkFilter,
   MiddlewareRoute,
   unlessPath,
 } from "@medusajs/framework/http"
-import {
-  validateAndTransformBody,
-  validateAndTransformQuery,
-} from "@medusajs/framework"
+import multer from "multer"
+import { DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT } from "../../../utils/middlewares"
 import { createBatchBody } from "../../utils/validators"
 import * as QueryConfig from "./query-config"
 import { maybeApplyPriceListsFilter } from "./utils"
@@ -33,7 +35,6 @@ import {
   CreateProduct,
   CreateProductVariant,
 } from "./validators"
-import multer from "multer"
 
 // TODO: For now we keep the files in memory, as that's how they get passed to the workflows
 // This will need revisiting once we are closer to prod-ready v2, since with workflows and potentially
@@ -71,6 +72,9 @@ export const adminProductRoutesMiddlewares: MiddlewareRoute[] = [
   {
     method: ["POST"],
     matcher: "/admin/products/batch",
+    bodyParser: {
+      sizeLimit: DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT,
+    },
     middlewares: [
       validateAndTransformBody(
         createBatchBody(CreateProduct, AdminBatchUpdateProduct)
@@ -168,6 +172,9 @@ export const adminProductRoutesMiddlewares: MiddlewareRoute[] = [
   {
     method: ["POST"],
     matcher: "/admin/products/:id/variants/batch",
+    bodyParser: {
+      sizeLimit: DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT,
+    },
     middlewares: [
       validateAndTransformBody(
         createBatchBody(CreateProductVariant, AdminBatchUpdateProductVariant)
@@ -282,6 +289,9 @@ export const adminProductRoutesMiddlewares: MiddlewareRoute[] = [
   {
     method: ["POST"],
     matcher: "/admin/products/:id/variants/inventory-items/batch",
+    bodyParser: {
+      sizeLimit: DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT,
+    },
     middlewares: [
       validateAndTransformBody(
         createBatchBody(

--- a/packages/medusa/src/api/admin/promotions/middlewares.ts
+++ b/packages/medusa/src/api/admin/promotions/middlewares.ts
@@ -1,8 +1,9 @@
-import { MiddlewareRoute, unlessPath } from "@medusajs/framework/http"
 import {
   validateAndTransformBody,
   validateAndTransformQuery,
 } from "@medusajs/framework"
+import { MiddlewareRoute, unlessPath } from "@medusajs/framework/http"
+import { DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT } from "../../../utils/middlewares"
 import { createBatchBody } from "../../utils/validators"
 import * as QueryConfig from "./query-config"
 import {
@@ -76,6 +77,9 @@ export const adminPromotionRoutesMiddlewares: MiddlewareRoute[] = [
   {
     method: ["POST"],
     matcher: "/admin/promotions/:id/rules/batch",
+    bodyParser: {
+      sizeLimit: DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT,
+    },
     middlewares: [
       validateAndTransformBody(
         createBatchBody(AdminCreatePromotionRule, AdminUpdatePromotionRule)
@@ -89,6 +93,9 @@ export const adminPromotionRoutesMiddlewares: MiddlewareRoute[] = [
   {
     method: ["POST"],
     matcher: "/admin/promotions/:id/target-rules/batch",
+    bodyParser: {
+      sizeLimit: DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT,
+    },
     middlewares: [
       validateAndTransformBody(
         createBatchBody(AdminCreatePromotionRule, AdminUpdatePromotionRule)
@@ -102,6 +109,9 @@ export const adminPromotionRoutesMiddlewares: MiddlewareRoute[] = [
   {
     method: ["POST"],
     matcher: "/admin/promotions/:id/buy-rules/batch",
+    bodyParser: {
+      sizeLimit: DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT,
+    },
     middlewares: [
       validateAndTransformBody(
         createBatchBody(AdminCreatePromotionRule, AdminUpdatePromotionRule)

--- a/packages/medusa/src/api/admin/shipping-options/middlewares.ts
+++ b/packages/medusa/src/api/admin/shipping-options/middlewares.ts
@@ -1,8 +1,9 @@
-import { maybeApplyLinkFilter, MiddlewareRoute } from "@medusajs/framework/http"
 import {
   validateAndTransformBody,
   validateAndTransformQuery,
 } from "@medusajs/framework"
+import { maybeApplyLinkFilter, MiddlewareRoute } from "@medusajs/framework/http"
+import { DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT } from "../../../utils/middlewares"
 import { createBatchBody } from "../../utils/validators"
 import {
   listTransformQueryConfig,
@@ -75,6 +76,9 @@ export const adminShippingOptionRoutesMiddlewares: MiddlewareRoute[] = [
   {
     method: ["POST"],
     matcher: "/admin/shipping-options/:id/rules/batch",
+    bodyParser: {
+      sizeLimit: DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT,
+    },
     middlewares: [
       validateAndTransformBody(
         createBatchBody(

--- a/packages/medusa/src/utils/middlewares/index.ts
+++ b/packages/medusa/src/utils/middlewares/index.ts
@@ -1,2 +1,4 @@
 export { authenticate } from "./authenticate-middleware"
 export { errorHandler } from "./error-handler"
+
+export const DEFAULT_BATCH_ENDPOINTS_SIZE_LIMIT = "2mb"


### PR DESCRIPTION
What:
 * Increase `bodyParser.sizeLimit` to `2mb` for all `/batch` endpoints