### PR TITLE
fix(types): removes customer_id from update cart workflow type

### DIFF
--- a/packages/core/types/src/cart/workflows.ts
+++ b/packages/core/types/src/cart/workflows.ts
@@ -88,7 +88,6 @@ export interface UpdateCartWorkflowInputDTO {
   id: string
   promo_codes?: string[]
   region_id?: string
-  customer_id?: string | null
   sales_channel_id?: string | null
   email?: string | null
   currency_code?: string


### PR DESCRIPTION
what:

since update cart workflow no longer handles customer_id, we can remove them cart workflow type