### PR TITLE
fix(product): Category repository missing ontext

### DIFF
--- a/packages/core/utils/src/dal/mikro-orm/mikro-orm-repository.ts
+++ b/packages/core/utils/src/dal/mikro-orm/mikro-orm-repository.ts
@@ -54,7 +54,7 @@ export class MikroOrmBase<T = any> {
     transactionManager,
     manager,
   }: Context = {}): TManager {
-    return (transactionManager ?? manager ?? this.manager_) as TManager
+    return (transactionManager ?? manager ?? this.getFreshManager()) as TManager
   }
 
   async transaction<TManager = unknown>(

--- a/packages/modules/product/integration-tests/__tests__/product-category.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-category.ts
@@ -235,38 +235,38 @@ moduleIntegrationTestRunner<Service>({
               mpath:
                 "electronics.computers.laptops.gaming-laptops.high-performance.4k-gaming",
               parent_category_id: "high-performance",
-              parent_category: {
+              parent_category: expect.objectContaining({
                 id: "high-performance",
                 parent_category_id: "gaming-laptops",
                 handle: "high-performance-gaming-laptops",
                 mpath:
                   "electronics.computers.laptops.gaming-laptops.high-performance",
-                parent_category: {
+                parent_category: expect.objectContaining({
                   id: "gaming-laptops",
                   handle: "gaming-laptops",
                   mpath: "electronics.computers.laptops.gaming-laptops",
                   parent_category_id: "laptops",
-                  parent_category: {
+                  parent_category: expect.objectContaining({
                     id: "laptops",
                     parent_category_id: "computers",
                     handle: "laptops",
                     mpath: "electronics.computers.laptops",
-                    parent_category: {
+                    parent_category: expect.objectContaining({
                       id: "computers",
                       handle: "computers-&-accessories",
                       mpath: "electronics.computers",
                       parent_category_id: "electronics",
-                      parent_category: {
+                      parent_category: expect.objectContaining({
                         id: "electronics",
                         parent_category_id: null,
                         handle: "electronics",
                         mpath: "electronics",
                         parent_category: null,
-                      },
-                    },
-                  },
-                },
-              },
+                      }),
+                    }),
+                  }),
+                }),
+              }),
             },
           ])
         })
@@ -421,38 +421,38 @@ moduleIntegrationTestRunner<Service>({
               handle: "category-1-a",
               mpath: "category-0.category-1.category-1-a",
               parent_category_id: "category-1",
-              parent_category: {
+              parent_category: expect.objectContaining({
                 id: "category-1",
                 handle: "category-1",
                 mpath: "category-0.category-1",
                 parent_category_id: "category-0",
-                parent_category: {
+                parent_category: expect.objectContaining({
                   id: "category-0",
                   handle: "category-0",
                   mpath: "category-0",
                   parent_category_id: null,
                   parent_category: null,
-                },
-              },
+                }),
+              }),
             },
             {
               id: "category-1-b",
               handle: "category-1-b",
               mpath: "category-0.category-1.category-1-b",
               parent_category_id: "category-1",
-              parent_category: {
+              parent_category: expect.objectContaining({
                 id: "category-1",
                 handle: "category-1",
                 mpath: "category-0.category-1",
                 parent_category_id: "category-0",
-                parent_category: {
+                parent_category: expect.objectContaining({
                   id: "category-0",
                   handle: "category-0",
                   mpath: "category-0",
                   parent_category_id: null,
                   parent_category: null,
-                },
-              },
+                }),
+              }),
             },
           ])
         })

--- a/packages/modules/product/integration-tests/__tests__/product-category.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-category.ts
@@ -457,7 +457,7 @@ moduleIntegrationTestRunner<Service>({
           ])
         })
 
