### PR TITLE
fix(core-flows): select stock locations for reservation from correct SC

### DIFF
--- a/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
@@ -2116,6 +2116,7 @@ medusaIntegrationTestRunner({
             ])
 
             let cart = await cartModuleService.createCarts({
+              sales_channel_id: salesChannel.id,
               currency_code: "usd",
               items: [
                 {

--- a/integration-tests/modules/__tests__/cart/store/carts.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/carts.spec.ts
@@ -1117,10 +1117,26 @@ medusaIntegrationTestRunner({
             )
           ).data.sales_channel
 
+          const salesChannel2 = (
+            await api.post(
+              "/admin/sales-channels",
+              { name: "second channel", description: "channel" },
+              adminHeaders
+            )
+          ).data.sales_channel
+
           stockLocation = (
             await api.post(
               `/admin/stock-locations`,
               { name: "test location" },
+              adminHeaders
+            )
+          ).data.stock_location
+
+          const stockLocation2 = (
+            await api.post(
+              `/admin/stock-locations`,
+              { name: "test location 2" },
               adminHeaders
             )
           ).data.stock_location
@@ -1145,8 +1161,23 @@ medusaIntegrationTestRunner({
           )
 
           await api.post(
+            `/admin/inventory-items/${inventoryItem.id}/location-levels`,
+            {
+              location_id: stockLocation2.id,
+              stocked_quantity: 10,
+            },
+            adminHeaders
+          )
+
+          await api.post(
             `/admin/stock-locations/${stockLocation.id}/sales-channels`,
             { add: [salesChannel.id] },
+            adminHeaders
+          )
+
+          await api.post(
+            `/admin/stock-locations/${stockLocation2.id}/sales-channels`,
+            { add: [salesChannel2.id] },
             adminHeaders
           )
 
@@ -1208,6 +1239,23 @@ medusaIntegrationTestRunner({
               },
               [Modules.FULFILLMENT]: {
                 fulfillment_set_id: fulfillmentSet.id,
+              },
+            },
+            {
+              [Modules.PRODUCT]: {
+                product_id: product.id,
+              },
+              [Modules.SALES_CHANNEL]: {
+                sales_channel_id: salesChannel2.id,
+              },
+            },
+            // Add product to 2 sales channels to test that the right stock location is selected for reservations
+            {
+              [Modules.PRODUCT]: {
+                product_id: product.id,
+              },
+              [Modules.SALES_CHANNEL]: {
+                sales_channel_id: salesChannel.id,
               },
             },
           ])

--- a/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
+++ b/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
@@ -67,7 +67,7 @@ export const prepareConfirmInventoryInput = (data: {
         hasSalesChannelStockLocation = true
       }
 
-      if (stock_locations) {
+      if (stock_locations && sales_channels?.id === salesChannelId) {
         stockLocationIds.add(stock_locations.id)
       }
 

--- a/packages/core/core-flows/src/cart/workflows/complete-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/complete-cart.ts
@@ -5,7 +5,7 @@ import {
 import {
   Modules,
   OrderStatus,
-  OrderWorkflowEvents
+  OrderWorkflowEvents,
 } from "@medusajs/framework/utils"
 import {
   createWorkflow,

--- a/packages/core/core-flows/src/order/workflows/order-edit/confirm-order-edit-request.ts
+++ b/packages/core/core-flows/src/order/workflows/order-edit/confirm-order-edit-request.ts
@@ -215,7 +215,7 @@ export const confirmOrderEditRequestWorkflow = createWorkflow(
     const formatedInventoryItems = transform(
       {
         input: {
-          sales_channel_id: (orderItems as any).order.sales_channel_id,
+          sales_channel_id: (orderItems as any).sales_channel_id,
           variants,
           items,
         },


### PR DESCRIPTION
**What**
- select a stock location for inventory reservation only if associated with the passed sales channel id
- fix passing SC id when creating OE reservations

---

CLOSES SUP-465
FIXES https://github.com/medusajs/medusa/issues/10658