### PR TITLE
fix(dashboard): Ensure all progress tabs are 200px wide

### DIFF
--- a/packages/admin/dashboard/src/routes/categories/category-create/components/create-category-form/create-category-form.tsx
+++ b/packages/admin/dashboard/src/routes/categories/category-create/components/create-category-form/create-category-form.tsx
@@ -133,12 +133,12 @@ export const CreateCategoryForm = ({
         >
           <RouteFocusModal.Header>
             <div className="flex w-full items-center justify-between">
-              <div className="-my-2 w-fit border-l">
-                <ProgressTabs.List className="grid w-full grid-cols-4">
+              <div className="-my-2 w-full max-w-[400px] border-l">
+                <ProgressTabs.List className="grid w-full grid-cols-2">
                   <ProgressTabs.Trigger
                     value={Tab.DETAILS}
                     status={detailsStatus}
-                    className="w-full min-w-0 max-w-[200px] overflow-hidden"
+                    className="w-full min-w-0 overflow-hidden"
                   >
                     <span className="truncate">
                       {t("categories.create.tabs.details")}
@@ -147,7 +147,7 @@ export const CreateCategoryForm = ({
                   <ProgressTabs.Trigger
                     value={Tab.ORGANIZE}
                     status={nestingStatus}
-                    className="w-full min-w-0 max-w-[200px] overflow-hidden"
+                    className="w-full min-w-0 overflow-hidden"
                   >
                     <span className="truncate">
                       {t("categories.create.tabs.organize")}


### PR DESCRIPTION
**What**
- Fixes onE FocusModal where the ProgressTabs weren't 200px wide. All others already have the correct width.

Resolves CC-110