### PR TITLE
docs-util: support @version tag

### DIFF
--- a/packages/core/utils/src/dml/entity-builder.ts
+++ b/packages/core/utils/src/dml/entity-builder.ts
@@ -254,11 +254,7 @@ export class EntityBuilder {
    * This method defines a float property that allows for
    * values with decimal places
    * 
-   * :::note
-   * 
-   * This property is only available after Medusa v2.1.2.
-   * 
-   * :::
+   * @version 2.1.2
    *
    * @example
    * import { model } from "@medusajs/framework/utils"

--- a/www/utils/packages/typedoc-config/tsdoc.json
+++ b/www/utils/packages/typedoc-config/tsdoc.json
@@ -49,6 +49,10 @@
     {
       "tagName": "@parentIgnore",
       "syntaxKind": "block"
+    },
+    {
+      "tagName": "@version",
+      "syntaxKind": "block"
     }
   ]
 }

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/render-utils.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/render-utils.ts
@@ -76,6 +76,7 @@ import workflowDiagramHelper from "./resources/helpers/workflow-diagram"
 import workflowHooksHelper from "./resources/helpers/workflow-hooks"
 import ifMemberShowTitleHelper from "./resources/helpers/if-member-show-title"
 import signatureCommentHelper from "./resources/helpers/signature-comment"
+import versionHelper from "./resources/helpers/version"
 import { MarkdownTheme } from "./theme"
 
 const TEMPLATE_PATH = path.join(__dirname, "resources", "templates")
@@ -180,4 +181,5 @@ export function registerHelpers(theme: MarkdownTheme) {
   workflowHooksHelper(theme)
   ifMemberShowTitleHelper(theme)
   signatureCommentHelper()
+  versionHelper()
 }

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/comments.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/comments.ts
@@ -7,6 +7,7 @@ const EXCLUDED_TAGS = [
   "@featureFlag",
   "@category",
   "@typeParamDefinition",
+  "@version",
 ]
 
 export default function () {

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/version.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/version.ts
@@ -1,0 +1,20 @@
+import * as Handlebars from "handlebars"
+import { Reflection } from "typedoc"
+
+export default function () {
+  Handlebars.registerHelper("version", function (reflection: Reflection) {
+    const versionTag = reflection.comment?.blockTags.find(
+      (tag) => tag.tag === "@version"
+    )
+
+    if (!versionTag) {
+      return ""
+    }
+
+    const tagContent = versionTag.content
+      .map((content) => content.text)
+      .join("")
+
+    return `:::note\n\nThis is only available after Medusa \`v${tagContent}\`.\n\n:::`
+  })
+}

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.declaration.hbs
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.declaration.hbs
@@ -8,6 +8,8 @@
 
 {{> comment}}
 
+{{{version this}}}
+
 {{/if}}
 
 {{#if (sectionEnabled "member_declaration_example")}}

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.react-query.signature.hbs
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.react-query.signature.hbs
@@ -22,6 +22,8 @@
 
 {{/with}}
 
+{{{version this}}}
+
 {{/if}}
 
 {{#if (sectionEnabled "member_signature_example")}}

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.signature.hbs
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.signature.hbs
@@ -22,6 +22,8 @@
 
 {{/with}}
 
+{{{version this}}}
+
 {{/if}}
 
 {{#if (sectionEnabled "member_signature_example")}}

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.step.hbs
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.step.hbs
@@ -4,6 +4,8 @@
 
 {{{signatureComment}}}
 
+{{{version this}}}
+
 {{/if}}
 
 {{#if (sectionEnabled "member_signature_example")}}

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.workflow.hbs
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/partials/member.workflow.hbs
@@ -4,6 +4,8 @@
 
 {{> comment}}
 
+{{{version this}}}
+
 {{/if}}
 
 {{#if (sectionEnabled "member_signature_example")}}


### PR DESCRIPTION
- Support `@version` tag in tsdocs (it's available in jsdocs but not in tsdocs)
- Modify typedoc markdown theme to show the version notice as a note

To use the `@version` tag:

```ts
/**
   * 
   * @version 2.1.2
   */
```

Closes DX-1206