### PR TITLE
fix(workflows-sdk): Paralellize steps rollback issue with config

### DIFF
--- a/.changeset/tall-starfishes-travel.md
+++ b/.changeset/tall-starfishes-travel.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/workflows-sdk": patch
+---
+
+fix(workflows-sdk): Paralellize steps rollback issue with config

--- a/packages/core/workflows-sdk/src/utils/composer/create-step.ts
+++ b/packages/core/workflows-sdk/src/utils/composer/create-step.ts
@@ -175,6 +175,15 @@ export function applyStep<
 
       delete localConfig.name
 
+      const handler = createStepHandler.bind(this)({
+        stepName: newStepName,
+        input,
+        invokeFn,
+        compensateFn,
+      })
+
+      wrapAsyncHandler(stepConfig, handler)
+
       this.handlers.set(newStepName, handler)
 
       this.flow.replaceAction(stepConfig.uuid!, newStepName, newConfig)


### PR DESCRIPTION
FIXES FRMW-2759

**What**
When using the `config` modifier on steps, the handlers are not properly re build leading to wrong output retrieval in case of compensation of those steps. This pr fixes the handler during the usage of the `config` modifier by re building new handlers based on the new step configuration