### PR TITLE
fix: Don't store token in SDK by default

### DIFF
--- a/packages/core/js-sdk/src/__tests__/client.spec.ts
+++ b/packages/core/js-sdk/src/__tests__/client.spec.ts
@@ -82,6 +82,18 @@ const server = setupServer(
       statusText: "Internal Server Error",
     })
   }),
+  http.get(`${baseUrl}/nostore`, ({ request }) => {
+    if (!request.headers.get("authorization")) {
+      return HttpResponse.json({
+        test: "test",
+      })
+    }
+
+    return new HttpResponse(null, {
+      status: 500,
+      statusText: "Internal Server Error",
+    })
+  }),
   http.all("*", ({ request, params, cookies }) => {
     return new HttpResponse(null, {
       status: 404,
@@ -185,11 +197,11 @@ describe("Client", () => {
   })
 
   describe("Authrized requests", () => {
-    it("should set the token in memory by default", async () => {
+    it("should not store the token by default", async () => {
       const token = "token-123" // Eg. from a response after a successful authentication
       client.setToken(token)
 
-      const resp = await client.fetch<any>("jwt")
+      const resp = await client.fetch<any>("nostore")
       expect(resp).toEqual({ test: "test" })
     })
 

--- a/packages/core/js-sdk/src/client.ts
+++ b/packages/core/js-sdk/src/client.ts
@@ -301,7 +301,8 @@ export class Client {
     const hasSession = hasStorage("sessionStorage")
 
     const storageMethod =
-      this.config.auth?.jwtTokenStorageMethod || (hasLocal ? "local" : "memory")
+      this.config.auth?.jwtTokenStorageMethod ||
+      (hasLocal ? "local" : "nostore")
     const storageKey =
       this.config.auth?.jwtTokenStorageKey || this.DEFAULT_JWT_STORAGE_KEY
 

--- a/packages/core/js-sdk/src/types.ts
+++ b/packages/core/js-sdk/src/types.ts
@@ -13,7 +13,7 @@ export type Config = {
   auth?: {
     type?: "jwt" | "session"
     jwtTokenStorageKey?: string
-    jwtTokenStorageMethod?: "local" | "session" | "memory"
+    jwtTokenStorageMethod?: "local" | "session" | "memory" | "nostore"
   }
   logger?: Logger
   debug?: boolean
@@ -21,15 +21,19 @@ export type Config = {
 
 export type FetchParams = Parameters<typeof fetch>
 
-export type ClientHeaders =
-  Record<string, string | null | { 
-    /**
-     * Tags to cache data under for Next.js applications.
-     * 
-     * Learn more in [Next.js's documentation](https://nextjs.org/docs/app/building-your-application/caching#fetch-optionsnexttags-and-revalidatetag).
-     */
-    tags: string[]
-  }>
+export type ClientHeaders = Record<
+  string,
+  | string
+  | null
+  | {
+      /**
+       * Tags to cache data under for Next.js applications.
+       *
+       * Learn more in [Next.js's documentation](https://nextjs.org/docs/app/building-your-application/caching#fetch-optionsnexttags-and-revalidatetag).
+       */
+      tags: string[]
+    }
+>
 
 export type FetchInput = FetchParams[0]
 


### PR DESCRIPTION
When using NextJS and the NextJS server manages the cookie that is then manually passed as a header to the BE, we don't want the in-memory token to interfere with the request as variables are global to the server across customers.

For this reason, we opt for a nostore approach to the SDK by default.