### PR TITLE
docs-util: fix helper step settings

### DIFF
--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/helper-steps.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/helper-steps.ts
@@ -45,6 +45,9 @@ const helperStepsOptions: FormattingOptionsType = {
       typeParameters: false,
       suffix: "- Helper Steps API Reference",
     },
+    reflectionGroups: {
+      "Type Parameters": false,
+    },
   },
 }
 

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/render-utils.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/render-utils.ts
@@ -75,6 +75,7 @@ import workflowOutputHelper from "./resources/helpers/workflow-output"
 import workflowDiagramHelper from "./resources/helpers/workflow-diagram"
 import workflowHooksHelper from "./resources/helpers/workflow-hooks"
 import ifMemberShowTitleHelper from "./resources/helpers/if-member-show-title"
+import signatureCommentHelper from "./resources/helpers/signature-comment"
 import { MarkdownTheme } from "./theme"
 
 const TEMPLATE_PATH = path.join(__dirname, "resources", "templates")
@@ -178,4 +179,5 @@ export function registerHelpers(theme: MarkdownTheme) {
   workflowDiagramHelper(theme)
   workflowHooksHelper(theme)
   ifMemberShowTitleHelper(theme)
+  signatureCommentHelper()
 }

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/signature-comment.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/signature-comment.ts
@@ -1,0 +1,14 @@
+import * as Handlebars from "handlebars"
+import { SignatureReflection } from "typedoc"
+
+export default function () {
+  Handlebars.registerHelper(
+    "signatureComment",
+    function (this: SignatureReflection) {
+      if (!this.comment && !this.parent.comment) {
+        return ""
+      }
+      return Handlebars.helpers.comments(this.comment || this.parent.comment)
+    }
+  )
+}

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.step.hbs
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.step.hbs
@@ -2,7 +2,7 @@
 
 {{#if (sectionEnabled "member_signature_comment")}}
 
-{{> comment}}
+{{{signatureComment}}}
 
 {{/if}}
 

--- a/www/utils/packages/utils/src/step-utils.ts
+++ b/www/utils/packages/utils/src/step-utils.ts
@@ -3,9 +3,16 @@ import { ArrayType, SignatureReflection, SomeType, UnionType } from "typedoc"
 const disallowedIntrinsicTypeNames = ["unknown", "void", "any", "never"]
 
 export function isWorkflowStep(reflection: SignatureReflection): boolean {
-  return (
-    reflection.parent?.children?.some((child) => child.name === "__step__") ||
-    false
+  if (reflection.parent?.children?.some((child) => child.name === "__step__")) {
+    return true
+  }
+  if (reflection.type?.type !== "intersection") {
+    return false
+  }
+  return reflection.type.types.some(
+    (refType) =>
+      refType.type === "reference" &&
+      refType.name === "StepFunctionReturnConfig"
   )
 }
 


### PR DESCRIPTION
- Fix type parameters showing for helper steps
- Fix some steps like `useQueryGraphStep` not recognized as a step