### PR TITLE
Update docs commerce modules so that tax links to the correct page

### DIFF
--- a/www/apps/book/components/Homepage/ModulesSection/index.tsx
+++ b/www/apps/book/components/Homepage/ModulesSection/index.tsx
@@ -101,7 +101,7 @@ const HomepageModulesSection = () => {
         {
           title: "Tax",
           text: "Granular tax control",
-          href: "/resources/commerce-modules/stock-location",
+          href: "/resources/commerce-modules/tax",
           image: basePathUrl("/images/tax-icon.png"),
         },
         {


### PR DESCRIPTION
### What

Update the href on the tax card on https://docs.medusajs.com/v2 to correctly link to https://docs.medusajs.com/v2/resources/commerce-modules/tax

### Why 

It is currently incorrectly linking to https://docs.medusajs.com/v2/resources/commerce-modules/stock-location

### How

Update the href value.

### Testing

To test open the docs page and verify that the link navigates to the correct page.