### PR TITLE
fix(core-flows, types): general fixes to types and tsdocs

### DIFF
--- a/packages/core/core-flows/src/common/steps/use-query-graph.ts
+++ b/packages/core/core-flows/src/common/steps/use-query-graph.ts
@@ -7,7 +7,7 @@ import {
 import { createStep, StepFunction, StepResponse } from "@medusajs/workflows-sdk"
 import { ContainerRegistrationKeys } from "@medusajs/utils"
 
-type EntryStepInput<TEntry extends string> = RemoteQueryInput<TEntry> & {
+export type EntryStepInput<TEntry extends string> = RemoteQueryInput<TEntry> & {
   options?: RemoteJoinerOptions
 }
 

--- a/packages/core/core-flows/src/common/steps/use-query-graph.ts
+++ b/packages/core/core-flows/src/common/steps/use-query-graph.ts
@@ -7,7 +7,7 @@ import {
 import { createStep, StepFunction, StepResponse } from "@medusajs/workflows-sdk"
 import { ContainerRegistrationKeys } from "@medusajs/utils"
 
-export type EntryStepInput<TEntry extends string> = RemoteQueryInput<TEntry> & {
+export type UseQueryGraphStepInput<TEntry extends string> = RemoteQueryInput<TEntry> & {
   options?: RemoteJoinerOptions
 }
 
@@ -15,7 +15,7 @@ const useQueryGraphStepId = "use-query-graph-step"
 
 const step = createStep(
   useQueryGraphStepId,
-  async (input: EntryStepInput<any>, { container }) => {
+  async (input: UseQueryGraphStepInput<any>, { container }) => {
     const query = container.resolve<RemoteQueryFunction>(
       ContainerRegistrationKeys.QUERY
     )
@@ -27,6 +27,6 @@ const step = createStep(
 )
 
 export const useQueryGraphStep = <const TEntry extends string>(
-  input: EntryStepInput<TEntry>
-): ReturnType<StepFunction<EntryStepInput<TEntry>, GraphResultSet<TEntry>>> =>
-  step(input as any) as unknown as ReturnType<StepFunction<EntryStepInput<TEntry>, GraphResultSet<TEntry>>>
+  input: UseQueryGraphStepInput<TEntry>
+): ReturnType<StepFunction<UseQueryGraphStepInput<TEntry>, GraphResultSet<TEntry>>> =>
+  step(input as any) as unknown as ReturnType<StepFunction<UseQueryGraphStepInput<TEntry>, GraphResultSet<TEntry>>>

--- a/packages/core/types/src/index-data/common.ts
+++ b/packages/core/types/src/index-data/common.ts
@@ -43,7 +43,7 @@ export type SchemaObjectEntityRepresentation = {
   fields: string[]
 
   /**
-   * @Listerners directive is required and all listeners found
+   * `@Listerners` directive is required and all listeners found
    * for the type will be stored here
    */
   listeners: string[]

--- a/packages/core/types/src/inventory/service.ts
+++ b/packages/core/types/src/inventory/service.ts
@@ -796,7 +796,7 @@ export interface IInventoryService extends IModuleService {
   /**
    * This method soft deletes reservations by their IDs.
    *
-   * @param {string[]} inventoryLevelIds - The reservations' IDs.
+   * @param {string[]} reservationItemIds - The reservations' IDs.
    * @param {SoftDeleteReturn<TReturnableLinkableKeys>} config - An object that is used to specify an entity's related entities that should be soft-deleted when the main entity is soft-deleted.
    * @param {Context} sharedContext - A context used to share resources, such as transaction manager, between the application and the module.
    * @returns {Promise<void | Record<string, string[]>>} An object that includes the IDs of related records that were also soft deleted.
@@ -808,7 +808,7 @@ export interface IInventoryService extends IModuleService {
    * ])
    */
   softDeleteReservationItems<TReturnableLinkableKeys extends string = string>(
-    ReservationItemIds: string[],
+    reservationItemIds: string[],
     config?: SoftDeleteReturn<TReturnableLinkableKeys>,
     sharedContext?: Context
   ): Promise<Record<string, string[]> | void>
@@ -816,7 +816,7 @@ export interface IInventoryService extends IModuleService {
   /**
    * This method restores soft deleted reservations by their IDs.
    *
-   * @param {string[]} ReservationItemIds - The reservations' IDs.
+   * @param {string[]} reservationItemIds - The reservations' IDs.
    * @param {RestoreReturn<TReturnableLinkableKeys>} config - Configurations determining which relations to restore along with each of the reservation. You can pass to its `returnLinkableKeys`
    * property any of the reservation's relation attribute names, such as `{type relation name}`.
    * @param {Context} sharedContext - A context used to share resources, such as transaction manager, between the application and the module.
@@ -829,7 +829,7 @@ export interface IInventoryService extends IModuleService {
    * ])
    */
   restoreReservationItems<TReturnableLinkableKeys extends string = string>(
-    ReservationItemIds: string[],
+    reservationItemIds: string[],
     config?: RestoreReturn<TReturnableLinkableKeys>,
     sharedContext?: Context
   ): Promise<Record<string, string[]> | void>
@@ -1017,6 +1017,48 @@ export interface IInventoryService extends IModuleService {
   /**
    * This method adjusts the inventory quantity of an item in a location.
    *
+   * @param data - The adjustments to make.
+   * @param {Context} context - A context used to share resources, such as transaction manager, between the application and the module.
+   * @returns {Promise<InventoryLevelDTO>} The updated inventory level.
+   *
+   * @example
+   * const inventoryLevel1 =
+   *   await inventoryModuleService.adjustInventory([
+   *     // add to the inventory quantity
+   *     {
+   *       inventoryItemId: "iitem_123",
+   *       locationId: "loc_123",
+   *       adjustment: 5
+   *     },
+   *     // subtract from the inventory quantity
+   *     {
+   *       inventoryItemId: "iitem_321",
+   *       locationId: "loc_321",
+   *       adjustment: -5
+   *     }
+   *   ])
+   */
+
+  adjustInventory(
+    data: {
+      /**
+       * The inventory item's ID.
+       */
+      inventoryItemId: string
+      /**
+       * The location's ID.
+       */
+      locationId: string
+      /**
+       * The adjustment to make to the quantity.
+       */
+      adjustment: BigNumberInput
+    }[],
+    context?: Context
+  ): Promise<InventoryLevelDTO[]>
+
+  /**
+   * 
    * @param {string} inventoryItemId - The inventory item's ID.
    * @param {string} locationId - The location's ID.
    * @param {number} adjustment - the adjustment to make to the quantity.
@@ -1040,16 +1082,6 @@ export interface IInventoryService extends IModuleService {
    *     -5
    *   )
    */
-
-  adjustInventory(
-    data: {
-      inventoryItemId: string
-      locationId: string
-      adjustment: BigNumberInput
-    }[],
-    context?: Context
-  ): Promise<InventoryLevelDTO[]>
-
   adjustInventory(
     inventoryItemId: string,
     locationId: string,

--- a/packages/core/types/src/order/common.ts
+++ b/packages/core/types/src/order/common.ts
@@ -2362,65 +2362,6 @@ export interface OrderTransactionDTO {
   reference_id: string
 
   /**
-   * When the transaction was created
-   */
-  created_at: Date | string
-
-  /**
-   * When the transaction was updated
-   */
-  updated_at: Date | string
-}
-
-/**
- * The order transaction details.
- */
-export interface OrderTransactionDTO {
-  /**
-   * The ID of the transaction
-   */
-  id: string
-
-  /**
-   * The ID of the associated order
-   */
-  order_id: string
-
-  /**
-   * The associated order
-   *
-   * @expandable
-   */
-  order: OrderDTO
-
-  /**
-   * The amount of the transaction
-   */
-  amount: BigNumberValue
-
-  /**
-   * The raw amount of the transaction
-   *
-   * @ignore
-   */
-  raw_amount: BigNumberRawValue
-
-  /**
-   * The currency code of the transaction
-   */
-  currency_code: string
-
-  /**
-   * The reference of the transaction
-   */
-  reference: string
-
-  /**
-   * The ID of the reference
-   */
-  reference_id: string
-
-  /**
    * The metadata of the transaction
    */
   metadata: Record<string, unknown> | null


### PR DESCRIPTION
- Export input type of `useQueryGraphStep` step
- Remove duplicate `OrderTransactionDTO`
- Fix some tsdoc errors