### PR TITLE
docs: add missing prerequisite in stripe's storefront integration

### DIFF
--- a/www/apps/resources/app/storefront-development/checkout/payment/stripe/page.mdx
+++ b/www/apps/resources/app/storefront-development/checkout/payment/stripe/page.mdx
@@ -23,6 +23,10 @@ For other types of storefronts, the steps are similar. However, refer to [Stripe
     text: "Stripe publishable API key.",
     link: "https://support.stripe.com/questions/locate-api-keys-in-the-dashboard"
   },
+  {
+    text: "Cart context in your storefront, which is used in a code snippet later.",
+    link: "/resources/storefront-development/cart/context"
+  },
 ]} />
 
 ## 1. Install Stripe SDK
@@ -56,6 +60,12 @@ For Next.js storefronts, the environment variable's name must be prefixed with `
 ## 3. Create Stripe Component
 
 Then, create a file holding the following Stripe component:
+
+<Note>
+
+This snippet assumes you're using the provider from the [Cart Context guide](../../../cart/context/page.mdx) in your storefront.
+
+</Note>
 
 export const highlights = [
   ["10", "useCart", "The `useCart` hook was defined in the Cart React Context documentation."],


### PR DESCRIPTION
Closes SUP-190
