### PR TITLE
docs: add stripe events to provider guide

### DIFF
--- a/www/apps/resources/app/commerce-modules/payment/payment-provider/stripe/page.mdx
+++ b/www/apps/resources/app/commerce-modules/payment/payment-provider/stripe/page.mdx
@@ -24,7 +24,7 @@ In this document, you’ll learn about the Stripe Module Provider and how to con
     link: "https://support.stripe.com/questions/locate-api-keys-in-the-dashboard"
   },
   {
-    text: "For deployed Medusa applications, a Stripe webhook secret. When creating the Webhook, set the endpoint URL to {server_url}/hooks/payment/stripe_stripe, where {server_url} with the URL to your deployed Medusa server.",
+    text: "For deployed Medusa applications, a Stripe webhook secret. Refer to the end of this guide for details on the URL and events.",
     link: "https://docs.stripe.com/webhooks#add-a-webhook-endpoint"
   }
 ]} />
@@ -192,33 +192,18 @@ STRIPE_API_KEY=<YOUR_STRIPE_API_KEY>
 
 ---
 
-## Use Provider
+## Setup Stripe Webhooks
 
-To use the Stripe provider, create a payment session for the provider:
+For production applications, you must set up webhooks in Stripe that inform Medusa of changes and updates to payments. Refer to [Stripe's documentation](https://docs.stripe.com/webhooks#add-a-webhook-endpoint) on how to setup webhooks.
 
-```ts
-const paymentSession =
-  await paymentModuleService.createPaymentSession(
-    "pay_col_123",
-    {
-      provider_id: "stripe-usd",
-      amount: 5000,
-      currency_code: "usd",
-      data: {
-        // any necessary data
-        // to pass to stripe
-      },
-    }
-  )
-```
+### Webhook URL
 
----
+Medusa has a `{server_url}/hooks/payment/{provider_id}` API route that you can use to register webhooks in Stripe, where:
 
-## Stripe Webhook Endpoint URLs
+- `{server_url}` is the URL to your deployed Medusa application in server mode.
+- `{provider_id}` is the ID of the provider, such as `stripe_stripe` for basic payments.
 
-As mentioned in the prerequisites, when you set up a webhook in Stripe, you set the webhook endpoint URL to `{server_url}/hooks/payment/stripe_stripe`. This endpoint URL is for basic payments with Stripe.
-
-The Stripe Module Provider supports other payment types, and the webhook endpoint URL is different for each:
+The Stripe Module Provider supports the following payment types, and the webhook endpoint URL is different for each:
 
 <Table>
   <Table.Header>
@@ -314,6 +299,14 @@ The Stripe Module Provider supports other payment types, and the webhook endpoin
     </Table.Row>
   </Table.Body>
 </Table>
+
+### Webhook Events
+
+When you set up the webhook in Stripe, choose the following events to listen to:
+
+- `payment_intent.amount_capturable_updated`
+- `payment_intent.succeeded`
+- `payment_intent.payment_failed`
 
 ---
 

--- a/www/apps/resources/generated/edit-dates.mjs
+++ b/www/apps/resources/generated/edit-dates.mjs
@@ -53,7 +53,7 @@ export const generatedEditDates = {
   "app/commerce-modules/payment/payment/page.mdx": "2024-10-09T10:59:08.463Z",
   "app/commerce-modules/payment/payment-collection/page.mdx": "2024-10-09T10:56:49.510Z",
   "app/commerce-modules/payment/payment-flow/page.mdx": "2024-10-09T11:18:53.332Z",
-  "app/commerce-modules/payment/payment-provider/stripe/page.mdx": "2024-12-12T12:46:28.557Z",
+  "app/commerce-modules/payment/payment-provider/stripe/page.mdx": "2024-12-16T13:21:03.554Z",
   "app/commerce-modules/payment/payment-provider/page.mdx": "2024-10-09T11:07:27.269Z",
   "app/commerce-modules/payment/payment-session/page.mdx": "2024-10-09T10:58:00.960Z",
   "app/commerce-modules/payment/webhook-events/page.mdx": "2024-11-19T11:45:02.167Z",


### PR DESCRIPTION
Add the stripe events to listen to when setting up the webhook in stripe.

Closes DX-1212
Closes #10608