### PR TITLE
fix(admin-vite-plugin,dashboard): Generate correct UI Route tree

### DIFF
--- a/packages/admin/admin-vite-plugin/src/custom-fields/generate-custom-field-hashes.ts
+++ b/packages/admin/admin-vite-plugin/src/custom-fields/generate-custom-field-hashes.ts
@@ -1,5 +1,12 @@
 import fs from "fs/promises"
-import { isIdentifier, isObjectProperty, parse, traverse } from "../babel"
+import {
+  File,
+  isIdentifier,
+  isObjectProperty,
+  parse,
+  ParseResult,
+  traverse,
+} from "../babel"
 import { logger } from "../logger"
 import { crawl, generateHash, getParserOptions } from "../utils"
 import { getConfigArgument } from "./helpers"
@@ -41,7 +48,18 @@ async function getCustomFieldContents(file: string): Promise<{
   display: string | null
 }> {
   const code = await fs.readFile(file, "utf-8")
-  const ast = parse(code, getParserOptions(file))
+
+  let ast: ParseResult<File> | null = null
+
+  try {
+    ast = parse(code, getParserOptions(file))
+  } catch (e) {
+    logger.error(`An error occurred while parsing the file.`, {
+      file,
+      error: e,
+    })
+    return { link: null, form: null, display: null }
+  }
 
   let linkContent: string | null = null
   let formContent: string | null = null

--- a/packages/admin/admin-vite-plugin/src/routes/generate-menu-items.ts
+++ b/packages/admin/admin-vite-plugin/src/routes/generate-menu-items.ts
@@ -1,6 +1,13 @@
 import fs from "fs/promises"
 import { outdent } from "outdent"
-import { isIdentifier, isObjectProperty, parse, traverse } from "../babel"
+import {
+  File,
+  isIdentifier,
+  isObjectProperty,
+  parse,
+  ParseResult,
+  traverse,
+} from "../babel"
 import { logger } from "../logger"
 import {
   crawl,
@@ -118,7 +125,18 @@ async function getRouteConfig(
   file: string
 ): Promise<{ label: boolean; icon: boolean } | null> {
   const code = await fs.readFile(file, "utf-8")
-  const ast = parse(code, getParserOptions(file))
+
+  let ast: ParseResult<File> | null = null
+
+  try {
+    ast = parse(code, getParserOptions(file))
+  } catch (e) {
+    logger.error(`An error occurred while parsing the file.`, {
+      file,
+      error: e,
+    })
+    return null
+  }
 
   let config: { label: boolean; icon: boolean } | null = null
 

--- a/packages/admin/admin-vite-plugin/src/routes/generate-route-hashes.ts
+++ b/packages/admin/admin-vite-plugin/src/routes/generate-route-hashes.ts
@@ -1,5 +1,5 @@
 import fs from "fs/promises"
-import { parse, traverse } from "../babel"
+import { File, parse, ParseResult, traverse } from "../babel"
 import { logger } from "../logger"
 import {
   crawl,
@@ -42,7 +42,18 @@ async function getRouteContents(
   file: string
 ): Promise<{ defaultExport: string | null; config: string | null }> {
   const code = await fs.readFile(file, "utf-8")
-  const ast = parse(code, getParserOptions(file))
+
+  let ast: ParseResult<File> | null = null
+
+  try {
+    ast = parse(code, getParserOptions(file))
+  } catch (e) {
+    logger.error(`An error occurred while parsing the file.`, {
+      file,
+      error: e,
+    })
+    return { defaultExport: null, config: null }
+  }
 
   let defaultExportContent: string | null = null
   let configContent: string | null = null

--- a/packages/admin/admin-vite-plugin/src/routes/generate-routes.ts
+++ b/packages/admin/admin-vite-plugin/src/routes/generate-routes.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises"
 import { outdent } from "outdent"
-import { parse } from "../babel"
+import { File, parse, ParseResult } from "../babel"
 import { logger } from "../logger"
 import {
   crawl,
@@ -88,7 +88,18 @@ async function parseFile(
 
 async function isValidRouteFile(file: string): Promise<boolean> {
   const code = await fs.readFile(file, "utf-8")
-  const ast = parse(code, getParserOptions(file))
+
+  let ast: ParseResult<File> | null = null
+
+  try {
+    ast = parse(code, getParserOptions(file))
+  } catch (e) {
+    logger.error("An error occurred while parsing the file.", {
+      file,
+      error: e,
+    })
+    return false
+  }
 
   try {
     return await hasDefaultExport(ast)


### PR DESCRIPTION
**What**
- Improves how the structure of UI Routes is output.
- Wraps parses of files in a try/catch to prevent badly formatted code from breaking the dev server. E.g. if the user saved a file with an unclosed html tag, it would bring down the Vite dev server, now the dev server will continue working, and just throw the correct error in the browser and log.

**Example structure**
```
- admin
  - routes
    - custom
      - page.tsx
      - nested
        - page.tsx
           - deeply-nested
             - page.tsx

```
    

**Before**
```
[
  {
    path: "custom",
    children: [
      path: "",
      lazy: () => ({ Component )}
    ]
  },
  {
    path: "nested",
    children: [
      path: "",
      lazy: () => ({ Component )}
    ]
  },
  //... others meaning we created a flat structure
]
```

**Now**
```
[
  {
    path: "custom",
    lazy: () => ({ Component )}
    children: [
      {
        path: "nested",
        lazy: () => ({ Component )},
        children: [ // ... nested ]
      }
    ]
  },
]
```

