### PR TITLE
feat(core-flows,types,medusa): ability to update/create custom shipping prices

### DIFF
--- a/packages/core/types/src/pricing/common/price-rule.ts
+++ b/packages/core/types/src/pricing/common/price-rule.ts
@@ -138,3 +138,9 @@ export interface FilterablePriceRuleProps
  * The possible operators to use in a price rule.
  */
 export type PricingRuleOperatorValues = "gt" | "lt" | "eq" | "lte" | "gte"
+
+export interface PriceRule {
+  attribute: string
+  operator: PricingRuleOperatorValues
+  value: number
+}

--- a/packages/core/types/src/workflow/fulfillment/update-shipping-options.ts
+++ b/packages/core/types/src/workflow/fulfillment/update-shipping-options.ts
@@ -1,5 +1,6 @@
-import { ShippingOptionPriceType } from "../../fulfillment"
 import { RuleOperatorType } from "../../common"
+import { ShippingOptionPriceType } from "../../fulfillment"
+import { PriceRule } from "../../pricing"
 
 export interface UpdateShippingOptionsWorkflowInput {
   id: string
@@ -19,11 +20,13 @@ export interface UpdateShippingOptionsWorkflowInput {
         id?: string
         currency_code?: string
         amount?: number
+        rules?: PriceRule[]
       }
     | {
         id?: string
         region_id?: string
         amount?: number
+        rules?: PriceRule[]
       }
   )[]
   rules?: {

--- a/packages/medusa/src/api/admin/shipping-options/query-config.ts
+++ b/packages/medusa/src/api/admin/shipping-options/query-config.ts
@@ -10,6 +10,7 @@ export const defaultAdminShippingOptionFields = [
   "*rules",
   "*type",
   "*prices",
+  "*prices.price_rules",
   "*service_zone",
   "*shipping_profile",
   "*provider",

--- a/packages/medusa/src/api/admin/shipping-options/validators.ts
+++ b/packages/medusa/src/api/admin/shipping-options/validators.ts
@@ -1,4 +1,5 @@
 import {
+  PricingRuleOperator,
   RuleOperator,
   ShippingOptionPriceType as ShippingOptionPriceTypeEnum,
 } from "@medusajs/framework/utils"
@@ -83,11 +84,20 @@ export const AdminCreateShippingOptionTypeObject = z
   })
   .strict()
 
+const AdminPriceRules = z.array(
+  z.object({
+    attribute: z.literal("cart_total"),
+    operator: z.nativeEnum(PricingRuleOperator),
+    value: z.number(),
+  })
+)
+
 // eslint-disable-next-line max-len
 export const AdminCreateShippingOptionPriceWithCurrency = z
   .object({
     currency_code: z.string(),
     amount: z.number(),
+    rules: AdminPriceRules.optional(),
   })
   .strict()
 
@@ -95,6 +105,7 @@ export const AdminCreateShippingOptionPriceWithRegion = z
   .object({
     region_id: z.string(),
     amount: z.number(),
+    rules: AdminPriceRules.optional(),
   })
   .strict()
 
@@ -103,6 +114,7 @@ export const AdminUpdateShippingOptionPriceWithCurrency = z
     id: z.string().optional(),
     currency_code: z.string().optional(),
     amount: z.number().optional(),
+    rules: AdminPriceRules.optional(),
   })
   .strict()
 
@@ -111,6 +123,7 @@ export const AdminUpdateShippingOptionPriceWithRegion = z
     id: z.string().optional(),
     region_id: z.string().optional(),
     amount: z.number().optional(),
+    rules: AdminPriceRules.optional(),
   })
   .strict()
 


### PR DESCRIPTION
what:

- adds rules to existing shipping option prices http validations
- update and create shipping option workflows are updated to be able to handle custom prices

The types and workflow steps in shipping options could use a nice cleanup. I'll schedule this after unblocking the FE tickets. 

RESOLVES CMRC-750
RESOLVES CMRC-749