### PR TITLE
docs-utils: make reference table of content in alphabetical order

### DIFF
--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/toc.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/toc.ts
@@ -30,12 +30,16 @@ export default function (theme: MarkdownTheme) {
         })
 
       function pushGroup(group: ReflectionGroup, md: string[]) {
-        const children = group.children.map(
-          (child) =>
-            `- [${escapeChars(child.name)}](${Handlebars.helpers.relativeURL(
-              child.url
-            )})`
-        )
+        const children = group.children
+          .sort((childA, childB) => {
+            return childA.name.localeCompare(childB.name)
+          })
+          .map(
+            (child) =>
+              `- [${escapeChars(child.name)}](${Handlebars.helpers.relativeURL(
+                child.url
+              )})`
+          )
         md.push(children.join("\n"))
       }
 
@@ -44,26 +48,34 @@ export default function (theme: MarkdownTheme) {
           md.push(`## Table of contents\n\n`)
         }
         const headingLevel = hideInPageTOC ? `##` : `###`
-        this.groups?.forEach((group) => {
-          const groupTitle = Object.hasOwn(reflectionGroupRename, group.title)
-            ? reflectionGroupRename[group.title]
-            : group.title
-          if (group.categories) {
-            group.categories.forEach((category) => {
-              md.push(`${headingLevel} ${category.title} ${groupTitle}\n\n`)
-              pushGroup(category as ReflectionGroup, md)
-              md.push("\n")
-            })
-          } else {
-            if (!hideInPageTOC || isVisible) {
-              if (!hideTocHeaders) {
-                md.push(`${headingLevel} ${groupTitle}\n\n`)
+        this.groups
+          ?.sort((groupA, groupB) => {
+            return groupA.title.localeCompare(groupB.title)
+          })
+          .forEach((group) => {
+            const groupTitle = Object.hasOwn(reflectionGroupRename, group.title)
+              ? reflectionGroupRename[group.title]
+              : group.title
+            if (group.categories) {
+              group.categories
+                .sort((catA, catB) => {
+                  return catA.title.localeCompare(catB.title)
+                })
+                .forEach((category) => {
+                  md.push(`${headingLevel} ${category.title} ${groupTitle}\n\n`)
+                  pushGroup(category as ReflectionGroup, md)
+                  md.push("\n")
+                })
+            } else {
+              if (!hideInPageTOC || isVisible) {
+                if (!hideTocHeaders) {
+                  md.push(`${headingLevel} ${groupTitle}\n\n`)
+                }
+                pushGroup(group, md)
+                md.push("\n")
               }
-              pushGroup(group, md)
-              md.push("\n")
             }
-          }
-        })
+          })
       }
       return md.length > 0 ? md.join("\n") : null
     }


### PR DESCRIPTION
Make table of contents in references in alphabetical order, similar to the sidebar.

Closes DX-856