### PR TITLE
fix: do not set default host to localhost

### DIFF
--- a/packages/cli/medusa-cli/src/create-cli.ts
+++ b/packages/cli/medusa-cli/src/create-cli.ts
@@ -18,8 +18,7 @@ const handlerP =
   }
 
 function buildLocalCommands(cli, isLocalProject) {
-  const defaultHost = `localhost`
-  const defaultPort = `9000`
+  const defaultPort = "9000"
   const directory = path.resolve(`.`)
 
   const projectInfo = { directory }
@@ -290,10 +289,10 @@ function buildLocalCommands(cli, isLocalProject) {
           .option(`H`, {
             alias: `host`,
             type: `string`,
-            default: process.env.HOST || defaultHost,
+            default: process.env.HOST,
             describe: process.env.HOST
-              ? `Set host. Defaults to ${process.env.HOST} (set by env.HOST) (otherwise defaults ${defaultHost})`
-              : `Set host. Defaults to ${defaultHost}`,
+              ? `Set host. Defaults to ${process.env.HOST} (set by env.HOST)`
+              : "",
           })
           .option(`p`, {
             alias: `port`,
@@ -328,10 +327,10 @@ function buildLocalCommands(cli, isLocalProject) {
           .option(`H`, {
             alias: `host`,
             type: `string`,
-            default: process.env.HOST || defaultHost,
+            default: process.env.HOST,
             describe: process.env.HOST
-              ? `Set host. Defaults to ${process.env.HOST} (set by env.HOST) (otherwise defaults ${defaultHost})`
-              : `Set host. Defaults to ${defaultHost}`,
+              ? `Set host. Defaults to ${process.env.HOST} (set by env.HOST)`
+              : ``,
           })
           .option(`p`, {
             alias: `port`,

--- a/packages/medusa/src/commands/start.ts
+++ b/packages/medusa/src/commands/start.ts
@@ -63,7 +63,7 @@ function displayAdminUrl({
   port,
   container,
 }: {
-  host: string
+  host?: string
   port: string | number
   container: MedusaContainer
 }) {
@@ -84,7 +84,7 @@ function displayAdminUrl({
     return
   }
 
-  logger.info(`Admin URL → http://${host}:${port}${adminPath}`)
+  logger.info(`Admin URL → http://${host || "localhost"}:${port}${adminPath}`)
 }
 
 async function start(args: {
@@ -94,7 +94,7 @@ async function start(args: {
   types?: boolean
   cluster?: number
 }) {
-  const { port = 9000, host = "localhost", directory, types } = args
+  const { port = 9000, host, directory, types } = args
 
   async function internalStart(generateTypes: boolean) {
     track("CLI_START")
@@ -142,7 +142,7 @@ async function start(args: {
         http_.listen(port, host).on("listening", () => {
           logger.success(
             serverActivity,
-            `Server is ready on http://${host}:${port}`
+            `Server is ready on http://${host || "localhost"}:${port}`
           )
           displayAdminUrl({ container, host, port })
           track("CLI_START_COMPLETED")


### PR DESCRIPTION
Fixes bug introduced by https://github.com/medusajs/medusa/pull/9912

By default the Node.js server listens on the `0.0.0.0` host. However, the related PR changes the host to `localhost` and hence resulted in an unwanted breaking change. This PR reverts the default value assignment and let Node.js decide the host when not explicitly specified.