### PR TITLE
docs-util: add configuration to generate js-sdk reference

### DIFF
--- a/www/utils/packages/typedoc-config/js-sdk.json
+++ b/www/utils/packages/typedoc-config/js-sdk.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": [
+    "../../../../packages/core/js-sdk/tsconfig.json"
+  ],
+  "include": ["../../../../packages/core/js-sdk/src"],
+  "exclude": [
+    "../../../../packages/core/js-sdk/dist", 
+    "../../../../packages/core/js-sdk/node_modules"
+  ]
+}

--- a/www/utils/packages/typedoc-generate-references/src/constants/base-options.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/base-options.ts
@@ -12,7 +12,7 @@ export const baseOptions: Partial<TypeDocOptions> = {
     "www/packages/eslint-config-docs/content.js"
   ),
   pluginsResolvePath: path.join(rootPathPrefix, "www"),
-  exclude: [path.join(rootPathPrefix, "node_modules/**")],
+  exclude: ["**/node_modules/**", "**/dist/**"],
   excludeInternal: true,
   excludeExternals: true,
   excludeReferences: true,

--- a/www/utils/packages/typedoc-generate-references/src/constants/base-options.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/base-options.ts
@@ -12,7 +12,7 @@ export const baseOptions: Partial<TypeDocOptions> = {
     "www/packages/eslint-config-docs/content.js"
   ),
   pluginsResolvePath: path.join(rootPathPrefix, "www"),
-  exclude: ["**/node_modules/**", "**/dist/**"],
+  exclude: ["**/node_modules/**"],
   excludeInternal: true,
   excludeExternals: true,
   excludeReferences: true,

