### PR TITLE
fix(core/js-sdk) Add the credentials field in the fetch() only if supported

### DIFF
--- a/packages/core/js-sdk/src/client.ts
+++ b/packages/core/js-sdk/src/client.ts
@@ -58,11 +58,17 @@ const normalizeRequest = (
     body = JSON.stringify(body)
   }
 
+  const isFetchCredentialsSupported = "credentials" in Request.prototype
+
   return {
     ...init,
     headers,
     // TODO: Setting this to "include" poses some security risks, as it will send cookies to any domain. We should consider making this configurable.
-    credentials: config.auth?.type === "session" ? "include" : "omit",
+    credentials: isFetchCredentialsSupported
+      ? config.auth?.type === "session"
+        ? "include"
+        : "omit"
+      : undefined,
     ...(body ? { body: body as RequestInit["body"] } : {}),
   } as RequestInit
 }


### PR DESCRIPTION
solves https://github.com/medusajs/nextjs-starter-medusa/issues/421

The root cause of the issue is that `credentials` is not supported by CloudFlare workers.