### PR TITLE
fix(core-flows): use customer create workflow to reuse the emit event

### DIFF
--- a/packages/core/core-flows/src/customer/workflows/create-customer-account.ts
+++ b/packages/core/core-flows/src/customer/workflows/create-customer-account.ts
@@ -6,8 +6,8 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import { setAuthAppMetadataStep } from "../../auth"
-import { createCustomersStep } from "../steps"
 import { validateCustomerAccountCreation } from "../steps/validate-customer-account-creation"
+import { createCustomersWorkflow } from "./create-customers"
 
 export type CreateCustomerAccountWorkflowInput = {
   authIdentityId: string
@@ -32,7 +32,11 @@ export const createCustomerAccountWorkflow = createWorkflow(
       }
     })
 
-    const customers = createCustomersStep([customerData])
+    const customers = createCustomersWorkflow.runAsStep({
+      input: {
+        customersData: [customerData],
+      },
+    })
 
     const customer = transform(
       customers,


### PR DESCRIPTION
what:

- uses the create customer workflow instead to reuse the event emit.

RESOLVES CMRC-792