--- a/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
@@ -72,12 +72,12 @@ const customOptions: Record<string, Partial<TypeDocOptions>> = {
     ],
   }),
   "medusa-config": getOptions({
-    entryPointPath: "packages/framework/src/config/types.ts",
+    entryPointPath: "packages/core/framework/src/config/types.ts",
     tsConfigName: "framework.json",
     name: "medusa-config",
   }),
   medusa: getOptions({
-    entryPointPath: "packages/medusa/src/index.js",
+    entryPointPath: "packages/medusa/src/index.ts",
     tsConfigName: "medusa.json",
     name: "medusa",
     jsonFileName: "0-medusa",

--- a/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
@@ -49,6 +49,16 @@ const customOptions: Record<string, Partial<TypeDocOptions>> = {
     name: "fulfillment-provider",
     parentIgnore: true,
   }),
+  "js-sdk": getOptions({
+    entryPointPath: [
+      "packages/core/js-sdk/src/admin/index.ts",
+      "packages/core/js-sdk/src/auth/index.ts",
+      "packages/core/js-sdk/src/store/index.ts",
+    ],
+    tsConfigName: "js-sdk.json",
+    name: "js-sdk",
+    enableInternalResolve: true,
+  }),
   "helper-steps": getOptions({
     entryPointPath: "packages/core/core-flows/src/common/index.ts",
     tsConfigName: "core-flows.json",
@@ -141,9 +151,11 @@ const customOptions: Record<string, Partial<TypeDocOptions>> = {
     exclude: [
       ...(baseOptions.exclude || []),
       "**/api-key/**",
+      "**/auth/**",
+      "**/bundles/**",
       "**/common/**",
       "**/dal/**/**",
-      "**/decorators/**",
+      "**/dml/**",
       "**/defaults/**",
       "**/**provider.ts",
       "**/event-bus/**",
@@ -151,10 +163,10 @@ const customOptions: Record<string, Partial<TypeDocOptions>> = {
       "**/feature-flags/**",
       "**/modules-sdk/**",
       "**/orchestration/**",
+      "**/pg/**",
       "**/pricing/builders.ts",
       "**/search/**",
       "**/totals/**",
-      "**/dml/**",
     ],
   }),
   workflows: getOptions({

--- a/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/custom-options.ts
@@ -75,6 +75,7 @@ const customOptions: Record<string, Partial<TypeDocOptions>> = {
     entryPointPath: "packages/core/framework/src/config/types.ts",
     tsConfigName: "framework.json",
     name: "medusa-config",
+    exclude: [...(baseOptions.exclude || []), "**/dist/**"],
   }),
   medusa: getOptions({
     entryPointPath: "packages/medusa/src/index.ts",
@@ -150,6 +151,7 @@ const customOptions: Record<string, Partial<TypeDocOptions>> = {
     enableInternalResolve: true,
     exclude: [
       ...(baseOptions.exclude || []),
+      "**/dist/**",
       "**/api-key/**",
       "**/auth/**",
       "**/bundles/**",

--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/index.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/index.ts
@@ -12,6 +12,7 @@ import taxProviderOptions from "./tax-provider.js"
 import workflowsOptions from "./workflows.js"
 import dmlOptions from "./dml.js"
 import coreFlowsOptions from "./core-flows.js"
+import jsSdkOptions from "./js-sdk.js"
 
 const mergerCustomOptions: FormattingOptionsType = {
   ...authProviderOptions,
@@ -20,6 +21,7 @@ const mergerCustomOptions: FormattingOptionsType = {
   ...fileOptions,
   ...fulfillmentProviderOptions,
   ...helperStepsOptions,
+  ...jsSdkOptions,
   ...medusaConfigOptions,
   ...medusaOptions,
   ...notificationOptions,

--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/js-sdk.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/js-sdk.ts
@@ -1,0 +1,82 @@
+import { FormattingOptionsType } from "types"
+import baseSectionsOptions from "../base-section-options.js"
+
+const jsSdkOptions: FormattingOptionsType = {
+  "^js_sdk": {
+    expandMembers: true,
+    expandProperties: true,
+    reflectionGroups: {
+      Constructors: false,
+    },
+    sections: {
+      ...baseSectionsOptions,
+      member_declaration_title: false,
+      member_declaration_children: true,
+    },
+  },
+  "^js_sdk/store/classes/.*Store": {
+    frontmatterData: {
+      slug: "/references/js-sdk/store",
+    },
+    reflectionDescription:
+      "The `sdk.store` class provides methods to send requests to Medusa's Store API routes.",
+    reflectionTitle: {
+      fullReplacement: "JS SDK Store Reference",
+    },
+  },
+  "^js_sdk/store/Store/properties/": {
+    frontmatterData: {
+      slug: "/references/js-sdk/admin/{{alias}}",
+      sidebar_label: "{{alias}}",
+    },
+    reflectionTitle: {
+      kind: false,
+      typeParameters: false,
+      suffix: "- JS SDK Store Reference",
+    },
+  },
+  "^js_sdk/store/classes/.*Admin": {
+    frontmatterData: {
+      slug: "/references/js-sdk/admin",
+    },
+    reflectionDescription:
+      "The `sdk.admin` class provides methods to send requests to Medusa's Admin API routes.",
+    reflectionTitle: {
+      fullReplacement: "JS SDK Admin Reference",
+    },
+  },
+  "^js_sdk/admin/Admin/properties/": {
+    frontmatterData: {
+      slug: "/references/js-sdk/admin/{{alias}}",
+      sidebar_label: "{{alias}}",
+    },
+    reflectionTitle: {
+      kind: false,
+      typeParameters: false,
+      suffix: "- JS SDK Admin Reference",
+    },
+  },
+  "^js_sdk/store/classes/.*Auth": {
+    frontmatterData: {
+      slug: "/references/js-sdk/auth",
+    },
+    reflectionDescription:
+      "The `sdk.auth` class provides methods to send requests to manage a user or customer's authentication",
+    reflectionTitle: {
+      fullReplacement: "JS SDK Auth Reference",
+    },
+  },
+  "^js_sdk/auth/Auth/methods/": {
+    frontmatterData: {
+      slug: "/references/js-sdk/auth/{{alias}}",
+      sidebar_label: "{{alias}}",
+    },
+    reflectionTitle: {
+      kind: false,
+      typeParameters: false,
+      suffix: "- JS SDK Auth Reference",
+    },
+  },
+}
+
+export default jsSdkOptions

--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/js-sdk.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/js-sdk.ts
@@ -34,6 +34,8 @@ const jsSdkOptions: FormattingOptionsType = {
       typeParameters: false,
       suffix: "- JS SDK Store Reference",
     },
+    reflectionDescription:
+      "This documentation provides a reference to the `sdk.store.{{alias}}` set of methods used to send requests to Medusa's Store API routes.",
   },
   "^js_sdk/store/classes/.*Admin": {
     frontmatterData: {
@@ -55,6 +57,8 @@ const jsSdkOptions: FormattingOptionsType = {
       typeParameters: false,
       suffix: "- JS SDK Admin Reference",
     },
+    reflectionDescription:
+      "This documentation provides a reference to the `sdk.admin.{{alias}}` set of methods used to send requests to Medusa's Admin API routes.",
   },
   "^js_sdk/store/classes/.*Auth": {
     frontmatterData: {
@@ -76,6 +80,8 @@ const jsSdkOptions: FormattingOptionsType = {
       typeParameters: false,
       suffix: "- JS SDK Auth Reference",
     },
+    reflectionDescription:
+      "This documentation provides a reference to the `sdk.auth.{{alias}}` method used to send requests to Medusa's Authentication API routes. It can be used for admin users, customers, or custom actor types.",
   },
 }
 

--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-options.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-options.ts
@@ -40,6 +40,7 @@ const mergerOptions: Partial<TypeDocOptions> = {
     "helper-steps",
     "workflows",
   ],
+  allPropertyReflectionsHaveOwnDocument: ["js-sdk"],
   allReflectionsHaveOwnDocumentInNamespace: [
     ...getNamespaceNames(getCoreFlowNamespaces()),
   ],

--- a/www/utils/packages/typedoc-generate-references/src/constants/references.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/references.ts
@@ -27,6 +27,7 @@ const allReferences = [
   "file",
   "fulfillment-provider",
   "helper-steps",
+  "js-sdk",
   "medusa-config",
   "medusa",
   "modules-sdk",

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/index.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/index.ts
@@ -41,6 +41,13 @@ export function load(app: Application) {
   })
 
   app.options.addDeclaration({
+    help: "[Markdown Plugin] Specify module names where property reflections are outputted into seperate files.",
+    name: "allPropertyReflectionsHaveOwnDocument",
+    type: ParameterType.Array,
+    defaultValue: [],
+  })
+
+  app.options.addDeclaration({
     help: "[Markdown Plugin] Specify namespace names where all reflections are outputted into seperate files.",
     name: "allReflectionsHaveOwnDocumentInNamespace",
     type: ParameterType.Array,

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.declaration.hbs
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.declaration.hbs
@@ -56,23 +56,9 @@
 
 {{#if type.declaration.signatures}}
 
-{{#if type.declaration.children}}
-
-{{{titleLevel}}} Call signature
-
-{{else}}
-
-{{{titleLevel}}} Type declaration
-
-{{/if}}
-
 {{#each type.declaration.signatures}}
 
-{{incrementCurrentTitleLevel}}
-
 {{> member.signature-wrapper showSources=false parent=../type.declaration }}
-
-{{decrementCurrentTitleLevel}}
 
 {{/each}}
 
@@ -84,17 +70,37 @@
 
 {{#if type.declaration.children}}
 
-{{#with type.declaration}}
+{{#unless (getFormattingOption "expandMembers")}}
 
 {{{titleLevel}}} Properties
 
-{{/with}}
+{{incrementCurrentTitleLevel}}
+
+{{/unless}}
+
+{{#if (shouldExpandProperties "Properties")}}
+
+{{#each type.declaration.children}}
+
+{{> member }}
+
+{{/each}}
+
+{{else}}
 
 {{#with type.declaration.children}}
 
 {{{typeDeclarationMembers sectionTitle=../name}}}
 
 {{/with}}
+
+{{/if}}
+
+{{#unless (getFormattingOption "expandMembers")}}
+
+{{decrementCurrentTitleLevel}}
+
+{{/unless}}
 
 {{/if}}
 

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/theme.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/theme.ts
@@ -30,6 +30,7 @@ import { Mapping } from "./types"
 
 export class MarkdownTheme extends Theme {
   allReflectionsHaveOwnDocument!: string[]
+  allPropertyReflectionsHaveOwnDocument!: string[]
   allReflectionsHaveOwnDocumentInNamespace: string[]
   entryDocument: string
   entryPoints!: string[]
@@ -65,6 +66,9 @@ export class MarkdownTheme extends Theme {
 
     // prettier-ignore
     this.allReflectionsHaveOwnDocument = this.getOption("allReflectionsHaveOwnDocument") as string[]
+    this.allPropertyReflectionsHaveOwnDocument = this.getOption(
+      "allPropertyReflectionsHaveOwnDocument"
+    ) as string[]
     this.allReflectionsHaveOwnDocumentInNamespace = this.getOption(
       "allReflectionsHaveOwnDocumentInNamespace"
     ) as string[]
@@ -334,7 +338,10 @@ export class MarkdownTheme extends Theme {
     return parents
   }
 
-  getAllReflectionsHaveOwnDocument(reflection: DeclarationReflection): boolean {
+  getAllReflectionsHaveOwnDocument(
+    reflection: DeclarationReflection,
+    checkProperties?: boolean
+  ): boolean {
     const moduleParents = this.getParentsOfKind(
       reflection,
       ReflectionKind.Module
@@ -343,6 +350,12 @@ export class MarkdownTheme extends Theme {
       reflection,
       ReflectionKind.Namespace
     )
+
+    if (checkProperties) {
+      return moduleParents.some((parent) =>
+        this.allPropertyReflectionsHaveOwnDocument.includes(parent.name)
+      )
+    }
 
     return (
       moduleParents.some((parent) =>
@@ -454,6 +467,20 @@ export class MarkdownTheme extends Theme {
               },
               isLeaf: true,
               directory: path.join(directoryPrefix || "", "methods"),
+              template: this.getReflectionMemberTemplate(),
+            },
+          ]
+        : []),
+      ...(this.getAllReflectionsHaveOwnDocument(reflection, true)
+        ? [
+            {
+              kind: [ReflectionKind.Property],
+              modifiers: {
+                has: [],
+                not: [],
+              },
+              isLeaf: true,
+              directory: path.join(directoryPrefix || "", "properties"),
               template: this.getReflectionMemberTemplate(),
             },
           ]

--- a/www/utils/packages/typedoc-plugin-workflows/src/plugin.ts
+++ b/www/utils/packages/typedoc-plugin-workflows/src/plugin.ts
@@ -92,7 +92,8 @@ class WorkflowsPlugin {
 
         const workflowId = this.helper.getStepOrWorkflowId(
           initializer,
-          context.project
+          context.project,
+          "workflow"
         )
 
         if (!workflowId) {
@@ -270,6 +271,7 @@ class WorkflowsPlugin {
         stepId = this.helper.getStepOrWorkflowId(
           originalInitializer,
           context.project,
+          "step",
           true
         )
         stepType = this.helper.getStepType(originalInitializer)

--- a/www/utils/packages/types/lib/index.d.ts
+++ b/www/utils/packages/types/lib/index.d.ts
@@ -141,6 +141,10 @@ export declare module "typedoc" {
      */
     allReflectionsHaveOwnDocument: string[]
     /**
+     * [Markdown Plugin] Specify module names where property reflections are outputted into seperate files.
+     */
+    allPropertyReflectionsHaveOwnDocument: string[]
+    /**
      * [Markdown Plugin] Separator used to format filenames.
      * @defaultValue "."
      */

--- a/www/utils/packages/utils/src/get-type-children.ts
+++ b/www/utils/packages/utils/src/get-type-children.ts
@@ -170,7 +170,12 @@ const REJECTED_CHILDREN_NAMES = ["__type"]
 
 function filterChildren(children: DeclarationReflection[]) {
   return children.filter(
-    (child) => !REJECTED_CHILDREN_NAMES.includes(child.name)
+    (child) =>
+      !REJECTED_CHILDREN_NAMES.includes(child.name) &&
+      !child.comment?.modifierTags.has("@ignore") &&
+      !child.signatures?.some(
+        (signature) => signature.comment?.modifierTags.has("@ignore")
+      )
   )
 }
 


### PR DESCRIPTION
Add the necessary configurations to later generate a reference for the JS SDK.

Closes DX-958