### PR TITLE
fix(docs): correct typo in variable manipulation workflow section

### DIFF
--- a/www/apps/book/app/advanced-development/workflows/variable-manipulation/page.mdx
+++ b/www/apps/book/app/advanced-development/workflows/variable-manipulation/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: `${pageNumber} Variable Manipulation in Workflows with transform`,
 }
 
+
 # {metadata.title}
 
 In this chapter, you'll learn how to manipulate variables in a workflow using the transform utility.

--- a/www/apps/book/app/advanced-development/workflows/variable-manipulation/page.mdx
+++ b/www/apps/book/app/advanced-development/workflows/variable-manipulation/page.mdx
@@ -6,7 +6,7 @@ export const metadata = {
 
 In this chapter, you'll learn how to manipulate variables in a workflow using the transform utility.
 
-## Why Variable Manipulation isn't Allowed in Worflows?
+## Why Variable Manipulation isn't Allowed in Workflows?
 
 Medusa creates an internal representation of the workflow definition you pass to `createWorkflow` to track and store its steps.
 


### PR DESCRIPTION
### Fix Typo in Documentation Heading

**Summary:**
This PR addresses a minor typo in the documentation. The heading currently reads **"Why Variable Manipulation isn't Allowed in Worflows?"**, where "Worflows" is a typo. This has been corrected to **"Why Variable Manipulation isn't Allowed in Workflows?"**.

**Changes:**
- Corrected the word "Worflows" to "Workflows" in the relevant documentation file.

**Reason for Change:**
- This change improves the accuracy and professionalism of the documentation.
