### PR TITLE
fix: Use the typed in email address when available instead of forcing…

### DIFF
--- a/packages/medusa/src/services/cart.ts
+++ b/packages/medusa/src/services/cart.ts
@@ -1223,6 +1223,10 @@ class CartService extends TransactionBaseService {
         const originalCartCustomer = { ...(cart.customer ?? {}) }
         if (data.customer_id) {
           await this.updateCustomerId_(cart, data.customer_id)
+
+          if (isDefined(data.email)) {
+            cart.email = data.email
+          }
         } else if (isDefined(data.email)) {
           const customer = await this.createOrFetchGuestCustomerFromEmail_(
             data.email


### PR DESCRIPTION
**What** - This change fixes checkout flow so that a typed in email address will be used.

**Why** - Currently when a customer is logged in, the Medusa backend forces them to use their account email address for ALL orders, regardless of what they type in to the email input.

**How** - After the cart has been updated with the logged in customer's information I check to see if an email was provided. If one was provided, I use that one for the cart instead.

This fixes the issue referenced here https://github.com/medusajs/medusa/issues/9849