### PR TITLE
fix: define ssl options when specified in the connection string

### DIFF
--- a/packages/medusa/src/commands/db/create.ts
+++ b/packages/medusa/src/commands/db/create.ts
@@ -132,10 +132,9 @@ export async function dbCreate({
     )
     logger.error(connectionState.error)
     return false
-  } else {
-    logger.info(`Connection established with the database "${dbName}"`)
   }
 
+  logger.info(`Connection established with the database "${dbName}"`)
   if (await dbExists(client, dbName)) {
     logger.info(`Database "${dbName}" already exists`)
 

--- a/packages/medusa/src/commands/db/create.ts
+++ b/packages/medusa/src/commands/db/create.ts
@@ -10,6 +10,15 @@ import {
   parseConnectionString,
 } from "@medusajs/framework/utils"
 
+async function connectClient(client: ReturnType<typeof createClient>) {
+  try {
+    await client.connect()
+    return { connected: true, error: null }
+  } catch (error) {
+    return { connected: false, error }
+  }
+}
+
 /**
  * A low-level utility to create the database. This util should
  * never exit the process implicitly.
@@ -69,28 +78,62 @@ export async function dbCreate({
   /**
    * Parse connection string specified as "DATABASE_URL" inside the
    * .env file and create a client instance from it.
-   *
-   * Remember we should not specify the database name from the
-   * connection string, because this database might not
-   * exist
    */
   const connectionOptions = parseConnectionString(dbConnectionString)
-  const client = createClient({
+
+  /**
+   * The following client config is without any database name. This is because
+   * we want to connect to the default database (whatever it is) and create
+   * a new database that we expect not to exist.
+   */
+  const clientConfig = {
     host: connectionOptions.host!,
     port: connectionOptions.port ? Number(connectionOptions.port) : undefined,
     user: connectionOptions.user,
     password: connectionOptions.password,
-  })
+    ...(connectionOptions.ssl ? { ssl: connectionOptions.ssl as any } : {}),
+  }
 
-  try {
-    await client.connect()
-    logger.info(`Connection established with the database "${dbName}"`)
-  } catch (error) {
+  /**
+   * In some case the default database (which is same as the username) does
+   * not exist. For example: With Neon, there is no database name after
+   * the connection username. Hence, we will have to connect with the
+   * postgres database.
+   */
+  const clientConfigWithPostgresDB = {
+    host: connectionOptions.host!,
+    port: connectionOptions.port ? Number(connectionOptions.port) : undefined,
+    user: connectionOptions.user,
+    database: "postgres",
+    password: connectionOptions.password,
+    ...(connectionOptions.ssl ? { ssl: connectionOptions.ssl as any } : {}),
+  }
+
+  /**
+   * First connect with the default DB
+   */
+  let client = createClient(clientConfig)
+  let connectionState = await connectClient(client)
+
+  /**
+   * In case of an error, connect with the postgres DB
+   */
+  if (!connectionState.connected) {
+    client = createClient(clientConfigWithPostgresDB)
+    connectionState = await connectClient(client)
+  }
+
+  /**
+   * Notify user about the connection state
+   */
+  if (!connectionState.connected) {
     logger.error(
       "Unable to establish database connection because of the following error"
     )
-    logger.error(error)
+    logger.error(connectionState.error)
     return false
+  } else {
+    logger.info(`Connection established with the database "${dbName}"`)
   }
 
   if (await dbExists(client, dbName)) {


### PR DESCRIPTION
Fixes: FRMW-2770

Currently the `db:create` command ignores the `ssl` query string in the connection query string and therefore connections that requires SSL fails.

Also, the command has been updated to connect to the `default (same as username)` and the `postgres` database before throwing an error to the user. The code docblocks covers the reason for this behavior.