### PR TITLE
chore: update links to v2 docs in source code and comments

### DIFF
--- a/packages/admin/dashboard/src/components/layout/user-menu/user-menu.tsx
+++ b/packages/admin/dashboard/src/components/layout/user-menu/user-menu.tsx
@@ -57,7 +57,7 @@ export const UserMenu = () => {
           </DropdownMenu.Item>
           <DropdownMenu.Separator />
           <DropdownMenu.Item asChild>
-            <Link to="https://docs.medusajs.com/v2" target="_blank">
+            <Link to="https://docs.medusajs.com" target="_blank">
               <BookOpen className="text-ui-fg-subtle mr-2" />
               {t("app.menus.user.documentation")}
             </Link>

--- a/packages/cli/create-medusa-app/src/utils/create-db.ts
+++ b/packages/cli/create-medusa-app/src/utils/create-db.ts
@@ -141,7 +141,7 @@ async function getForDbName({
       })
     } catch (e) {
       logMessage({
-        message: `Couldn't connect to PostgreSQL because of the following error: ${e}.${EOL}${EOL}Make sure you have PostgreSQL installed and the credentials you provided are correct.${EOL}${EOL}You can learn how to install PostgreSQL here: https://docs.medusajs.com/development/backend/prepare-environment?os=${getCurrentOs()}#postgresql${EOL}${EOL}If you keep running into this issue despite having PostgreSQL installed, please check out our troubleshooting guidelines: https://docs.medusajs.com/troubleshooting/database-error`,
+        message: `Couldn't connect to PostgreSQL because of the following error: ${e}.${EOL}${EOL}Make sure you have PostgreSQL installed and the credentials you provided are correct.${EOL}${EOL}If you keep running into this issue despite having PostgreSQL installed, please check out our troubleshooting guidelines: https://docs.medusajs.com/resources/troubleshooting/database-errors`,
         type: "error",
       })
     }

--- a/packages/cli/oas/medusa-oas-cli/src/command-oas.ts
+++ b/packages/cli/oas/medusa-oas-cli/src/command-oas.ts
@@ -170,7 +170,7 @@ async function getOASFromCodebase(apiType: ApiType): Promise<OpenAPIObject> {
 }
 
 async function getPublicOas(apiType: ApiType) {
-  const url = `https://docs.medusajs.com/v2/api/api/download/${apiType}`
+  const url = `https://docs.medusajs.com/api/download/${apiType}`
   return (await OpenAPIParser.parse(url)) as OpenAPIObject
 }
 

