### PR TITLE
docs-util: add publishable api key header parameter to store routes OAS

### DIFF
--- a/www/apps/api-reference/components/Tags/Operation/DescriptionSection/Parameters/index.tsx
+++ b/www/apps/api-reference/components/Tags/Operation/DescriptionSection/Parameters/index.tsx
@@ -18,6 +18,11 @@ const TagsOperationDescriptionSectionParameters = ({
     required: [],
     properties: {},
   }
+  const headerParameters: SchemaObject = {
+    type: "object",
+    required: [],
+    properties: {},
+  }
 
   parameters.forEach((parameter) => {
     const parameterObject = {
@@ -37,11 +42,27 @@ const TagsOperationDescriptionSectionParameters = ({
         queryParameters.required?.push(parameter.name)
       }
       queryParameters.properties[parameter.name] = parameterObject
+    } else if (parameter.in === "header") {
+      if (parameter.required) {
+        headerParameters.required?.push(parameter.name)
+      }
+      headerParameters.properties[parameter.name] = parameterObject
     }
   })
 
   return (
     <>
+      {Object.values(headerParameters.properties).length > 0 && (
+        <>
+          <h3 className="border-medusa-border-base border-b py-1.5">
+            Header Parameters
+          </h3>
+          <TagOperationParameters
+            schemaObject={headerParameters}
+            topLevel={true}
+          />
+        </>
+      )}
       {Object.values(pathParameters.properties).length > 0 && (
         <>
           <h3 className="border-medusa-border-base border-b py-1.5">

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminShippingOptionPriceRule.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminShippingOptionPriceRule.yaml
@@ -17,8 +17,13 @@ properties:
     title: id
     description: The price rule's ID.
   value:
-    type: string
-    title: value
+    oneOf:
+      - type: string
+        title: value
+        description: The price rule's value.
+      - type: number
+        title: value
+        description: The price rule's value.
     description: The price rule's value.
   operator:
     type: string

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminShippingOptionRule.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminShippingOptionRule.yaml
@@ -26,18 +26,8 @@ properties:
     description: The shipping option rule's operator.
     example: eq
   value:
-    oneOf:
-      - type: string
-        title: value
-        description: The rule's value.
-        example: '"true"'
-      - type: array
-        description: The rule's values.
-        items:
-          type: string
-          title: value
-          description: A rule's value
-          example: '"true"'
+    type: string
+    title: value
   shipping_option_id:
     type: string
     title: shipping_option_id

--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -53046,8 +53046,13 @@ components:
           title: id
           description: The price rule's ID.
         value:
-          type: string
-          title: value
+          oneOf:
+            - type: string
+              title: value
+              description: The price rule's value.
+            - type: number
+              title: value
+              description: The price rule's value.
           description: The price rule's value.
         operator:
           type: string

--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -53131,18 +53131,8 @@ components:
           description: The shipping option rule's operator.
           example: eq
         value:
-          oneOf:
-            - type: string
-              title: value
-              description: The rule's value.
-              example: '"true"'
-            - type: array
-              description: The rule's values.
-              items:
-                type: string
-                title: value
-                description: A rule's value
-                example: '"true"'
+          type: string
+          title: value
         shipping_option_id:
           type: string
           title: shipping_option_id

--- a/www/apps/api-reference/specs/store/components/schemas/AdminShippingOptionPriceRule.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminShippingOptionPriceRule.yaml
@@ -17,8 +17,13 @@ properties:
     title: id
     description: The price rule's ID.
   value:
-    type: string
-    title: value
+    oneOf:
+      - type: string
+        title: value
+        description: The price rule's value.
+      - type: number
+        title: value
+        description: The price rule's value.
     description: The price rule's value.
   operator:
     type: string

--- a/www/apps/api-reference/specs/store/components/schemas/AdminShippingOptionRule.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminShippingOptionRule.yaml
@@ -26,18 +26,8 @@ properties:
     description: The shipping option rule's operator.
     example: eq
   value:
-    oneOf:
-      - type: string
-        title: value
-        description: The rule's value.
-        example: '"true"'
-      - type: array
-        description: The rule's values.
-        items:
-          type: string
-          title: value
-          description: A rule's value
-          example: '"true"'
+    type: string
+    title: value
   shipping_option_id:
     type: string
     title: shipping_option_id

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -568,6 +568,14 @@ paths:
       description: Create a cart.
       x-authenticated: false
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -632,6 +640,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -681,6 +697,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -754,6 +778,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -857,6 +889,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: |-
@@ -915,6 +955,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -987,6 +1035,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -1057,6 +1113,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -1136,6 +1200,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -1208,6 +1280,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -1269,6 +1349,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -1344,6 +1432,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -1392,6 +1488,14 @@ paths:
         url: https://docs.medusajs.com/v2/resources/storefront-development/products/collections/list
         description: 'Storefront guide: How to retrieve a list of collections.'
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2020,6 +2124,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2064,6 +2176,14 @@ paths:
       description: Retrieve a list of currencies. The currencies can be filtered by fields such as `code`. The currencies can also be sorted or paginated.
       x-authenticated: false
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2184,6 +2304,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2231,6 +2359,14 @@ paths:
         description: 'Storefront guide: How to register a customer.'
       x-authenticated: true
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2297,6 +2433,14 @@ paths:
         url: https://docs.medusajs.com/v2/resources/storefront-development/customers/retrieve
         description: 'Storefront guide: How to retrieve the logged-in customer.'
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2347,6 +2491,14 @@ paths:
         description: 'Storefront guide: How to edit a customer''s profile.'
       x-authenticated: true
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2412,6 +2564,14 @@ paths:
         url: https://docs.medusajs.com/v2/resources/storefront-development/customers/addresses#list-customer-addresses
         description: 'Storefront guide: How to retrieve the logged-in customer''s addresses.'
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2544,6 +2704,14 @@ paths:
         description: 'Storefront guide: How to create an address for the logged-in customer.'
       x-authenticated: true
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2677,6 +2845,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2734,6 +2910,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2858,6 +3042,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -2935,6 +3127,14 @@ paths:
       description: Retrieve the orders of the logged-in customer. The orders can be filtered by fields such as `id`. The orders can also be sorted or paginated.
       x-authenticated: true
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -3113,6 +3313,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -3165,6 +3373,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: |-
@@ -3229,6 +3445,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: |-
@@ -3287,6 +3511,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: |-
@@ -3351,6 +3583,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: |-
@@ -3410,6 +3650,14 @@ paths:
         description: 'Storefront guide: How to implement payment during checkout.'
       x-authenticated: false
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -3474,6 +3722,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -3531,6 +3787,14 @@ paths:
         url: https://docs.medusajs.com/v2/resources/storefront-development/checkout/payment
         description: 'Storefront guide: How to implement payment during checkout.'
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -3643,6 +3907,14 @@ paths:
         url: https://docs.medusajs.com/v2/resources/storefront-development/products/categories/list
         description: 'Storefront guide: How to retrieve a list of product categories.'
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -4298,6 +4570,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -4361,6 +4641,14 @@ paths:
         url: https://docs.medusajs.com/v2/resources/storefront-development/products/price
         description: 'Storefront guide: How to retrieve a product variants'' prices.'
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -5143,6 +5431,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -5188,6 +5484,36 @@ paths:
             type: string
             title: cart_id
             description: The ID of the customer's cart. If set, the cart's region and shipping address's country code and province are used instead of the `region_id`, `country_code`, and `province` properties.
+        - name: limit
+          in: query
+          description: Limit the number of items returned in the list.
+          required: false
+          schema:
+            type: number
+            title: limit
+            description: Limit the number of items returned in the list.
+            externalDocs:
+              url: '#pagination'
+        - name: offset
+          in: query
+          description: The number of items to skip when retrieving a list.
+          required: false
+          schema:
+            type: number
+            title: offset
+            description: The number of items to skip when retrieving a list.
+            externalDocs:
+              url: '#pagination'
+        - name: order
+          in: query
+          description: The field to sort the data by. By default, the sort order is ascending. To change the order to descending, prefix the field name with `-`.
+          required: false
+          schema:
+            type: string
+            title: order
+            description: The field to sort the data by. By default, the sort order is ascending. To change the order to descending, prefix the field name with `-`.
+            externalDocs:
+              url: '#pagination'
       x-codeSamples:
         - lang: Shell
           label: cURL
@@ -5225,6 +5551,14 @@ paths:
         url: https://docs.medusajs.com/v2/resources/storefront-development/regions/list
         description: 'Storefront guide: How to retrieve a list of regions.'
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -5402,6 +5736,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -5500,6 +5842,15 @@ paths:
         '500':
           $ref: '#/components/responses/500_error'
       x-workflow: createAndCompleteReturnOrderWorkflow
+      parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
   /store/return-reasons:
     get:
       operationId: GetReturnReasons
@@ -5507,6 +5858,14 @@ paths:
       description: Retrieve a list of return reasons. The return reasons can be sorted or paginated.
       x-authenticated: false
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -5614,6 +5973,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -5664,6 +6031,14 @@ paths:
         description: 'Storefront guide: How to implement shipping during checkout.'
       x-authenticated: false
       parameters:
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default fields. without prefix it will replace the entire default fields.
@@ -5779,6 +6154,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-publishable-api-key
+          in: header
+          description: Publishable API Key created in the Medusa Admin.
+          required: true
+          schema:
+            type: string
+            externalDocs:
+              url: https://docs.medusajs.com/api/store#publishable-api-key
         - name: fields
           in: query
           description: |-
@@ -15284,8 +15667,13 @@ components:
           title: id
           description: The price rule's ID.
         value:
-          type: string
-          title: value
+          oneOf:
+            - type: string
+              title: value
+              description: The price rule's value.
+            - type: number
+              title: value
+              description: The price rule's value.
           description: The price rule's value.
         operator:
           type: string

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -15752,18 +15752,8 @@ components:
           description: The shipping option rule's operator.
           example: eq
         value:
-          oneOf:
-            - type: string
-              title: value
-              description: The rule's value.
-              example: '"true"'
-            - type: array
-              description: The rule's values.
-              items:
-                type: string
-                title: value
-                description: A rule's value
-                example: '"true"'
+          type: string
+          title: value
         shipping_option_id:
           type: string
           title: shipping_option_id

--- a/www/apps/api-reference/specs/store/paths/store_carts.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts.yaml
@@ -4,6 +4,14 @@ post:
   description: Create a cart.
   x-authenticated: false
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_carts_{id}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts_{id}.yaml
@@ -12,6 +12,14 @@ get:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-
@@ -70,6 +78,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_carts_{id}_complete.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts_{id}_complete.yaml
@@ -14,6 +14,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_carts_{id}_customer.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts_{id}_customer.yaml
@@ -17,6 +17,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_carts_{id}_line-items.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts_{id}_line-items.yaml
@@ -15,6 +15,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_carts_{id}_line-items_{line_id}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts_{id}_line-items_{line_id}.yaml
@@ -21,6 +21,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-
@@ -94,6 +102,14 @@ delete:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_carts_{id}_promotions.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts_{id}_promotions.yaml
@@ -11,6 +11,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-
@@ -84,6 +92,14 @@ delete:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_carts_{id}_shipping-methods.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts_{id}_shipping-methods.yaml
@@ -17,6 +17,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_carts_{id}_taxes.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts_{id}_taxes.yaml
@@ -11,6 +11,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_collections.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_collections.yaml
@@ -10,6 +10,14 @@ get:
       https://docs.medusajs.com/v2/resources/storefront-development/products/collections/list
     description: 'Storefront guide: How to retrieve a list of collections.'
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_collections_{id}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_collections_{id}.yaml
@@ -16,6 +16,14 @@ get:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_currencies.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_currencies.yaml
@@ -6,6 +6,14 @@ get:
     as `code`. The currencies can also be sorted or paginated.
   x-authenticated: false
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_currencies_{code}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_currencies_{code}.yaml
@@ -12,6 +12,14 @@ get:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_customers.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_customers.yaml
@@ -11,6 +11,14 @@ post:
     description: 'Storefront guide: How to register a customer.'
   x-authenticated: true
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_customers_me.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_customers_me.yaml
@@ -11,6 +11,14 @@ get:
       https://docs.medusajs.com/v2/resources/storefront-development/customers/retrieve
     description: 'Storefront guide: How to retrieve the logged-in customer.'
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-
@@ -68,6 +76,14 @@ post:
     description: 'Storefront guide: How to edit a customer''s profile.'
   x-authenticated: true
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_customers_me_addresses.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_customers_me_addresses.yaml
@@ -12,6 +12,14 @@ get:
       https://docs.medusajs.com/v2/resources/storefront-development/customers/addresses#list-customer-addresses
     description: 'Storefront guide: How to retrieve the logged-in customer''s addresses.'
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-
@@ -156,6 +164,14 @@ post:
     description: 'Storefront guide: How to create an address for the logged-in customer.'
   x-authenticated: true
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_customers_me_addresses_{address_id}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_customers_me_addresses_{address_id}.yaml
@@ -13,6 +13,14 @@ get:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-
@@ -77,6 +85,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-
@@ -209,6 +225,14 @@ delete:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_orders.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_orders.yaml
@@ -7,6 +7,14 @@ get:
     fields such as `id`. The orders can also be sorted or paginated.
   x-authenticated: true
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_orders_{id}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_orders_{id}.yaml
@@ -12,6 +12,14 @@ get:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_orders_{id}_transfer_accept.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_orders_{id}_transfer_accept.yaml
@@ -18,6 +18,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_orders_{id}_transfer_cancel.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_orders_{id}_transfer_cancel.yaml
@@ -15,6 +15,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_orders_{id}_transfer_decline.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_orders_{id}_transfer_decline.yaml
@@ -14,6 +14,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_orders_{id}_transfer_request.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_orders_{id}_transfer_request.yaml
@@ -15,6 +15,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_payment-collections.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_payment-collections.yaml
@@ -10,6 +10,14 @@ post:
     description: 'Storefront guide: How to implement payment during checkout.'
   x-authenticated: false
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_payment-collections_{id}_payment-sessions.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_payment-collections_{id}_payment-sessions.yaml
@@ -19,6 +19,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_payment-providers.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_payment-providers.yaml
@@ -10,6 +10,14 @@ get:
       https://docs.medusajs.com/v2/resources/storefront-development/checkout/payment
     description: 'Storefront guide: How to implement payment during checkout.'
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_product-categories.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_product-categories.yaml
@@ -11,6 +11,14 @@ get:
       https://docs.medusajs.com/v2/resources/storefront-development/products/categories/list
     description: 'Storefront guide: How to retrieve a list of product categories.'
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_product-categories_{id}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_product-categories_{id}.yaml
@@ -16,6 +16,14 @@ get:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_products.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_products.yaml
@@ -10,6 +10,14 @@ get:
       https://docs.medusajs.com/v2/resources/storefront-development/products/price
     description: 'Storefront guide: How to retrieve a product variants'' prices.'
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_products_{id}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_products_{id}.yaml
@@ -16,6 +16,14 @@ get:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-
@@ -89,6 +97,41 @@ get:
           The ID of the customer's cart. If set, the cart's region and shipping
           address's country code and province are used instead of the
           `region_id`, `country_code`, and `province` properties.
+    - name: limit
+      in: query
+      description: Limit the number of items returned in the list.
+      required: false
+      schema:
+        type: number
+        title: limit
+        description: Limit the number of items returned in the list.
+        externalDocs:
+          url: '#pagination'
+    - name: offset
+      in: query
+      description: The number of items to skip when retrieving a list.
+      required: false
+      schema:
+        type: number
+        title: offset
+        description: The number of items to skip when retrieving a list.
+        externalDocs:
+          url: '#pagination'
+    - name: order
+      in: query
+      description: >-
+        The field to sort the data by. By default, the sort order is ascending.
+        To change the order to descending, prefix the field name with `-`.
+      required: false
+      schema:
+        type: string
+        title: order
+        description: >-
+          The field to sort the data by. By default, the sort order is
+          ascending. To change the order to descending, prefix the field name
+          with `-`.
+        externalDocs:
+          url: '#pagination'
   x-codeSamples:
     - lang: Shell
       label: cURL

--- a/www/apps/api-reference/specs/store/paths/store_regions.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_regions.yaml
@@ -9,6 +9,14 @@ get:
     url: https://docs.medusajs.com/v2/resources/storefront-development/regions/list
     description: 'Storefront guide: How to retrieve a list of regions.'
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_regions_{id}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_regions_{id}.yaml
@@ -12,6 +12,14 @@ get:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_return-reasons.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_return-reasons.yaml
@@ -6,6 +6,14 @@ get:
     paginated.
   x-authenticated: false
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_return-reasons_{id}.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_return-reasons_{id}.yaml
@@ -12,6 +12,14 @@ get:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_return.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_return.yaml
@@ -37,3 +37,12 @@ post:
     '500':
       $ref: ../components/responses/500_error.yaml
   x-workflow: createAndCompleteReturnOrderWorkflow
+  parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key

--- a/www/apps/api-reference/specs/store/paths/store_shipping-options.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_shipping-options.yaml
@@ -13,6 +13,14 @@ get:
     description: 'Storefront guide: How to implement shipping during checkout.'
   x-authenticated: false
   parameters:
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/apps/api-reference/specs/store/paths/store_shipping-options_{id}_calculate.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_shipping-options_{id}_calculate.yaml
@@ -10,6 +10,14 @@ post:
       required: true
       schema:
         type: string
+    - name: x-publishable-api-key
+      in: header
+      description: Publishable API Key created in the Medusa Admin.
+      required: true
+      schema:
+        type: string
+        externalDocs:
+          url: https://docs.medusajs.com/api/store#publishable-api-key
     - name: fields
       in: query
       description: >-

--- a/www/packages/docs-ui/src/utils/capitalize.ts
+++ b/www/packages/docs-ui/src/utils/capitalize.ts
@@ -1,3 +1,3 @@
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()
+  return str.charAt(0).toUpperCase() + str.slice(1)
 }

--- a/www/utils/generated/oas-output/operations/store/delete_store_carts_[id]_line-items_[line_id].ts
+++ b/www/utils/generated/oas-output/operations/store/delete_store_carts_[id]_line-items_[line_id].ts
@@ -21,6 +21,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/delete_store_carts_[id]_promotions.ts
+++ b/www/utils/generated/oas-output/operations/store/delete_store_carts_[id]_promotions.ts
@@ -11,6 +11,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/delete_store_customers_me_addresses_[address_id].ts
+++ b/www/utils/generated/oas-output/operations/store/delete_store_customers_me_addresses_[address_id].ts
@@ -15,6 +15,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_carts_[id].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_carts_[id].ts
@@ -11,6 +11,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_collections.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_collections.ts
@@ -8,6 +8,14 @@
  *   url: https://docs.medusajs.com/v2/resources/storefront-development/products/collections/list
  *   description: "Storefront guide: How to retrieve a list of collections."
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_collections_[id].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_collections_[id].ts
@@ -14,6 +14,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_currencies.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_currencies.ts
@@ -5,6 +5,14 @@
  * description: Retrieve a list of currencies. The currencies can be filtered by fields such as `code`. The currencies can also be sorted or paginated.
  * x-authenticated: false
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_currencies_[code].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_currencies_[code].ts
@@ -11,6 +11,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_customers_me.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_customers_me.ts
@@ -9,6 +9,14 @@
  *   url: https://docs.medusajs.com/v2/resources/storefront-development/customers/retrieve
  *   description: "Storefront guide: How to retrieve the logged-in customer."
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_customers_me_addresses.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_customers_me_addresses.ts
@@ -9,6 +9,14 @@
  *   url: https://docs.medusajs.com/v2/resources/storefront-development/customers/addresses#list-customer-addresses
  *   description: "Storefront guide: How to retrieve the logged-in customer's addresses."
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_customers_me_addresses_[address_id].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_customers_me_addresses_[address_id].ts
@@ -12,6 +12,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_orders.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_orders.ts
@@ -6,6 +6,14 @@
  * description: Retrieve the orders of the logged-in customer. The orders can be filtered by fields such as `id`. The orders can also be sorted or paginated.
  * x-authenticated: true
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_orders_[id].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_orders_[id].ts
@@ -11,6 +11,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_payment-providers.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_payment-providers.ts
@@ -8,6 +8,14 @@
  *   url: https://docs.medusajs.com/v2/resources/storefront-development/checkout/payment
  *   description: "Storefront guide: How to implement payment during checkout."
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_product-categories.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_product-categories.ts
@@ -8,6 +8,14 @@
  *   url: https://docs.medusajs.com/v2/resources/storefront-development/products/categories/list
  *   description: "Storefront guide: How to retrieve a list of product categories."
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_product-categories_[id].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_product-categories_[id].ts
@@ -14,6 +14,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_products.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_products.ts
@@ -8,6 +8,14 @@
  *   url: https://docs.medusajs.com/v2/resources/storefront-development/products/price
  *   description: "Storefront guide: How to retrieve a product variants' prices."
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_products_[id].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_products_[id].ts
@@ -14,6 +14,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default
@@ -61,6 +69,36 @@
  *       type: string
  *       title: cart_id
  *       description: The ID of the customer's cart. If set, the cart's region and shipping address's country code and province are used instead of the `region_id`, `country_code`, and `province` properties.
+ *   - name: limit
+ *     in: query
+ *     description: Limit the number of items returned in the list.
+ *     required: false
+ *     schema:
+ *       type: number
+ *       title: limit
+ *       description: Limit the number of items returned in the list.
+ *       externalDocs:
+ *         url: "#pagination"
+ *   - name: offset
+ *     in: query
+ *     description: The number of items to skip when retrieving a list.
+ *     required: false
+ *     schema:
+ *       type: number
+ *       title: offset
+ *       description: The number of items to skip when retrieving a list.
+ *       externalDocs:
+ *         url: "#pagination"
+ *   - name: order
+ *     in: query
+ *     description: The field to sort the data by. By default, the sort order is ascending. To change the order to descending, prefix the field name with `-`.
+ *     required: false
+ *     schema:
+ *       type: string
+ *       title: order
+ *       description: The field to sort the data by. By default, the sort order is ascending. To change the order to descending, prefix the field name with `-`.
+ *       externalDocs:
+ *         url: "#pagination"
  * x-codeSamples:
  *   - lang: Shell
  *     label: cURL

--- a/www/utils/generated/oas-output/operations/store/get_store_regions.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_regions.ts
@@ -8,6 +8,14 @@
  *   url: https://docs.medusajs.com/v2/resources/storefront-development/regions/list
  *   description: "Storefront guide: How to retrieve a list of regions."
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_regions_[id].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_regions_[id].ts
@@ -11,6 +11,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_return-reasons.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_return-reasons.ts
@@ -5,6 +5,14 @@
  * description: Retrieve a list of return reasons. The return reasons can be sorted or paginated.
  * x-authenticated: false
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_return-reasons_[id].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_return-reasons_[id].ts
@@ -11,6 +11,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/get_store_shipping-options.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_shipping-options.ts
@@ -11,6 +11,14 @@
  *   description: "Storefront guide: How to implement shipping during checkout."
  * x-authenticated: false
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_carts.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts.ts
@@ -5,6 +5,14 @@
  * description: Create a cart.
  * x-authenticated: false
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_carts_[id].ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts_[id].ts
@@ -11,6 +11,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_complete.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_complete.ts
@@ -14,6 +14,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_customer.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_customer.ts
@@ -15,6 +15,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: |-

--- a/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_line-items.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_line-items.ts
@@ -15,6 +15,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_line-items_[line_id].ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_line-items_[line_id].ts
@@ -21,6 +21,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_promotions.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_promotions.ts
@@ -12,6 +12,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_shipping-methods.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_shipping-methods.ts
@@ -15,6 +15,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_taxes.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_taxes.ts
@@ -12,6 +12,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_customers.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_customers.ts
@@ -8,6 +8,14 @@
  *   description: "Storefront guide: How to register a customer."
  * x-authenticated: true
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_customers_me.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_customers_me.ts
@@ -8,6 +8,14 @@
  *   description: "Storefront guide: How to edit a customer's profile."
  * x-authenticated: true
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_customers_me_addresses.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_customers_me_addresses.ts
@@ -9,6 +9,14 @@
  *   description: "Storefront guide: How to create an address for the logged-in customer."
  * x-authenticated: true
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_customers_me_addresses_[address_id].ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_customers_me_addresses_[address_id].ts
@@ -15,6 +15,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_accept.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_accept.ts
@@ -14,6 +14,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: |-

--- a/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_cancel.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_cancel.ts
@@ -12,6 +12,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: |-

--- a/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_decline.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_decline.ts
@@ -12,6 +12,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: |-

--- a/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_request.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_request.ts
@@ -13,6 +13,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: |-

--- a/www/utils/generated/oas-output/operations/store/post_store_payment-collections.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_payment-collections.ts
@@ -8,6 +8,14 @@
  *   description: "Storefront guide: How to implement payment during checkout."
  * x-authenticated: false
  * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_payment-collections_[id]_payment-sessions.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_payment-collections_[id]_payment-sessions.ts
@@ -16,6 +16,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: Comma-separated fields that should be included in the returned data. if a field is prefixed with `+` it will be added to the default fields, using `-` will remove it from the default

--- a/www/utils/generated/oas-output/operations/store/post_store_return.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_return.ts
@@ -55,6 +55,15 @@
  *   "500":
  *     $ref: "#/components/responses/500_error"
  * x-workflow: createAndCompleteReturnOrderWorkflow
+ * parameters:
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/store/post_store_shipping-options_[id]_calculate.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_shipping-options_[id]_calculate.ts
@@ -11,6 +11,14 @@
  *     required: true
  *     schema:
  *       type: string
+ *   - name: x-publishable-api-key
+ *     in: header
+ *     description: Publishable API Key created in the Medusa Admin.
+ *     required: true
+ *     schema:
+ *       type: string
+ *       externalDocs:
+ *         url: https://docs.medusajs.com/api/store#publishable-api-key
  *   - name: fields
  *     in: query
  *     description: |-

--- a/www/utils/generated/oas-output/schemas/AdminShippingOptionPriceRule.ts
+++ b/www/utils/generated/oas-output/schemas/AdminShippingOptionPriceRule.ts
@@ -19,8 +19,13 @@
  *     title: id
  *     description: The price rule's ID.
  *   value:
- *     type: string
- *     title: value
+ *     oneOf:
+ *       - type: string
+ *         title: value
+ *         description: The price rule's value.
+ *       - type: number
+ *         title: value
+ *         description: The price rule's value.
  *     description: The price rule's value.
  *   operator:
  *     type: string

--- a/www/utils/generated/oas-output/schemas/AdminShippingOptionRule.ts
+++ b/www/utils/generated/oas-output/schemas/AdminShippingOptionRule.ts
@@ -28,18 +28,8 @@
  *     description: The shipping option rule's operator.
  *     example: eq
  *   value:
- *     oneOf:
- *       - type: string
- *         title: value
- *         description: The rule's value.
- *         example: '"true"'
- *       - type: array
- *         description: The rule's values.
- *         items:
- *           type: string
- *           title: value
- *           description: A rule's value
- *           example: '"true"'
+ *     type: string
+ *     title: value
  *   shipping_option_id:
  *     type: string
  *     title: shipping_option_id


### PR DESCRIPTION
- Add to docs-generator tool inferring header parameter for publishable API key of store routes
- Re-generate OAS
- Show header parameters in API reference