### PR TITLE
fix(js-sdk): remove list and retrieve methods of paymentCollection

### DIFF
--- a/packages/core/js-sdk/src/admin/payment-collection.ts
+++ b/packages/core/js-sdk/src/admin/payment-collection.ts
@@ -14,33 +14,6 @@ export class PaymentCollection {
     this.client = client
   }
 
-  async list(
-    query?: HttpTypes.AdminPaymentCollectionFilters,
-    headers?: ClientHeaders
-  ) {
-    return await this.client.fetch<HttpTypes.AdminPaymentCollectionsResponse>(
-      `/admin/payment-collections`,
-      {
-        query,
-        headers,
-      }
-    )
-  }
-
-  async retrieve(
-    id: string,
-    query?: HttpTypes.AdminPaymentCollectionFilters,
-    headers?: ClientHeaders
-  ) {
-    return await this.client.fetch<HttpTypes.AdminPaymentCollectionResponse>(
-      `/admin/payment-collections/${id}`,
-      {
-        query,
-        headers,
-      }
-    )
-  }
-
   async create(
     body: HttpTypes.AdminCreatePaymentCollection,
     query?: SelectParams,


### PR DESCRIPTION
The `PaymentCollection` class has `list` and `retrieve` methods that point to API routes that don't exist.