--- a/packages/core/core-flows/src/common/steps/create-remote-links.ts
+++ b/packages/core/core-flows/src/common/steps/create-remote-links.ts
@@ -7,7 +7,7 @@ export const createLinksStepId = "create-remote-links"
 /**
  * This step creates remote links between two records of linked data models.
  *
- * Learn more in the [Remote Link documentation.](https://docs.medusajs.com/v2/advanced-development/modules/remote-link#create-link).
+ * Learn more in the [Remote Link documentation.](https://docs.medusajs.com/advanced-development/modules/remote-link#create-link).
  *
  * @example
  * import {

--- a/packages/core/core-flows/src/common/steps/dismiss-remote-links.ts
+++ b/packages/core/core-flows/src/common/steps/dismiss-remote-links.ts
@@ -11,7 +11,7 @@ export const dismissRemoteLinkStepId = "dismiss-remote-links"
 /**
  * This step removes remote links between two records of linked data models.
  *
- * Learn more in the [Remote Link documentation.](https://docs.medusajs.com/v2/advanced-development/modules/remote-link#dismiss-link).
+ * Learn more in the [Remote Link documentation.](https://docs.medusajs.com/advanced-development/modules/remote-link#dismiss-link).
  *
  * @example
  * import {

--- a/packages/core/core-flows/src/common/steps/remove-remote-links.ts
+++ b/packages/core/core-flows/src/common/steps/remove-remote-links.ts
@@ -9,7 +9,7 @@ export const removeRemoteLinkStepId = "remove-remote-links"
 /**
  * This step deletes linked records of a record.
  *
- * Learn more in the [Remote Link documentation](https://docs.medusajs.com/v2/advanced-development/modules/remote-link#cascade-delete-linked-records)
+ * Learn more in the [Remote Link documentation](https://docs.medusajs.com/advanced-development/modules/remote-link#cascade-delete-linked-records)
  *
  * @example
  * import {

--- a/packages/core/core-flows/src/common/steps/use-remote-query.ts
+++ b/packages/core/core-flows/src/common/steps/use-remote-query.ts
@@ -50,7 +50,7 @@ export const useRemoteQueryStepId = "use-remote-query"
 /**
  * This step fetches data across modules using the remote query.
  *
- * Learn more in the [Remote Query documentation](https://docs.medusajs.com/v2/advanced-development/modules/remote-query).
+ * Learn more in the [Remote Query documentation](https://docs.medusajs.com/advanced-development/modules/remote-query).
  *
  * @example
  *

--- a/packages/core/framework/src/config/types.ts
+++ b/packages/core/framework/src/config/types.ts
@@ -574,7 +574,7 @@ export type ProjectConfigOptions = {
      * However, some platforms don't offer access to the HTTP layer and in those cases, this is a good alternative.
      *
      * If you enable HTTP compression and you want to disable it for specific API Routes, you can pass in the request header `"x-no-compression": true`.
-     * Learn more in the [API Reference](https://docs.medusajs.com/v2/api/store#http-compression).
+     * Learn more in the [API Reference](https://docs.medusajs.com/api/store#http-compression).
      *
      * @example
      * ```ts title="medusa-config.ts"

--- a/packages/core/js-sdk/src/admin/api-key.ts
+++ b/packages/core/js-sdk/src/admin/api-key.ts
@@ -16,7 +16,7 @@ export class ApiKey {
 
   /**
    * This methods retrieves a paginated list of API keys. It sends a request to the 
-   * [List API Keys](https://docs.medusajs.com/v2/api/admin#api-keys_getapikeys) API route.
+   * [List API Keys](https://docs.medusajs.com/api/admin#api-keys_getapikeys) API route.
    * 
    * @param queryParams - Filters and pagination configurations.
    * @param headers - Headers to pass in the request.
@@ -58,7 +58,7 @@ export class ApiKey {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(
     queryParams?: HttpTypes.AdminGetApiKeysParams,
@@ -73,7 +73,7 @@ export class ApiKey {
   }
 
   /**
-   * This method creates an API key. It sends a request to the [Create API Key](https://docs.medusajs.com/v2/api/admin#api-keys_postapikeys)
+   * This method creates an API key. It sends a request to the [Create API Key](https://docs.medusajs.com/api/admin#api-keys_postapikeys)
    * API route.
    * 
    * @param body - The API key's details.
@@ -108,7 +108,7 @@ export class ApiKey {
 
   /**
    * This method revokes an API key. It sends a request to the 
-   * [Revoke API Key](https://docs.medusajs.com/v2/api/admin#api-keys_postapikeysidrevoke) API route.
+   * [Revoke API Key](https://docs.medusajs.com/api/admin#api-keys_postapikeysidrevoke) API route.
    * 
    * @param id - The API key's ID.
    * @param headers - Headers to pass in the request.
@@ -132,7 +132,7 @@ export class ApiKey {
 
   /**
    * This method retrieves an API key's details. It sends a request to the 
-   * [Get API key](https://docs.medusajs.com/v2/api/admin#api-keys_getapikeysid) API route.
+   * [Get API key](https://docs.medusajs.com/api/admin#api-keys_getapikeysid) API route.
    * 
    * @param id - The API key's ID.
    * @param headers - Headers to pass in the request.
@@ -155,7 +155,7 @@ export class ApiKey {
 
   /**
    * This method updates an API key's details. It sends a request to the 
-   * [Update API Key](https://docs.medusajs.com/v2/api/admin#api-keys_postapikeysid) API route.
+   * [Update API Key](https://docs.medusajs.com/api/admin#api-keys_postapikeysid) API route.
    * 
    * @param id - The API key's ID.
    * @param body - The data to update in the API key.
@@ -190,7 +190,7 @@ export class ApiKey {
 
   /**
    * This method deletes an API key by its ID. It sends a request to the 
-   * [Delete API Key](https://docs.medusajs.com/v2/api/admin#api-keys_deleteapikeysid) API route.
+   * [Delete API Key](https://docs.medusajs.com/api/admin#api-keys_deleteapikeysid) API route.
    * 
    * @param id - The API key's ID.
    * @param headers - Headers to pass in the request.
@@ -214,7 +214,7 @@ export class ApiKey {
 
   /**
    * This method manages the sales channels associated with a publishable API key to either add
-   * or remove associations. It sends a request to the [Manage Sales Channels](https://docs.medusajs.com/v2/api/admin#api-keys_postapikeysidsaleschannels)
+   * or remove associations. It sends a request to the [Manage Sales Channels](https://docs.medusajs.com/api/admin#api-keys_postapikeysidsaleschannels)
    * API route.
    * 
    * @param id - The API key's ID.

--- a/packages/core/js-sdk/src/admin/campaign.ts
+++ b/packages/core/js-sdk/src/admin/campaign.ts
@@ -16,7 +16,7 @@ export class Campaign {
 
   /**
    * This method retrieves a campaign by its ID. It sends a request to the 
-   * [Get Campaign](https://docs.medusajs.com/v2/api/admin#campaigns_getcampaignsid) API route.
+   * [Get Campaign](https://docs.medusajs.com/api/admin#campaigns_getcampaignsid) API route.
    * 
    * @param id - The campaign's ID.
    * @param query - Configure the fields to retrieve in the campaign.
@@ -44,7 +44,7 @@ export class Campaign {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async retrieve(
     id: string,
@@ -62,7 +62,7 @@ export class Campaign {
 
   /**
    * This method retrieves a paginated list of campaigns. It sends a request to the 
-   * [List Campaigns](https://docs.medusajs.com/v2/api/admin#campaigns_getcampaigns) API route.
+   * [List Campaigns](https://docs.medusajs.com/api/admin#campaigns_getcampaigns) API route.
    * 
    * @param query - Filters and pagination configurations.
    * @param headers - Headers to pass in the request.
@@ -104,7 +104,7 @@ export class Campaign {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(
     query?: HttpTypes.AdminGetCampaignsParams,
@@ -121,7 +121,7 @@ export class Campaign {
 
   /**
    * This method creates a campaign. It sends a request to the 
-   * [Create Campaign](https://docs.medusajs.com/v2/api/admin#campaigns_postcampaigns) API route.
+   * [Create Campaign](https://docs.medusajs.com/api/admin#campaigns_postcampaigns) API route.
    * 
    * @param payload - The details of the campaign to create.
    * @param headers - Headers to pass in the request
@@ -151,7 +151,7 @@ export class Campaign {
 
   /**
    * This method updates a campaign. It sends a request to the 
-   * [Update Campaign](https://docs.medusajs.com/v2/api/admin#campaigns_postcampaignsid) API route.
+   * [Update Campaign](https://docs.medusajs.com/api/admin#campaigns_postcampaignsid) API route.
    * 
    * @param id - The campaign's ID.
    * @param payload - The data to update in the campaign.
@@ -183,7 +183,7 @@ export class Campaign {
 
   /**
    * This method deletes a campaign by its ID. It sends a request to the
-   * [Delete Campaign](https://docs.medusajs.com/v2/api/admin#campaigns_deletecampaignsid) API route.
+   * [Delete Campaign](https://docs.medusajs.com/api/admin#campaigns_deletecampaignsid) API route.
    * 
    * @param id - The campaign's ID.
    * @param headers - Headers to pass in the request
@@ -207,7 +207,7 @@ export class Campaign {
 
   /**
    * This method manages the promotions of a campaign to either add or remove the association between them.
-   * It sends a request to the [Manage Promotions](https://docs.medusajs.com/v2/api/admin#campaigns_postcampaignsidpromotions)
+   * It sends a request to the [Manage Promotions](https://docs.medusajs.com/api/admin#campaigns_postcampaignsidpromotions)
    * API route.
    * 
    * @param id - The campaign's ID.

--- a/packages/core/js-sdk/src/admin/claim.ts
+++ b/packages/core/js-sdk/src/admin/claim.ts
@@ -17,7 +17,7 @@ export class Claim {
 
   /**
    * This method retrieves a paginated list of claims. It sends a request to the 
-   * [List Claims](https://docs.medusajs.com/v2/api/admin#claims_getclaims) API route.
+   * [List Claims](https://docs.medusajs.com/api/admin#claims_getclaims) API route.
    * 
    * @param query - Filters and pagination configurations.
    * @param headers - Headers to pass in the request.
@@ -59,7 +59,7 @@ export class Claim {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(query?: HttpTypes.AdminClaimListParams, headers?: ClientHeaders) {
     return await this.client.fetch<HttpTypes.AdminClaimListResponse>(
@@ -73,7 +73,7 @@ export class Claim {
 
   /**
    * This method retrieves a claim. It sends a request to the
-   * [Get Claim](https://docs.medusajs.com/v2/api/admin#claims_getclaimsid) API route.
+   * [Get Claim](https://docs.medusajs.com/api/admin#claims_getclaimsid) API route.
    * 
    * @param id - The claim's ID.
    * @param query - Configure the fields to retrieve in the claim.
@@ -101,7 +101,7 @@ export class Claim {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async retrieve(
     id: string,
@@ -119,7 +119,7 @@ export class Claim {
 
   /**
    * This method creates a claim. It sends a request to the 
-   * [Create Claim](https://docs.medusajs.com/v2/api/admin#claims_postclaims) API route.
+   * [Create Claim](https://docs.medusajs.com/api/admin#claims_postclaims) API route.
    * 
    * @param body - The claim's details.
    * @param query - Configure the fields to retrieve in the claim.
@@ -153,7 +153,7 @@ export class Claim {
 
   /**
    * This method cancels a claim. It sends a request to the
-   * [Cancel Claim](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidcancel) API route.
+   * [Cancel Claim](https://docs.medusajs.com/api/admin#claims_postclaimsidcancel) API route.
    * 
    * @param id - The claim's ID.
    * @param query - Configure the fields to retrieve in the claim.
@@ -183,7 +183,7 @@ export class Claim {
 
   /**
    * This method adds items to the claim. It sends a request to the
-   * [Add Items](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidclaimitems) API route.
+   * [Add Items](https://docs.medusajs.com/api/admin#claims_postclaimsidclaimitems) API route.
    * 
    * @param id - The ID of the claim to add the items to.
    * @param body - The items' details.
@@ -223,7 +223,7 @@ export class Claim {
 
   /**
    * This method updates a claim item by the ID of the item's `WRITE_OFF_ITEM` action. It
-   * sends a request to the [Update Claim Item](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidclaimitemsaction_id) API route.
+   * sends a request to the [Update Claim Item](https://docs.medusajs.com/api/admin#claims_postclaimsidclaimitemsaction_id) API route.
    * 
    * Every item has an `actions` property, whose value is an array of actions. 
    * You can check the action's name using its `action` property, and use the value of the `id` property.
@@ -267,7 +267,7 @@ export class Claim {
 
   /**
    * This method removes a claim item from a claim by the ID of the item's `WRITE_OFF_ITEM` action.
-   * It sends a request to the [Remove Claim Item](https://docs.medusajs.com/v2/api/admin#claims_deleteclaimsidclaimitemsaction_id)
+   * It sends a request to the [Remove Claim Item](https://docs.medusajs.com/api/admin#claims_deleteclaimsidclaimitemsaction_id)
    * API route.
    * 
    * Every item has an `actions` property, whose value is an array of actions. 
@@ -307,7 +307,7 @@ export class Claim {
   /**
    * This method adds inbound (or return) items to the claim. These inbound items will have a `RETURN_ITEM` action.
    * 
-   * This method sends a request to the [Add Inbound Items](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidinbounditems)
+   * This method sends a request to the [Add Inbound Items](https://docs.medusajs.com/api/admin#claims_postclaimsidinbounditems)
    * API route.
    * 
    * @param id - The ID of the claim to add the inbound items to.
@@ -351,7 +351,7 @@ export class Claim {
 
   /**
    * This method updates an inbound (or return) item of a claim using the ID of the item's `RETURN_ITEM` action.
-   * It sends a request to the [Update Inbound Item](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidinbounditemsaction_id)
+   * It sends a request to the [Update Inbound Item](https://docs.medusajs.com/api/admin#claims_postclaimsidinbounditemsaction_id)
    * API route.
    * 
    * Every item has an `actions` property, whose value is an array of actions. 
@@ -396,7 +396,7 @@ export class Claim {
 
   /**
    * This method removes an inbound (or return) item from a claim using the ID of the item's `RETURN_ITEM` action.
-   * It sends a request to the [Remove Inbound Item](https://docs.medusajs.com/v2/api/admin#claims_deleteclaimsidinbounditemsaction_id)
+   * It sends a request to the [Remove Inbound Item](https://docs.medusajs.com/api/admin#claims_deleteclaimsidinbounditemsaction_id)
    * API route.
    * 
    * Every item has an `actions` property, whose value is an array of actions. 
@@ -437,7 +437,7 @@ export class Claim {
    * This method adds an inbound (or return) shipping method to a claim. 
    * The inbound shipping method will have a `SHIPPING_ADD` action.
    * 
-   * This method sends a request to the [Add Inbound Shipping](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidinboundshippingmethod)
+   * This method sends a request to the [Add Inbound Shipping](https://docs.medusajs.com/api/admin#claims_postclaimsidinboundshippingmethod)
    * API route.
    * 
    * @param id - The claim's ID.
@@ -477,7 +477,7 @@ export class Claim {
 
   /**
    * This method updates a shipping method for returning items in the claim using the ID of the method's `SHIPPING_ADD` action.
-   * It sends a request to the [Update Inbound Shipping](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidinboundshippingmethodaction_id)
+   * It sends a request to the [Update Inbound Shipping](https://docs.medusajs.com/api/admin#claims_postclaimsidinboundshippingmethodaction_id)
    * API route.
    * 
    * Every shipping method has an `actions` property, whose value is an array of actions. 
@@ -522,7 +522,7 @@ export class Claim {
 
   /**
    * This method deletes a shipping method for returning items in the claim using the ID of the method's `SHIPPING_ADD` action.
-   * It sends a request to the [Remove Inbound Shipping](https://docs.medusajs.com/v2/api/admin#claims_deleteclaimsidinboundshippingmethodaction_id)
+   * It sends a request to the [Remove Inbound Shipping](https://docs.medusajs.com/api/admin#claims_deleteclaimsidinboundshippingmethodaction_id)
    * API route.
    * 
    * Every shipping method has an `actions` property, whose value is an array of actions. 
@@ -561,7 +561,7 @@ export class Claim {
 
   /**
    * This method adds outbound (or new) items to a claim. These outbound items will have an `ITEM_ADD` action.
-   * It sends a request to the [Add Outbound Items](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidoutbounditems)
+   * It sends a request to the [Add Outbound Items](https://docs.medusajs.com/api/admin#claims_postclaimsidoutbounditems)
    * API route.
    * 
    * @param id - The ID of the claim to add the outbound items to.
@@ -603,7 +603,7 @@ export class Claim {
 
   /**
    * This method updates an outbound (or new) item of a claim using the ID of the item's `ITEM_ADD` action.
-   * It sends a request to the [Update Outbound Item](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidoutbounditemsaction_id)
+   * It sends a request to the [Update Outbound Item](https://docs.medusajs.com/api/admin#claims_postclaimsidoutbounditemsaction_id)
    * API route.
    * 
    * Every item has an `actions` property, whose value is an array of actions. 
@@ -648,7 +648,7 @@ export class Claim {
 
   /**
    * This method removes an outbound (or new) item from a claim using the ID of the item's `ITEM_ADD` action.
-   * It sends a request to the [Remove Outbound Item](https://docs.medusajs.com/v2/api/admin#claims_deleteclaimsidoutbounditemsaction_id)
+   * It sends a request to the [Remove Outbound Item](https://docs.medusajs.com/api/admin#claims_deleteclaimsidoutbounditemsaction_id)
    * API route.
    * 
    * Every item has an `actions` property, whose value is an array of actions. 
@@ -690,7 +690,7 @@ export class Claim {
    * The outbound shipping method will have a `SHIPPING_ADD` action.
    * 
    * This method sends a request to the 
-   * [Add Outbound Shipping](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidoutboundshippingmethod)
+   * [Add Outbound Shipping](https://docs.medusajs.com/api/admin#claims_postclaimsidoutboundshippingmethod)
    * API route.
    * 
    * @param id - The claim's ID.
@@ -730,7 +730,7 @@ export class Claim {
 
   /**
    * This method updates the shipping method for delivering outbound items in a claim using the ID of the method's `SHIPPING_ADD` action.
-   * It sends a request to the [Update Outbound Shipping](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidoutboundshippingmethodaction_id)
+   * It sends a request to the [Update Outbound Shipping](https://docs.medusajs.com/api/admin#claims_postclaimsidoutboundshippingmethodaction_id)
    * API route.
    * 
    * Every shipping method has an `actions` property, whose value is an array of actions. 
@@ -812,7 +812,7 @@ export class Claim {
 
   /**
    * This method confirms a claim request, applying its changes on the associated order.
-   * It sends a request to the [Confirm Claim Request](https://docs.medusajs.com/v2/api/admin#claims_postclaimsidrequest)
+   * It sends a request to the [Confirm Claim Request](https://docs.medusajs.com/api/admin#claims_postclaimsidrequest)
    * API route.
    * 
    * @param id - The claim's ID.
@@ -849,7 +849,7 @@ export class Claim {
 
   /**
    * This method cancels a requested claim. It sends a request to the
-   * [Cancel Claim Request](https://docs.medusajs.com/v2/api/admin#claims_deleteclaimsidrequest)
+   * [Cancel Claim Request](https://docs.medusajs.com/api/admin#claims_deleteclaimsidrequest)
    * API route.
    * 
    * @param id - The claim's ID.

--- a/packages/core/js-sdk/src/admin/currency.ts
+++ b/packages/core/js-sdk/src/admin/currency.ts
@@ -16,7 +16,7 @@ export class Currency {
 
   /**
    * This method retrieves a paginated list of currencies. It sends a request to the
-   * [List Currencies](https://docs.medusajs.com/v2/api/admin#currencies_getcurrencies)
+   * [List Currencies](https://docs.medusajs.com/api/admin#currencies_getcurrencies)
    * API route.
    * 
    * @param query - Filters and pagination configurations.
@@ -59,7 +59,7 @@ export class Currency {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(
     query?: HttpTypes.AdminCurrencyListParams,
@@ -76,7 +76,7 @@ export class Currency {
 
   /**
    * This method retrieves a currency by its code. It sends a request to the
-   * [Get Currency](https://docs.medusajs.com/v2/api/admin#currencies_getcurrenciescode) API route.
+   * [Get Currency](https://docs.medusajs.com/api/admin#currencies_getcurrenciescode) API route.
    * 
    * @param code - The currency's code.
    * @param query - Configure the fields to retrieve in the currency.
@@ -104,7 +104,7 @@ export class Currency {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async retrieve(
     code: string,

--- a/packages/core/js-sdk/src/admin/customer-group.ts
+++ b/packages/core/js-sdk/src/admin/customer-group.ts
@@ -16,7 +16,7 @@ export class CustomerGroup {
 
   /**
    * This method retrieves a customer group by its ID. It sends a request to the
-   * [Get Customer Group](https://docs.medusajs.com/v2/api/admin#customer-groups_getcustomergroupsid) API route.
+   * [Get Customer Group](https://docs.medusajs.com/api/admin#customer-groups_getcustomergroupsid) API route.
    * 
    * @param id - The customer group's ID.
    * @param query - Configure the fields to retrieve in the customer group.
@@ -44,7 +44,7 @@ export class CustomerGroup {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async retrieve(
     id: string,
@@ -63,7 +63,7 @@ export class CustomerGroup {
 
   /**
    * This method retrieves a paginated list of customer groups. It sends a request to the
-   * [List Customer Groups](https://docs.medusajs.com/v2/api/admin#customer-groups_getcustomergroups)
+   * [List Customer Groups](https://docs.medusajs.com/api/admin#customer-groups_getcustomergroups)
    * API route.
    * 
    * @param query - Filters and pagination configurations.
@@ -106,7 +106,7 @@ export class CustomerGroup {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(
     query?: HttpTypes.AdminGetCustomerGroupsParams,
@@ -124,7 +124,7 @@ export class CustomerGroup {
 
   /**
    * This method creates a customer group. It sends a request to the
-   * [Create Customer Group](https://docs.medusajs.com/v2/api/admin#customer-groups_postcustomergroups)
+   * [Create Customer Group](https://docs.medusajs.com/api/admin#customer-groups_postcustomergroups)
    * API route.
    * 
    * @param body - The customer group's details.
@@ -158,7 +158,7 @@ export class CustomerGroup {
 
   /**
    * This method updates a customer group's details. It sends a request to the
-   * [Update Customer](https://docs.medusajs.com/v2/api/admin#customer-groups_postcustomergroupsid)
+   * [Update Customer](https://docs.medusajs.com/api/admin#customer-groups_postcustomergroupsid)
    * API route.
    * 
    * @param id - The customer group's ID.
@@ -194,7 +194,7 @@ export class CustomerGroup {
 
   /**
    * This method deletes a customer group. This method sends a request to the
-   * [Delete Customer Group](https://docs.medusajs.com/v2/api/admin#customer-groups_deletecustomergroupsid)
+   * [Delete Customer Group](https://docs.medusajs.com/api/admin#customer-groups_deletecustomergroupsid)
    * API route.
    * 
    * @param id - The customer group's ID.
@@ -219,7 +219,7 @@ export class CustomerGroup {
 
   /**
    * This method manages customers of a group to add or remove them from the group.
-   * It sends a request to the [Manage Customers](https://docs.medusajs.com/v2/api/admin#customer-groups_postcustomergroupsidcustomers)
+   * It sends a request to the [Manage Customers](https://docs.medusajs.com/api/admin#customer-groups_postcustomergroupsidcustomers)
    * API route.
    * 
    * @param id - The group's ID.

--- a/packages/core/js-sdk/src/admin/customer.ts
+++ b/packages/core/js-sdk/src/admin/customer.ts
@@ -19,7 +19,7 @@ export class Customer {
 
   /**
    * This method creates a customer. It sends a request to the
-   * [Create Customer](https://docs.medusajs.com/v2/api/admin#customers_postcustomers) API route.
+   * [Create Customer](https://docs.medusajs.com/api/admin#customers_postcustomers) API route.
    * 
    * @param body - The customer's details.
    * @param query - Configure the fields to retrieve in the customer.
@@ -51,7 +51,7 @@ export class Customer {
 
   /**
    * This method updates a customer's details. It sends a request to the
-   * [Update Customer](https://docs.medusajs.com/v2/api/admin#customers_postcustomersid) API route.
+   * [Update Customer](https://docs.medusajs.com/api/admin#customers_postcustomersid) API route.
    * 
    * @param id - The customer's ID.
    * @param body - The details to update of the customer.
@@ -86,7 +86,7 @@ export class Customer {
 
   /**
    * This method retrieves a paginated list of customers. It sends a request to the
-   * [List Customers](https://docs.medusajs.com/v2/api/admin#customers_getcustomers)
+   * [List Customers](https://docs.medusajs.com/api/admin#customers_getcustomers)
    * API route.
    * 
    * @param queryParams - Filters and pagination configurations.
@@ -129,7 +129,7 @@ export class Customer {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(
     queryParams?: HttpTypes.AdminCustomerFilters,
@@ -145,7 +145,7 @@ export class Customer {
 
   /**
    * This method retrieves a customer by its ID. It sends a request to the 
-   * [Get Customer](https://docs.medusajs.com/v2/api/admin#customers_getcustomersid)
+   * [Get Customer](https://docs.medusajs.com/api/admin#customers_getcustomersid)
    * API route.
    * 
    * @param id - The customer's ID.
@@ -174,7 +174,7 @@ export class Customer {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async retrieve(id: string, query?: SelectParams, headers?: ClientHeaders) {
     return this.client.fetch<HttpTypes.AdminCustomerResponse>(
@@ -188,7 +188,7 @@ export class Customer {
 
   /**
    * This method deletes a customer by its ID. It sends a request to the 
-   * [Delete Customer](https://docs.medusajs.com/v2/api/admin#customers_deletecustomersid)
+   * [Delete Customer](https://docs.medusajs.com/api/admin#customers_deletecustomersid)
    * API route.
    * 
    * @param id - The customer's ID.

--- a/packages/core/js-sdk/src/admin/exchange.ts
+++ b/packages/core/js-sdk/src/admin/exchange.ts
@@ -17,7 +17,7 @@ export class Exchange {
 
   /**
    * This method retrieves a paginated list of exchanges. It sends a request to the
-   * [List Exchanges](https://docs.medusajs.com/v2/api/admin#exchanges_getexchanges)
+   * [List Exchanges](https://docs.medusajs.com/api/admin#exchanges_getexchanges)
    * API route.
    * 
    * @param query - Filters and pagination configurations.
@@ -60,7 +60,7 @@ export class Exchange {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(
     query?: HttpTypes.AdminExchangeListParams,
@@ -77,7 +77,7 @@ export class Exchange {
 
   /**
    * This method retrieves an exchange by its ID. It sends a request to the 
-   * [Get Exchange](https://docs.medusajs.com/v2/api/admin#exchanges_getexchangesid)
+   * [Get Exchange](https://docs.medusajs.com/api/admin#exchanges_getexchangesid)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -106,7 +106,7 @@ export class Exchange {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async retrieve(
     id: string,
@@ -124,7 +124,7 @@ export class Exchange {
 
   /**
    * This method creates an admin exchange. It sends a request to the
-   * [Create Exchange](https://docs.medusajs.com/v2/api/admin#exchanges_postexchanges) API route.
+   * [Create Exchange](https://docs.medusajs.com/api/admin#exchanges_postexchanges) API route.
    * 
    * @param body - The exchange's details.
    * @param query - Configure the fields to retrieve in the exchange.
@@ -157,7 +157,7 @@ export class Exchange {
 
   /**
    * This method cancels an exchange. It sends a request to the
-   * [Cancel Exchange](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidcancel) API route.
+   * [Cancel Exchange](https://docs.medusajs.com/api/admin#exchanges_postexchangesidcancel) API route.
    * 
    * @param id - The exchange's ID.
    * @param query - Configure the fields to retrieve in the exchange.
@@ -189,7 +189,7 @@ export class Exchange {
    * This method adds inbound (or return) items to an exchange. These inbound items will 
    * have the action `RETURN_ITEM`.
    * 
-   * This method sends a request to the [Add Inbound Items](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidinbounditems)
+   * This method sends a request to the [Add Inbound Items](https://docs.medusajs.com/api/admin#exchanges_postexchangesidinbounditems)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -233,7 +233,7 @@ export class Exchange {
    * Every item has an `actions` property, whose value is an array of actions. You can 
    * check the action's name using its `action` property, and use the value of the `id` property.
    * 
-   * This method sends a request to the [Update Inbound Item](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidinbounditemsaction_id)
+   * This method sends a request to the [Update Inbound Item](https://docs.medusajs.com/api/admin#exchanges_postexchangesidinbounditemsaction_id)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -280,7 +280,7 @@ export class Exchange {
    * Every item has an `actions` property, whose value is an array of actions. 
    * You can check the action's name using its `action` property, and use the value of the `id` property.
    * 
-   * This method sends a request to the [Remove Inbound Item](https://docs.medusajs.com/v2/api/admin#exchanges_deleteexchangesidinbounditemsaction_id)
+   * This method sends a request to the [Remove Inbound Item](https://docs.medusajs.com/api/admin#exchanges_deleteexchangesidinbounditemsaction_id)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -318,10 +318,10 @@ export class Exchange {
    * This method adds an inbound (or return) shipping method to an exchange. 
    * The inbound shipping method will have a `SHIPPING_ADD` action.
    * 
-   * This method sends a request to the [Add Inbound Shipping](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidinboundshippingmethod)
+   * This method sends a request to the [Add Inbound Shipping](https://docs.medusajs.com/api/admin#exchanges_postexchangesidinboundshippingmethod)
    * API route.
    * 
-   * This method sends a request to the [Add Inbound Shipping](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidinboundshippingmethod)
+   * This method sends a request to the [Add Inbound Shipping](https://docs.medusajs.com/api/admin#exchanges_postexchangesidinboundshippingmethod)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -362,7 +362,7 @@ export class Exchange {
    * Every shipping method has an `actions` property, whose value is an array of actions. 
    * You can check the action's name using its `action` property, and use the value of the `id` property.
    * 
-   * This method sends a request to the [Update Inbound Shipping](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidinboundshippingmethodaction_id)
+   * This method sends a request to the [Update Inbound Shipping](https://docs.medusajs.com/api/admin#exchanges_postexchangesidinboundshippingmethodaction_id)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -409,7 +409,7 @@ export class Exchange {
    * Every shipping method has an `actions` property, whose value is an array of actions. 
    * You can check the action's name using its `action` property, and use the value of the `id` property.
    * 
-   * This method sends a request to the [Remove Inbound Shipping](https://docs.medusajs.com/v2/api/admin#exchanges_deleteexchangesidinboundshippingmethodaction_id)
+   * This method sends a request to the [Remove Inbound Shipping](https://docs.medusajs.com/api/admin#exchanges_deleteexchangesidinboundshippingmethodaction_id)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -447,7 +447,7 @@ export class Exchange {
    * This method adds outbound (or new) items to an exchange. 
    * These outbound items will have the action `ITEM_ADD`.
    * 
-   * This method sends a request to the [Add Outbound Items](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidoutbounditems)
+   * This method sends a request to the [Add Outbound Items](https://docs.medusajs.com/api/admin#exchanges_postexchangesidoutbounditems)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -491,7 +491,7 @@ export class Exchange {
    * Every item has an `actions` property, whose value is an array of actions. 
    * You can check the action's name using its `action` property, and use the value of the `id` property.
    * 
-   * This method sends a request to the [Update Inbound Item](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidoutbounditemsaction_id)
+   * This method sends a request to the [Update Inbound Item](https://docs.medusajs.com/api/admin#exchanges_postexchangesidoutbounditemsaction_id)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -538,7 +538,7 @@ export class Exchange {
    * Every item has an `actions` property, whose value is an array of actions. 
    * You can check the action's name using its `action` property, and use the value of the `id` property.
    * 
-   * This method sends a request to the [Update Outbound Item](https://docs.medusajs.com/v2/api/admin#exchanges_deleteexchangesidoutbounditemsaction_id)
+   * This method sends a request to the [Update Outbound Item](https://docs.medusajs.com/api/admin#exchanges_deleteexchangesidoutbounditemsaction_id)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -576,7 +576,7 @@ export class Exchange {
    * This method adds an outbound shipping method to an exchange. The outbound shipping method 
    * will have a `SHIPPING_ADD` action.
    * 
-   * This method sends a request to the [Add Outbound Shipping](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidoutboundshippingmethod)
+   * This method sends a request to the [Add Outbound Shipping](https://docs.medusajs.com/api/admin#exchanges_postexchangesidoutboundshippingmethod)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -617,7 +617,7 @@ export class Exchange {
    * Every shipping method has an `actions` property, whose value is an array of actions. 
    * You can check the action's name using its `action` property, and use the value of the `id` property.
    * 
-   * This method sends a request to the [Update Outbound Shipping](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidoutboundshippingmethodaction_id)
+   * This method sends a request to the [Update Outbound Shipping](https://docs.medusajs.com/api/admin#exchanges_postexchangesidoutboundshippingmethodaction_id)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -664,7 +664,7 @@ export class Exchange {
    * Every shipping method has an `actions` property, whose value is an array of actions. 
    * You can check the action's name using its `action` property, and use the value of the `id` property.
    * 
-   * This method sends a request to the [Remove Outbound Shipping](https://docs.medusajs.com/v2/api/admin#exchanges_deleteexchangesidoutboundshippingmethodaction_id)
+   * This method sends a request to the [Remove Outbound Shipping](https://docs.medusajs.com/api/admin#exchanges_deleteexchangesidoutboundshippingmethodaction_id)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -701,7 +701,7 @@ export class Exchange {
   /**
    * This method confirms an exchange request, applying its changes on the associated order.
    * 
-   * This method sends a request to the [Confirm Exchange](https://docs.medusajs.com/v2/api/admin#exchanges_postexchangesidrequest)
+   * This method sends a request to the [Confirm Exchange](https://docs.medusajs.com/api/admin#exchanges_postexchangesidrequest)
    * API route.
    * 
    * @param id - The exchange's ID.
@@ -735,7 +735,7 @@ export class Exchange {
 
   /**
    * This method cancels an exchange request. It sends a request to the
-   * [Cancel Exchange Request](https://docs.medusajs.com/v2/api/admin#exchanges_deleteexchangesidrequest)
+   * [Cancel Exchange Request](https://docs.medusajs.com/api/admin#exchanges_deleteexchangesidrequest)
    * API route.
    * 
    * @param id - The exchange's ID.

--- a/packages/core/js-sdk/src/admin/fulfillment-provider.ts
+++ b/packages/core/js-sdk/src/admin/fulfillment-provider.ts
@@ -16,7 +16,7 @@ export class FulfillmentProvider {
 
   /**
    * This method retrieves a paginated list of fulfillment providers. It sends a request to the
-   * [List Fulfillment Providers](https://docs.medusajs.com/v2/api/admin#fulfillment-providers_getfulfillmentproviders)
+   * [List Fulfillment Providers](https://docs.medusajs.com/api/admin#fulfillment-providers_getfulfillmentproviders)
    * API route.
    * 
    * @param query - Filters and pagination configurations.
@@ -59,7 +59,7 @@ export class FulfillmentProvider {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(
     query?: HttpTypes.AdminFulfillmentProviderListParams,

--- a/packages/core/js-sdk/src/admin/fulfillment-set.ts
+++ b/packages/core/js-sdk/src/admin/fulfillment-set.ts
@@ -16,7 +16,7 @@ export class FulfillmentSet {
 
   /**
    * This method deletes a fulfillment set. It sends a request to the
-   * [Delete Fulfillment Set](https://docs.medusajs.com/v2/api/admin#fulfillment-sets_deletefulfillmentsetsid)
+   * [Delete Fulfillment Set](https://docs.medusajs.com/api/admin#fulfillment-sets_deletefulfillmentsetsid)
    * API route.
    * 
    * @param id - The fulfillment set's ID.
@@ -41,7 +41,7 @@ export class FulfillmentSet {
 
   /**
    * This method adds a service zone to a fulfillment set. It uses the 
-   * [Add Service Zone](https://docs.medusajs.com/v2/api/admin#fulfillment-sets_postfulfillmentsetsidservicezones)
+   * [Add Service Zone](https://docs.medusajs.com/api/admin#fulfillment-sets_postfulfillmentsetsidservicezones)
    * API route.
    * 
    * @param id - The fulfillment set's ID.
@@ -81,7 +81,7 @@ export class FulfillmentSet {
 
   /**
    * This method retrieves a fulfillment set's service zone's details. It sends a request to the
-   * [Get Service Zone](https://docs.medusajs.com/v2/api/admin#fulfillment-sets_getfulfillmentsetsidservicezoneszone_id)
+   * [Get Service Zone](https://docs.medusajs.com/api/admin#fulfillment-sets_getfulfillmentsetsidservicezoneszone_id)
    * API route.
    * 
    * @param fulfillmentSetId - The fulfillment set's ID. 
@@ -118,7 +118,7 @@ export class FulfillmentSet {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async retrieveServiceZone(
     fulfillmentSetId: string,
@@ -138,7 +138,7 @@ export class FulfillmentSet {
 
   /**
    * This method updates a service zone in a fulfillment set. It sends a request to the
-   * [Update Service Zone](https://docs.medusajs.com/v2/api/admin#fulfillment-sets_postfulfillmentsetsidservicezoneszone_id)
+   * [Update Service Zone](https://docs.medusajs.com/api/admin#fulfillment-sets_postfulfillmentsetsidservicezoneszone_id)
    * API route.
    * 
    * @param fulfillmentSetId - The fulfillment set's ID.
@@ -180,7 +180,7 @@ export class FulfillmentSet {
 
   /**
    * This method deletes a service zone in a fulfillment set. It sends a request to the
-   * [Remove Service Zone](https://docs.medusajs.com/v2/api/admin#fulfillment-sets_deletefulfillmentsetsidservicezoneszone_id)
+   * [Remove Service Zone](https://docs.medusajs.com/api/admin#fulfillment-sets_deletefulfillmentsetsidservicezoneszone_id)
    * API route.
    * 
    * @param fulfillmentSetId - The fulfullment set's ID.

--- a/packages/core/js-sdk/src/admin/fulfillment.ts
+++ b/packages/core/js-sdk/src/admin/fulfillment.ts
@@ -16,7 +16,7 @@ export class Fulfillment {
 
   /**
    * This method creates a fulfillment. It sends a request to the 
-   * [Create Fulfillment](https://docs.medusajs.com/v2/api/admin#fulfillments_postfulfillments)
+   * [Create Fulfillment](https://docs.medusajs.com/api/admin#fulfillments_postfulfillments)
    * API route.
    * 
    * @param body - The fulfillment's details.
@@ -65,7 +65,7 @@ export class Fulfillment {
 
   /**
    * This method cancels a fulfillment. It sends a request to the
-   * [Cancel Fulfillment](https://docs.medusajs.com/v2/api/admin#fulfillments_postfulfillmentsidcancel)
+   * [Cancel Fulfillment](https://docs.medusajs.com/api/admin#fulfillments_postfulfillmentsidcancel)
    * API route.
    * 
    * @param id - The fulfillment's ID.
@@ -97,7 +97,7 @@ export class Fulfillment {
 
   /**
    * This method creates a shipment for a fulfillment. It sends a request to the
-   * [Create Shipment](https://docs.medusajs.com/v2/api/admin#fulfillments_postfulfillmentsidshipment)
+   * [Create Shipment](https://docs.medusajs.com/api/admin#fulfillments_postfulfillmentsidshipment)
    * API route.
    * 
    * @param id - The fulfillment's ID.

--- a/packages/core/js-sdk/src/admin/inventory-item.ts
+++ b/packages/core/js-sdk/src/admin/inventory-item.ts
@@ -16,7 +16,7 @@ export class InventoryItem {
 
   /**
    * This method creates an inventory item. It sends a request to the 
-   * [Create Inventory Item](https://docs.medusajs.com/v2/api/admin#inventory-items_postinventoryitems)
+   * [Create Inventory Item](https://docs.medusajs.com/api/admin#inventory-items_postinventoryitems)
    * API route.
    * 
    * @param body - The inventory item's details.
@@ -50,7 +50,7 @@ export class InventoryItem {
 
   /**
    * This method updates an inventory level. It sends a request to the
-   * [Update Inventory Item](https://docs.medusajs.com/v2/api/admin#inventory-items_postinventoryitemsid)
+   * [Update Inventory Item](https://docs.medusajs.com/api/admin#inventory-items_postinventoryitemsid)
    * API route.
    * 
    * @param id - The inventory item's ID.
@@ -86,7 +86,7 @@ export class InventoryItem {
 
   /**
    * This method retrieves a paginated list of inventory items. It sends a request to the 
-   * [List Inventory Items](https://docs.medusajs.com/v2/api/admin#inventory-items_getinventoryitems)
+   * [List Inventory Items](https://docs.medusajs.com/api/admin#inventory-items_getinventoryitems)
    * API route.
    * 
    * @param query - Filters and pagination configurations.
@@ -129,7 +129,7 @@ export class InventoryItem {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(
     query?: HttpTypes.AdminInventoryItemParams,
@@ -146,7 +146,7 @@ export class InventoryItem {
 
   /**
    * This method retrieves an inventory item by its ID. It sends a request to the 
-   * [Get Inventory Item](https://docs.medusajs.com/v2/api/admin#inventory-items_getinventoryitemsid) API route.
+   * [Get Inventory Item](https://docs.medusajs.com/api/admin#inventory-items_getinventoryitemsid) API route.
    * 
    * @param id - The inventory item's ID.
    * @param query - Configure the fields to retrieve in the inventory item.
@@ -174,7 +174,7 @@ export class InventoryItem {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async retrieve(id: string, query?: SelectParams, headers?: ClientHeaders) {
     return await this.client.fetch<HttpTypes.AdminInventoryItemResponse>(
@@ -188,7 +188,7 @@ export class InventoryItem {
 
   /**
    * This method deletes an inventory item. This sends a request to the
-   * [Delete Inventory Item](https://docs.medusajs.com/v2/api/admin#inventory-items_deleteinventoryitemsid)
+   * [Delete Inventory Item](https://docs.medusajs.com/api/admin#inventory-items_deleteinventoryitemsid)
    * API route.
    * 
    * @param id - The inventory item's ID.
@@ -213,7 +213,7 @@ export class InventoryItem {
 
   /**
    * This method retrieves a paginated list of inventory levels that belong to an inventory item.
-   * It sends a request to the [List Inventory Items](https://docs.medusajs.com/v2/api/admin#inventory-items_getinventoryitems)
+   * It sends a request to the [List Inventory Items](https://docs.medusajs.com/api/admin#inventory-items_getinventoryitems)
    * API route.
    * 
    * @param id - The inventory item's ID.
@@ -257,7 +257,7 @@ export class InventoryItem {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async listLevels(
     id: string,
@@ -278,7 +278,7 @@ export class InventoryItem {
    * stock location.
    * 
    * This method sends a request to the 
-   * [Update Inventory Level](https://docs.medusajs.com/v2/api/admin#inventory-items_postinventoryitemsidlocationlevelslocation_id)
+   * [Update Inventory Level](https://docs.medusajs.com/api/admin#inventory-items_postinventoryitemsidlocationlevelslocation_id)
    * API route.
    * 
    * @param id - The inventory item's ID.
@@ -323,7 +323,7 @@ export class InventoryItem {
    * and a stock location.
    * 
    * This method sends a request to the 
-   * [Remove Inventory Level](https://docs.medusajs.com/v2/api/admin#inventory-items_deleteinventoryitemsidlocationlevelslocation_id)
+   * [Remove Inventory Level](https://docs.medusajs.com/api/admin#inventory-items_deleteinventoryitemsidlocationlevelslocation_id)
    * API route.
    * 
    * @param id - The inventory item's ID.
@@ -352,7 +352,7 @@ export class InventoryItem {
 
   /**
    * This method manages the inventory levels of an inventory item. It sends a request to the
-   * [Manage Inventory Levels](https://docs.medusajs.com/v2/api/admin#inventory-items_postinventoryitemsidlocationlevelsbatch)
+   * [Manage Inventory Levels](https://docs.medusajs.com/api/admin#inventory-items_postinventoryitemsidlocationlevelsbatch)
    * API route.
    * 
    * @param id - The inventory item's ID.

--- a/packages/core/js-sdk/src/admin/invite.ts
+++ b/packages/core/js-sdk/src/admin/invite.ts
@@ -23,7 +23,7 @@ export class Invite {
    * the {@link Auth.register}.
    * 
    * This method sends a request to the [Accept Invite]
-   * (https://docs.medusajs.com/v2/api/admin#invites_postinvitesaccept)
+   * (https://docs.medusajs.com/api/admin#invites_postinvitesaccept)
    * API route.
    * 
    * @param input - The details of the user to create.
@@ -76,7 +76,7 @@ export class Invite {
 
   /**
    * This method creates an invite. It sends a request to the
-   * [Create Invite](https://docs.medusajs.com/v2/api/admin#invites_postinvites)
+   * [Create Invite](https://docs.medusajs.com/api/admin#invites_postinvites)
    * API route.
    * 
    * @param body - The invite's details.
@@ -110,7 +110,7 @@ export class Invite {
 
   /**
    * This method retrieves an invite by its ID. It sends a request to the
-   * [Get Invite](https://docs.medusajs.com/v2/api/admin#invites_getinvitesid)
+   * [Get Invite](https://docs.medusajs.com/api/admin#invites_getinvitesid)
    * API route.
    * 
    * @param id - The invite's ID.
@@ -139,7 +139,7 @@ export class Invite {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async retrieve(id: string, query?: SelectParams, headers?: ClientHeaders) {
     return await this.client.fetch<HttpTypes.AdminInviteResponse>(
@@ -153,7 +153,7 @@ export class Invite {
 
   /**
    * This method retrieves a paginated list of invites. It sends a request to the
-   * [List Invites](https://docs.medusajs.com/v2/api/admin#invites_getinvites)
+   * [List Invites](https://docs.medusajs.com/api/admin#invites_getinvites)
    * API route.
    * 
    * @param queryParams - Filters and pagination configurations.
@@ -196,7 +196,7 @@ export class Invite {
    * })
    * ```
    * 
-   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   async list(queryParams?: FindParams, headers?: ClientHeaders) {
     return await this.client.fetch<
@@ -209,7 +209,7 @@ export class Invite {
 
   /**
    * This method refreshes the token of an invite. It sends a request to the
-   * [Refresh Invite Token](https://docs.medusajs.com/v2/api/admin#invites_postinvitesidresend)
+   * [Refresh Invite Token](https://docs.medusajs.com/api/admin#invites_postinvitesidresend)
    * API route.
    * 
    * @param id - The invite's ID.
@@ -234,7 +234,7 @@ export class Invite {
 
   /**
    * This method deletes an invite. It sends a request to the
-   * [Delete Invite](https://docs.medusajs.com/v2/api/admin#invites_deleteinvitesid)
+   * [Delete Invite](https://docs.medusajs.com/api/admin#invites_deleteinvitesid)
    * API route.
    * 
    * @param id - The invite's ID.

--- a/packages/core/js-sdk/src/auth/index.ts
+++ b/packages/core/js-sdk/src/auth/index.ts
@@ -13,7 +13,7 @@ export class Auth {
 
   /**
    * This method is used to retrieve a registration JWT token for a user, customer, or custom actor type. It sends a request to the
-   * [Retrieve Registration Token API route](https://docs.medusajs.com/v2/api/store#auth_postactor_typeauth_provider_register).
+   * [Retrieve Registration Token API route](https://docs.medusajs.com/api/store#auth_postactor_typeauth_provider_register).
    * 
    * @param actor - The actor type. For example, `user` for admin user, or `customer` for customer.
    * @param method - The authentication provider to use. For example, `emailpass` or `google`.
@@ -53,10 +53,10 @@ export class Auth {
 
   /**
    * This method retrieves the JWT authenticated token for an admin user, customer, or custom
-   * actor type. It sends a request to the [Authenticate API Route](https://docs.medusajs.com/v2/api/admin#auth_postactor_typeauth_provider).
+   * actor type. It sends a request to the [Authenticate API Route](https://docs.medusajs.com/api/admin#auth_postactor_typeauth_provider).
    * 
    * If the `auth.type` of the SDK is set to `session`, this method will also send a request to the
-   * [Set Authentication Session API route](https://docs.medusajs.com/v2/api/admin#auth_postsession).
+   * [Set Authentication Session API route](https://docs.medusajs.com/api/admin#auth_postsession).
    * 
    * Subsequent requests using the SDK will automatically have the necessary authentication headers / session
    * set.
@@ -105,7 +105,7 @@ export class Auth {
 
   /**
    * This method is used to validate an Oauth callback from a third-party service, such as Google, for an admin user, customer, or custom actor types.
-   * It sends a request to the [Validate Authentication Callback](https://docs.medusajs.com/v2/api/admin#auth_postactor_typeauth_providercallback).
+   * It sends a request to the [Validate Authentication Callback](https://docs.medusajs.com/api/admin#auth_postactor_typeauth_providercallback).
    * 
    * @param actor - The actor type. For example, `user` for admin user, or `customer` for customer.
    * @param method - The authentication provider to use. For example, `google`.
@@ -147,7 +147,7 @@ export class Auth {
 
   /**
    * This method refreshes a JWT authentication token, which is useful after validating the Oauth callback
-   * with {@link callback}. It sends a request to the [Refresh Authentication Token API route](https://docs.medusajs.com/v2/api/admin#auth_postadminauthtokenrefresh).
+   * with {@link callback}. It sends a request to the [Refresh Authentication Token API route](https://docs.medusajs.com/api/admin#auth_postadminauthtokenrefresh).
    * 
    * @returns The refreshed JWT authentication token.
    * 
@@ -173,7 +173,7 @@ export class Auth {
 
   /**
    * This method deletes the authentication session of the currently logged-in user to log them out.
-   * It sends a request to the [Delete Authentication Session API route](https://docs.medusajs.com/v2/api/admin#auth_deletesession).
+   * It sends a request to the [Delete Authentication Session API route](https://docs.medusajs.com/api/admin#auth_deletesession).
    * 
    * @example
    * sdk.auth.logout()
@@ -193,11 +193,11 @@ export class Auth {
 
   /**
    * This method requests a reset password token for an admin user, customer, or custom actor type.
-   * It sends a request to the [Generate Reset Password Token API route](https://docs.medusajs.com/v2/api/admin#auth_postactor_typeauth_providerresetpassword).
+   * It sends a request to the [Generate Reset Password Token API route](https://docs.medusajs.com/api/admin#auth_postactor_typeauth_providerresetpassword).
    * 
    * To reset the password later using the token delivered to the user, use the {@link updateProvider} method.
    * 
-   * Related guide: [How to allow customers to reset their passwords in a storefront](https://docs.medusajs.com/v2/resources/storefront-development/customers/reset-password).
+   * Related guide: [How to allow customers to reset their passwords in a storefront](https://docs.medusajs.com/resources/storefront-development/customers/reset-password).
    * 
    * @param actor - The actor type. For example, `user` for admin user, or `customer` for customer.
    * @param provider - The authentication provider to use. For example, `emailpass`.
@@ -239,9 +239,9 @@ export class Auth {
    * More specifically, use this method when updating the password of an admin user, customer, or 
    * custom actor type after requesting to reset their password with {@link resetPassword}.
    * 
-   * This method sends a request to [this API route](https://docs.medusajs.com/v2/api/admin#auth_postactor_typeauth_providerupdate).
+   * This method sends a request to [this API route](https://docs.medusajs.com/api/admin#auth_postactor_typeauth_providerupdate).
    * 
-   * Related guide: [How to allow customers to reset their passwords in a storefront](https://docs.medusajs.com/v2/resources/storefront-development/customers/reset-password).
+   * Related guide: [How to allow customers to reset their passwords in a storefront](https://docs.medusajs.com/resources/storefront-development/customers/reset-password).
    * 
    * @param actor - The actor type. For example, `user` for admin user, or `customer` for customer.
    * @param provider - The authentication provider to use. For example, `emailpass`.

--- a/packages/core/js-sdk/src/store/index.ts
+++ b/packages/core/js-sdk/src/store/index.ts
@@ -22,9 +22,9 @@ export class Store {
   public region = {
     /**
      * This method retrieves the paginated list of regions in the store. It sends a request to the 
-     * [List Regions API route](https://docs.medusajs.com/v2/api/store#regions_getregions).
+     * [List Regions API route](https://docs.medusajs.com/api/store#regions_getregions).
      * 
-     * Related guide: [How to list regions in a storefront](https://docs.medusajs.com/v2/resources/storefront-development/regions/list).
+     * Related guide: [How to list regions in a storefront](https://docs.medusajs.com/resources/storefront-development/regions/list).
      * 
      * @param query - Filters and pagination configurations.
      * @param headers - Headers to pass in the request
@@ -66,7 +66,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     list: async (
       query?: FindParams & HttpTypes.StoreRegionFilters,
@@ -80,10 +80,10 @@ export class Store {
       })
     },
     /**
-     * This method retrieves a region by its ID. It sends a request to the [Get Region](https://docs.medusajs.com/v2/api/store#regions_getregionsid)
+     * This method retrieves a region by its ID. It sends a request to the [Get Region](https://docs.medusajs.com/api/store#regions_getregionsid)
      * API route.
      * 
-     * Related guide: [Store and retrieve regions in a storefront](https://docs.medusajs.com/v2/resources/storefront-development/regions/store-retrieve-region).
+     * Related guide: [Store and retrieve regions in a storefront](https://docs.medusajs.com/resources/storefront-development/regions/store-retrieve-region).
      * 
      * @param id - The region's ID.
      * @param query - Configure the fields to retrieve in the region.
@@ -114,7 +114,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     retrieve: async (
       id: string,
@@ -134,9 +134,9 @@ export class Store {
   public collection = {
     /**
      * This method retrieves a paginated list of product collections. It sends a request to the
-     * [List Collections](https://docs.medusajs.com/v2/api/store#collections_getcollections) API route.
+     * [List Collections](https://docs.medusajs.com/api/store#collections_getcollections) API route.
      * 
-     * Related guide: [How to retrieve collections in a storefront](https://docs.medusajs.com/v2/resources/storefront-development/products/collections/list).
+     * Related guide: [How to retrieve collections in a storefront](https://docs.medusajs.com/resources/storefront-development/products/collections/list).
      * 
      * @param query - Filters and pagination configurations.
      * @param headers - Headers to pass in the request
@@ -178,7 +178,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     list: async (
       query?: FindParams & HttpTypes.StoreCollectionFilters,
@@ -192,10 +192,10 @@ export class Store {
       })
     },
     /**
-     * This method retrieves a collection by its ID. It sends a request to the [Get Collection](https://docs.medusajs.com/v2/api/store#collections_getcollectionsid)
+     * This method retrieves a collection by its ID. It sends a request to the [Get Collection](https://docs.medusajs.com/api/store#collections_getcollectionsid)
      * API route.
      * 
-     * Related guide: [How to retrieve a collection in a storefront](https://docs.medusajs.com/v2/resources/storefront-development/products/collections/retrieve).
+     * Related guide: [How to retrieve a collection in a storefront](https://docs.medusajs.com/resources/storefront-development/products/collections/retrieve).
      * 
      * @param id - The ID of the collection to retrieve.
      * @param query - Configure the fields to retrieve in the collection.
@@ -223,7 +223,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     retrieve: async (
       id: string,
@@ -243,9 +243,9 @@ export class Store {
   public category = {
     /**
      * This method retrieves a paginated list of product categories. It sends a request to the 
-     * [List Categories](https://docs.medusajs.com/v2/api/store#product-categories_getproductcategories) API route.
+     * [List Categories](https://docs.medusajs.com/api/store#product-categories_getproductcategories) API route.
      * 
-     * Related guide: [How to retrieve list of categories in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/products/categories/list).
+     * Related guide: [How to retrieve list of categories in the storefront](https://docs.medusajs.com/resources/storefront-development/products/categories/list).
      * 
      * @param query - Filters and pagination configurations.
      * @param headers - Headers to pass in the request.
@@ -287,7 +287,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     list: async (
       query?: FindParams & HttpTypes.StoreProductCategoryListParams,
@@ -302,9 +302,9 @@ export class Store {
     },
     /**
      * This method retrieves a category by its ID. It sends a request to the 
-     * [Retrieve Product Category](https://docs.medusajs.com/v2/api/store#product-categories_getproductcategoriesid).
+     * [Retrieve Product Category](https://docs.medusajs.com/api/store#product-categories_getproductcategoriesid).
      * 
-     * Related guide: [How to retrieve a category in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/products/categories/retrieve).
+     * Related guide: [How to retrieve a category in the storefront](https://docs.medusajs.com/resources/storefront-development/products/categories/retrieve).
      * 
      * @param id - The ID of the category to retrieve.
      * @param query - Configure the fields to retrieve in the category.
@@ -332,7 +332,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     retrieve: async (
       id: string,
@@ -351,12 +351,12 @@ export class Store {
   public product = {
     /**
      * This method retrieves a list of products. It sends a request to the
-     * [List Products API route](https://docs.medusajs.com/v2/api/store#products_getproducts).
+     * [List Products API route](https://docs.medusajs.com/api/store#products_getproducts).
      * 
      * Related guides:
      * 
-     * - [How to list products in a storefront](https://docs.medusajs.com/v2/resources/storefront-development/products/list).
-     * - [How to retrieve a product variant's prices in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/products/price)
+     * - [How to list products in a storefront](https://docs.medusajs.com/resources/storefront-development/products/list).
+     * - [How to retrieve a product variant's prices in the storefront](https://docs.medusajs.com/resources/storefront-development/products/price)
      * 
      * @param query - Filters and pagination configurations.
      * @param headers - Headers to pass in the request.
@@ -398,7 +398,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     list: async (
       query?: HttpTypes.StoreProductParams,
@@ -414,12 +414,12 @@ export class Store {
     },
     /**
      * This method is used to retrieve a product by its ID. It sends a request to the 
-     * [Get Product](https://docs.medusajs.com/v2/api/store#products_getproductsid) API route.
+     * [Get Product](https://docs.medusajs.com/api/store#products_getproductsid) API route.
      * 
      * Related guides:
      * 
-     * - [How to retrieve a product in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/products/retrieve).
-     * - [How to retrieve a product variant's prices in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/products/price)
+     * - [How to retrieve a product in the storefront](https://docs.medusajs.com/resources/storefront-development/products/retrieve).
+     * - [How to retrieve a product variant's prices in the storefront](https://docs.medusajs.com/resources/storefront-development/products/price)
      * 
      * @param id - The product's ID.
      * @param query - Configure the fields to retrieve in the product.
@@ -447,7 +447,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     retrieve: async (
       id: string,
@@ -465,14 +465,14 @@ export class Store {
   }
 
   /**
-   * Related guides: [How to implement carts in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/cart).
+   * Related guides: [How to implement carts in the storefront](https://docs.medusajs.com/resources/storefront-development/cart).
    */
   public cart = {
     /**
-     * This method creates a cart. It sends a request to the [Create Cart](https://docs.medusajs.com/v2/api/store#carts_postcarts)
+     * This method creates a cart. It sends a request to the [Create Cart](https://docs.medusajs.com/api/store#carts_postcarts)
      * API route.
      * 
-     * Related guide: [How to create a cart in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/cart/create).
+     * Related guide: [How to create a cart in the storefront](https://docs.medusajs.com/resources/storefront-development/cart/create).
      * 
      * @param body - The details of the cart to create.
      * @param query - Configure the fields to retrieve in the cart.
@@ -501,9 +501,9 @@ export class Store {
     },
     /**
      * This method updates a cart. It sends a request to the
-     * [Update Cart](https://docs.medusajs.com/v2/api/store#carts_postcartsid) API route.
+     * [Update Cart](https://docs.medusajs.com/api/store#carts_postcartsid) API route.
      * 
-     * Related guide: [How to update a cart in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/cart/update).
+     * Related guide: [How to update a cart in the storefront](https://docs.medusajs.com/resources/storefront-development/cart/update).
      * 
      * @param id - The cart's ID.
      * @param body - The data to update in the cart.
@@ -537,9 +537,9 @@ export class Store {
     },
     /**
      * This method retrieves a cart by its ID. It sends a request to the 
-     * [Get Cart](https://docs.medusajs.com/v2/api/store#carts_getcartsid) API route.
+     * [Get Cart](https://docs.medusajs.com/api/store#carts_getcartsid) API route.
      * 
-     * Related guide: [How to retrieve a cart in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/cart/retrieve).
+     * Related guide: [How to retrieve a cart in the storefront](https://docs.medusajs.com/resources/storefront-development/cart/retrieve).
      * 
      * @param id - The cart's ID.
      * @param query - Configure the fields to retrieve in the cart.
@@ -567,7 +567,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     retrieve: async (
       id: string,
@@ -584,9 +584,9 @@ export class Store {
     },
     /**
      * This methods adds a product variant to the cart as a line item. It sends a request to the
-     * [Add Line Item](https://docs.medusajs.com/v2/api/store#carts_postcartsidlineitems) API route.
+     * [Add Line Item](https://docs.medusajs.com/api/store#carts_postcartsidlineitems) API route.
      * 
-     * Related guide: [How to manage a cart's line items in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/cart/manage-items).
+     * Related guide: [How to manage a cart's line items in the storefront](https://docs.medusajs.com/resources/storefront-development/cart/manage-items).
      * 
      * @param cartId - The cart's ID.
      * @param body - The details of the item to add.
@@ -621,9 +621,9 @@ export class Store {
     },
     /**
      * This method updates a line item in a cart. It sends a request to the 
-     * [Update Line Item](https://docs.medusajs.com/v2/api/store#carts_postcartsidlineitemsline_id) API route.
+     * [Update Line Item](https://docs.medusajs.com/api/store#carts_postcartsidlineitemsline_id) API route.
      * 
-     * Related guide: [How to manage a cart's line items in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/cart/manage-items).
+     * Related guide: [How to manage a cart's line items in the storefront](https://docs.medusajs.com/resources/storefront-development/cart/manage-items).
      * 
      * @param cartId - The cart's ID.
      * @param lineItemId - The line item's ID.
@@ -663,9 +663,9 @@ export class Store {
     },
     /**
      * This method deletes a line item from a cart. It sends a request to the
-     * [Remove Line Item](https://docs.medusajs.com/v2/api/store#carts_deletecartsidlineitemsline_id) API route.
+     * [Remove Line Item](https://docs.medusajs.com/api/store#carts_deletecartsidlineitemsline_id) API route.
      * 
-     * Related guide: [How to manage a cart's line items in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/cart/manage-items).
+     * Related guide: [How to manage a cart's line items in the storefront](https://docs.medusajs.com/resources/storefront-development/cart/manage-items).
      * 
      * @param cartId - The cart's ID.
      * @param lineItemId - The item's ID.
@@ -696,9 +696,9 @@ export class Store {
     },
     /**
      * This method adds a shipping method to a cart. It sends a request to 
-     * the [Add Shipping Method](https://docs.medusajs.com/v2/api/store#carts_postcartsidshippingmethods) API routes.
+     * the [Add Shipping Method](https://docs.medusajs.com/api/store#carts_postcartsidshippingmethods) API routes.
      * 
-     * Related guide: [Implement shipping step during checkout](https://docs.medusajs.com/v2/resources/storefront-development/checkout/shipping).
+     * Related guide: [Implement shipping step during checkout](https://docs.medusajs.com/resources/storefront-development/checkout/shipping).
      * 
      * @param cartId - The cart's ID.
      * @param body - The shipping method's details.
@@ -735,10 +735,10 @@ export class Store {
     },
     /**
      * This method completes a cart and places the order. It's the last step of the checkout flow.
-     * The method sends a request to the [Complete Cart](https://docs.medusajs.com/v2/api/store#carts_postcartsidcomplete)
+     * The method sends a request to the [Complete Cart](https://docs.medusajs.com/api/store#carts_postcartsidcomplete)
      * API route.
      * 
-     * Related guide: [Learn how to complete cart in checkout flow](https://docs.medusajs.com/v2/resources/storefront-development/checkout/complete-cart).
+     * Related guide: [Learn how to complete cart in checkout flow](https://docs.medusajs.com/resources/storefront-development/checkout/complete-cart).
      * 
      * @param cartId - The cart's ID.
      * @param query - Configure the fields to retrieve in the created order.
@@ -775,10 +775,10 @@ export class Store {
   public fulfillment = {
     /**
      * This method retrieves the list of shipping options for a cart. It sends a request to
-     * the [List Shipping Options](https://docs.medusajs.com/v2/api/store#shipping-options_getshippingoptions)
+     * the [List Shipping Options](https://docs.medusajs.com/api/store#shipping-options_getshippingoptions)
      * API route.
      * 
-     * Related guide: [Implement shipping step during checkout](https://docs.medusajs.com/v2/resources/storefront-development/checkout/shipping).
+     * Related guide: [Implement shipping step during checkout](https://docs.medusajs.com/resources/storefront-development/checkout/shipping).
      * 
      * @param query - The cart's details along with configurations of the fields to retrieve in the options.
      * @param headers - Headers to pass in the request.
@@ -808,10 +808,10 @@ export class Store {
   public payment = {
     /**
      * This method retrieves the payment providers available in a region, which is useful during checkout.
-     * It sends a request to the [List Payment Providers](https://docs.medusajs.com/v2/api/store#payment-providers_getpaymentproviders)
+     * It sends a request to the [List Payment Providers](https://docs.medusajs.com/api/store#payment-providers_getpaymentproviders)
      * API route.
      * 
-     * Related guide: [Implement payment step during checkout](https://docs.medusajs.com/v2/resources/storefront-development/checkout/payment).
+     * Related guide: [Implement payment step during checkout](https://docs.medusajs.com/resources/storefront-development/checkout/payment).
      * 
      * @param query - The filters to apply on the retrieved providers, along with configurations of the 
      * fields to retrieve in the options.
@@ -860,7 +860,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     listPaymentProviders: async (
       query?: FindParams & HttpTypes.StorePaymentProviderFilters,
@@ -876,14 +876,14 @@ export class Store {
 
     /**
      * This method creates a payment session of a cart's payment collection, selecting a payment provider.
-     * It sends a request to the [Initialize Payment Session](https://docs.medusajs.com/v2/api/store#payment-collections_postpaymentcollectionsidpaymentsessions)
+     * It sends a request to the [Initialize Payment Session](https://docs.medusajs.com/api/store#payment-collections_postpaymentcollectionsidpaymentsessions)
      * API route.
      * 
      * If the cart doesn't have a payment collection, a payment collection is created for the cart by
-     * sending a request to the [Create Payment Collection](https://docs.medusajs.com/v2/api/store#payment-collections_postpaymentcollections)
+     * sending a request to the [Create Payment Collection](https://docs.medusajs.com/api/store#payment-collections_postpaymentcollections)
      * API route.
      * 
-     * Related guide: [Implement payment step during checkout](https://docs.medusajs.com/v2/resources/storefront-development/checkout/payment).
+     * Related guide: [Implement payment step during checkout](https://docs.medusajs.com/resources/storefront-development/checkout/payment).
      * 
      * @param cart - The cart's details.
      * @param body - The payment session's details.
@@ -941,7 +941,7 @@ export class Store {
   public order = {
     /**
      * This method retrieves a paginated list of orders matching the specified filters. It
-     * sends a request to the [List Orders](https://docs.medusajs.com/v2/api/store#orders_getorders)
+     * sends a request to the [List Orders](https://docs.medusajs.com/api/store#orders_getorders)
      * API route.
      * 
      * @param query - Configure the fields to retrieve in the orders.
@@ -984,7 +984,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     list: async (
       query?: HttpTypes.StoreOrderFilters,
@@ -999,7 +999,7 @@ export class Store {
     },
     /**
      * This method retrieves an order by its ID. It sends a request to the 
-     * [Get Order](https://docs.medusajs.com/v2/api/store#orders_getordersid) API route.
+     * [Get Order](https://docs.medusajs.com/api/store#orders_getordersid) API route.
      * 
      * @param id - The order's ID.
      * @param query - Configure the fields to retrieve in the order.
@@ -1027,7 +1027,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     retrieve: async (
       id: string,
@@ -1046,13 +1046,13 @@ export class Store {
 
   public customer = {
     /**
-     * This method registers a customer. It sends a request to the [Register Customer](https://docs.medusajs.com/v2/api/store#customers_postcustomers)
+     * This method registers a customer. It sends a request to the [Register Customer](https://docs.medusajs.com/api/store#customers_postcustomers)
      * API route.
      * 
      * You must use the {@link Auth.register} method first to retrieve a registration token. Then, pass that
      * registration token in the `headers` parameter of this method as an authorization bearer header. 
      * 
-     * Related guide: [How to register customer in storefront](https://docs.medusajs.com/v2/resources/storefront-development/customers/register)
+     * Related guide: [How to register customer in storefront](https://docs.medusajs.com/resources/storefront-development/customers/register)
      * 
      * @param body - The customer's details.
      * @param query - Configure the fields to retrieve in the customer.
@@ -1097,9 +1097,9 @@ export class Store {
      * first with the {@link Auth.login} method.
      * 
      * It sends a request to the
-     * [Update Customer](https://docs.medusajs.com/v2/api/store#customers_postcustomersme) API route.
+     * [Update Customer](https://docs.medusajs.com/api/store#customers_postcustomersme) API route.
      * 
-     * Related guide: [How to edit customer's profile in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/customers/profile).
+     * Related guide: [How to edit customer's profile in the storefront](https://docs.medusajs.com/resources/storefront-development/customers/profile).
      * 
      * @param body - The customer's details to update.
      * @param query - Configure the fields to retrieve in the customer.
@@ -1135,7 +1135,7 @@ export class Store {
      * This method retrieves the logged-in customer's details. The customer must be logged in
      * first with the {@link Auth.login} method.
      * 
-     * It sends a request to the [Get Logged-In Customer](https://docs.medusajs.com/v2/api/store#customers_getcustomersme)
+     * It sends a request to the [Get Logged-In Customer](https://docs.medusajs.com/api/store#customers_getcustomersme)
      * API route.
      * 
      * @param query - Configure the fields to retrieve in the customer.
@@ -1161,10 +1161,10 @@ export class Store {
      * This method creates an address for the logged-in customer. The customer must be logged in
      * first with the {@link Auth.login} method.
      * 
-     * It sends a request to the [Create Address](https://docs.medusajs.com/v2/api/store#customers_postcustomersmeaddresses)
+     * It sends a request to the [Create Address](https://docs.medusajs.com/api/store#customers_postcustomersmeaddresses)
      * API route.
      * 
-     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/customers/addresses)
+     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/resources/storefront-development/customers/addresses)
      * 
      * @param body - The address's details.
      * @param query - Configure the fields to retrieve in the customer.
@@ -1197,10 +1197,10 @@ export class Store {
      * This method updates the address of the logged-in customer. The customer must be logged in
      * first with the {@link Auth.login} method.
      * 
-     * It sends a request to the [Update Address](https://docs.medusajs.com/v2/api/store#customers_postcustomersmeaddressesaddress_id)
+     * It sends a request to the [Update Address](https://docs.medusajs.com/api/store#customers_postcustomersmeaddressesaddress_id)
      * API route.
      * 
-     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/customers/addresses)
+     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/resources/storefront-development/customers/addresses)
      * 
      * @param addressId - The ID of the address to update.
      * @param body - The details to update in the address.
@@ -1241,10 +1241,10 @@ export class Store {
      * This method retrieves the logged-in customer's address. The customer must be logged in
      * first with the {@link Auth.login} method.
      * 
-     * It sends a request to the [List Customer's Address](https://docs.medusajs.com/v2/api/store#customers_getcustomersmeaddresses)
+     * It sends a request to the [List Customer's Address](https://docs.medusajs.com/api/store#customers_getcustomersmeaddresses)
      * API route.
      * 
-     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/customers/addresses)
+     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/resources/storefront-development/customers/addresses)
      * 
      * @param query - Configure the fields to retrieve in the addresses.
      * @param headers - Headers to pass in the request.
@@ -1286,7 +1286,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     listAddress: async (
       query?: FindParams & HttpTypes.StoreCustomerAddressFilters,
@@ -1303,10 +1303,10 @@ export class Store {
      * This method retrieves an address of the logged-in customer. The customer must be logged in
      * first with the {@link Auth.login} method.
      * 
-     * It sends a request to the [Get Address](https://docs.medusajs.com/v2/api/store#customers_getcustomersmeaddressesaddress_id)
+     * It sends a request to the [Get Address](https://docs.medusajs.com/api/store#customers_getcustomersmeaddressesaddress_id)
      * API route.
      * 
-     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/customers/addresses)
+     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/resources/storefront-development/customers/addresses)
      * 
      * @param addressId - The address's ID.
      * @param query - Configure the fields to retrieve in the address.
@@ -1339,7 +1339,7 @@ export class Store {
      * })
      * ```
      * 
-     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+     * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     retrieveAddress: async (
       addressId: string,
@@ -1360,10 +1360,10 @@ export class Store {
      * This method deletes an address of the logged-in customer. The customer must be logged in
      * first with the {@link Auth.login} method.
      * 
-     * It sends a request to the [Remove Address](https://docs.medusajs.com/v2/api/store#customers_deletecustomersmeaddressesaddress_id)
+     * It sends a request to the [Remove Address](https://docs.medusajs.com/api/store#customers_deletecustomersmeaddressesaddress_id)
      * API route.
      * 
-     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/v2/resources/storefront-development/customers/addresses)
+     * Related guides: [How to manage customer's addresses in the storefront](https://docs.medusajs.com/resources/storefront-development/customers/addresses)
      * 
      * @param addressId - The address's ID.
      * @param headers - Headers to pass in the request.

--- a/packages/core/types/src/common/config-module.ts
+++ b/packages/core/types/src/common/config-module.ts
@@ -568,7 +568,7 @@ export type ProjectConfigOptions = {
      * However, some platforms don't offer access to the HTTP layer and in those cases, this is a good alternative.
      *
      * If you enable HTTP compression and you want to disable it for specific API Routes, you can pass in the request header `"x-no-compression": true`.
-     * Learn more in the [API Reference](https://docs.medusajs.com/v2/api/store#http-compression).
+     * Learn more in the [API Reference](https://docs.medusajs.com/api/store#http-compression).
      *
      * @example
      * ```js title="medusa-config.js"

--- a/packages/core/types/src/http/cart/store/payloads.ts
+++ b/packages/core/types/src/http/cart/store/payloads.ts
@@ -105,7 +105,7 @@ export interface StoreAddCartShippingMethods {
   /**
    * Data useful for the associated fulfillment provider.
    * 
-   * Learn more in [this documentation](https://docs.medusajs.com/v2/resources/commerce-modules/fulfillment/shipping-option#data-property).
+   * Learn more in [this documentation](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#data-property).
    */
   data?: Record<string, unknown>
 }

