### PR TITLE
chore(workflow-engine): Migrate to DML

### DIFF
--- a/.changeset/clean-paws-build.md
+++ b/.changeset/clean-paws-build.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/workflow-engine-inmemory": patch
+"@medusajs/workflow-engine-redis": patch
+"@medusajs/utils": patch
+---
+
+chore(workflow-engine): Migrate to DML

--- a/packages/core/utils/src/modules-sdk/__tests__/joiner-config-builder.spec.ts
+++ b/packages/core/utils/src/modules-sdk/__tests__/joiner-config-builder.spec.ts
@@ -668,8 +668,8 @@ describe("joiner-config-builder", () => {
         serviceName: "myService",
         field: "car",
         entity: "Car",
-        linkable: "car_number_plate",
-        primaryKey: "number_plate",
+        linkable: "car_id",
+        primaryKey: "id",
       })
       expect(linkConfig.user.toJSON()).toEqual({
         serviceName: "myService",

--- a/packages/core/utils/src/modules-sdk/joiner-config-builder.ts
+++ b/packages/core/utils/src/modules-sdk/joiner-config-builder.ts
@@ -17,7 +17,7 @@ import {
   toCamelCase,
   upperCaseFirst,
 } from "../common"
-import { DmlEntity } from "../dml"
+import { DmlEntity, IdProperty } from "../dml"
 import { toGraphQLSchema } from "../dml/helpers/create-graphql"
 import { PrimaryKeyModifier } from "../dml/properties/primary-key"
 import { BaseRelationship } from "../dml/relations/base"
@@ -396,7 +396,10 @@ export function buildLinkConfigFromModelObjects<
       }
 
       const parsedProperty = (value as PropertyType<any>).parse(property)
-      if (PrimaryKeyModifier.isPrimaryKeyModifier(value)) {
+      if (
+        PrimaryKeyModifier.isPrimaryKeyModifier(value) ||
+        IdProperty.isIdProperty(value)
+      ) {
         const linkableKeyName =
           parsedProperty.dataType.options?.linkable ??
           `${camelToSnakeCase(model.name).toLowerCase()}_${property}`

--- a/packages/modules/workflow-engine-inmemory/src/migrations/.snapshot-medusa-workflows.json
+++ b/packages/modules/workflow-engine-inmemory/src/migrations/.snapshot-medusa-workflows.json
@@ -1,0 +1,171 @@
+{
+  "namespaces": [
+    "public"
+  ],
+  "name": "public",
+  "tables": [
+    {
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "execution": {
+          "name": "execution",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "enumItems": [
+            "not_started",
+            "invoking",
+            "waiting_to_compensate",
+            "compensating",
+            "done",
+            "reverted",
+            "failed"
+          ],
+          "mappedType": "enum"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "default": "now()",
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "default": "now()",
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 6,
+          "mappedType": "datetime"
+        }
+      },
+      "name": "workflow_execution",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "IDX_workflow_execution_deleted_at",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_deleted_at\" ON \"workflow_execution\" (deleted_at) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_workflow_execution_id",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_id\" ON \"workflow_execution\" (id) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_workflow_execution_workflow_id_transaction_id_unique",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE UNIQUE INDEX IF NOT EXISTS \"IDX_workflow_execution_workflow_id_transaction_id_unique\" ON \"workflow_execution\" (workflow_id, transaction_id) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_workflow_execution_workflow_id",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_workflow_id\" ON \"workflow_execution\" (workflow_id) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_workflow_execution_transaction_id",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_transaction_id\" ON \"workflow_execution\" (transaction_id) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_workflow_execution_state",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_state\" ON \"workflow_execution\" (state) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "workflow_execution_pkey",
+          "columnNames": [
+            "workflow_id",
+            "transaction_id"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {}
+    }
+  ]
+}

--- a/packages/modules/workflow-engine-inmemory/src/migrations/Migration20241206101446.ts
+++ b/packages/modules/workflow-engine-inmemory/src/migrations/Migration20241206101446.ts
@@ -1,0 +1,27 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20241206101446 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      `DROP INDEX IF EXISTS "IDX_workflow_execution_id";
+      DROP INDEX IF EXISTS "IDX_workflow_execution_workflow_id";
+      DROP INDEX IF EXISTS "IDX_workflow_execution_transaction_id";
+      DROP INDEX IF EXISTS "IDX_workflow_execution_state";`
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_deleted_at" ON "workflow_execution" (deleted_at) WHERE deleted_at IS NULL;'
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_id" ON "workflow_execution" (id) WHERE deleted_at IS NULL;'
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_workflow_id" ON "workflow_execution" (workflow_id) WHERE deleted_at IS NULL;'
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_transaction_id" ON "workflow_execution" (transaction_id) WHERE deleted_at IS NULL;'
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_state" ON "workflow_execution" (state) WHERE deleted_at IS NULL;'
+    )
+  }
+}

