### PR TITLE
fix(core-flows): Fix date usage accross workflows

### DIFF
--- a/packages/core/core-flows/src/order/workflows/claim/confirm-claim-request.ts
+++ b/packages/core/core-flows/src/order/workflows/claim/confirm-claim-request.ts
@@ -306,13 +306,17 @@ export const confirmClaimRequestWorkflow = createWorkflow(
     when({ returnId }, ({ returnId }) => {
       return !!returnId
     }).then(() => {
-      updateReturnsStep([
-        {
-          id: returnId,
-          status: ReturnStatus.REQUESTED,
-          requested_at: new Date(),
-        },
-      ])
+      const data = transform({ returnId }, ({ returnId }) => {
+        return [
+          {
+            id: returnId,
+            status: ReturnStatus.REQUESTED,
+            requested_at: new Date(),
+          },
+        ]
+      })
+
+      updateReturnsStep(data)
     })
 
     const claimId = transform(

--- a/packages/core/core-flows/src/order/workflows/claim/confirm-claim-request.ts
+++ b/packages/core/core-flows/src/order/workflows/claim/confirm-claim-request.ts
@@ -47,6 +47,18 @@ export type ConfirmClaimRequestWorkflowInput = {
   confirmed_by?: string
 }
 
+function getUpdateReturnData({ returnId }: { returnId: string }) {
+  return transform({ returnId }, ({ returnId }) => {
+    return [
+      {
+        id: returnId,
+        status: ReturnStatus.REQUESTED,
+        requested_at: new Date(),
+      },
+    ]
+  })
+}
+
 /**
  * This step validates that a requested claim can be confirmed.
  */
@@ -306,17 +318,8 @@ export const confirmClaimRequestWorkflow = createWorkflow(
     when({ returnId }, ({ returnId }) => {
       return !!returnId
     }).then(() => {
-      const data = transform({ returnId }, ({ returnId }) => {
-        return [
-          {
-            id: returnId,
-            status: ReturnStatus.REQUESTED,
-            requested_at: new Date(),
-          },
-        ]
-      })
-
-      updateReturnsStep(data)
+      const updateReturnDate = getUpdateReturnData({ returnId })
+      updateReturnsStep(updateReturnDate)
     })
 
     const claimId = transform(

--- a/packages/core/core-flows/src/order/workflows/exchange/confirm-exchange-request.ts
+++ b/packages/core/core-flows/src/order/workflows/exchange/confirm-exchange-request.ts
@@ -203,6 +203,18 @@ function extractShippingOption({ orderPreview, orderExchange, returnId }) {
   }
 }
 
+function getUpdateReturnData({ returnId }: { returnId: string }) {
+  return transform({ returnId }, ({ returnId }) => {
+    return [
+      {
+        id: returnId,
+        status: ReturnStatus.REQUESTED,
+        requested_at: new Date(),
+      },
+    ]
+  })
+}
+
 export const confirmExchangeRequestWorkflowId = "confirm-exchange-request"
 /**
  * This workflow confirms an exchange request.
@@ -294,13 +306,8 @@ export const confirmExchangeRequestWorkflow = createWorkflow(
     when({ returnId }, ({ returnId }) => {
       return !!returnId
     }).then(() => {
-      updateReturnsStep([
-        {
-          id: returnId,
-          status: ReturnStatus.REQUESTED,
-          requested_at: new Date(),
-        },
-      ])
+      const updateReturnData = getUpdateReturnData({ returnId })
+      updateReturnsStep(updateReturnData)
     })
 
     const exchangeId = transform(

--- a/packages/core/core-flows/src/order/workflows/return/confirm-return-request.ts
+++ b/packages/core/core-flows/src/order/workflows/return/confirm-return-request.ts
@@ -158,6 +158,18 @@ function extractReturnShippingOptionId({ orderPreview, orderReturn }) {
   return returnShippingMethod.shipping_option_id
 }
 
+function getUpdateReturnData({ orderReturn }: { orderReturn: { id: string } }) {
+  return transform({ orderReturn }, ({ orderReturn }) => {
+    return [
+      {
+        id: orderReturn.id,
+        status: ReturnStatus.REQUESTED,
+        requested_at: new Date(),
+      },
+    ]
+  })
+}
+
 export const confirmReturnRequestWorkflowId = "confirm-return-request"
 /**
  * This workflow confirms a return request.
@@ -277,14 +289,10 @@ export const confirmReturnRequestWorkflow = createWorkflow(
       createRemoteLinkStep(link)
     })
 
+    const updateReturnData = getUpdateReturnData({ orderReturn })
+
     parallelize(
-      updateReturnsStep([
-        {
-          id: orderReturn.id,
-          status: ReturnStatus.REQUESTED,
-          requested_at: new Date(),
-        },
-      ]),
+      updateReturnsStep(updateReturnData),
       confirmOrderChanges({
         changes: [orderChange],
         orderId: order.id,


### PR DESCRIPTION
FIXES CMRC-691

**What**
`Date` is something that get executed, since workflows are meant to compose the definition of what will be executed, the date where always having the same value as they was executed once during composition.
Instead wrap those into transformer that will be executed when needed and fix the Date issues