### PR TITLE
fix(product): change export name of ProductImage

### DIFF
--- a/.changeset/purple-maps-bow.md
+++ b/.changeset/purple-maps-bow.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/product": patch
+---
+
+fix(product): change export name of ProductImage

--- a/packages/modules/product/integration-tests/__fixtures__/product/index.ts
+++ b/packages/modules/product/integration-tests/__fixtures__/product/index.ts
@@ -5,7 +5,7 @@ import {
 } from "@medusajs/framework/utils"
 import { SqlEntityManager } from "@mikro-orm/postgresql"
 import {
-  Image,
+  ProductImage,
   Product,
   ProductCategory,
   ProductCollection,
@@ -133,7 +133,7 @@ export async function createImages(
   imagesData: string[]
 ) {
   const images: any[] = imagesData.map((img) => {
-    return manager.create(toMikroORMEntity(Image), { url: img })
+    return manager.create(toMikroORMEntity(ProductImage), { url: img })
   })
 
   await manager.persistAndFlush(images)

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
@@ -12,7 +12,7 @@ import {
   ProductStatus,
 } from "@medusajs/framework/utils"
 import {
-  Image,
+  ProductImage,
   Product,
   ProductCategory,
   ProductCollection,
@@ -1345,17 +1345,17 @@ moduleIntegrationTestRunner<IProductModuleService>({
           const manager = MikroOrmWrapper.forkManager()
 
           const images = [
-            manager.create(Image, {
+            manager.create(ProductImage, {
               product_id: product.id,
               url: "image-one",
               rank: 1,
             }),
-            manager.create(Image, {
+            manager.create(ProductImage, {
               product_id: product.id,
               url: "image-two",
               rank: 0,
             }),
-            manager.create(Image, {
+            manager.create(ProductImage, {
               product_id: product.id,
               url: "image-three",
               rank: 2,

--- a/packages/modules/product/src/models/index.ts
+++ b/packages/modules/product/src/models/index.ts
@@ -1,7 +1,7 @@
 export { default as Product } from "./product"
 export { default as ProductCategory } from "./product-category"
 export { default as ProductCollection } from "./product-collection"
-export { default as Image } from "./product-image"
+export { default as ProductImage } from "./product-image"
 export { default as ProductOption } from "./product-option"
 export { default as ProductOptionValue } from "./product-option-value"
 export { default as ProductTag } from "./product-tag"

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -13,7 +13,7 @@ import {
   Product,
   ProductCategory,
   ProductCollection,
-  Image as ProductImage,
+  ProductImage,
   ProductOption,
   ProductOptionValue,
   ProductTag,


### PR DESCRIPTION
Change export of `Image` to `ProductImage` to match the data model's name.