### PR TITLE
fix(dashboard,js-sdk): remove method and hook for deleting claim

### DIFF
--- a/packages/admin/dashboard/src/hooks/api/claims.tsx
+++ b/packages/admin/dashboard/src/hooks/api/claims.tsx
@@ -119,34 +119,6 @@ export const useCancelClaim = (
   })
 }
 
-export const useDeleteClaim = (
-  id: string,
-  orderId: string,
-  options?: UseMutationOptions<HttpTypes.AdminClaimDeleteResponse, FetchError>
-) => {
-  return useMutation({
-    mutationFn: () => sdk.admin.claim.delete(id),
-    onSuccess: (data: any, variables: any, context: any) => {
-      queryClient.invalidateQueries({
-        queryKey: ordersQueryKeys.details(),
-      })
-
-      queryClient.invalidateQueries({
-        queryKey: ordersQueryKeys.preview(orderId),
-      })
-
-      queryClient.invalidateQueries({
-        queryKey: claimsQueryKeys.details(),
-      })
-      queryClient.invalidateQueries({
-        queryKey: claimsQueryKeys.lists(),
-      })
-      options?.onSuccess?.(data, variables, context)
-    },
-    ...options,
-  })
-}
-
 export const useAddClaimItems = (
   id: string,
   orderId: string,

--- a/packages/core/js-sdk/src/admin/claim.ts
+++ b/packages/core/js-sdk/src/admin/claim.ts
@@ -70,21 +70,6 @@ export class Claim {
     )
   }
 
-  async delete(
-    id: string,
-    query?: HttpTypes.SelectParams,
-    headers?: ClientHeaders
-  ) {
-    return await this.client.fetch<HttpTypes.AdminClaimDeleteResponse>(
-      `/admin/claims/${id}`,
-      {
-        method: "DELETE",
-        headers,
-        query,
-      }
-    )
-  }
-
   async addItems(
     id: string,
     body: HttpTypes.AdminAddClaimItems,


### PR DESCRIPTION
Remove the JS SDK method and dashboard hook to delete a claim since the API route they're pointing at doesn't exist.