### PR TITLE
chore: small tsdoc update to dml float property.

### DIFF
--- a/packages/core/utils/src/dml/entity-builder.ts
+++ b/packages/core/utils/src/dml/entity-builder.ts
@@ -253,6 +253,12 @@ export class EntityBuilder {
   /**
    * This method defines a float property that allows for
    * values with decimal places
+   * 
+   * :::note
+   * 
+   * This property is only available after Medusa v2.1.2.
+   * 
+   * :::
    *
    * @example
    * import { model } from "@medusajs/framework/utils"


### PR DESCRIPTION
Update the tsdocs of the `float` property to mention it's available only after v2.1.2 of Medusa