### PR TITLE
feat(createProductCategoriesWorkflow): add productCategoriesCreated hook

### DIFF
--- a/packages/core/core-flows/src/product-category/workflows/create-product-categories.ts
+++ b/packages/core/core-flows/src/product-category/workflows/create-product-categories.ts
@@ -3,6 +3,7 @@ import { ProductCategoryWorkflowEvents } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   WorkflowResponse,
+  createHook,
   createWorkflow,
   transform,
 } from "@medusajs/framework/workflows-sdk"
@@ -18,12 +19,12 @@ export const createProductCategoriesWorkflow = createWorkflow(
   (
     input: WorkflowData<ProductCategoryWorkflow.CreateProductCategoriesWorkflowInput>
   ) => {
-    const createdProducts = createProductCategoriesStep(input)
+    const createdProductCategories = createProductCategoriesStep(input)
 
     const productCategoryIdEvents = transform(
-      { createdProducts },
-      ({ createdProducts }) => {
-        return createdProducts.map((v) => {
+      { createdProductCategories },
+      ({ createdProductCategories }) => {
+        return createdProductCategories.map((v) => {
           return { id: v.id }
         })
       }
@@ -34,6 +35,13 @@ export const createProductCategoriesWorkflow = createWorkflow(
       data: productCategoryIdEvents,
     })
 
-    return new WorkflowResponse(createdProducts)
+    const productCategoriesCreated = createHook("productCategoriesCreated", {
+      createdProductCategories,
+      additional_data: input.additional_data,
+    })
+
+    return new WorkflowResponse(createdProductCategories, {
+      hooks: [productCategoriesCreated]
+    })
   }
 )


### PR DESCRIPTION
### What
This commit introduces the `productCategoriesCreated` hook to the `createProductCategoriesWorkflow`. It also fixes inconsistent variable names within the workflow.

### Why
The hook was missing and necessary to improve the workflow's extensibility.
- Variable names like `createdProducts` were misleading and did not match the context. They were updated to `createdProductCategories` for clarity.

### How
Added the `productCategoriesCreated` hook and updated related logic within the workflow.
- Renamed variables from `createdProducts` to `createdProductCategories` to reflect their actual purpose.

Fixes: #10230