### PR TITLE
fix(dashboard): temp hide order column on reservations

### DIFF
--- a/packages/admin/dashboard/src/routes/reservations/reservation-list/components/reservation-list-table/use-reservation-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/reservations/reservation-list/components/reservation-list-table/use-reservation-table-columns.tsx
@@ -30,26 +30,29 @@ export const useReservationTableColumns = () => {
           )
         },
       }),
-      columnHelper.accessor("line_item", {
-        header: t("fields.order"),
-        cell: ({ getValue }) => {
-          const inventoryItem = getValue()
-
-          if (!inventoryItem || !inventoryItem.order?.display_id) {
-            return <PlaceholderCell />
-          }
-
-          return (
-            <div className="flex size-full items-center overflow-hidden">
-              <LinkButton to={`/orders/${inventoryItem.order.id}`}>
-                <span className="truncate">
-                  #{inventoryItem.order.display_id}
-                </span>
-              </LinkButton>
-            </div>
-          )
-        },
-      }),
+      /**
+       * TEMP: hide this column until a link is added
+       */
+      // columnHelper.accessor("line_item", {
+      //   header: t("fields.order"),
+      //   cell: ({ getValue }) => {
+      //     const inventoryItem = getValue()
+      //
+      //     if (!inventoryItem || !inventoryItem.order?.display_id) {
+      //       return <PlaceholderCell />
+      //     }
+      //
+      //     return (
+      //       <div className="flex size-full items-center overflow-hidden">
+      //         <LinkButton to={`/orders/${inventoryItem.order.id}`}>
+      //           <span className="truncate">
+      //             #{inventoryItem.order.display_id}
+      //           </span>
+      //         </LinkButton>
+      //       </div>
+      //     )
+      //   },
+      // }),
       columnHelper.accessor("description", {
         header: t("fields.description"),
         cell: ({ getValue }) => {


### PR DESCRIPTION
**What**
- hide the order column on the reservations list until a link is introduced + impl. of `listOrderItems`