### PR TITLE
docs-util: remove duplicate methods from JS SDK reference

### DIFF
--- a/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/js-sdk.ts
+++ b/www/utils/packages/typedoc-generate-references/src/constants/merger-custom-options/js-sdk.ts
@@ -36,6 +36,11 @@ const jsSdkOptions: FormattingOptionsType = {
     },
     reflectionDescription:
       "This documentation provides a reference to the `sdk.store.{{alias}}` set of methods used to send requests to Medusa's Store API routes.",
+    sections: {
+      ...baseSectionsOptions,
+      member_declaration_title: false,
+      member_declaration_children: false,
+    },
   },
   "^js_sdk/admin/classes/.*Admin": {
     frontmatterData: {

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.declaration.hbs
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.declaration.hbs
@@ -114,7 +114,7 @@
 
 {{#each (getDeclarationChildren)}}
 
-{{> member}}
+{{> member }}
 
 {{/each}}
 


### PR DESCRIPTION
The JS SDK reference for store methods show the same method two times. This PR fixes the configuration of these references so that they're only shown once.

The fix will be live the next time the references are generated (on next release)

Closes DX-1087