### PR TITLE
chore(utils): Ensure DML name convention follow the same as the class  name for simplicity

### DIFF
--- a/packages/core/utils/src/dml/__tests__/entity-builder.spec.ts
+++ b/packages/core/utils/src/dml/__tests__/entity-builder.spec.ts
@@ -77,7 +77,7 @@ describe("Entity builder", () => {
         phones: model.array(),
       })
 
-      expect(user.name).toEqual("user")
+      expect(user.name).toEqual("User")
       expect(user.parse().tableName).toEqual("user")
 
       const User = toMikroORMEntity(user)
@@ -216,7 +216,7 @@ describe("Entity builder", () => {
         }
       )
 
-      expect(user.name).toEqual("user")
+      expect(user.name).toEqual("User")
       expect(user.parse().tableName).toEqual("user_table")
 
       const User = toMikroORMEntity(user)
@@ -346,7 +346,7 @@ describe("Entity builder", () => {
         }
       )
 
-      expect(user.name).toEqual("userRole")
+      expect(user.name).toEqual("UserRole")
       expect(user.parse().tableName).toEqual("user_role")
 
       const User = toMikroORMEntity(user)
@@ -1355,7 +1355,7 @@ describe("Entity builder", () => {
         phones: model.json().default({ number: "22222222" }),
       })
 
-      expect(user.name).toEqual("user")
+      expect(user.name).toEqual("User")
       expect(user.parse().tableName).toEqual("user")
 
       const User = toMikroORMEntity(user)
@@ -4456,7 +4456,7 @@ describe("Entity builder", () => {
           })
 
       expect(defineEmail).toThrow(
-        'Cannot cascade delete "user" relationship(s) from "email" entity. Child to parent cascades are not allowed'
+        'Cannot cascade delete "user" relationship(s) from "Email" entity. Child to parent cascades are not allowed'
       )
     })
 

--- a/packages/core/utils/src/dml/entity.ts
+++ b/packages/core/utils/src/dml/entity.ts
@@ -8,7 +8,7 @@ import {
   InferDmlEntityNameFromConfig,
   QueryCondition,
 } from "@medusajs/types"
-import { isObject, isString, toCamelCase } from "../common"
+import { isObject, isString, toCamelCase, upperCaseFirst } from "../common"
 import { transformIndexWhere } from "./helpers/entity-builder/build-indexes"
 import { BelongsTo } from "./relations/belongs-to"
 
@@ -28,7 +28,9 @@ function extractNameAndTableName<const Config extends IDmlEntityConfig>(
   if (isString(nameOrConfig)) {
     const [schema, ...rest] = nameOrConfig.split(".")
     const name = rest.length ? rest.join(".") : schema
-    result.name = toCamelCase(name) as InferDmlEntityNameFromConfig<Config>
+    result.name = upperCaseFirst(
+      toCamelCase(name)
+    ) as InferDmlEntityNameFromConfig<Config>
 
     result.tableName = nameOrConfig
   }
@@ -44,7 +46,9 @@ function extractNameAndTableName<const Config extends IDmlEntityConfig>(
     const [schema, ...rest] = potentialName.split(".")
     const name = rest.length ? rest.join(".") : schema
 
-    result.name = toCamelCase(name) as InferDmlEntityNameFromConfig<Config>
+    result.name = upperCaseFirst(
+      toCamelCase(name)
+    ) as InferDmlEntityNameFromConfig<Config>
     result.tableName = nameOrConfig.tableName
   }
 

--- a/packages/core/utils/src/dml/integration-tests/__tests__/many-to-many.spec.ts
+++ b/packages/core/utils/src/dml/integration-tests/__tests__/many-to-many.spec.ts
@@ -292,7 +292,7 @@ describe("manyToMany - manyToMany", () => {
 
     expect(error).toBeDefined()
     expect(error?.message).toEqual(
-      'Invalid relationship reference for "user.squads". Make sure to set the mappedBy property on one side or the other or both.'
+      'Invalid relationship reference for "User.squads". Make sure to set the mappedBy property on one side or the other or both.'
     )
   })
 


### PR DESCRIPTION
**What**
DML class name and mikro orm entity name are different, it was ok and the idea was to accept that and do the transformation when needed. But since class name are usually upper case first we decided to re integrate that convention in the DML class name as well to simplify consumption of the dml name without having to worry about the normal case