### PR TITLE
fix: adding line items to cart forwards cart_id to the pricing context

### DIFF
--- a/packages/medusa/src/api/routes/store/carts/create-line-item/utils/handler-steps.ts
+++ b/packages/medusa/src/api/routes/store/carts/create-line-item/utils/handler-steps.ts
@@ -31,6 +31,7 @@ export async function addOrUpdateLineItem({
     .withTransaction(manager)
     .generate(data.variant_id, cart.region_id, data.quantity, {
       customer_id: data.customer_id || cart.customer_id,
+      cart,
       metadata: data.metadata,
     })
 

--- a/packages/medusa/src/services/cart.ts
+++ b/packages/medusa/src/services/cart.ts
@@ -955,6 +955,7 @@ class CartService extends TransactionBaseService {
                   },
                 ],
                 {
+                  cart_id: cart.id,
                   region_id: cart.region_id,
                   customer_id: cart.customer_id,
                   include_discount_prices: true,

--- a/packages/medusa/src/services/line-item.ts
+++ b/packages/medusa/src/services/line-item.ts
@@ -293,6 +293,7 @@ class LineItemService extends TransactionBaseService {
           variantsPricing = await this.pricingService_
             .withTransaction(transactionManager)
             .getProductVariantsPricing(variantsToCalculatePricingFor, {
+              cart_id: context?.cart?.cart_id,
               region_id: regionId,
               customer_id: context?.customer_id,
               include_discount_prices: true,

--- a/packages/medusa/src/types/totals.ts
+++ b/packages/medusa/src/types/totals.ts
@@ -10,6 +10,7 @@ import {
 } from "../models"
 
 export type CalculationContextData = {
+  cart_id?: string;
   discounts: Discount[]
   items: LineItem[]
   customer: Customer


### PR DESCRIPTION
# Problem description

When calling `[POST] /store/carts/{id}/line-items` to add an item into the cart, basically two major things happen:
- `lineItemService.generate(...)` is called to generate the line item
- `txCartService.addOrUpdateLineItems(...)` is called to add the line item to the respective cart

When there is a custom `PriceSelectionStrategy` in place, which relies on the `cart_id` in the context to actually calculate a price, the first method call `lineItemService.generate(...)` will fail, as the `cart` is not added to the context, thus `Cannot generate line item for variant <id> without a price` is thrown.

# Solution
This PR should fix the issue, by passing the cart context forward to the nested method calls in `addOrUpdateLineItem` such that when we call `getProductVariantsPricing` the cart context is available when we call the `PriceSelectionStrategy`.

See that the current implementation of `CartService.addOrUpdateLineItems(...)` does this already correct as we can see here:
```
          if (currentItem) {
            const variantsPricing = await this.pricingService_
              .withTransaction(transactionManager)
              .getProductVariantsPricing(
                [
                  {
                    variantId: item.variant_id!,
                    quantity: item.quantity,
                  },
                ],
                {
                  cart_id: cart.id,
                  region_id: cart.region_id,
                  customer_id: cart.customer_id,
                  include_discount_prices: true,
                }
              )
```


Unfortunately I don't really know how it influences orders / swaps, etc. and there is no test added yet, as the test setup needed seems to be quite complex, as currently in the tests for the `LineItemService` the price calculation strategy is completely mocked and independent of any input values.
However, I'm open for discussing how and if we can bring this fix into the `v1.x` branch and hopefully into a new `v1` release, as currently we are relying on a dirty fix which avoids this issue.