### PR TITLE
fix(medusa): calculate sales channel availability correctly for variants

### DIFF
--- a/packages/core/core-flows/src/product/steps/get-variant-availability.ts
+++ b/packages/core/core-flows/src/product/steps/get-variant-availability.ts
@@ -1,5 +1,8 @@
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
-import { getVariantAvailability } from "@medusajs/framework/utils"
+import {
+  ContainerRegistrationKeys,
+  getVariantAvailability,
+} from "@medusajs/framework/utils"
 
 export type GetVariantAvailabilityStepInput = {
   variant_ids: string[]

--- a/packages/core/core-flows/src/product/steps/get-variant-availability.ts
+++ b/packages/core/core-flows/src/product/steps/get-variant-availability.ts
@@ -13,7 +13,7 @@ export const getVariantAvailabilityId = "get-variant-availability"
 export const getVariantAvailabilityStep = createStep(
   getVariantAvailabilityId,
   async (data: GetVariantAvailabilityStepInput, { container }) => {
-    const query = container.resolve("query")
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
     const availability = await getVariantAvailability(query, data)
     return new StepResponse(availability)
   }

--- a/packages/core/core-flows/src/product/steps/get-variant-availability.ts
+++ b/packages/core/core-flows/src/product/steps/get-variant-availability.ts
@@ -1,0 +1,20 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { getVariantAvailability } from "@medusajs/framework/utils"
+
+export type GetVariantAvailabilityStepInput = {
+  variant_ids: string[]
+  sales_channel_id: string
+}
+
+export const getVariantAvailabilityId = "get-variant-availability"
+/**
+ * Computes the varaint availability for a list of variants in a given sales channel
+ */
+export const getVariantAvailabilityStep = createStep(
+  getVariantAvailabilityId,
+  async (data: GetVariantAvailabilityStepInput, { container }) => {
+    const query = container.resolve("query")
+    const availability = await getVariantAvailability(query, data)
+    return new StepResponse(availability)
+  }
+)

--- a/packages/core/utils/src/product/get-variant-availability.ts
+++ b/packages/core/utils/src/product/get-variant-availability.ts
@@ -1,0 +1,178 @@
+import { RemoteQueryFunction } from "@medusajs/types"
+
+/**
+ * Computes the varaint availability for a list of variants in a given sales channel
+ *
+ * The availability algorithm works as follows:
+ * 1. For each variant, we retrieve its inventory items.
+ * 2. We calculate the available quantity for each inventory item, considering only the stock locations associated with the given sales channel.
+ * 3. For each inventory item, we calculate the maximum deliverable quantity by dividing the available quantity by the quantity required for the variant.
+ * 4. We take the minimum of these maximum deliverable quantities across all inventory items for the variant.
+ * 5. This minimum value represents the overall availability of the variant in the given sales channel.
+ *
+ * The algorithm takes into account:
+ * - Variant inventory items: The inventory records associated with each variant.
+ * - Required quantities: The quantity of each inventory item required to fulfill one unit of the variant.
+ * - Sales channels: The specific sales channel for which we're calculating availability.
+ * - Stock locations: The inventory locations associated with the sales channel.
+ *
+ * @param query - The Query function
+ * @param data - An object containing the variant ids and the sales channel id to compute the availability for
+ * @returns an object containing the variant ids and their availability
+ */
+export async function getVariantAvailability(
+  query: Omit<RemoteQueryFunction, symbol>,
+  data: VariantAvailabilityData
+): Promise<{
+  [variant_id: string]: {
+    availability: number
+    sales_channel_id: string
+  }
+}> {
+  const { variantInventoriesMap, locationIds } = await getDataForComputation(
+    query,
+    data
+  )
+
+  return data.variant_ids.reduce((acc, variantId) => {
+    const variantInventoryItems = variantInventoriesMap.get(variantId) || []
+    acc[variantId] = {
+      availability: computeVariantAvailability(
+        variantInventoryItems,
+        locationIds,
+        { requireChannelCheck: true }
+      ),
+      sales_channel_id: data.sales_channel_id,
+    }
+    return acc
+  }, {})
+}
+
+type TotalVariantAvailabilityData = {
+  variant_ids: string[]
+}
+
+/**
+ * Computes the total availability for a list of variants across all stock locations
+ *
+ * @param query - The Query function
+ * @param data - An object containing the variant ids to compute the availability for
+ * @returns the total availability for the given variants
+ */
+export async function getTotalVariantAvailability(
+  query: Omit<RemoteQueryFunction, symbol>,
+  data: TotalVariantAvailabilityData
+): Promise<{
+  [variant_id: string]: {
+    availability: number
+  }
+}> {
+  const { variantInventoriesMap, locationIds } = await getDataForComputation(
+    query,
+    data
+  )
+
+  return data.variant_ids.reduce((acc, variantId) => {
+    const variantInventoryItems = variantInventoriesMap.get(variantId) || []
+    acc[variantId] = {
+      availability: computeVariantAvailability(
+        variantInventoryItems,
+        locationIds,
+        { requireChannelCheck: false }
+      ),
+    }
+    return acc
+  }, {})
+}
+
+interface VariantItems {
+  variant_id: string
+  required_quantity: number
+  variant: {
+    manage_inventory: boolean
+    allow_backorder: boolean
+  }
+  inventory: {
+    location_levels: {
+      location_id: string
+      available_quantity: number
+    }[]
+  }
+}
+
+const computeVariantAvailability = (
+  variantInventoryItems: VariantItems[],
+  channelLocationsSet: Set<string>,
+  { requireChannelCheck } = { requireChannelCheck: true }
+) => {
+  const inventoryQuantities: number[] = []
+
+  for (const link of variantInventoryItems) {
+    const requiredQuantity = link.required_quantity
+    const availableQuantity = (link.inventory?.location_levels || []).reduce(
+      (sum, level) => {
+        if (
+          requireChannelCheck &&
+          !channelLocationsSet.has(level.location_id)
+        ) {
+          return sum
+        }
+
+        return sum + (level?.available_quantity || 0)
+      },
+      0
+    )
+
+    // This will give us the maximum deliverable quantities for each inventory item
+    const maxInventoryQuantity = Math.floor(
+      availableQuantity / requiredQuantity
+    )
+
+    inventoryQuantities.push(maxInventoryQuantity)
+  }
+
+  return inventoryQuantities.length ? Math.min(...inventoryQuantities) : 0
+}
+
+type VariantAvailabilityData = {
+  variant_ids: string[]
+  sales_channel_id: string
+}
+
+const getDataForComputation = async (
+  query: Omit<RemoteQueryFunction, symbol>,
+  data: { variant_ids: string[]; sales_channel_id?: string }
+) => {
+  const { data: variantInventoryItems } = await query.graph({
+    entity: "product_variant_inventory_items",
+    fields: [
+      "variant_id",
+      "required_quantity",
+      "variant.manage_inventory",
+      "variant.allow_backorder",
+      "inventory.*",
+      "inventory.location_levels.*",
+    ],
+    filters: { variant_id: data.variant_ids },
+  })
+
+  const variantInventoriesMap = new Map()
+  variantInventoryItems.forEach((link) => {
+    const array = variantInventoriesMap.get(link.variant_id) || []
+    array.push(link)
+    variantInventoriesMap.set(link.variant_id, array)
+  })
+
+  const locationIds = new Set<string>()
+  if (data.sales_channel_id) {
+    const { data: channelLocations } = await query.graph({
+      entity: "sales_channel_locations",
+      fields: ["stock_location_id"],
+      filters: { sales_channel_id: data.sales_channel_id },
+    })
+
+    channelLocations.forEach((loc) => locationIds.add(loc.stock_location_id))
+  }
+
+  return { variantInventoriesMap, locationIds }
+}

--- a/packages/core/utils/src/product/index.ts
+++ b/packages/core/utils/src/product/index.ts
@@ -6,3 +6,4 @@ export enum ProductStatus {
 }
 
 export * from "./events"
+export * from "./get-variant-availability"

--- a/packages/medusa/src/api/admin/product-variants/route.ts
+++ b/packages/medusa/src/api/admin/product-variants/route.ts
@@ -4,7 +4,7 @@ import {
   refetchEntities,
 } from "@medusajs/framework/http"
 import { HttpTypes } from "@medusajs/framework/types"
-import { wrapVariantsWithInventoryQuantity } from "../../utils/middlewares"
+import { wrapVariantsWithTotalInventoryQuantity } from "../../utils/middlewares"
 import { remapKeysForVariant, remapVariantResponse } from "../products/helpers"
 
 export const GET = async (
@@ -30,7 +30,7 @@ export const GET = async (
   )
 
   if (withInventoryQuantity) {
-    await wrapVariantsWithInventoryQuantity(req, variants || [])
+    await wrapVariantsWithTotalInventoryQuantity(req, variants || [])
   }
 
   res.json({

--- a/packages/medusa/src/api/admin/products/[id]/variants/route.ts
+++ b/packages/medusa/src/api/admin/products/[id]/variants/route.ts
@@ -4,7 +4,7 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { wrapVariantsWithInventoryQuantity } from "../../../../utils/middlewares"
+import { wrapVariantsWithTotalInventoryQuantity } from "../../../../utils/middlewares"
 import { refetchEntities, refetchEntity } from "@medusajs/framework/http"
 import {
   remapKeysForProduct,
@@ -38,7 +38,7 @@ export const GET = async (
   )
 
   if (withInventoryQuantity) {
-    await wrapVariantsWithInventoryQuantity(req, variants || [])
+    await wrapVariantsWithTotalInventoryQuantity(req, variants || [])
   }
 
   res.json({

--- a/packages/medusa/src/api/store/products/[id]/route.ts
+++ b/packages/medusa/src/api/store/products/[id]/route.ts
@@ -1,6 +1,6 @@
 import { isPresent, MedusaError } from "@medusajs/framework/utils"
 import { MedusaResponse } from "@medusajs/framework/http"
-import { wrapVariantsWithInventoryQuantity } from "../../../utils/middlewares"
+import { wrapVariantsWithInventoryQuantityForSalesChannel } from "../../../utils/middlewares"
 import {
   refetchProduct,
   RequestWithContext,
@@ -48,7 +48,10 @@ export const GET = async (
   }
 
   if (withInventoryQuantity) {
-    await wrapVariantsWithInventoryQuantity(req, product.variants || [])
+    await wrapVariantsWithInventoryQuantityForSalesChannel(
+      req,
+      product.variants || []
+    )
   }
 
   await wrapProductsWithTaxPrices(req, [product])

--- a/packages/medusa/src/api/store/products/helpers.ts
+++ b/packages/medusa/src/api/store/products/helpers.ts
@@ -1,8 +1,4 @@
-import {
-  MedusaRequest,
-  refetchEntities,
-  refetchEntity,
-} from "@medusajs/framework/http"
+import { MedusaStoreRequest, refetchEntity } from "@medusajs/framework/http"
 import {
   HttpTypes,
   ItemTaxLineDTO,
@@ -13,7 +9,7 @@ import {
 import { calculateAmountsWithTax, Modules } from "@medusajs/framework/utils"
 import { TaxModuleService } from "@medusajs/tax/dist/services"
 
-export type RequestWithContext<T> = MedusaRequest<T> & {
+export type RequestWithContext<T> = MedusaStoreRequest<T> & {
   taxContext: {
     taxLineContext?: TaxCalculationContext
     taxInclusivityContext?: {
@@ -28,27 +24,6 @@ export const refetchProduct = async (
   fields: string[]
 ) => {
   return await refetchEntity("product", idOrFilter, scope, fields)
-}
-
-export const maybeApplyStockLocationId = async (req: MedusaRequest, ctx) => {
-  const withInventoryQuantity = req.remoteQueryConfig.fields.some((field) =>
-    field.includes("variants.inventory_quantity")
-  )
-
-  if (!withInventoryQuantity) {
-    return
-  }
-
-  const salesChannelId = req.filterableFields.sales_channel_id || []
-
-  const entities = await refetchEntities(
-    "sales_channel_location",
-    { sales_channel_id: salesChannelId },
-    req.scope,
-    ["stock_location_id"]
-  )
-
-  return entities.map((entity) => entity.stock_location_id)
 }
 
 export const wrapProductsWithTaxPrices = async <T>(

--- a/packages/medusa/src/api/store/products/middlewares.ts
+++ b/packages/medusa/src/api/store/products/middlewares.ts
@@ -6,7 +6,6 @@ import {
   clearFiltersByKey,
   maybeApplyLinkFilter,
   MiddlewareRoute,
-  setContext,
 } from "@medusajs/framework/http"
 import { isPresent, ProductStatus } from "@medusajs/framework/utils"
 import {
@@ -15,7 +14,6 @@ import {
   setPricingContext,
   setTaxContext,
 } from "../../utils/middlewares"
-import { maybeApplyStockLocationId } from "./helpers"
 import * as QueryConfig from "./query-config"
 import { StoreGetProductsParams } from "./validators"
 
@@ -32,9 +30,6 @@ export const storeProductRoutesMiddlewares: MiddlewareRoute[] = [
         QueryConfig.listProductQueryConfig
       ),
       filterByValidSalesChannels(),
-      setContext({
-        stock_location_id: maybeApplyStockLocationId,
-      }),
       maybeApplyLinkFilter({
         entryPoint: "product_sales_channel",
         resourceId: "product_id",
@@ -73,9 +68,6 @@ export const storeProductRoutesMiddlewares: MiddlewareRoute[] = [
       ),
       applyParamsAsFilters({ id: "id" }),
       filterByValidSalesChannels(),
-      setContext({
-        stock_location_id: maybeApplyStockLocationId,
-      }),
       maybeApplyLinkFilter({
         entryPoint: "product_sales_channel",
         resourceId: "product_id",

--- a/packages/medusa/src/api/store/products/route.ts
+++ b/packages/medusa/src/api/store/products/route.ts
@@ -4,7 +4,7 @@ import {
   remoteQueryObjectFromString,
 } from "@medusajs/framework/utils"
 import { MedusaResponse } from "@medusajs/framework/http"
-import { wrapVariantsWithInventoryQuantity } from "../../utils/middlewares"
+import { wrapVariantsWithInventoryQuantityForSalesChannel } from "../../utils/middlewares"
 import { RequestWithContext, wrapProductsWithTaxPrices } from "./helpers"
 import { HttpTypes } from "@medusajs/framework/types"
 
@@ -43,7 +43,7 @@ export const GET = async (
   const { rows: products, metadata } = await remoteQuery(queryObject)
 
   if (withInventoryQuantity) {
-    await wrapVariantsWithInventoryQuantity(
+    await wrapVariantsWithInventoryQuantityForSalesChannel(
       req,
       products.map((product) => product.variants).flat(1)
     )

--- a/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
@@ -15,7 +15,7 @@ export const wrapVariantsWithTotalInventoryQuantity = async (
     return
   }
 
-  const query = req.scope.resolve("query")
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const availability = await getTotalVariantAvailability(query, {
     variant_ids: variantIds,
   })

--- a/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
@@ -1,89 +1,54 @@
 import {
-  ContainerRegistrationKeys,
-  LINKS,
-  remoteQueryObjectFromString,
+  getTotalVariantAvailability,
+  getVariantAvailability,
+  MedusaError,
 } from "@medusajs/framework/utils"
-import { MedusaRequest } from "@medusajs/framework/http"
+import { MedusaRequest, MedusaStoreRequest } from "@medusajs/framework/http"
 
-export async function getVariantInventoryItems({
-  req,
-  variantIds,
-  additionalFilters = {},
-  asMap = true,
-}) {
-  const remoteQuery = req.scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
+export const wrapVariantsWithTotalInventoryQuantity = async (
+  req: MedusaRequest,
+  variants: VariantInput[]
+) => {
+  const variantIds = (variants ?? []).map((variant) => variant.id).flat(1)
 
-  const linkQuery = remoteQueryObjectFromString({
-    service: LINKS.ProductVariantInventoryItem,
-    variables: {
-      filters: {
-        variant_id: variantIds,
-      },
-      ...additionalFilters,
-    },
-    fields: [
-      "variant_id",
-      "variant.manage_inventory",
-      "variant.allow_backorder",
-      "required_quantity",
-      "inventory.*",
-      "inventory.location_levels.*",
-    ],
-  } as any)
-
-  const links = await remoteQuery(linkQuery)
-
-  if (!asMap) {
-    return links
+  if (!variantIds.length) {
+    return
   }
 
-  const variantInventoriesMap = new Map()
-
-  links.forEach((link) => {
-    const array = variantInventoriesMap.get(link.variant_id) || []
-
-    array.push(link)
-
-    variantInventoriesMap.set(link.variant_id, array)
+  const query = req.scope.resolve("query")
+  const availability = await getTotalVariantAvailability(query, {
+    variant_ids: variantIds,
   })
 
-  return variantInventoriesMap
+  wrapVariants(variants, availability)
 }
 
-export async function computeVariantInventoryQuantity({
-  variantInventoryItems,
-}) {
-  const links = variantInventoryItems
-  const inventoryQuantities: number[] = []
+export const wrapVariantsWithInventoryQuantityForSalesChannel = async (
+  req: MedusaStoreRequest<unknown>,
+  variants: VariantInput[]
+) => {
+  const salesChannelId = req.filterableFields.sales_channel_id as
+    | string
+    | string[]
+  const { sales_channel_ids: idsFromPublishableKey = [] } =
+    req.publishable_key_context
 
-  for (const link of links) {
-    const requiredQuantity = link.required_quantity
-    const availableQuantity = (link.inventory?.location_levels || []).reduce(
-      (sum, level) => sum + (level?.available_quantity || 0),
-      0
-    )
-
-    // This will give us the maximum deliverable quantities for each inventory item
-    const maxInventoryQuantity = Math.floor(
-      availableQuantity / requiredQuantity
-    )
-
-    inventoryQuantities.push(maxInventoryQuantity)
+  let channelToUse: string | undefined
+  if (salesChannelId && !Array.isArray(salesChannelId)) {
+    channelToUse = salesChannelId
   }
 
-  // Since each of these inventory items need to be available to perform an order,
-  // we pick the smallest of the deliverable quantities as the total inventory quantity.
-  return inventoryQuantities.length ? Math.min(...inventoryQuantities) : 0
-}
+  if (idsFromPublishableKey.length === 1) {
+    channelToUse = idsFromPublishableKey[0]
+  }
 
-export const wrapVariantsWithInventoryQuantity = async (
-  req: MedusaRequest,
-  variants: {
-    id: string
-    inventory_quantity?: number
-    manage_inventory?: boolean
-  }[]
-) => {
+  if (!channelToUse) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Inventory availability cannot be calculated in the given context. Either provide a sales channel id or configure a single sales channel in the publishable key`
+    )
+  }
+
   variants ??= []
   const variantIds = variants.map((variant) => variant.id).flat(1)
 
@@ -91,19 +56,34 @@ export const wrapVariantsWithInventoryQuantity = async (
     return
   }
 
-  const variantInventoriesMap = await getVariantInventoryItems({
-    req,
-    variantIds,
+  const query = req.scope.resolve("query")
+  const availability = await getVariantAvailability(query, {
+    variant_ids: variantIds,
+    sales_channel_id: channelToUse,
   })
 
+  wrapVariants(variants, availability)
+}
+
+type VariantInput = {
+  id: string
+  inventory_quantity?: number
+  manage_inventory?: boolean
+}
+
+type VariantAvailability = Awaited<
+  ReturnType<typeof getTotalVariantAvailability>
+>
+
+const wrapVariants = (
+  variants: VariantInput[],
+  availability: VariantAvailability
+) => {
   for (const variant of variants) {
     if (!variant.manage_inventory) {
       continue
     }
 
-    const links = variantInventoriesMap.get(variant.id) || []
-    variant.inventory_quantity = await computeVariantInventoryQuantity({
-      variantInventoryItems: links,
-    })
+    variant.inventory_quantity = availability[variant.id].availability
   }
 }

--- a/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
@@ -1,4 +1,5 @@
 import {
+  ContainerRegistrationKeys,
   getTotalVariantAvailability,
   getVariantAvailability,
   MedusaError,

--- a/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
@@ -56,7 +56,7 @@ export const wrapVariantsWithInventoryQuantityForSalesChannel = async (
     return
   }
 
-  const query = req.scope.resolve("query")
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const availability = await getVariantAvailability(query, {
     variant_ids: variantIds,
     sales_channel_id: channelToUse,


### PR DESCRIPTION
**What**
- Fixes inventory calculations on store endpoints which didn't take the sales channel into account.
- Adds a new utility to framework/utils function to calculate inventory availability based on variant and sales channel ids
- Adds a new step to core-flows that can be used to calculate inventory availability as part of a workflow.
- Adds a test for more involved inventory calculations. The existing suite didn't test directly for the channel->location->item->variant relationships.

**Why**
- Medusa's availability calculation is powerful, but takes some steps to compute. We don't want to put the burden of computing this value on developers who might need it in their customizations. Therefore we are now providing an easy mechanism for getting the inventory quantity.

**Usage**
```typescript
import { getVariantAvailability } from "@medusajs/framework/utils"

const query = container.resolve("query")
const availability = await getVariantAvailability(query, {
  variant_ids: ["variant_1234"],
  sales_channel_id: "sc_1234",
})

// availability -> { variant_1234: { availability: 23, sales_channel_id: "sc_1234" } }
```