### PR TITLE
fix(types): Add AdminBatchUpdateProductVariant type

### DIFF
--- a/.changeset/real-gifts-grow.md
+++ b/.changeset/real-gifts-grow.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": patch
+---
+
+fix(types): Add AdminBatchUpdateProductVariant type, which includes ID.

--- a/packages/core/types/src/http/product/admin/payloads.ts
+++ b/packages/core/types/src/http/product/admin/payloads.ts
@@ -11,7 +11,7 @@ export interface AdminBatchProductRequest
 export interface AdminBatchProductVariantRequest
   extends BatchMethodRequest<
     AdminCreateProductVariant,
-    AdminUpdateProductVariant
+    AdminBatchUpdateProductVariant
   > {}
 
 export interface AdminBatchProductVariantInventoryItemRequest
@@ -107,6 +107,10 @@ export interface AdminUpdateProductVariant {
   metadata?: Record<string, unknown> | null
   prices?: AdminCreateProductVariantPrice[]
   options?: Record<string, string>
+}
+
+export interface AdminBatchUpdateProductVariant extends AdminUpdateProductVariant {
+  id: string
 }
 
 export interface AdminUpdateProduct {


### PR DESCRIPTION
**What**
- Add new type, that includes variant ID for the `POST /admin/products/:id/variants/batch` endpoint.

**Why**
- The currently used type does not match the validator.

Resolves CMRC-676