### PR TITLE
fix(dashboard): Allow using enter key to create newline in Textarea

### DIFF
--- a/packages/admin/dashboard/src/components/utilities/keybound-form/keybound-form.tsx
+++ b/packages/admin/dashboard/src/components/utilities/keybound-form/keybound-form.tsx
@@ -14,6 +14,13 @@ export const KeyboundForm = React.forwardRef<
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLFormElement>) => {
     if (event.key === "Enter") {
+      if (
+        event.target instanceof HTMLTextAreaElement &&
+        !(event.metaKey || event.ctrlKey)
+      ) {
+        return
+      }
+
       event.preventDefault()
 
       if (event.metaKey || event.ctrlKey) {

--- a/packages/admin/dashboard/src/i18n/translations/$schema.json
+++ b/packages/admin/dashboard/src/i18n/translations/$schema.json
@@ -1555,6 +1555,26 @@
           ],
           "additionalProperties": false
         },
+        "edit": {
+          "type": "object",
+          "properties": {
+            "header": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "successToast": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "header",
+            "description",
+            "successToast"
+          ],
+          "additionalProperties": false
+        },
         "create": {
           "type": "object",
           "properties": {
@@ -1892,9 +1912,6 @@
           "type": "string"
         },
         "attributes": {
-          "type": "string"
-        },
-        "editProduct": {
           "type": "string"
         },
         "editAttributes": {
@@ -2667,13 +2684,13 @@
       "required": [
         "domain",
         "list",
+        "edit",
         "create",
         "export",
         "import",
         "deleteWarning",
         "variants",
         "attributes",
-        "editProduct",
         "editAttributes",
         "editOptions",
         "editPrices",

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -380,6 +380,11 @@
     "list": {
       "noRecordsMessage": "Create your first product to start selling."
     },
+    "edit": {
+      "header": "Edit Product",
+      "description": "Edit the product details.",
+      "successToast": "Product {{title}} was successfully updated."
+    },
     "create": {
       "header": "General",
       "tabs": {
@@ -462,7 +467,6 @@
     "deleteWarning": "You are about to delete the product {{title}}. This action cannot be undone.",
     "variants": "Variants",
     "attributes": "Attributes",
-    "editProduct": "Edit Product",
     "editAttributes": "Edit Attributes",
     "editOptions": "Edit Options",
     "editPrices": "Edit prices",

--- a/packages/admin/dashboard/src/routes/products/product-edit/components/edit-product-form/edit-product-form.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-edit/components/edit-product-form/edit-product-form.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Select, Text, Textarea } from "@medusajs/ui"
+import { Button, Input, Select, Text, Textarea, toast } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
 
@@ -69,8 +69,14 @@ export const EditProductForm = ({ product }: EditProductFormProps) => {
         ...nullableData,
       },
       {
-        onSuccess: () => {
+        onSuccess: ({ product }) => {
+          toast.success(
+            t("products.edit.successToast", { title: product.title })
+          )
           handleSuccess()
+        },
+        onError: (e) => {
+          toast.error(e.message)
         },
       }
     )

--- a/packages/admin/dashboard/src/routes/products/product-edit/product-edit.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-edit/product-edit.tsx
@@ -23,8 +23,11 @@ export const ProductEdit = () => {
     <RouteDrawer>
       <RouteDrawer.Header>
         <RouteDrawer.Title asChild>
-          <Heading>{t("products.editProduct")}</Heading>
+          <Heading>{t("products.edit.header")}</Heading>
         </RouteDrawer.Title>
+        <RouteDrawer.Description className="sr-only">
+          {t("products.edit.description")}
+        </RouteDrawer.Description>
       </RouteDrawer.Header>
       {!isLoading && product && <EditProductForm product={product} />}
     </RouteDrawer>


### PR DESCRIPTION
**What**
- Adds rule to KeyboundForm to allow using the Enter key to add a newline in Textareas.
- Adds missing toasts to product edit form.

Resolves CC-654