### PR TITLE
Made variants.options fields optional in StoreGetProductsParams

### DIFF
--- a/packages/medusa/src/api/store/products/validators.ts
+++ b/packages/medusa/src/api/store/products/validators.ts
@@ -28,7 +28,7 @@ export const StoreGetProductParams = createSelectParams().merge(
 export const StoreGetProductVariantsParamsFields = z.object({
   q: z.string().optional(),
   id: z.union([z.string(), z.array(z.string())]).optional(),
-  options: z.object({ value: z.string(), option_id: z.string() }).optional(),
+  options: z.object({ value: z.string().optional(), option_id: z.string().optional() }).optional(),
   created_at: createOperatorMap().optional(),
   updated_at: createOperatorMap().optional(),
   deleted_at: createOperatorMap().optional(),
@@ -67,7 +67,7 @@ export const StoreGetProductsParams = createFindParams({
 
           .object({
             options: z
-              .object({ value: z.string(), option_id: z.string() })
+              .object({ value: z.string().optional(), option_id: z.string().optional() })
               .optional(),
           })
           .merge(applyAndAndOrOperators(StoreGetProductVariantsParamsFields))


### PR DESCRIPTION
<img width="1475" alt="image" src="https://github.com/user-attachments/assets/2bb12bc3-3ff6-40b5-a8dc-7e02e1711a12" />
This pull request includes changes to the `packages/medusa/src/api/store/products/validators.ts` file to make certain fields optional in the product parameters.

Changes to product parameters:

* [`StoreGetProductVariantsParamsFields`](diffhunk://#diff-2607a9f03ce924abaee31471890e3daa8c6538a0089a83a56fbce537fe0c15edL31-R31): Modified the `options` object to make `value` and `option_id` fields optional.
* [`StoreGetProductsParams`](diffhunk://#diff-2607a9f03ce924abaee31471890e3daa8c6538a0089a83a56fbce537fe0c15edL70-R70): Modified the `options` object to make `value` and `option_id` fields optional.