### PR TITLE
breaking: pluralization rule for the info word

### DIFF
--- a/packages/core/types/src/common/__tests__/pluralize.spec.ts
+++ b/packages/core/types/src/common/__tests__/pluralize.spec.ts
@@ -10,6 +10,7 @@ describe("Pluralize", () => {
     expectTypeOf<Pluralize<"series">>().toEqualTypeOf<"series">()
     expectTypeOf<Pluralize<"species">>().toEqualTypeOf<"species">()
     expectTypeOf<Pluralize<"deer">>().toEqualTypeOf<"deer">()
+    expectTypeOf<Pluralize<"info">>().toEqualTypeOf<"info">()
   })
 
   test("pluralize words ending with fe", () => {

--- a/packages/core/types/src/common/common.ts
+++ b/packages/core/types/src/common/common.ts
@@ -52,7 +52,9 @@ export interface SoftDeletableEntity extends BaseEntity {
 /**
  * Temporary type fixing to allow any level of orders until we get to properly clean all the types
  */
-export type FindConfigOrder = { [Key: string]: "ASC" | "DESC" | string & {} | FindConfigOrder }
+export type FindConfigOrder = {
+  [Key: string]: "ASC" | "DESC" | (string & {}) | FindConfigOrder
+}
 
 /**
  * @interface
@@ -344,6 +346,7 @@ type UncountableRules =
   | "you"
   | "deer"
   | "sheep"
+  | "info"
 
 type PluralizationSpecialRules = {
   person: "people"

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -48,6 +48,7 @@
     "@graphql-tools/merge": "^9.0.7",
     "@graphql-tools/schema": "^10.0.6",
     "@medusajs/types": "^2.1.1",
+    "@types/pluralize": "^0.0.33",
     "bignumber.js": "^9.1.2",
     "dotenv": "^16.4.5",
     "dotenv-expand": "^11.0.6",

--- a/packages/core/utils/src/common/__tests__/pluralize.spec.ts
+++ b/packages/core/utils/src/common/__tests__/pluralize.spec.ts
@@ -12,6 +12,7 @@ describe("pluralize", function () {
       "hero",
       "potato",
       "address",
+      "info",
     ]
 
     const expectedOutput = [
@@ -24,6 +25,7 @@ describe("pluralize", function () {
       "heroes",
       "potatoes",
       "addresses",
+      "info",
     ]
 
     words.forEach((word, index) => {

--- a/packages/core/utils/src/common/plurailze.ts
+++ b/packages/core/utils/src/common/plurailze.ts
@@ -1,4 +1,5 @@
 import pluralizeEN from "pluralize"
+pluralizeEN.addUncountableRule("info")
 
 /**
  * Function to pluralize English words.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6764,6 +6764,7 @@ __metadata:
     "@swc/core": ^1.7.28
     "@swc/jest": ^0.2.36
     "@types/express": ^4.17.21
+    "@types/pluralize": ^0.0.33
     awilix: ^8.0.1
     bignumber.js: ^9.1.2
     dotenv: ^16.4.5
@@ -13853,6 +13854,13 @@ __metadata:
     pg-protocol: "*"
     pg-types: ^4.0.1
   checksum: c8800d0ab2c6424308e6c6b40c73f19583ee1aed758462bd07694844b0a551b5841442205a4ee05207b80109ba502f33f20241b1bd9b4902e713611fb9e08f6c
+  languageName: node
+  linkType: hard
+
+"@types/pluralize@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "@types/pluralize@npm:0.0.33"
+  checksum: 24899caf85b79dd291a6b6e9b9f3b67b452b18d578d0ac0d531a705bf5ee0361d9386ea1f8532c64de9e22c6e9606c5497787bb5e31bd299c487980436c59785
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
FIXES: FRMW-2847

This PR fixes the pluralization rules for the `info` word at both runtime and the types level.

@olivermrbl I later realized that `VendorLegalInfo` is not a core module, so we should be okay with having a breaking change.