### PR TITLE
fix(medusa): remove request body type argument from cancel order transfer routes

### DIFF
--- a/.changeset/nasty-tigers-cross.md
+++ b/.changeset/nasty-tigers-cross.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): remove request body type argument from cancel order transfer routes

--- a/packages/medusa/src/api/admin/orders/[id]/transfer/cancel/route.ts
+++ b/packages/medusa/src/api/admin/orders/[id]/transfer/cancel/route.ts
@@ -4,11 +4,10 @@ import {
   MedusaResponse,
 } from "@medusajs/framework/http"
 import { AdminOrder, HttpTypes } from "@medusajs/framework/types"
-import { AdminCancelOrderTransferRequestType } from "../../../validators"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest<AdminCancelOrderTransferRequestType>,
+  req: AuthenticatedMedusaRequest,
   res: MedusaResponse<HttpTypes.AdminOrderResponse>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)

--- a/packages/medusa/src/api/store/orders/[id]/transfer/cancel/route.ts
+++ b/packages/medusa/src/api/store/orders/[id]/transfer/cancel/route.ts
@@ -7,10 +7,9 @@ import {
   MedusaResponse,
 } from "@medusajs/framework/http"
 import { HttpTypes } from "@medusajs/framework/types"
-import { StoreCancelOrderTransferRequestType } from "../../../validators"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest<StoreCancelOrderTransferRequestType>,
+  req: AuthenticatedMedusaRequest,
   res: MedusaResponse<HttpTypes.StoreOrderResponse>
 ) => {
   const orderId = req.params.id


### PR DESCRIPTION
Remove the request body type passed as a type argument for admin and store routes for order transfer cancelation. Since the type is empty, it leads to a generated empty request body schema in the API reference.