### PR TITLE
fix(js-sdk): Drop engine requirement to >=18 for js-sdk

### DIFF
--- a/packages/core/js-sdk/package.json
+++ b/packages/core/js-sdk/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/core/js-sdk"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**What**
- A requirement of `>=20` was recently added to the js-sdk. This PR drops it to >=18.

**Why**
- Services like Vercel still use Node.JS 18 per default, and this prevented users from using the js-sdk when deploying their storefront/admin without changing the version that is used in the Vercel dashboard..