### PR TITLE
docs: documented fetchCredentials options of JS SDK

### DIFF
--- a/www/apps/resources/app/js-sdk/page.mdx
+++ b/www/apps/resources/app/js-sdk/page.mdx
@@ -190,6 +190,31 @@ The `Medusa` initializer accepts as a parameter an object with the following pro
     <Table.Row>
       <Table.Cell>
 
+      `auth.fetchCredentials`
+
+      </Table.Cell>
+      <Table.Cell>
+
+      By default, if `auth.type` is `session`, the `credentials: include` option is passed in [fetch requests](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#including_credentials) under the hood. However, some platforms or environments may not support passing this option.
+
+      This option accepts a string to configure the value of `credentials` when the authentication type is `session`. It accepts one of the following values:
+
+      - `include`: (default) to pass the `credentials: include` option.
+      - `omit`: to pass the `credentials: omit` option.
+      - `same-origin`: to pass the `credentials: same-origin` option.
+
+      This option is only available after [Medusa v2.1.1](https://github.com/medusajs/medusa/releases/tag/v2.1.1).
+
+      </Table.Cell>
+      <Table.Cell>
+
+      `local`
+
+      </Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>
+
       `globalHeaders`
 
       </Table.Cell>


### PR DESCRIPTION
Closes DX-1186