--- a/packages/core/types/src/http/common/request.ts
+++ b/packages/core/types/src/http/common/request.ts
@@ -2,7 +2,7 @@ export interface SelectParams {
   /**
    * The fields and relations to retrieve.
    * 
-   * Learn more in the [API reference](https://docs.medusajs.com/v2/api/store#select-fields-and-relations).
+   * Learn more in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
    */
   fields?: string
 }

--- a/packages/core/types/src/http/fulfillment/admin/entitites.ts
+++ b/packages/core/types/src/http/fulfillment/admin/entitites.ts
@@ -182,7 +182,7 @@ export interface AdminFulfillment {
   /**
    * Data useful for the fulfillment provider handling the fulfillment.
    * 
-   * Learn more in [this documentation](https://docs.medusajs.com/v2/resources/commerce-modules/fulfillment#data-property).
+   * Learn more in [this documentation](https://docs.medusajs.com/resources/commerce-modules/fulfillment#data-property).
    */
   data: Record<string, unknown> | null
   /**

--- a/packages/core/types/src/http/fulfillment/admin/payloads.ts
+++ b/packages/core/types/src/http/fulfillment/admin/payloads.ts
@@ -122,7 +122,7 @@ export interface AdminCreateFulfillment {
   /**
    * Data useful for the fulfillment provider handling the fulfillment.
    * 
-   * Learn more in [this documentation](https://docs.medusajs.com/v2/resources/commerce-modules/fulfillment#data-property).
+   * Learn more in [this documentation](https://docs.medusajs.com/resources/commerce-modules/fulfillment#data-property).
    */
   data?: Record<string, unknown> | null
   /**

--- a/packages/core/types/src/http/fulfillment/store/index.ts
+++ b/packages/core/types/src/http/fulfillment/store/index.ts
@@ -32,7 +32,7 @@ export interface StoreCartShippingOption {
   /**
    * The data useful for the fulfillment provider when handling the shipment and fulfillment.
    * 
-   * Learn more in [this documentation](https://docs.medusajs.com/v2/resources/commerce-modules/fulfillment/shipping-option#data-property).
+   * Learn more in [this documentation](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#data-property).
    */
   data: Record<string, unknown> | null
   /**

--- a/packages/core/types/src/http/order/common.ts
+++ b/packages/core/types/src/http/order/common.ts
@@ -282,7 +282,7 @@ export interface BaseOrderShippingMethod {
   /**
    * Data relevant for the fulfillment provider handling the shipping.
    * 
-   * Learn more in [this guide](https://docs.medusajs.com/v2/resources/commerce-modules/fulfillment/shipping-option#data-property).
+   * Learn more in [this guide](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#data-property).
    */
   data: Record<string, unknown> | null
   /**
@@ -686,7 +686,7 @@ export interface BaseOrderFulfillment {
   /**
    * Data necessary for the provider handling the fulfillment.
    * 
-   * Learn more in [this guide](https://docs.medusajs.com/v2/resources/commerce-modules/fulfillment/shipping-option#data-property).
+   * Learn more in [this guide](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#data-property).
    */
   data: Record<string, unknown> | null
   /**

--- a/packages/core/types/src/http/payment/store/payloads.ts
+++ b/packages/core/types/src/http/payment/store/payloads.ts
@@ -16,7 +16,7 @@ export interface StoreInitializePaymentSession {
   /**
    * Any data necessary for the payment provider to process the payment.
    * 
-   * Learn more in [this documentation](https://docs.medusajs.com/v2/resources/commerce-modules/payment/payment-session#data-property).
+   * Learn more in [this documentation](https://docs.medusajs.com/resources/commerce-modules/payment/payment-session#data-property).
    */
   data?: Record<string, unknown>
 }

