### PR TITLE
feat: node_modules plugins resolve

### DIFF
--- a/packages/medusa/src/loaders/helpers/resolve-plugins.ts
+++ b/packages/medusa/src/loaders/helpers/resolve-plugins.ts
@@ -93,8 +93,6 @@ function resolvePlugin(pluginName: string): {
         includeExtensionDirectoryPath: true,
       })
     }
-
-    throw new Error(`Unable to find the plugin "${pluginName}".`)
   }
 
   try {

--- a/packages/medusa/src/loaders/helpers/resolve-plugins.ts
+++ b/packages/medusa/src/loaders/helpers/resolve-plugins.ts
@@ -93,6 +93,24 @@ function resolvePlugin(pluginName: string): {
         includeExtensionDirectoryPath: true,
       })
     }
+
+    resolvedPath = path.resolve(`${process.cwd()}/node_modules/${pluginName}`)
+    const doesExistsInNodeModules = existsSync(resolvedPath)
+    if (doesExistsInNodeModules) {
+      const packageJSON = JSON.parse(
+        fs.readFileSync(`${resolvedPath}/package.json`, `utf-8`)
+      )
+
+      const computedResolvedPath = path.join(resolvedPath, "dist")
+
+      return {
+        resolve: computedResolvedPath,
+        id: createPluginId(packageJSON.name),
+        name: packageJSON.name,
+        options: {},
+        version: packageJSON.version,
+      }
+    }
   }
 
   try {


### PR DESCRIPTION
## What
Fixed the plugin load when installed 

## Why
Plugins won't load normally if the plugin is in the node_modules

## How
Added a resolve for node_modules
```typescript
resolvedPath = path.resolve(`${process.cwd()}/node_modules/${pluginName}`)
const doesExistsInNodeModules = existsSync(resolvedPath)
if (doesExistsInNodeModules) {
  const packageJSON = JSON.parse(
    fs.readFileSync(`${resolvedPath}/package.json`, `utf-8`)
  )

   const computedResolvedPath = path.join(resolvedPath, "dist")

  return {
    resolve: computedResolvedPath,
    id: createPluginId(packageJSON.name),
    name: packageJSON.name,
    options: {},
    version: packageJSON.version,
  }
}
```

## Testing
No tests written for this feature