-        it("includes the entire list of descendants an parents when include_descendants_tree and include_ancestors_tree are true for multiple results", async () => {
+        it.only("includes the entire list of descendants an parents when include_descendants_tree and include_ancestors_tree are true for multiple results", async () => {
           const productCategoryResults = await service.list(
             {
               parent_category_id: "category-1",
@@ -469,29 +469,25 @@ moduleIntegrationTestRunner<Service>({
             }
           )
 
-          const serializedObject = JSON.parse(
-            JSON.stringify(productCategoryResults)
-          )
-
-          expect(serializedObject).toEqual([
+          expect(productCategoryResults).toEqual([
             {
               id: "category-1-a",
               handle: "category-1-a",
               mpath: "category-0.category-1.category-1-a",
               parent_category_id: "category-1",
-              parent_category: {
+              parent_category: expect.objectContaining({
                 id: "category-1",
                 handle: "category-1",
                 mpath: "category-0.category-1",
                 parent_category_id: "category-0",
-                parent_category: {
+                parent_category: expect.objectContaining({
                   id: "category-0",
                   handle: "category-0",
                   mpath: "category-0",
                   parent_category_id: null,
                   parent_category: null,
-                },
-              },
+                }),
+              }),
               category_children: [],
             },
             {
@@ -499,26 +495,26 @@ moduleIntegrationTestRunner<Service>({
               handle: "category-1-b",
               mpath: "category-0.category-1.category-1-b",
               parent_category_id: "category-1",
-              parent_category: {
+              parent_category: expect.objectContaining({
                 id: "category-1",
                 handle: "category-1",
                 mpath: "category-0.category-1",
                 parent_category_id: "category-0",
-                parent_category: {
+                parent_category: expect.objectContaining({
                   id: "category-0",
                   handle: "category-0",
                   mpath: "category-0",
                   parent_category_id: null,
                   parent_category: null,
-                },
-              },
+                }),
+              }),
               category_children: [
-                {
+                expect.objectContaining({
                   id: "category-1-b-1",
                   handle: "category-1-b-1",
                   mpath: "category-0.category-1.category-1-b.category-1-b-1",
                   parent_category_id: "category-1-b",
-                },
+                }),
               ],
             },
           ])

--- a/packages/modules/product/integration-tests/__tests__/product-category.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-category.ts
@@ -457,7 +457,7 @@ moduleIntegrationTestRunner<Service>({
           ])
         })
 
-        it.only("includes the entire list of descendants an parents when include_descendants_tree and include_ancestors_tree are true for multiple results", async () => {
+        it("includes the entire list of descendants an parents when include_descendants_tree and include_ancestors_tree are true for multiple results", async () => {
           const productCategoryResults = await service.list(
             {
               parent_category_id: "category-1",

--- a/packages/modules/product/src/repositories/product-category.ts
+++ b/packages/modules/product/src/repositories/product-category.ts
@@ -6,9 +6,9 @@ import {
 } from "@medusajs/framework/types"
 import { DALUtils, isDefined, MedusaError } from "@medusajs/framework/utils"
 import {
-  LoadStrategy,
   FilterQuery as MikroFilterQuery,
   FindOptions as MikroOptions,
+  LoadStrategy,
 } from "@mikro-orm/core"
 import { SqlEntityManager } from "@mikro-orm/postgresql"
 import { ProductCategory } from "@models"
@@ -93,7 +93,8 @@ export class ProductCategoryRepository extends DALUtils.MikroOrmBaseTreeReposito
         ancestors: transformOptions.includeAncestorsTree,
       },
       productCategories,
-      findOptions_
+      findOptions_,
+      context
     )
 
     return this.sortCategoriesByRank(categoriesTree)
@@ -250,7 +251,8 @@ export class ProductCategoryRepository extends DALUtils.MikroOrmBaseTreeReposito
         ancestors: transformOptions.includeAncestorsTree,
       },
       productCategories,
-      findOptions_
+      findOptions_,
+      context
     )
 
     return [this.sortCategoriesByRank(categoriesTree), count]


### PR DESCRIPTION
**What**
- Fix product category repository missing context passed to down level methods
- Ensure the base repository when getting the active manager returns a fresh one if possible instead of the global one in order to prevent shared entity map by mistake