### PR TITLE
fix(core-flows): export getItemTaxLinesStep

### DIFF
--- a/.changeset/wet-queens-deliver.md
+++ b/.changeset/wet-queens-deliver.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): export getItemTaxLinesStep

--- a/packages/core/core-flows/src/tax/steps/index.ts
+++ b/packages/core/core-flows/src/tax/steps/index.ts
@@ -1,5 +1,6 @@
 export * from "./create-tax-regions"
 export * from "./delete-tax-regions"
+export * from "./get-item-tax-lines"
 export * from "./create-tax-rates"
 export * from "./update-tax-rates"
 export * from "./delete-tax-rates"


### PR DESCRIPTION
Export `getItemTaxLinesStep` so that it can be generated in the workflow reference.