### PR TITLE
fix(js-sdk, medusa): Allow users to change their mind during the checkout process 

### DIFF
--- a/packages/core/js-sdk/src/store/index.ts
+++ b/packages/core/js-sdk/src/store/index.ts
@@ -960,22 +960,20 @@ export class Store {
       query?: SelectParams,
       headers?: ClientHeaders
     ) => {
-      let paymentCollectionId = (cart as any).payment_collection?.id
-      if (!paymentCollectionId) {
-        const collectionBody = {
-          cart_id: cart.id,
-        }
-        paymentCollectionId = (
-          await this.client.fetch<HttpTypes.StorePaymentCollectionResponse>(
-            `/store/payment-collections`,
-            {
-              method: "POST",
-              headers,
-              body: collectionBody,
-            }
-          )
-        ).payment_collection.id
+      const collectionBody = {
+        cart_id: cart.id,
       }
+      const paymentCollectionId = (
+        await this.client.fetch<HttpTypes.StorePaymentCollectionResponse>(
+          `/store/payment-collections`,
+          {
+            method: "POST",
+            headers,
+            body: collectionBody,
+          }
+        )
+      ).payment_collection.id
+
 
       return this.client.fetch<HttpTypes.StorePaymentCollectionResponse>(
         `/store/payment-collections/${paymentCollectionId}/payment-sessions`,

--- a/packages/medusa/src/api/store/payment-collections/route.ts
+++ b/packages/medusa/src/api/store/payment-collections/route.ts
@@ -1,4 +1,4 @@
-import { createPaymentCollectionForCartWorkflow } from "@medusajs/core-flows"
+import { createPaymentCollectionForCartWorkflow, refreshPaymentCollectionForCartWorkflow } from "@medusajs/core-flows"
 import {
   ContainerRegistrationKeys,
   remoteQueryObjectFromString,
@@ -9,40 +9,41 @@ import {
 } from "@medusajs/framework/http"
 import { HttpTypes } from "@medusajs/framework/types"
 
-export const POST = async (
-  req: AuthenticatedMedusaRequest<HttpTypes.StoreCreatePaymentCollection>,
-  res: MedusaResponse<HttpTypes.StorePaymentCollectionResponse>
-) => {
+const getPaymentCollectionForCart = async (req: AuthenticatedMedusaRequest<HttpTypes.StoreCreatePaymentCollection>) => {
   const remoteQuery = req.scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
   const { cart_id } = req.body
 
-  // We can potentially refactor the workflow to behave more like an upsert and return an existing collection if there is one.
   const [cartCollectionRelation] = await remoteQuery(
     remoteQueryObjectFromString({
       entryPoint: "cart_payment_collection",
       variables: { filters: { cart_id } },
       fields: req.remoteQueryConfig.fields.map(
         (f) => `payment_collection.${f}`
-      ),
+      ) as any,
     })
   )
-  let paymentCollection = cartCollectionRelation?.payment_collection
+  return cartCollectionRelation?.payment_collection
+}
 
+export const POST = async (
+  req: AuthenticatedMedusaRequest<HttpTypes.StoreCreatePaymentCollection>,
+  res: MedusaResponse<HttpTypes.StorePaymentCollectionResponse>
+) => {
+  const { cart_id } = req.body
+
+  // We can potentially refactor the workflow to behave more like an upsert and return an existing collection if there is one.
+
+  let paymentCollection = await getPaymentCollectionForCart(req)
   if (!paymentCollection) {
     await createPaymentCollectionForCartWorkflow(req.scope).run({
       input: req.body,
     })
-
-    const [cartCollectionRelation] = await remoteQuery(
-      remoteQueryObjectFromString({
-        entryPoint: "cart_payment_collection",
-        variables: { filters: { cart_id } },
-        fields: req.remoteQueryConfig.fields.map(
-          (f) => `payment_collection.${f}`
-        ),
-      })
-    )
-    paymentCollection = cartCollectionRelation?.payment_collection
+    paymentCollection = await getPaymentCollectionForCart(req)
+  } else {
+    await refreshPaymentCollectionForCartWorkflow(req.scope).run({
+      input: { cart_id },
+    })
+    paymentCollection = await getPaymentCollectionForCart(req)
   }
 
   res.status(200).json({ payment_collection: paymentCollection })


### PR DESCRIPTION
…and update the payment collection accordingly

- refresh the payment collection on every POST request in the API (makes use of the pre-existing workflow that only creates a new collection if the existing one is out of sync with the cart)
- change the frontend library to request a check of the payment collection everytime before initializing a payment session


Addresses  #10670 