### PR TITLE
docs-util: normalize RelationNullableModifier in model references

### DIFF
--- a/www/utils/packages/typedoc-plugin-custom/src/dml-types-normalizer.ts
+++ b/www/utils/packages/typedoc-plugin-custom/src/dml-types-normalizer.ts
@@ -28,7 +28,8 @@ export function load(app: Application) {
 function normalizeNullable(reflection: DeclarationReflection) {
   if (
     reflection.type?.type !== "reference" ||
-    reflection.type.name !== "NullableModifier" ||
+    (reflection.type.name !== "NullableModifier" &&
+      reflection.type.name !== "RelationNullableModifier") ||
     !reflection.type.typeArguments ||
     reflection.type.typeArguments.length < 2
   ) {


### PR DESCRIPTION
Normalize relations of type `RelationNullableModifier` to be the relationship type and optional flag.

Requires regenerating references

Closes DX-1182