### PR TITLE
fix(orders): fixs date comparison when using different locale

### DIFF
--- a/packages/admin-ui/ui/src/components/molecules/filter-dropdown/item.tsx
+++ b/packages/admin-ui/ui/src/components/molecules/filter-dropdown/item.tsx
@@ -6,6 +6,7 @@ import { addHours, atMidnight, dateToUnixTimestamp } from "../../../utils/time"
 
 import clsx from "clsx"
 import moment from "moment"
+import { useTranslation } from "react-i18next"
 import { DateFilters } from "../../../utils/filters"
 import { CalendarComponent } from "../../atoms/date-picker/date-picker"
 import Spinner from "../../atoms/spinner"
@@ -31,6 +32,7 @@ const FilterDropdownItem = ({
   onShowNext,
   onShowPrev,
 }) => {
+  const { t } = useTranslation()
   const prefilled = useMemo(() => {
     try {
       const toReturn = filters.reduce((acc, f) => {
@@ -148,7 +150,7 @@ const FilterDropdownItem = ({
             <div className="flex items-center justify-center py-1">
               <Spinner size={"large"} variant={"secondary"} />
             </div>
-          ) : filterTitle === "Date" ? (
+          ) : filterTitle === t("order-filter-dropdown-date", "Date") ? (
             <DateFilter
               options={options}
               open={open}


### PR DESCRIPTION
This PR fixs the inline if for date filter in the orders page when the admin is in a different locale 

How it is currently:
![image](https://github.com/user-attachments/assets/508b835e-c295-46ed-a8fb-8c6ebdd3c9a9)

How it should be in every locale:
![image](https://github.com/user-attachments/assets/5eb7c466-0a50-4f22-9181-74695652c16c)

(in my examples, I'm using the pt-BR locale)