### PR TITLE
fix(dashboard): updated variant title is used when creating product

### DIFF
--- a/packages/admin/dashboard/src/routes/products/product-create/constants.ts
+++ b/packages/admin/dashboard/src/routes/products/product-create/constants.ts
@@ -25,7 +25,6 @@ const ProductCreateVariantSchema = z.object({
   weight: optionalInt,
   material: z.string().optional(),
   origin_country: z.string().optional(),
-  custom_title: z.string().optional(),
   sku: z.string().optional(),
   manage_inventory: z.boolean().optional(),
   allow_backorder: z.boolean().optional(),

--- a/packages/admin/dashboard/src/routes/products/product-create/utils.ts
+++ b/packages/admin/dashboard/src/routes/products/product-create/utils.ts
@@ -53,8 +53,7 @@ export const normalizeVariants = (
   regionsCurrencyMap: Record<string, string>
 ) => {
   return variants.map((variant) => ({
-    title:
-      variant.custom_title || Object.values(variant.options || {}).join(" / "),
+    title: variant.title || Object.values(variant.options || {}).join(" / "),
     options: variant.options,
     sku: variant.sku || undefined,
     manage_inventory: !!variant.manage_inventory,


### PR DESCRIPTION
what:

When editing titles for product variants in the bulk editor form, the new titles were not being picked up during create product api call due to incorrect attribute being picked for variant title. This PR fixes uses variant.title instead of variant.custom_title to fix this issue.

RESOLVES SUP-218