### PR TITLE
Fix JWT expiration time mismatch by converting expiresIn to string

### DIFF
--- a/packages/modules/user/src/services/user-module.ts
+++ b/packages/modules/user/src/services/user-module.ts
@@ -381,7 +381,7 @@ export default class UserModuleService
     const jwtSecret: string = this.moduleDeclaration["jwt_secret"]
     return jwt.sign(data, jwtSecret, {
       jwtid: crypto.randomUUID(),
-      expiresIn: this.config.expiresIn,
+      expiresIn: String(this.config.expiresIn),
     })
   }
 }


### PR DESCRIPTION
This pull request fixes the issue where the invite JWT was not expiring after 24 hours as expected. The problem was caused by a mismatch in the units for the expiration duration. Specifically, the DEFAULT_VALID_INVITE_DURATION constant was defined in milliseconds, but the expiresIn field in the jsonwebtoken library expects seconds when passed as a numeric value, or milliseconds when passed as a string. This mismatch led to incorrect expiration calculations, causing the invite token to expire in 24000 hours instead of 24 hours.

The issue prevented the invite token from expiring after the intended 24-hour period, leading to the token being valid for a longer period then intended. Fixing this ensures that the invite token behaves as expected and expires in the correct time frame.

How:
The expiration duration is now passed as a string by converting the this.config.expiresIn value using String(this.config.expiresIn). This ensures that the expiresIn option in the jsonwebtoken library is correctly interpreted as milliseconds when passed as a string, resolving the mismatch issue.

Testing:

    To test this fix, a user invite can be triggered, and the invite token retrieved either from the database or URL.
    Decode the JWT and verify that the expiration (exp field) reflects the correct 24-hour expiration from the time the invite was issued.
    The token should now expire in exactly 24 hours, ensuring it is not valid after that period.