### PR TITLE
fix(utils): read dir recursive

### DIFF
--- a/.changeset/clever-singers-vanish.md
+++ b/.changeset/clever-singers-vanish.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+fix(utils): set readonly property on recursive dir read

--- a/packages/core/utils/src/common/__tests__/read-dir-recursive.spec.ts
+++ b/packages/core/utils/src/common/__tests__/read-dir-recursive.spec.ts
@@ -30,23 +30,30 @@ describe("readDirRecursive", () => {
 
     const result = await readDirRecursive("/root")
 
+    const paths = result.map((r) => r.path)
+
+    expect(paths).toEqual([
+      "/root",
+      "/root",
+      "/root/subdir",
+      "/root/subdir",
+      "/root/subdir/nested",
+    ])
+
     expect(result).toEqual([
-      { name: "file1.txt", isDirectory: expect.any(Function), path: "/root" },
-      { name: "subdir", isDirectory: expect.any(Function), path: "/root" },
+      { name: "file1.txt", isDirectory: expect.any(Function) },
+      { name: "subdir", isDirectory: expect.any(Function) },
       {
         name: "file2.txt",
         isDirectory: expect.any(Function),
-        path: "/root/subdir",
       },
       {
         name: "nested",
         isDirectory: expect.any(Function),
-        path: "/root/subdir",
       },
       {
         name: "file3.txt",
         isDirectory: expect.any(Function),
-        path: "/root/subdir/nested",
       },
     ])
 

--- a/packages/core/utils/src/common/read-dir-recursive.ts
+++ b/packages/core/utils/src/common/read-dir-recursive.ts
@@ -9,7 +9,9 @@ export async function readDirRecursive(dir: string): Promise<Dirent[]> {
 
     for (const entry of entries) {
       const fullPath = join(dir, entry.name)
-      entry.path = dir
+      Object.defineProperty(entry, "path", {
+        value: dir,
+      })
       allEntries.push(entry)
 
       if (entry.isDirectory()) {


### PR DESCRIPTION
What:
 - Using `Object.defineProperty) to avoid issues on Node versions that set this property as readonly.