### PR TITLE
fix(framework): add missing query type argument in request types

### DIFF
--- a/.changeset/thick-cars-smash.md
+++ b/.changeset/thick-cars-smash.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/framework": patch
+---
+
+fix(framework): add missing query type argument in request types

--- a/packages/core/framework/src/http/types.ts
+++ b/packages/core/framework/src/http/types.ts
@@ -163,13 +163,14 @@ export interface PublishableKeyContext {
   sales_channel_ids: string[]
 }
 
-export interface AuthenticatedMedusaRequest<Body = never>
-  extends MedusaRequest<Body> {
+export interface AuthenticatedMedusaRequest<Body = never, QueryFields = never>
+  extends MedusaRequest<Body, QueryFields> {
   auth_context: AuthContext
   publishable_key_context?: PublishableKeyContext
 }
 
-export interface MedusaStoreRequest<Body = never> extends MedusaRequest<Body> {
+export interface MedusaStoreRequest<Body = never, QueryFields = never> 
+  extends MedusaRequest<Body, QueryFields> {
   auth_context?: AuthContext
   publishable_key_context: PublishableKeyContext
 }

--- a/packages/core/framework/src/http/types.ts
+++ b/packages/core/framework/src/http/types.ts
@@ -163,13 +163,13 @@ export interface PublishableKeyContext {
   sales_channel_ids: string[]
 }
 
-export interface AuthenticatedMedusaRequest<Body = never, QueryFields = never>
+export interface AuthenticatedMedusaRequest<Body = unknown, QueryFields = Record<string, unknown>>
   extends MedusaRequest<Body, QueryFields> {
   auth_context: AuthContext
   publishable_key_context?: PublishableKeyContext
 }
 
-export interface MedusaStoreRequest<Body = never, QueryFields = never> 
+export interface MedusaStoreRequest<Body = unknown, QueryFields = Record<string, unknown>>
   extends MedusaRequest<Body, QueryFields> {
   auth_context?: AuthContext
   publishable_key_context: PublishableKeyContext


### PR DESCRIPTION
We recently added support for specifying query type arguments in `MedusaRequest`. This adds the type argument to `AuthenticatedMedusaRequest` and `MedusaStoreRequest`, to be passed to `MedusaRequest`

> SIde note: it doesn't seem like `MedusaStoreRequest` is used anywhere, not sure why we have it.