### PR TITLE
fix: consider --host flag and HOST env variable

### DIFF
--- a/packages/cli/medusa-cli/src/create-cli.ts
+++ b/packages/cli/medusa-cli/src/create-cli.ts
@@ -290,8 +290,10 @@ function buildLocalCommands(cli, isLocalProject) {
           .option(`H`, {
             alias: `host`,
             type: `string`,
-            default: defaultHost,
-            describe: `Set host. Defaults to ${defaultHost}`,
+            default: process.env.HOST || defaultHost,
+            describe: process.env.HOST
+              ? `Set host. Defaults to ${process.env.HOST} (set by env.HOST) (otherwise defaults ${defaultHost})`
+              : `Set host. Defaults to ${defaultHost}`,
           })
           .option(`p`, {
             alias: `port`,
@@ -326,8 +328,10 @@ function buildLocalCommands(cli, isLocalProject) {
           .option(`H`, {
             alias: `host`,
             type: `string`,
-            default: defaultHost,
-            describe: `Set host. Defaults to ${defaultHost}`,
+            default: process.env.HOST || defaultHost,
+            describe: process.env.HOST
+              ? `Set host. Defaults to ${process.env.HOST} (set by env.HOST) (otherwise defaults ${defaultHost})`
+              : `Set host. Defaults to ${defaultHost}`,
           })
           .option(`p`, {
             alias: `port`,

--- a/packages/medusa/src/commands/start.ts
+++ b/packages/medusa/src/commands/start.ts
@@ -59,9 +59,11 @@ export async function registerInstrumentation(directory: string) {
 export var traceRequestHandler: (...args: any[]) => Promise<any> = void 0 as any
 
 function displayAdminUrl({
-  container,
+  host,
   port,
+  container,
 }: {
+  host: string
   port: string | number
   container: MedusaContainer
 }) {
@@ -82,7 +84,7 @@ function displayAdminUrl({
     return
   }
 
-  logger.info(`Admin URL → http://localhost:${port}${adminPath}`)
+  logger.info(`Admin URL → http://${host}:${port}${adminPath}`)
 }
 
 async function start(args: {
@@ -138,8 +140,11 @@ async function start(args: {
       const serverActivity = logger.activity(`Creating server`)
       const server = GracefulShutdownServer.create(
         http_.listen(port, host).on("listening", () => {
-          logger.success(serverActivity, `Server is ready on port: ${port}`)
-          displayAdminUrl({ container, port })
+          logger.success(
+            serverActivity,
+            `Server is ready on http://${host}:${port}`
+          )
+          displayAdminUrl({ container, host, port })
           track("CLI_START_COMPLETED")
         })
       )

--- a/packages/medusa/src/commands/start.ts
+++ b/packages/medusa/src/commands/start.ts
@@ -87,11 +87,12 @@ function displayAdminUrl({
 
 async function start(args: {
   directory: string
+  host?: string
   port?: number
   types?: boolean
   cluster?: number
 }) {
-  const { port = 9000, directory, types } = args
+  const { port = 9000, host = "localhost", directory, types } = args
 
   async function internalStart(generateTypes: boolean) {
     track("CLI_START")
@@ -136,7 +137,7 @@ async function start(args: {
 
       const serverActivity = logger.activity(`Creating server`)
       const server = GracefulShutdownServer.create(
-        http_.listen(port).on("listening", () => {
+        http_.listen(port, host).on("listening", () => {
           logger.success(serverActivity, `Server is ready on port: ${port}`)
           displayAdminUrl({ container, port })
           track("CLI_START_COMPLETED")


### PR DESCRIPTION
Fixes: FRMW-2756

After this PR we consider both the `HOST` environment variable and the `--host` CLI flag for starting the server on the specified host.

**Examples**

```sh
npx medusa develop --host=0.0.0.0 --port=3333
# Runs on -> http://0.0.0.0:3333

HOST=0.0.0.0 PORT=3333 npx medusa develop
# Runs on -> http://0.0.0.0:3333

HOST=0.0.0.0 PORT=3333 npx medusa develop --port=3000
# Runs on -> http://0.0.0.0:3000 (--port flag has priority over the environment variable)
```
