### PR TITLE
fix(medusa): add query type argument to RequestWithContext

### DIFF
--- a/.changeset/empty-snails-admire.md
+++ b/.changeset/empty-snails-admire.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): add query type argument to RequestWithContext

--- a/packages/medusa/src/api/store/products/helpers.ts
+++ b/packages/medusa/src/api/store/products/helpers.ts
@@ -9,14 +9,15 @@ import {
 import { calculateAmountsWithTax, Modules } from "@medusajs/framework/utils"
 import { TaxModuleService } from "@medusajs/tax/dist/services"
 
-export type RequestWithContext<T> = MedusaStoreRequest<T> & {
-  taxContext: {
-    taxLineContext?: TaxCalculationContext
-    taxInclusivityContext?: {
-      automaticTaxes: boolean
+export type RequestWithContext<Body, QueryFields = Record<string, unknown>> = 
+  MedusaStoreRequest<Body, QueryFields> & {
+    taxContext: {
+      taxLineContext?: TaxCalculationContext
+      taxInclusivityContext?: {
+        automaticTaxes: boolean
+      }
     }
   }
-}
 
 export const refetchProduct = async (
   idOrFilter: string | object,


### PR DESCRIPTION
Missed this one in the last PR that added the query type arguments to request types