### PR TITLE
fix(core-flows): keep same customer on cart update

### DIFF
--- a/.changeset/bright-bees-decide.md
+++ b/.changeset/bright-bees-decide.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+Keep customer when updating cart

--- a/integration-tests/modules/__tests__/cart/store/carts.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/carts.spec.ts
@@ -1959,11 +1959,6 @@ medusaIntegrationTestRunner({
             )
           ).data.customer
 
-          console.log(
-            JSON.stringify(customerData, null, 2),
-            JSON.stringify(currentCart.data.cart, null, 2)
-          )
-
           currentCartCustomer = currentCart.data.cart.customer
 
           expect(currentCartCustomer).not.toEqual(originalCartCustomer)

--- a/integration-tests/modules/__tests__/cart/store/carts.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/carts.spec.ts
@@ -1882,7 +1882,7 @@ medusaIntegrationTestRunner({
           })
         })
 
-        it("should keep the same customer when updating the guest cart and update Cart's and Customer's email if provided", async () => {
+        it("should create another guest customer and update the cart email when an different email is provided", async () => {
           const cart = (
             await api.post(
               `/store/carts`,
@@ -1923,7 +1923,10 @@ medusaIntegrationTestRunner({
           let currentCartCustomer = currentCart.data.cart.customer
 
           let customerData = (
-            await api.get(`/admin/customers/${cart.customer_id}`, adminHeaders)
+            await api.get(
+              `/admin/customers/${currentCart.data.cart.customer_id}`,
+              adminHeaders
+            )
           ).data.customer
 
           expect(currentCartCustomer).toEqual(originalCartCustomer)
@@ -1950,13 +1953,21 @@ medusaIntegrationTestRunner({
           currentCart = await api.get(`/store/carts/${cart.id}`, storeHeaders)
 
           customerData = (
-            await api.get(`/admin/customers/${cart.customer_id}`, adminHeaders)
+            await api.get(
+              `/admin/customers/${currentCart.data.cart.customer_id}`,
+              adminHeaders
+            )
           ).data.customer
+
+          console.log(
+            JSON.stringify(customerData, null, 2),
+            JSON.stringify(currentCart.data.cart, null, 2)
+          )
 
           currentCartCustomer = currentCart.data.cart.customer
 
           expect(currentCartCustomer).not.toEqual(originalCartCustomer)
-          expect(currentCart.data.cart.customer_id).toEqual(
+          expect(currentCart.data.cart.customer_id).not.toEqual(
             originalCartCustomer.id
           )
           expect(customerData.email).toEqual(currentCart.data.cart.email)
@@ -2014,7 +2025,10 @@ medusaIntegrationTestRunner({
           let currentCartCustomer = currentCart.data.cart.customer
 
           let customerData = (
-            await api.get(`/admin/customers/${cart.customer_id}`, adminHeaders)
+            await api.get(
+              `/admin/customers/${currentCart.data.cart.customer_id}`,
+              adminHeaders
+            )
           ).data.customer
 
           expect(currentCartCustomer).toEqual(originalCartCustomer)
@@ -2039,7 +2053,10 @@ medusaIntegrationTestRunner({
           currentCart = await api.get(`/store/carts/${cart.id}`, storeHeaders)
 
           customerData = (
-            await api.get(`/admin/customers/${cart.customer_id}`, adminHeaders)
+            await api.get(
+              `/admin/customers/${currentCart.data.cart.customer_id}`,
+              adminHeaders
+            )
           ).data.customer
 
           currentCartCustomer = currentCart.data.cart.customer

--- a/packages/core/core-flows/src/cart/workflows/update-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-cart.ts
@@ -53,7 +53,7 @@ export const updateCartWorkflow = createWorkflow(
       }
     })
 
-    const [salesChannel] = parallelize(
+    const [salesChannel, customer] = parallelize(
       findSalesChannelStep({
         salesChannelId: input.sales_channel_id,
       }),
@@ -83,7 +83,7 @@ export const updateCartWorkflow = createWorkflow(
       {
         input,
         region,
-        customerDataInput,
+        customer,
         salesChannel,
         cartToUpdate,
       },
@@ -136,8 +136,16 @@ export const updateCartWorkflow = createWorkflow(
           }
         }
 
-        if (isDefined(updateCartData.email)) {
-          data_.email = data.customerDataInput?.email
+        if (isDefined(updateCartData.email) && data.customer?.customer) {
+          const currentCustomer = data.customer.customer!
+          data_.customer_id = currentCustomer.id
+
+          // registered customers can update the cart email
+          if (currentCustomer.has_account) {
+            data_.email = updateCartData.email
+          } else {
+            data_.email = data.customer.email
+          }
         }
 
         if (isDefined(updateCartData.sales_channel_id)) {


### PR DESCRIPTION
What:
  * When the email is updated:
    * If the Customer associated with it has an account, only the Cart's email is updated
    * If the Customer is a Guest and the email is different, a new guest customer is created and associated with the Cart

FIXES: CMRC-664