### PR TITLE
chore(utils): DML#hasOne allow mappedBy to not be defined

### DIFF
--- a/.changeset/good-moles-camp.md
+++ b/.changeset/good-moles-camp.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+chore(utils): DML#hasOne allow mappedBy to not be defined

--- a/packages/core/utils/src/dml/__tests__/entity-builder.spec.ts
+++ b/packages/core/utils/src/dml/__tests__/entity-builder.spec.ts
@@ -2986,6 +2986,7 @@ describe("Entity builder", () => {
         username: model.text(),
         email: model.hasOne(() => email, {
           foreignKey: true,
+          mappedBy: undefined,
         }),
       })
 
@@ -3097,6 +3098,7 @@ describe("Entity builder", () => {
         emails: model
           .hasOne(() => email, {
             foreignKey: true,
+            mappedBy: undefined,
           })
           .nullable(),
       })
@@ -3352,6 +3354,7 @@ describe("Entity builder", () => {
           entity: "Email",
           nullable: false,
           cascade: ["persist", "soft-remove"],
+          mappedBy: "user",
         },
         email_id: {
           columnType: "text",
@@ -3527,6 +3530,7 @@ describe("Entity builder", () => {
           entity: "Email",
           nullable: false,
           cascade: ["persist", "soft-remove"],
+          mappedBy: "user",
         },
         email_id: {
           columnType: "text",

--- a/packages/core/utils/src/dml/__tests__/entity-builder.spec.ts
+++ b/packages/core/utils/src/dml/__tests__/entity-builder.spec.ts
@@ -2461,6 +2461,93 @@ describe("Entity builder", () => {
       })
     })
 
+    test("define custom mappedBy key to undefined to not get the auto generated value", () => {
+      const email = model.define("email", {
+        email: model.text(),
+        isVerified: model.boolean(),
+      })
+
+      const user = model.define("user", {
+        id: model.number(),
+        username: model.text(),
+        email: model.hasOne(() => email, { mappedBy: undefined }),
+      })
+
+      const User = toMikroORMEntity(user)
+      expectTypeOf(new User()).toMatchTypeOf<{
+        id: number
+        username: string
+        email: { email: string; isVerified: boolean }
+      }>()
+
+      const metaData = MetadataStorage.getMetadataFromDecorator(User)
+      expect(metaData.className).toEqual("User")
+      expect(metaData.path).toEqual("User")
+      expect(metaData.properties).toEqual({
+        id: {
+          reference: "scalar",
+          type: "number",
+          columnType: "integer",
+          name: "id",
+          fieldName: "id",
+          nullable: false,
+          getter: false,
+          setter: false,
+        },
+        username: {
+          reference: "scalar",
+          type: "string",
+          columnType: "text",
+          name: "username",
+          fieldName: "username",
+          nullable: false,
+          getter: false,
+          setter: false,
+        },
+        email: {
+          reference: "1:1",
+          name: "email",
+          entity: "Email",
+          nullable: false,
+        },
+        created_at: {
+          reference: "scalar",
+          type: "date",
+          columnType: "timestamptz",
+          name: "created_at",
+          fieldName: "created_at",
+          defaultRaw: "now()",
+          onCreate: expect.any(Function),
+          nullable: false,
+          getter: false,
+          setter: false,
+        },
+        updated_at: {
+          reference: "scalar",
+          type: "date",
+          columnType: "timestamptz",
+          name: "updated_at",
+          fieldName: "updated_at",
+          defaultRaw: "now()",
+          onCreate: expect.any(Function),
+          onUpdate: expect.any(Function),
+          nullable: false,
+          getter: false,
+          setter: false,
+        },
+        deleted_at: {
+          reference: "scalar",
+          type: "date",
+          columnType: "timestamptz",
+          name: "deleted_at",
+          fieldName: "deleted_at",
+          nullable: true,
+          getter: false,
+          setter: false,
+        },
+      })
+    })
+
     test("define custom mappedBy key for relationship", () => {
       const email = model.define("email", {
         email: model.text(),

--- a/packages/core/utils/src/dml/helpers/entity-builder/define-relationship.ts
+++ b/packages/core/utils/src/dml/helpers/entity-builder/define-relationship.ts
@@ -7,7 +7,6 @@ import {
 } from "@medusajs/types"
 import {
   BeforeCreate,
-  Cascade,
   ManyToMany,
   ManyToOne,
   OneToMany,

--- a/packages/core/utils/src/dml/helpers/entity-builder/define-relationship.ts
+++ b/packages/core/utils/src/dml/helpers/entity-builder/define-relationship.ts
@@ -144,8 +144,7 @@ export function defineHasOneRelationship(
 
   let mappedBy: string | undefined = camelToSnakeCase(MikroORMEntity.name)
   if ("mappedBy" in relationship) {
-    mappedBy =
-      relationship.mappedBy === undefined ? undefined : relationship.mappedBy
+    mappedBy = relationship.mappedBy
   }
 
   OneToOne({
@@ -170,12 +169,10 @@ export function defineHasOneWithFKRelationship(
 ) {
   const foreignKeyName = camelToSnakeCase(`${relationship.name}Id`)
   const shouldRemoveRelated = !!cascades.delete?.includes(relationship.name)
-  let mappedBy: string | undefined
 
+  let mappedBy: string | undefined = camelToSnakeCase(MikroORMEntity.name)
   if ("mappedBy" in relationship) {
     mappedBy = relationship.mappedBy
-  } else {
-    mappedBy = camelToSnakeCase(MikroORMEntity.name)
   }
 
   OneToOne({
@@ -185,7 +182,7 @@ export function defineHasOneWithFKRelationship(
     cascade: shouldRemoveRelated
       ? (["persist", "soft-remove"] as any)
       : undefined,
-  } as any)(MikroORMEntity.prototype, relationship.name)
+  } as OneToOneOptions<any, any>)(MikroORMEntity.prototype, relationship.name)
 
   Property({
     type: "string",

--- a/packages/core/utils/src/dml/relations/base.ts
+++ b/packages/core/utils/src/dml/relations/base.ts
@@ -71,7 +71,9 @@ export abstract class BaseRelationship<T> implements RelationshipType<T> {
     return {
       name: relationshipName,
       nullable: false,
-      mappedBy: this.options.mappedBy,
+      ...("mappedBy" in this.options
+        ? { mappedBy: this.options.mappedBy }
+        : {}),
       options: this.options,
       searchable: this.#searchable,
       entity: this.#referencedEntity,


### PR DESCRIPTION
RESOLVES FRMW-2826

**What**
We have many places where we define only one to one on one side of the relation. In that case it is a one to one that does not mapped by to the other side relation since it is not defined. This pr allow to create a one to one without mapped by. In order to remove breaking changes, in that case we ask the user to explicitly define the `mappedBy` as `undefined`