--- a/packages/modules/workflow-engine-inmemory/src/models/index.ts
+++ b/packages/modules/workflow-engine-inmemory/src/models/index.ts
@@ -1,1 +1,1 @@
-export { default as WorkflowExecution } from "./workflow-execution"
+export { WorkflowExecution } from "./workflow-execution"

--- a/packages/modules/workflow-engine-inmemory/src/models/workflow-execution.ts
+++ b/packages/modules/workflow-engine-inmemory/src/models/workflow-execution.ts
@@ -1,76 +1,30 @@
 import { TransactionState } from "@medusajs/framework/orchestration"
-import { DALUtils, generateEntityId } from "@medusajs/framework/utils"
-import {
-  BeforeCreate,
-  Entity,
-  Enum,
-  Filter,
-  Index,
-  OnInit,
-  OptionalProps,
-  PrimaryKey,
-  Property,
-  Unique,
-} from "@mikro-orm/core"
+import { model } from "@medusajs/framework/utils"
 
-type OptionalFields = "deleted_at"
-
-@Entity()
-@Unique({
-  name: "IDX_workflow_execution_workflow_id_transaction_id_unique",
-  properties: ["workflow_id", "transaction_id"],
-})
-@Filter(DALUtils.mikroOrmSoftDeletableFilterOptions)
-export default class WorkflowExecution {
-  [OptionalProps]?: OptionalFields
-
-  @Property({ columnType: "text", nullable: false })
-  @Index({ name: "IDX_workflow_execution_id" })
-  id!: string
-
-  @Index({ name: "IDX_workflow_execution_workflow_id" })
-  @PrimaryKey({ columnType: "text" })
-  workflow_id: string
-
-  @Index({ name: "IDX_workflow_execution_transaction_id" })
-  @PrimaryKey({ columnType: "text" })
-  transaction_id: string
-
-  @Property({ columnType: "jsonb", nullable: true })
-  execution: Record<string, unknown> | null = null
-
-  @Property({ columnType: "jsonb", nullable: true })
-  context: Record<string, unknown> | null = null
-
-  @Index({ name: "IDX_workflow_execution_state" })
-  @Enum(() => TransactionState)
-  state: TransactionState
-
-  @Property({
-    onCreate: () => new Date(),
-    columnType: "timestamptz",
-    defaultRaw: "now()",
+export const WorkflowExecution = model
+  .define("workflow_execution", {
+    id: model.id({ prefix: "wf_exec" }),
+    workflow_id: model.text().primaryKey(),
+    transaction_id: model.text().primaryKey(),
+    execution: model.json().nullable(),
+    context: model.json().nullable(),
+    state: model.enum(TransactionState),
   })
-  created_at: Date
-
-  @Property({
-    onCreate: () => new Date(),
-    onUpdate: () => new Date(),
-    columnType: "timestamptz",
-    defaultRaw: "now()",
-  })
-  updated_at: Date
-
-  @Property({ columnType: "timestamptz", nullable: true })
-  deleted_at: Date | null = null
-
-  @BeforeCreate()
-  onCreate() {
-    this.id = generateEntityId(this.id, "wf_exec")
-  }
-
-  @OnInit()
-  onInit() {
-    this.id = generateEntityId(this.id, "wf_exec")
-  }
-}
+  .indexes([
+    {
+      on: ["id"],
+      where: "deleted_at IS NULL",
+    },
+    {
+      on: ["workflow_id"],
+      where: "deleted_at IS NULL",
+    },
+    {
+      on: ["transaction_id"],
+      where: "deleted_at IS NULL",
+    },
+    {
+      on: ["state"],
+      where: "deleted_at IS NULL",
+    },
+  ])

--- a/packages/modules/workflow-engine-inmemory/src/services/workflows-module.ts
+++ b/packages/modules/workflow-engine-inmemory/src/services/workflows-module.ts
@@ -1,6 +1,7 @@
 import {
   Context,
   DAL,
+  InferEntityType,
   InternalModuleDeclaration,
   MedusaContainer,
   ModulesSdkTypes,
@@ -25,9 +26,11 @@ type InjectedDependencies = {
 }
 
 export class WorkflowsModuleService<
-  TWorkflowExecution extends WorkflowExecution = WorkflowExecution
+  TWorkflowExecution extends InferEntityType<
+    typeof WorkflowExecution
+  > = InferEntityType<typeof WorkflowExecution>
 > extends ModulesSdkUtils.MedusaService<{
-  WorkflowExecution: { dto: WorkflowExecution }
+  WorkflowExecution: { dto: InferEntityType<typeof WorkflowExecution> }
 }>({ WorkflowExecution }) {
   protected baseRepository_: DAL.RepositoryService
   protected workflowExecutionService_: ModulesSdkTypes.IMedusaInternalService<TWorkflowExecution>

--- a/packages/modules/workflow-engine-inmemory/src/utils/workflow-orchestrator-storage.ts
+++ b/packages/modules/workflow-engine-inmemory/src/utils/workflow-orchestrator-storage.ts
@@ -48,6 +48,8 @@ export class InMemoryDistributedTransactionStorage
   }
 
   private async saveToDb(data: TransactionCheckpoint) {
+    const foo = await this.workflowExecutionService_.list()
+    console.log(foo)
     await this.workflowExecutionService_.upsert([
       {
         workflow_id: data.flow.modelId,

--- a/packages/modules/workflow-engine-inmemory/src/utils/workflow-orchestrator-storage.ts
+++ b/packages/modules/workflow-engine-inmemory/src/utils/workflow-orchestrator-storage.ts
@@ -48,8 +48,6 @@ export class InMemoryDistributedTransactionStorage
   }
 
   private async saveToDb(data: TransactionCheckpoint) {
-    const foo = await this.workflowExecutionService_.list()
-    console.log(foo)
     await this.workflowExecutionService_.upsert([
       {
         workflow_id: data.flow.modelId,

--- a/packages/modules/workflow-engine-redis/integration-tests/utils/database.ts
+++ b/packages/modules/workflow-engine-redis/integration-tests/utils/database.ts
@@ -15,11 +15,11 @@ const redisUrl = process.env.REDIS_URL || "redis://localhost:6379"
 const redis = new Redis(redisUrl)
 
 interface TestDatabase {
-  clearTables(knex): Promise<void>
+  clearTables(): Promise<void>
 }
 
 export const TestDatabase: TestDatabase = {
-  clearTables: async (knex) => {
+  clearTables: async () => {
     await cleanRedis()
   },
 }

--- a/packages/modules/workflow-engine-redis/src/migrations/.snapshot-medusa-workflows.json
+++ b/packages/modules/workflow-engine-redis/src/migrations/.snapshot-medusa-workflows.json
@@ -1,0 +1,163 @@
+{
+  "namespaces": [
+    "public"
+  ],
+  "name": "public",
+  "tables": [
+    {
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "execution": {
+          "name": "execution",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "enumItems": [
+            "not_started",
+            "invoking",
+            "waiting_to_compensate",
+            "compensating",
+            "done",
+            "reverted",
+            "failed"
+          ],
+          "mappedType": "enum"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "default": "now()",
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "default": "now()",
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 6,
+          "mappedType": "datetime"
+        }
+      },
+      "name": "workflow_execution",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "IDX_workflow_execution_deleted_at",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_deleted_at\" ON \"workflow_execution\" (deleted_at) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_workflow_execution_id",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_id\" ON \"workflow_execution\" (id) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_workflow_execution_workflow_id",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_workflow_id\" ON \"workflow_execution\" (workflow_id) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_workflow_execution_transaction_id",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_transaction_id\" ON \"workflow_execution\" (transaction_id) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_workflow_execution_state",
+          "columnNames": [],
+          "composite": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_workflow_execution_state\" ON \"workflow_execution\" (state) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "workflow_execution_pkey",
+          "columnNames": [
+            "workflow_id",
+            "transaction_id"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {}
+    }
+  ]
+}

--- a/packages/modules/workflow-engine-redis/src/migrations/Migration20241206123341.ts
+++ b/packages/modules/workflow-engine-redis/src/migrations/Migration20241206123341.ts
@@ -1,0 +1,27 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20241206123341 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      `DROP INDEX IF EXISTS "IDX_workflow_execution_id";
+      DROP INDEX IF EXISTS "IDX_workflow_execution_workflow_id";
+      DROP INDEX IF EXISTS "IDX_workflow_execution_transaction_id";
+      DROP INDEX IF EXISTS "IDX_workflow_execution_state";`
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_deleted_at" ON "workflow_execution" (deleted_at) WHERE deleted_at IS NULL;'
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_id" ON "workflow_execution" (id) WHERE deleted_at IS NULL;'
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_workflow_id" ON "workflow_execution" (workflow_id) WHERE deleted_at IS NULL;'
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_transaction_id" ON "workflow_execution" (transaction_id) WHERE deleted_at IS NULL;'
+    )
+    this.addSql(
+      'CREATE INDEX IF NOT EXISTS "IDX_workflow_execution_state" ON "workflow_execution" (state) WHERE deleted_at IS NULL;'
+    )
+  }
+}

--- a/packages/modules/workflow-engine-redis/src/models/index.ts
+++ b/packages/modules/workflow-engine-redis/src/models/index.ts
@@ -1,1 +1,1 @@
-export { default as WorkflowExecution } from "./workflow-execution"
+export { WorkflowExecution } from "./workflow-execution"

--- a/packages/modules/workflow-engine-redis/src/models/workflow-execution.ts
+++ b/packages/modules/workflow-engine-redis/src/models/workflow-execution.ts
@@ -1,76 +1,30 @@
 import { TransactionState } from "@medusajs/framework/orchestration"
-import { DALUtils, generateEntityId } from "@medusajs/framework/utils"
-import {
-  BeforeCreate,
-  Entity,
-  Enum,
-  Filter,
-  Index,
-  OnInit,
-  OptionalProps,
-  PrimaryKey,
-  Property,
-  Unique,
-} from "@mikro-orm/core"
+import { model } from "@medusajs/framework/utils"
 
-type OptionalFields = "deleted_at"
-
-@Entity()
-@Unique({
-  name: "IDX_workflow_execution_workflow_id_transaction_id_unique",
-  properties: ["workflow_id", "transaction_id"],
-})
-@Filter(DALUtils.mikroOrmSoftDeletableFilterOptions)
-export default class WorkflowExecution {
-  [OptionalProps]?: OptionalFields
-
-  @Property({ columnType: "text", nullable: false })
-  @Index({ name: "IDX_workflow_execution_id" })
-  id!: string
-
-  @Index({ name: "IDX_workflow_execution_workflow_id" })
-  @PrimaryKey({ columnType: "text" })
-  workflow_id: string
-
-  @Index({ name: "IDX_workflow_execution_transaction_id" })
-  @PrimaryKey({ columnType: "text" })
-  transaction_id: string
-
-  @Property({ columnType: "jsonb", nullable: true })
-  execution: Record<string, unknown> | null = null
-
-  @Property({ columnType: "jsonb", nullable: true })
-  context: Record<string, unknown> | null = null
-
-  @Index({ name: "IDX_workflow_execution_state" })
-  @Enum(() => TransactionState)
-  state: TransactionState
-
-  @Property({
-    onCreate: () => new Date(),
-    columnType: "timestamptz",
-    defaultRaw: "now()",
+export const WorkflowExecution = model
+  .define("workflow_execution", {
+    id: model.id({ prefix: "wf_exec" }),
+    workflow_id: model.text().primaryKey(),
+    transaction_id: model.text().primaryKey(),
+    execution: model.json().nullable(),
+    context: model.json().nullable(),
+    state: model.enum(TransactionState),
   })
-  created_at: Date
-
-  @Property({
-    onCreate: () => new Date(),
-    onUpdate: () => new Date(),
-    columnType: "timestamptz",
-    defaultRaw: "now()",
-  })
-  updated_at: Date
-
-  @Property({ columnType: "timestamptz", nullable: true })
-  deleted_at: Date | null = null
-
-  @BeforeCreate()
-  onCreate() {
-    this.id = generateEntityId(this.id, "wf_exec")
-  }
-
-  @OnInit()
-  onInit() {
-    this.id = generateEntityId(this.id, "wf_exec")
-  }
-}
+  .indexes([
+    {
+      on: ["id"],
+      where: "deleted_at IS NULL",
+    },
+    {
+      on: ["workflow_id"],
+      where: "deleted_at IS NULL",
+    },
+    {
+      on: ["transaction_id"],
+      where: "deleted_at IS NULL",
+    },
+    {
+      on: ["state"],
+      where: "deleted_at IS NULL",
+    },
+  ])

--- a/packages/modules/workflow-engine-redis/src/services/workflows-module.ts
+++ b/packages/modules/workflow-engine-redis/src/services/workflows-module.ts
@@ -1,6 +1,7 @@
 import {
   Context,
   DAL,
+  InferEntityType,
   InternalModuleDeclaration,
   ModulesSdkTypes,
   WorkflowsSdkTypes,
@@ -25,9 +26,11 @@ type InjectedDependencies = {
 }
 
 export class WorkflowsModuleService<
-  TWorkflowExecution extends WorkflowExecution = WorkflowExecution
+  TWorkflowExecution extends InferEntityType<
+    typeof WorkflowExecution
+  > = InferEntityType<typeof WorkflowExecution>
 > extends ModulesSdkUtils.MedusaService<{
-  WorkflowExecution: { dto: WorkflowExecution }
+  WorkflowExecution: { dto: InferEntityType<typeof WorkflowExecution> }
 }>({ WorkflowExecution }) {
   protected baseRepository_: DAL.RepositoryService
   protected workflowExecutionService_: ModulesSdkTypes.IMedusaInternalService<TWorkflowExecution>


### PR DESCRIPTION
RESOLVES FRMW-2832
RESOLVES FRMW-2833

**What**
Migrate workflow engines to DML. Alos includes and update to the linkable generation which now takes into account id and primary keys to generate the linkable instead of only primary keys