### PR TITLE
fix(types): change options to be required in http type

### DIFF
--- a/packages/core/types/src/http/product/admin/payloads.ts
+++ b/packages/core/types/src/http/product/admin/payloads.ts
@@ -72,7 +72,7 @@ export interface AdminCreateProduct {
   collection_id?: string
   categories?: { id: string }[]
   tags?: { id: string }[]
-  options?: AdminCreateProductOption[]
+  options: AdminCreateProductOption[]
   variants?: AdminCreateProductVariant[]
   sales_channels?: { id: string }[]
   weight?: number


### PR DESCRIPTION
`options` is now required when creating a product. This PR updates the http type