### PR TITLE
chore: fix to DML action

### DIFF
--- a/.github/workflows/generate-rc-references.yml
+++ b/.github/workflows/generate-rc-references.yml
@@ -116,3 +116,5 @@ jobs:
           branch: "chore/generate-dml-json"
           branch-suffix: "timestamp"
           add-paths: www/utils/generated/dml-output/**
+          base: "develop"
+          labels: "type: chore"


### PR DESCRIPTION
Fix the update on RC DML action that requires the `base` option set to open a PR.