### PR TITLE
fix(promotion, core-flows): updating cart with removed promotion removes adjustments

### DIFF
--- a/.changeset/empty-trees-walk.md
+++ b/.changeset/empty-trees-walk.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/promotion": patch
+"@medusajs/core-flows": patch
+---
+
+fix(promotion, core-flows): updating cart with removed promotion removes adjustments

--- a/integration-tests/http/__tests__/cart/store/cart.spec.ts
+++ b/integration-tests/http/__tests__/cart/store/cart.spec.ts
@@ -1344,6 +1344,52 @@ medusaIntegrationTestRunner({
             })
           )
         })
+
+        it("should remove promotion adjustments when promotion is deleted", async () => {
+          let cartBeforeRemovingPromotion = (
+            await api.get(`/store/carts/${cart.id}`, storeHeaders)
+          ).data.cart
+
+          expect(cartBeforeRemovingPromotion).toEqual(
+            expect.objectContaining({
+              id: cart.id,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  adjustments: [
+                    {
+                      id: expect.any(String),
+                      code: "PROMOTION_APPLIED",
+                      promotion_id: promotion.id,
+                      amount: 100,
+                    },
+                  ],
+                }),
+              ]),
+            })
+          )
+
+          await api.delete(`/admin/promotions/${promotion.id}`, adminHeaders)
+
+          let response = await api.post(
+            `/store/carts/${cart.id}`,
+            {
+              email: "test@test.com",
+            },
+            storeHeaders
+          )
+
+          expect(response.status).toEqual(200)
+          expect(response.data.cart).toEqual(
+            expect.objectContaining({
+              id: cart.id,
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  adjustments: [],
+                }),
+              ]),
+            })
+          )
+        })
       })
 
       describe("POST /store/carts/:id/customer", () => {

--- a/packages/core/core-flows/src/cart/workflows/refresh-cart-items.ts
+++ b/packages/core/core-flows/src/cart/workflows/refresh-cart-items.ts
@@ -106,13 +106,16 @@ export const refreshCartItemsWorkflow = createWorkflow(
       input: { cart_id: cart.id },
     })
 
-    const cartPromoCodes = transform({ cart, input }, ({ cart, input }) => {
-      if (isDefined(input.promo_codes)) {
-        return input.promo_codes
-      } else {
-        return cart.promotions.map((p) => p.code)
+    const cartPromoCodes = transform(
+      { refetchedCart, input },
+      ({ refetchedCart, input }) => {
+        if (isDefined(input.promo_codes)) {
+          return input.promo_codes
+        } else {
+          return refetchedCart.promotions.map((p) => p?.code).filter(Boolean)
+        }
       }
-    })
+    )
 
     updateCartPromotionsWorkflow.runAsStep({
       input: {

--- a/packages/modules/promotion/integration-tests/__tests__/services/promotion-module/compute-actions.spec.ts
+++ b/packages/modules/promotion/integration-tests/__tests__/services/promotion-module/compute-actions.spec.ts
@@ -57,68 +57,6 @@ moduleIntegrationTestRunner({
 
           expect(response).toEqual([])
         })
-
-        it("should throw error when code in items adjustment does not exist", async () => {
-          await createDefaultPromotion(service, {})
-
-          const error = await service
-            .computeActions(["PROMOTION_TEST"], {
-              items: [
-                {
-                  id: "item_cotton_tshirt",
-                  quantity: 1,
-                  subtotal: 100,
-                  adjustments: [
-                    {
-                      id: "test-adjustment",
-                      code: "DOES_NOT_EXIST",
-                    },
-                  ],
-                },
-                {
-                  id: "item_cotton_sweater",
-                  quantity: 5,
-                  subtotal: 750,
-                },
-              ],
-            })
-            .catch((e) => e)
-
-          expect(error.message).toContain(
-            "Applied Promotion for code (DOES_NOT_EXIST) not found"
-          )
-        })
-
-        it("should throw error when code in shipping adjustment does not exist", async () => {
-          await createDefaultPromotion(service, {})
-
-          const error = await service
-            .computeActions(["PROMOTION_TEST"], {
-              items: [
-                {
-                  id: "item_cotton_tshirt",
-                  quantity: 1,
-                  subtotal: 100,
-                },
-                {
-                  id: "item_cotton_sweater",
-                  quantity: 5,
-                  subtotal: 750,
-                  adjustments: [
-                    {
-                      id: "test-adjustment",
-                      code: "DOES_NOT_EXIST",
-                    },
-                  ],
-                },
-              ],
-            })
-            .catch((e) => e)
-
-          expect(error.message).toContain(
-            "Applied Promotion for code (DOES_NOT_EXIST) not found"
-          )
-        })
       })
 
       describe("when promotion is for items and allocation is each", () => {

--- a/packages/modules/promotion/src/services/promotion-module.ts
+++ b/packages/modules/promotion/src/services/promotion-module.ts
@@ -397,6 +397,7 @@ export default class PromotionModuleService
         ],
       },
       {
+        take: null,
         relations: [
           "application_method",
           "application_method.target_rules",
@@ -421,18 +422,10 @@ export default class PromotionModuleService
     const appliedCodes = [...appliedShippingCodes, ...appliedItemCodes]
 
     for (const appliedCode of appliedCodes) {
-      const promotion = existingPromotionsMap.get(appliedCode)
       const adjustments = codeAdjustmentMap.get(appliedCode) || []
       const action = appliedShippingCodes.includes(appliedCode)
         ? ComputedActions.REMOVE_SHIPPING_METHOD_ADJUSTMENT
         : ComputedActions.REMOVE_ITEM_ADJUSTMENT
-
-      if (!promotion) {
-        throw new MedusaError(
-          MedusaError.Types.INVALID_DATA,
-          `Applied Promotion for code (${appliedCode}) not found`
-        )
-      }
 
       adjustments.forEach((adjustment) =>
         computedActions.push({


### PR DESCRIPTION
what:

- when updating a cart with a deleted promotion, the next cart operation should result in deleted adjustments

RESOLVES CMRC-759

FIXES https://github.com/medusajs/medusa/issues/10357