### PR TITLE
feat(medusa): Add health endpoint for all running modes of medusa

### DIFF
--- a/packages/core/framework/src/http/express-loader.ts
+++ b/packages/core/framework/src/http/express-loader.ts
@@ -95,10 +95,6 @@ export async function expressLoader({ app }: { app: Express }): Promise<{
   // Currently we don't allow configuration of static files, but this can be revisited as needed.
   app.use("/static", express.static(path.join(baseDir, "static")))
 
-  app.get("/health", (req, res) => {
-    res.status(200).send("OK")
-  })
-
   const shutdown = async () => {
     redisClient?.disconnect()
   }

--- a/packages/medusa/src/commands/start.ts
+++ b/packages/medusa/src/commands/start.ts
@@ -138,6 +138,12 @@ async function start(args: {
       }
 
       const serverActivity = logger.activity(`Creating server`)
+
+      // Register a health check endpoint. Ideally this also checks the readiness of the service, rather than just returning a static response.
+      app.get("/health", (_, res) => {
+        res.status(200).send("OK")
+      })
+
       const server = GracefulShutdownServer.create(
         http_.listen(port, host).on("listening", () => {
           logger.success(


### PR DESCRIPTION
When running the service in eg. K8s, we need a way to check the readiness of the service, regardless if it runs in server, shared, or worker mode. This allows for that, as previously we only registered the health endpoint in shared or server mode.