### PR TITLE
fix: Updates email id

### DIFF
--- a/packages/modules/providers/auth-emailpass/src/services/emailpass.ts
+++ b/packages/modules/providers/auth-emailpass/src/services/emailpass.ts
@@ -43,11 +43,11 @@ export class EmailPassAuthService extends AbstractAuthModuleProvider {
   }
 
   async update(
-    data: { password: string; entity_id: string },
+    data: { password: string; email: string },
     authIdentityService: AuthIdentityProviderService
   ) {
-    const { password, entity_id } = data ?? {}
-
+    const { password, email } = data ?? {}
+    const entity_id = email
     if (!entity_id) {
       return {
         success: false,


### PR DESCRIPTION
the entity_id is the same as the email address. However, the body, in turn data received via the api doesn't have an entity id field, it has only an email field. 
Thus, a small PR to fix this. Otherwise one has to add messy middleware to ensure that the entity id is sent as a part of the body.