### PR TITLE
docs: remove duplicate buttons in code actions

### DIFF
--- a/www/packages/docs-ui/src/components/CodeBlock/Header/index.tsx
+++ b/www/packages/docs-ui/src/components/CodeBlock/Header/index.tsx
@@ -17,6 +17,7 @@ type CodeBlockHeaderProps = {
   title?: string
   blockStyle?: CodeBlockStyle
   actionsProps: CodeBlockActionsProps
+  hideActions?: boolean
 } & CodeBlockHeaderMeta
 
 export const CodeBlockHeader = ({
@@ -25,6 +26,7 @@ export const CodeBlockHeader = ({
   badgeLabel,
   actionsProps,
   badgeColor,
+  hideActions = false
 }: CodeBlockHeaderProps) => {
   const { colorMode } = useColorMode()
 
@@ -54,7 +56,7 @@ export const CodeBlockHeader = ({
           </div>
         )}
       </div>
-      <CodeBlockActions {...actionsProps} />
+      {!hideActions && <CodeBlockActions {...actionsProps} />}
     </CodeBlockHeaderWrapper>
   )
 }

--- a/www/packages/docs-ui/src/components/CodeBlock/index.tsx
+++ b/www/packages/docs-ui/src/components/CodeBlock/index.tsx
@@ -363,6 +363,7 @@ export const CodeBlock = ({
               ...actionsProps,
               inHeader: true,
             }}
+            hideActions={hasTabs}
           />
         )}
         <div


### PR DESCRIPTION
Remove duplicate buttons showing when a code block has tabs and title

Closes DX-1016