### PR TITLE
docs: S3 providers - add example for DigitalOcean Spaces endpoint

### DIFF
--- a/www/apps/resources/app/architectural-modules/file/s3/page.mdx
+++ b/www/apps/resources/app/architectural-modules/file/s3/page.mdx
@@ -260,7 +260,7 @@ module.exports = {
 
       - For AWS S3, the endpoint is of the format `https://s3.{region}.amazonaws.com`
       - For MinIO, it's the URL to the MinIO server.
-      - For DigitalOcean Spaces, it's the Spaces Origin Endpoint.
+      - For DigitalOcean Spaces, it's the Spaces Origin Endpoint `https://{region}.digitaloceanspaces.com`.
       - For Supabase, it's the Endpoint URL in the [Storage Settings](https://supabase.com/docs/guides/storage/s3/authentication?queryGroups=language&language=javascript#s3-access-keys).
       
       </Table.Cell>

--- a/www/apps/resources/app/architectural-modules/file/s3/page.mdx
+++ b/www/apps/resources/app/architectural-modules/file/s3/page.mdx
@@ -260,7 +260,7 @@ module.exports = {
 
       - For AWS S3, the endpoint is of the format `https://s3.{region}.amazonaws.com`
       - For MinIO, it's the URL to the MinIO server.
-      - For DigitalOcean Spaces, it's the Spaces Origin Endpoint `https://{region}.digitaloceanspaces.com`.
+      - For DigitalOcean Spaces, it's the Spaces Origin Endpoint of the format `https://{region}.digitaloceanspaces.com`.
       - For Supabase, it's the Endpoint URL in the [Storage Settings](https://supabase.com/docs/guides/storage/s3/authentication?queryGroups=language&language=javascript#s3-access-keys).
       
       </Table.Cell>


### PR DESCRIPTION
The [S3 providers docs](https://docs.medusajs.com/resources/architectural-modules/file/s3#:R1d5rtttqj5db:) instructs DigitalOcean users to set the endpoint address to the "Spaces Origin Endpoint":
```
For DigitalOcean Spaces, it's the Spaces Origin Endpoint.
```

On DigitalOcean's user interface they include the bucket name in their origin endpoint:
![image](https://github.com/user-attachments/assets/e4c6ab05-ff1c-40ad-bb2b-49653b990e6b)

Using this url for the endpoint will cause an error.

The example URL `https://{region}.digitaloceanspaces.com` should tip users off to remove the bucketname.

Cheers!