--- a/packages/core/types/src/tax/common.ts
+++ b/packages/core/types/src/tax/common.ts
@@ -43,7 +43,7 @@ export interface TaxRateDTO {
   /**
    * Whether the tax rate should be combined with parent rates.
    *
-   * Learn more [here](https://docs.medusajs.com/v2/resources/commerce-modules/tax/tax-rates-and-rules#combinable-tax-rates).
+   * Learn more [here](https://docs.medusajs.com/resources/commerce-modules/tax/tax-rates-and-rules#combinable-tax-rates).
    */
   is_combinable: boolean
 

--- a/packages/core/types/src/tax/mutations.ts
+++ b/packages/core/types/src/tax/mutations.ts
@@ -129,7 +129,7 @@ export interface UpdateTaxRateDTO {
   /**
    * Whether the tax rate is combinable.
    *
-   * Learn more [here](https://docs.medusajs.com/v2/resources/commerce-modules/tax/tax-rates-and-rules#combinable-tax-rates).
+   * Learn more [here](https://docs.medusajs.com/resources/commerce-modules/tax/tax-rates-and-rules#combinable-tax-rates).
    */
   is_combinable?: boolean
 

--- a/packages/core/utils/src/auth/abstract-auth-provider.ts
+++ b/packages/core/utils/src/auth/abstract-auth-provider.ts
@@ -134,7 +134,7 @@ export abstract class AbstractAuthModuleProvider implements IAuthProvider {
    * The authentication happens either by directly authenticating or returning a redirect URL to continue
    * the authentication with a third party provider.
    *
-   * Related Read: [Learn about the different authentication flows in Medusa](https://docs.medusajs.com/v2/resources/commerce-modules/auth/authentication-route).
+   * Related Read: [Learn about the different authentication flows in Medusa](https://docs.medusajs.com/resources/commerce-modules/auth/authentication-route).
    *
    * @param {AuthenticationInput} data - The details of the authentication request.
    * @param {AuthIdentityProviderService} authIdentityProviderService - The service used to retrieve or
@@ -239,7 +239,7 @@ export abstract class AbstractAuthModuleProvider implements IAuthProvider {
    * This method is only used in a basic authentication flow, such as when using an email and password
    * to register and authenticate a user.
    *
-   * Related Read: [Learn about the different authentication flows in Medusa](https://docs.medusajs.com/v2/resources/commerce-modules/auth/authentication-route).
+   * Related Read: [Learn about the different authentication flows in Medusa](https://docs.medusajs.com/resources/commerce-modules/auth/authentication-route).
    *
    * @param {AuthenticationInput} data - The details of the authentication request.
    * @param {AuthIdentityProviderService} authIdentityProviderService - The service used to retrieve or
@@ -372,7 +372,7 @@ export abstract class AbstractAuthModuleProvider implements IAuthProvider {
    * - `user_metadata`: Store metadata of the user's details. For example, if the third-party service returns the user's information such as email
    * or name, you store this data in this property.
    *
-   * Related Guide: [Learn about the different authentication flows in Medusa](https://docs.medusajs.com/v2/resources/commerce-modules/auth/authentication-route).
+   * Related Guide: [Learn about the different authentication flows in Medusa](https://docs.medusajs.com/resources/commerce-modules/auth/authentication-route).
    *
    * @param {AuthenticationInput} data - The details of the authentication request.
    * @param {AuthIdentityProviderService} authIdentityProviderService - The service used to retrieve or

--- a/packages/core/utils/src/payment/abstract-payment-provider.ts
+++ b/packages/core/utils/src/payment/abstract-payment-provider.ts
@@ -144,7 +144,7 @@ export abstract class AbstractPaymentProvider<TConfig = Record<string, unknown>>
    *
    * - The {@link authorizePayment} method returns the status `captured`, which automatically executed this method after authorization.
    * - The merchant requests to capture the payment after its associated payment session was authorized.
-   * - A webhook event occurred that instructs the payment provider to capture the payment session. Learn more about handing webhook events in [this guide](https://docs.medusajs.com/v2/resources/commerce-modules/payment/webhook-events).
+   * - A webhook event occurred that instructs the payment provider to capture the payment session. Learn more about handing webhook events in [this guide](https://docs.medusajs.com/resources/commerce-modules/payment/webhook-events).
    *
    * In this method, use the third-party provider to capture the payment.
    *
@@ -194,7 +194,7 @@ export abstract class AbstractPaymentProvider<TConfig = Record<string, unknown>>
    * This method authorizes a payment session. When authorized successfully, a payment is created by the Payment
    * Module which can be later captured using the {@link capturePayment} method.
    *
-   * Refer to [this guide](https://docs.medusajs.com/v2/resources/commerce-modules/payment/payment-flow#3-authorize-payment-session)
+   * Refer to [this guide](https://docs.medusajs.com/resources/commerce-modules/payment/payment-flow#3-authorize-payment-session)
    * to learn more about how this fits into the payment flow and how to handle required actions.
    *
    * To automatically capture the payment after authorization, return the status `captured`.
@@ -619,7 +619,7 @@ export abstract class AbstractPaymentProvider<TConfig = Record<string, unknown>>
    * This method is executed when a webhook event is received from the third-party payment provider. Use it
    * to process the action of the payment provider.
    *
-   * Learn more in [this documentation](https://docs.medusajs.com/v2/resources/commerce-modules/payment/webhook-events)
+   * Learn more in [this documentation](https://docs.medusajs.com/resources/commerce-modules/payment/webhook-events)
    *
    * @param data - The webhook event's data
    * @returns The webhook result. If the `action`'s value is `captured`, the payment is captured within Medusa as well.

--- a/packages/core/workflows-sdk/src/utils/composer/create-hook.ts
+++ b/packages/core/workflows-sdk/src/utils/composer/create-hook.ts
@@ -23,7 +23,7 @@ export type Hook<Name extends string, Input> = {
  *
  * A handler hook can later be registered to consume the hook and perform custom functionality.
  *
- * Learn more in [this documentation](https://docs.medusajs.com/v2/advanced-development/workflows/add-workflow-hook).
+ * Learn more in [this documentation](https://docs.medusajs.com/advanced-development/workflows/add-workflow-hook).
  *
  * @param name - The hook's name. This is used when the hook handler is registered to consume the workflow.
  * @param input - The input to pass to the hook handler.

--- a/packages/core/workflows-sdk/src/utils/composer/type.ts
+++ b/packages/core/workflows-sdk/src/utils/composer/type.ts
@@ -229,7 +229,7 @@ export type ReturnWorkflow<TData, TResult, THooks extends any[]> = {
   /**
    * This method executes the workflow as a step. Useful when running a workflow within another.
    *
-   * Learn more in [this documentation](https://docs.medusajs.com/v2/advanced-development/workflows/execute-another-workflow).
+   * Learn more in [this documentation](https://docs.medusajs.com/advanced-development/workflows/execute-another-workflow).
    *
    * @param param0 - The options to execute the workflow.
    * @returns The workflow's result
@@ -266,7 +266,7 @@ export type ReturnWorkflow<TData, TResult, THooks extends any[]> = {
   /**
    * The workflow's exposed hooks, used to register a handler to consume the hook.
    *
-   * Learn more in [this documentation](https://docs.medusajs.com/v2/advanced-development/workflows/add-workflow-hook#how-to-consume-a-hook).
+   * Learn more in [this documentation](https://docs.medusajs.com/advanced-development/workflows/add-workflow-hook#how-to-consume-a-hook).
    */
   hooks: ConvertHooksToFunctions<THooks>
 }

--- a/packages/design-system/ui/CONTRIBUTING.md
+++ b/packages/design-system/ui/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for considering contributing to Medusa! This document will outline how to submit changes to this repository and which conventions to follow. If you are ever in doubt about anything we encourage you to reach out either by submitting an issue here or reaching out [via Discord](https://discord.gg/xpCwq3Kfn8).
 
-If you're contributing to our documentation, make sure to also check out the [contribution guidelines on our documentation website](https://docs.medusajs.com/contribution-guidelines).
+If you're contributing to our documentation, make sure to also check out the [contribution guidelines on our documentation website](https://docs.medusajs.com/resources/contribution-guidelines/docs).
 
 ### Important
 

--- a/packages/medusa/README.md
+++ b/packages/medusa/README.md
@@ -40,23 +40,19 @@
 
 ## Getting Started
 
-Visit the [Quickstart Guide](https://docs.medusajs.com/create-medusa-app) to set up a server.
-
-Visit the [Docs](https://docs.medusajs.com/development/backend/prepare-environment) to learn more about our system requirements.
+Visit the [Quickstart Guide](https://docs.medusajs.com/learn) to set up a server.
 
 ## What is Medusa
 
 Medusa is a set of commerce modules and tools that allow you to build rich, reliable, and performant commerce applications without reinventing core commerce logic. The modules can be customized and used to build advanced ecommerce stores, marketplaces, or any product that needs foundational commerce primitives. All modules are open-source and freely available on npm.
 
-Learn more about [Medusa’s architecture](https://docs.medusajs.com/development/fundamentals/architecture-overview) and [commerce modules](https://docs.medusajs.com/modules/overview) in the Docs.
+Learn more about [Medusa’s architecture](https://docs.medusajs.com/learn/advanced-development/architecture/overview) and [commerce modules](https://docs.medusajs.com/resources/commerce-modules) in the Docs.
 
-## Roadmap, Upgrades & Plugins
+## Roadmap & Upgrades
 
 You can view the planned, started and completed features in the [Roadmap discussion](https://github.com/medusajs/medusa/discussions/categories/roadmap).
 
 Follow the [Upgrade Guides](https://docs.medusajs.com/upgrade-guides/) to keep your Medusa project up-to-date.
-
-Check out all [available Medusa plugins](https://medusajs.com/plugins/).
 
 ## Community & Contributions
 

--- a/packages/modules/product/README.md
+++ b/packages/modules/product/README.md
@@ -2,7 +2,7 @@
 
 The Product Module gives you access Products, Variants, Categories, and more through a standalone package that can be installed and run in Next.js functions and other Node.js compatible runtimes.
 
-[Product Module documentation](https://docs.medusajs.com/modules/product/serverless-module) | [Medusa Website](https://medusajs.com/) | [Medusa Repository](https://github.com/medusajs/medusa)
+[Product Module documentation](https://docs.medusajs.com/v2/resources/commerce-modules/product) | [Medusa Website](https://medusajs.com/) | [Medusa Repository](https://github.com/medusajs/medusa)
 
 > The Product Module is currently in beta. The beta version comes with limited functionality, primarily centered around retrieving products. In the official version, the product module will be fully-fledged and on par with the product functionality in our core package.
 


### PR DESCRIPTION
Update links in source code and comments to remove the `/v2` prefix from documentation links.
