### PR TITLE
fix: allow additional_data to be undefined or null

### DIFF
--- a/packages/core/framework/src/http/__tests__/validate-body.spec.ts
+++ b/packages/core/framework/src/http/__tests__/validate-body.spec.ts
@@ -18,28 +18,102 @@ describe("validateAndTransformBody", () => {
   it("should pass additionalDataValidator to validator factory", async () => {
     let mockRequest = {
       query: {},
+      body: {
+        additional_data: {},
+      },
+    } as MedusaRequest
+
+    const mockResponse = {} as MedusaResponse
+    const nextFunction = jest.fn()
+
+    mockRequest.additionalDataValidator = zod
+      .object({
+        brand_id: zod.number(),
+      })
+      .nullish()
+
+    const validatorFactory = (
+      schema?: Zod.ZodOptional<Zod.ZodNullable<Zod.ZodObject<any, any>>>
+    ) => {
+      return schema
+        ? createLinkBody().extend({
+            additional_data: schema,
+          })
+        : createLinkBody()
+    }
+
+    let middleware = validateAndTransformBody(validatorFactory)
+
+    await middleware(mockRequest, mockResponse, nextFunction)
+    expect(nextFunction.mock.calls[0]).toEqual([
+      new MedusaError(
+        "invalid_data",
+        `Invalid request: Field 'additional_data, brand_id' is required`
+      ),
+    ])
+  })
+
+  it("should allow additional_data to be undefined", async () => {
+    let mockRequest = {
+      query: {},
       body: {},
     } as MedusaRequest
 
     const mockResponse = {} as MedusaResponse
     const nextFunction = jest.fn()
 
-    mockRequest.additionalDataValidator = zod.object({
-      brand_id: zod.number(),
-    })
+    mockRequest.additionalDataValidator = zod
+      .object({
+        brand_id: zod.number(),
+      })
+      .nullish()
 
-    const validatorFactory = (schema?: Zod.ZodObject<any, any>) => {
-      return schema ? createLinkBody().merge(schema) : createLinkBody()
+    const validatorFactory = (
+      schema?: Zod.ZodOptional<Zod.ZodNullable<Zod.ZodObject<any, any>>>
+    ) => {
+      return schema
+        ? createLinkBody().extend({
+            additional_data: schema,
+          })
+        : createLinkBody()
     }
 
     let middleware = validateAndTransformBody(validatorFactory)
 
     await middleware(mockRequest, mockResponse, nextFunction)
-    expect(nextFunction).toHaveBeenCalledWith(
-      new MedusaError(
-        "invalid_data",
-        `Invalid request: Field 'brand_id' is required`
-      )
-    )
+    expect(nextFunction.mock.calls[0]).toEqual([])
+  })
+
+  it("should allow additional_data nested properties to be undefined", async () => {
+    let mockRequest = {
+      query: {},
+      body: {
+        additional_data: {},
+      },
+    } as MedusaRequest
+
+    const mockResponse = {} as MedusaResponse
+    const nextFunction = jest.fn()
+
+    mockRequest.additionalDataValidator = zod
+      .object({
+        brand_id: zod.number().optional(),
+      })
+      .nullish()
+
+    const validatorFactory = (
+      schema?: Zod.ZodOptional<Zod.ZodNullable<Zod.ZodObject<any, any>>>
+    ) => {
+      return schema
+        ? createLinkBody().extend({
+            additional_data: schema,
+          })
+        : createLinkBody()
+    }
+
+    let middleware = validateAndTransformBody(validatorFactory)
+
+    await middleware(mockRequest, mockResponse, nextFunction)
+    expect(nextFunction.mock.calls[0]).toEqual([])
   })
 })

--- a/packages/core/framework/src/http/types.ts
+++ b/packages/core/framework/src/http/types.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from "express"
-import { ZodObject } from "zod"
+import { ZodNullable, ZodObject, ZodOptional } from "zod"
 
 import {
   FindConfig,
@@ -148,7 +148,7 @@ export interface MedusaRequest<Body = unknown>
    * Custom validator to validate the `additional_data` property in
    * requests that allows for additional_data
    */
-  additionalDataValidator?: ZodObject<any, any>
+  additionalDataValidator?: ZodOptional<ZodNullable<ZodObject<any, any>>>
 }
 
 export interface AuthContext {

--- a/packages/core/framework/src/http/utils/define-middlewares.ts
+++ b/packages/core/framework/src/http/utils/define-middlewares.ts
@@ -47,7 +47,9 @@ export function defineMiddlewares<
        */
       if (additionalDataValidator) {
         customMiddleware.push((req, _, next) => {
-          req.additionalDataValidator = zod.object(additionalDataValidator)
+          req.additionalDataValidator = zod
+            .object(additionalDataValidator)
+            .nullish()
           next()
         })
       }

--- a/packages/core/framework/src/http/utils/validate-body.ts
+++ b/packages/core/framework/src/http/utils/validate-body.ts
@@ -7,7 +7,7 @@ export function validateAndTransformBody(
   zodSchema:
     | z.ZodObject<any, any>
     | ((
-        customSchema?: z.ZodObject<any, any>
+        customSchema?: z.ZodOptional<z.ZodNullable<z.ZodObject<any, any>>>
       ) => z.ZodObject<any, any> | z.ZodEffects<any, any>)
 ): (
   req: MedusaRequest,

--- a/packages/medusa/src/api/utils/validators.ts
+++ b/packages/medusa/src/api/utils/validators.ts
@@ -1,4 +1,4 @@
-import { z, ZodEffects, ZodObject } from "zod"
+import { z, ZodEffects, ZodNullable, ZodObject, ZodOptional } from "zod"
 
 /**
  * Wraps the original schema to a function to accept and merge
@@ -8,7 +8,9 @@ export const WithAdditionalData = <T extends ZodObject<any, any>>(
   originalSchema: T,
   modifyCallback?: (schema: T) => ZodObject<any, any> | ZodEffects<any, any>
 ) => {
-  return (additionalDataValidator?: ZodObject<any, any>) => {
+  return (
+    additionalDataValidator?: ZodOptional<ZodNullable<ZodObject<any, any>>>
+  ) => {
     let schema: ZodObject<any, any>
 
     if (!additionalDataValidator) {


### PR DESCRIPTION
Fixes: FRMW-2751

This PR allows `null` and `undefined` values to be passed when using a custom validation schema for the `additional_data`. 

## Question

However, there is another thing that we might have to either fix in docs or in the implementation. That is the usage of `additional_data` within workflows.

When additional_data is not provided in an API call, it is set to `undefined` and the same value is passed to the workflow hooks. However, I have noticed that our documentation assumes that the additional_data is always an object. For example: https://docs.medusajs.com/v2/learn/advanced-development/api-routes/additional-data#use-additional-data-in-a-hook

The `!additional_data.brand` check will throw an exception in cases where no `additional_data` was passed during the request.

**Question: Do we want to set it to an empty object when its not defined in an API call? Or do we want to update the docs to handle the case.**