### PR TITLE
Update Order service's update method

### DIFF
--- a/packages/medusa/src/services/order.ts
+++ b/packages/medusa/src/services/order.ts
@@ -1162,7 +1162,7 @@ class OrderService extends TransactionBaseService {
         await this.updateBillingAddress(order, billing_address as Address)
       }
 
-      if (update.no_notification) {
+      if (update.no_notification !== undefined) {
         order.no_notification = no_notification ?? false
       }
 


### PR DESCRIPTION
Since `no_notification` is an optional boolean, should check if it's empty or not.