### PR TITLE
Fix/production logging

### DIFF
--- a/packages/cli/medusa-cli/src/reporter/index.ts
+++ b/packages/cli/medusa-cli/src/reporter/index.ts
@@ -5,7 +5,7 @@ import { ulid } from "ulid"
 import winston from "winston"
 import { panicHandler } from "./panic-handler"
 
-const LOG_LEVEL = process.env.LOG_LEVEL || "info"
+const LOG_LEVEL = process.env.LOG_LEVEL || "http"
 const LOG_FILE = process.env.LOG_FILE || ""
 const NODE_ENV = process.env.NODE_ENV || "development"
 const IS_DEV = NODE_ENV.startsWith("dev")

--- a/packages/core/framework/src/http/express-loader.ts
+++ b/packages/core/framework/src/http/express-loader.ts
@@ -76,12 +76,15 @@ export async function expressLoader({ app }: { app: Express }): Promise<{
    * The middleware to use for logging. We write the log messages
    * using winston, but rely on morgan to hook into HTTP requests
    */
-  const loggingMiddleware = morgan(IS_DEV ? "dev" : "tiny", {
-    skip: shouldSkipHttpLog,
-    stream: {
-      write: (message: string) => logger.http(message),
-    },
-  })
+  const loggingMiddleware = morgan(
+    IS_DEV ? ":method :url ← :referrer (:status)" : "combined",
+    {
+      skip: shouldSkipHttpLog,
+      stream: {
+        write: (message: string) => logger.http(message.trim()),
+      },
+    }
+  )
 
   app.use(loggingMiddleware)
   app.use(cookieParser())

--- a/packages/core/framework/src/http/express-loader.ts
+++ b/packages/core/framework/src/http/express-loader.ts
@@ -77,7 +77,9 @@ export async function expressLoader({ app }: { app: Express }): Promise<{
    * using winston, but rely on morgan to hook into HTTP requests
    */
   const loggingMiddleware = morgan(
-    IS_DEV ? ":method :url ← :referrer (:status)" : "combined",
+    IS_DEV
+      ? ":method :url ← :referrer (:status) - :response-time ms"
+      : "combined",
     {
       skip: shouldSkipHttpLog,
       stream: {


### PR DESCRIPTION
Keep the old format (ie combined) when logging in production.

**Development**
![CleanShot 2024-10-18 at 16 51 18@2x](https://github.com/user-attachments/assets/7656422a-0329-4062-ad6a-5bbc4a892b37)

**Production**
![CleanShot 2024-10-18 at 16 52 25@2x](https://github.com/user-attachments/assets/89527547-25e3-432f-b561-2514856b6aec)
