### PR TITLE
docs: update and fix UI props docs

### DIFF
--- a/www/apps/book/next.config.mjs
+++ b/www/apps/book/next.config.mjs
@@ -167,12 +167,12 @@ const nextConfig = {
     }
   },
   redirects,
-  experimental: {
-    outputFileTracingExcludes: {
-      "*": ["node_modules/@medusajs/icons"],
-    },
+  outputFileTracingExcludes: {
+    "*": ["node_modules/@medusajs/icons"],
   },
-  optimizePackageImports: ["@medusajs/icons", "@medusajs/ui"],
+  experimental: {
+    optimizePackageImports: ["@medusajs/icons", "@medusajs/ui"],
+  },
 }
 
 export default withMDX(nextConfig)

--- a/www/apps/ui/src/components/component-reference.tsx
+++ b/www/apps/ui/src/components/component-reference.tsx
@@ -66,7 +66,10 @@ const ComponentReference = ({
                         <PropTable props={componentSpec.props!} />
                       </Suspense>
                     </Container>
-                    <Feedback title={`props of ${component}`} />
+                    <Feedback
+                      title={`props of ${component}`}
+                      question="Was this helpful?"
+                    />
                   </>
                 )}
               </>

--- a/www/apps/ui/src/components/props-table.tsx
+++ b/www/apps/ui/src/components/props-table.tsx
@@ -45,7 +45,10 @@ const Row = ({
   propData: { tsType: tsType, defaultValue, description },
 }: RowProps) => {
   const normalizeRaw = (str: string): string => {
-    return str.replace("\\|", "|")
+    return str
+      .replace("\\|", "|")
+      .replaceAll("&#60;", "<")
+      .replaceAll("&#62;", ">")
   }
   const getTypeRaw = useCallback((type: PropSpecType): string => {
     let raw = "raw" in type ? type.raw || type.name : type.name
@@ -74,9 +77,11 @@ const Row = ({
   }, [])
   const getTypeTooltipContent = useCallback(
     (type: PropSpecType): string | undefined => {
-      if (type?.name === "signature" && "type" in type) {
-        return getTypeRaw(type)
-      } else if (type?.name === "Array" && type.raw) {
+      if (
+        (type?.name === "signature" && "type" in type) ||
+        (type?.name === "Array" && type.raw) ||
+        ("raw" in type && type.raw)
+      ) {
         return getTypeRaw(type)
       }
 
@@ -106,6 +111,11 @@ const Row = ({
           typeNodes.push({
             text: element.value,
             canBeCopied: true,
+          })
+        } else if ("raw" in element) {
+          typeNodes.push({
+            text: getTypeText(element),
+            tooltipContent: getTypeTooltipContent(element),
           })
         } else {
           typeNodes.push({

--- a/www/apps/ui/src/config/site.ts
+++ b/www/apps/ui/src/config/site.ts
@@ -29,4 +29,8 @@ export const siteConfig: SiteConfig = {
     showCategories: true,
   },
   logo: `${process.env.NEXT_PUBLIC_BASE_PATH}/images/logo.png`,
+  version: {
+    ...globalConfig.version,
+    hide: true,
+  },
 }

--- a/www/apps/ui/src/content/docs/components/drawer.mdx
+++ b/www/apps/ui/src/content/docs/components/drawer.mdx
@@ -31,4 +31,12 @@ import { Drawer } from "@medusajs/ui"
 
 ---
 
-<ComponentReference mainComponent="Drawer" />
+<ComponentReference mainComponent="Drawer" componentsToShow={[
+  "Drawer",
+  "Drawer.Trigger",
+  "Drawer.Content",
+  "Drawer.Header",
+  "Drawer.Title",
+  "Drawer.Body",
+  "Drawer.Footer"
+]} />

--- a/www/apps/ui/src/content/docs/components/focus-modal.mdx
+++ b/www/apps/ui/src/content/docs/components/focus-modal.mdx
@@ -30,8 +30,11 @@ import { FocusModal } from "@medusajs/ui"
 
 <ComponentReference mainComponent="FocusModal" componentsToShow={[
   "FocusModal",
+  "FocusModal.Trigger",
+  "FocusModal.Content",
   "FocusModal.Header",
   "FocusModal.Body",
+  "FocusModal.Footer"
 ]} />
 
 ## Example: Control Open State

--- a/www/apps/ui/src/content/docs/components/select.mdx
+++ b/www/apps/ui/src/content/docs/components/select.mdx
@@ -39,7 +39,8 @@ import { Select } from "@medusajs/ui"
   "Select.Value",
   "Select.Group",
   "Select.Label",
-  "Select.Item"
+  "Select.Item",
+  "Select.Content"
 ]} />
 
 ## Examples
@@ -49,6 +50,10 @@ import { Select } from "@medusajs/ui"
 ### Small
 
 <ComponentExample name="select-small" />
+
+### Item-Aligned Position
+
+<ComponentExample name="select-item-aligned" />
 
 ### Disabled
 

--- a/www/apps/ui/src/examples/select-item-aligned.tsx
+++ b/www/apps/ui/src/examples/select-item-aligned.tsx
@@ -1,0 +1,35 @@
+import { Select } from "@medusajs/ui"
+
+export default function SelectItemAligned() {
+  return (
+    <div className="w-[256px]">
+      <Select>
+        <Select.Trigger>
+          <Select.Value placeholder="Select a currency" />
+        </Select.Trigger>
+        <Select.Content position="item-aligned">
+          {currencies.map((item) => (
+            <Select.Item key={item.value} value={item.value}>
+              {item.label}
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select>
+    </div>
+  )
+}
+
+const currencies = [
+  {
+    value: "eur",
+    label: "EUR",
+  },
+  {
+    value: "usd",
+    label: "USD",
+  },
+  {
+    value: "dkk",
+    label: "DKK",
+  },
+]

--- a/www/apps/ui/src/registries/example-registry.tsx
+++ b/www/apps/ui/src/registries/example-registry.tsx
@@ -545,6 +545,11 @@ export const ExampleRegistry: Record<string, ExampleType> = {
     component: React.lazy(async () => import("@/examples/button-loading")),
     file: "src/examples/button-loading.tsx",
   },
+  "select-item-aligned": {
+    name: "select-item-aligned",
+    component: React.lazy(async () => import("@/examples/select-item-aligned")),
+    file: "src/examples/select-item-aligned.tsx",
+  },
   "select-small": {
     name: "select-small",
     component: React.lazy(async () => import("@/examples/select-small")),

--- a/www/apps/ui/src/specs/Avatar/Avatar.json
+++ b/www/apps/ui/src/specs/Avatar/Avatar.json
@@ -23,6 +23,20 @@
         "computed": false
       },
       "description": "The style of the avatar.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"squared\" \\| \"rounded\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"squared\""
+          },
+          {
+            "name": "literal",
+            "value": "\"rounded\""
+          }
+        ]
+      },
       "required": false
     },
     "size": {
@@ -31,6 +45,36 @@
         "computed": false
       },
       "description": "The size of the avatar's border radius.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"2xsmall\" \\| \"xsmall\" \\| \"small\" \\| \"base\" \\| \"large\" \\| \"xlarge\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"2xsmall\""
+          },
+          {
+            "name": "literal",
+            "value": "\"xsmall\""
+          },
+          {
+            "name": "literal",
+            "value": "\"small\""
+          },
+          {
+            "name": "literal",
+            "value": "\"base\""
+          },
+          {
+            "name": "literal",
+            "value": "\"large\""
+          },
+          {
+            "name": "literal",
+            "value": "\"xlarge\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/Badge/Badge.json
+++ b/www/apps/ui/src/specs/Badge/Badge.json
@@ -20,6 +20,32 @@
         "computed": false
       },
       "description": "The badge's size.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"2xsmall\" \\| \"xsmall\" \\| \"small\" \\| \"base\" \\| \"large\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"2xsmall\""
+          },
+          {
+            "name": "literal",
+            "value": "\"xsmall\""
+          },
+          {
+            "name": "literal",
+            "value": "\"small\""
+          },
+          {
+            "name": "literal",
+            "value": "\"base\""
+          },
+          {
+            "name": "literal",
+            "value": "\"large\""
+          }
+        ]
+      },
       "required": false
     },
     "rounded": {
@@ -28,6 +54,20 @@
         "computed": false
       },
       "description": "The style of the badge's border radius.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"base\" \\| \"full\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"base\""
+          },
+          {
+            "name": "literal",
+            "value": "\"full\""
+          }
+        ]
+      },
       "required": false
     },
     "color": {
@@ -36,6 +76,36 @@
         "computed": false
       },
       "description": "The badge's color.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"green\" \\| \"red\" \\| \"blue\" \\| \"orange\" \\| \"grey\" \\| \"purple\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"green\""
+          },
+          {
+            "name": "literal",
+            "value": "\"red\""
+          },
+          {
+            "name": "literal",
+            "value": "\"blue\""
+          },
+          {
+            "name": "literal",
+            "value": "\"orange\""
+          },
+          {
+            "name": "literal",
+            "value": "\"grey\""
+          },
+          {
+            "name": "literal",
+            "value": "\"purple\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/Button/Button.json
+++ b/www/apps/ui/src/specs/Button/Button.json
@@ -31,6 +31,28 @@
         "computed": false
       },
       "description": "The button's style.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"primary\" \\| \"transparent\" \\| \"secondary\" \\| \"danger\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"primary\""
+          },
+          {
+            "name": "literal",
+            "value": "\"transparent\""
+          },
+          {
+            "name": "literal",
+            "value": "\"secondary\""
+          },
+          {
+            "name": "literal",
+            "value": "\"danger\""
+          }
+        ]
+      },
       "required": false
     },
     "size": {
@@ -39,6 +61,28 @@
         "computed": false
       },
       "description": "The button's size.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"small\" \\| \"base\" \\| \"large\" \\| \"xlarge\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"small\""
+          },
+          {
+            "name": "literal",
+            "value": "\"base\""
+          },
+          {
+            "name": "literal",
+            "value": "\"large\""
+          },
+          {
+            "name": "literal",
+            "value": "\"xlarge\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/Calendar/Calendar.json
+++ b/www/apps/ui/src/specs/Calendar/Calendar.json
@@ -1,106 +1,105 @@
 {
-  "description": "",
+  "description": "Calendar component used to select a date.\nIts props are based on [React Aria Calendar](https://react-spectrum.adobe.com/react-aria/Calendar.html#calendar-1).",
   "methods": [],
   "displayName": "Calendar",
   "props": {
-    "value": {
+    "autoFocus": {
+      "description": "Whether to automatically focus the calendar when it mounts.",
       "required": false,
       "tsType": {
-        "name": "union",
-        "raw": "Date | null",
-        "elements": [
-          {
-            "name": "Date"
-          },
-          {
-            "name": "null"
-          }
-        ]
-      },
-      "description": ""
+        "name": "boolean"
+      }
     },
-    "defaultValue": {
+    "defaultFocusedValue": {
+      "description": "The date that is focused when the calendar first mounts (uncountrolled).",
       "required": false,
       "tsType": {
-        "name": "union",
-        "raw": "Date | null",
-        "elements": [
-          {
-            "name": "Date"
-          },
-          {
-            "name": "null"
-          }
-        ]
-      },
-      "description": ""
+        "name": "DateValue",
+        "elements": [],
+        "raw": "DateValue"
+      }
     },
-    "onChange": {
+    "errorMessage": {
+      "description": "An error message to display when the selected value is invalid.",
+      "required": false,
+      "tsType": {
+        "name": "ReactNode",
+        "elements": [],
+        "raw": "ReactNode"
+      }
+    },
+    "focusedValue": {
+      "description": "Controls the currently focused date within the calendar.",
+      "required": false,
+      "tsType": {
+        "name": "DateValue",
+        "elements": [],
+        "raw": "DateValue"
+      }
+    },
+    "isDisabled": {
+      "description": "Whether the calendar is disabled.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "isInvalid": {
+      "description": "Whether the current selection is invalid according to application logic.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "isReadOnly": {
+      "description": "Whether the calendar value is immutable.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "onFocusChange": {
+      "description": "Handler that is called when the focused date changes.",
       "required": false,
       "tsType": {
         "name": "signature",
         "type": "function",
-        "raw": "(value: Date | null) => void",
+        "raw": "(date: CalendarDate) => void",
         "signature": {
           "arguments": [
             {
+              "name": "date",
               "type": {
-                "name": "union",
-                "raw": "Date | null",
-                "elements": [
-                  {
-                    "name": "Date"
-                  },
-                  {
-                    "name": "null"
-                  }
-                ]
+                "name": "CalendarDate",
+                "elements": [],
+                "raw": "CalendarDate"
               },
-              "name": "value"
+              "rest": false
             }
           ],
           "return": {
             "name": "void"
           }
         }
-      },
-      "description": ""
+      }
     },
-    "isDateUnavailable": {
+    "pageBehavior": {
+      "description": "Controls the behavior of paging. Pagination either works by advancing the visible page by visibleDuration (default) or one unit of visibleDuration.",
       "required": false,
       "tsType": {
-        "name": "signature",
-        "type": "function",
-        "raw": "(date: Date) => boolean",
-        "signature": {
-          "arguments": [
-            {
-              "type": {
-                "name": "Date"
-              },
-              "name": "date"
-            }
-          ],
-          "return": {
-            "name": "boolean"
-          }
-        }
-      },
-      "description": ""
+        "name": "PageBehavior",
+        "elements": [],
+        "raw": "PageBehavior"
+      }
     },
-    "minValue": {
+    "validationState": {
+      "description": "Whether the current selection is valid or invalid according to application logic.",
       "required": false,
       "tsType": {
-        "name": "Date"
-      },
-      "description": ""
-    },
-    "maxValue": {
-      "required": false,
-      "tsType": {
-        "name": "Date"
-      },
-      "description": ""
+        "name": "ValidationState",
+        "elements": [],
+        "raw": "ValidationState"
+      }
     }
   },
   "composes": [

--- a/www/apps/ui/src/specs/CurrencyInput/CurrencyInput.json
+++ b/www/apps/ui/src/specs/CurrencyInput/CurrencyInput.json
@@ -23,7 +23,238 @@
         "computed": false
       },
       "description": "The input's size.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"small\" \\| \"base\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"small\""
+          },
+          {
+            "name": "literal",
+            "value": "\"base\""
+          }
+        ]
+      },
       "required": false
+    },
+    "allowDecimals": {
+      "description": "Allow decimals\n\nDefault = true",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "allowNegativeValue": {
+      "description": "Allow user to enter negative value\n\nDefault = true",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "className": {
+      "description": "Class names",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "customInput": {
+      "description": "Custom component\n\nDefault = <input/>",
+      "required": false,
+      "tsType": {
+        "name": "ElementType",
+        "elements": [],
+        "raw": "ElementType"
+      }
+    },
+    "decimalScale": {
+      "description": "Specify decimal scale for padding/trimming\n\nExample:\n  1.5 -> 1.50\n  1.234 -> 1.23",
+      "required": false,
+      "tsType": {
+        "name": "number"
+      }
+    },
+    "decimalSeparator": {
+      "description": "Separator between integer part and fractional part of value.\n\nThis cannot be a number",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "decimalsLimit": {
+      "description": "Limit length of decimals allowed\n\nDefault = 2",
+      "required": false,
+      "tsType": {
+        "name": "number"
+      }
+    },
+    "defaultValue": {
+      "description": "Default value if not passing in value via props",
+      "required": false,
+      "tsType": {
+        "name": "union",
+        "raw": "string \\| number",
+        "elements": [
+          {
+            "name": "string"
+          },
+          {
+            "name": "number"
+          }
+        ]
+      }
+    },
+    "disableAbbreviations": {
+      "description": "Disable abbreviations (m, k, b)\n\nDefault = false",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "disabled": {
+      "description": "Disabled\n\nDefault = false",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "disableGroupSeparators": {
+      "description": "Disable auto adding separator between values eg. 1000 -> 1,000\n\nDefault = false",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "fixedDecimalLength": {
+      "description": "Value will always have the specified length of decimals\n\nExample:\n  123 -> 1.23\n\nNote: This formatting only happens onBlur",
+      "required": false,
+      "tsType": {
+        "name": "number"
+      }
+    },
+    "formatValueOnBlur": {
+      "description": "When set to false, the formatValueOnBlur flag disables the application of the __onValueChange__ function\nspecifically on blur events. If disabled or set to false, the onValueChange will not trigger on blur.\nDefault = true",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "groupSeparator": {
+      "description": "Separator between thousand, million and billion\n\nThis cannot be a number",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "id": {
+      "description": "Component id",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "intlConfig": {
+      "description": "International locale config, examples:\n  { locale: 'ja-JP', currency: 'JPY' }\n  { locale: 'en-IN', currency: 'INR' }\n\nAny prefix, groupSeparator or decimalSeparator options passed in\nwill override Intl Locale config",
+      "required": false,
+      "tsType": {
+        "name": "IntlConfig",
+        "elements": [],
+        "raw": "IntlConfig"
+      }
+    },
+    "maxLength": {
+      "description": "Maximum characters the user can enter",
+      "required": false,
+      "tsType": {
+        "name": "number"
+      }
+    },
+    "onValueChange": {
+      "description": "Handle change in value",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(value: undefined \\| string, name?: string, values?: CurrencyInputOnChangeValues) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "value",
+              "type": {
+                "name": "union",
+                "raw": "undefined \\| string",
+                "elements": [
+                  {
+                    "name": "undefined"
+                  },
+                  {
+                    "name": "string"
+                  }
+                ]
+              },
+              "rest": false
+            },
+            {
+              "name": "name",
+              "type": {
+                "name": "string"
+              },
+              "rest": false
+            },
+            {
+              "name": "values",
+              "type": {
+                "name": "CurrencyInputOnChangeValues",
+                "elements": [],
+                "raw": "CurrencyInputOnChangeValues"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "placeholder": {
+      "description": "Placeholder if there is no value",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "step": {
+      "description": "Incremental value change on arrow down and arrow up key press",
+      "required": false,
+      "tsType": {
+        "name": "number"
+      }
+    },
+    "transformRawValue": {
+      "description": "Transform the raw value form the input before parsing",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(rawValue: string) => string",
+        "signature": {
+          "arguments": [
+            {
+              "name": "rawValue",
+              "type": {
+                "name": "string"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "string"
+          }
+        }
+      }
     }
   },
   "composes": [

--- a/www/apps/ui/src/specs/DatePicker/DatePicker.json
+++ b/www/apps/ui/src/specs/DatePicker/DatePicker.json
@@ -3,29 +3,420 @@
   "methods": [],
   "displayName": "DatePicker",
   "props": {
-    "size": {
-      "defaultValue": {
-        "value": "\"base\"",
-        "computed": false
-      },
-      "description": "",
-      "required": false
+    "aria-describedby": {
+      "description": "Identifies the element (or elements) that describes the object.",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
     },
-    "shouldCloseOnSelect": {
-      "defaultValue": {
-        "value": "true",
-        "computed": false
-      },
-      "description": "",
-      "required": false
+    "aria-details": {
+      "description": "Identifies the element (or elements) that provide a detailed, extended description for the object.",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
     },
-    "modal": {
-      "defaultValue": {
-        "value": "false",
-        "computed": false
-      },
-      "description": "",
-      "required": false
+    "aria-label": {
+      "description": "Defines a string value that labels the current element.",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "aria-labelledby": {
+      "description": "Identifies the element (or elements) that labels the current element.",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "autoFocus": {
+      "description": "Whether the element should receive focus on render.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "defaultOpen": {
+      "description": "Whether the overlay is open by default (uncontrolled).",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "description": {
+      "description": "A description for the field. Provides a hint such as specific requirements for what to choose.",
+      "required": false,
+      "tsType": {
+        "name": "ReactNode",
+        "elements": [],
+        "raw": "ReactNode"
+      }
+    },
+    "errorMessage": {
+      "description": "An error message for the field.",
+      "required": false,
+      "tsType": {
+        "name": "union",
+        "raw": "ReactNode \\| (v: ValidationResult) => ReactNode",
+        "elements": [
+          {
+            "name": "ReactNode",
+            "elements": [],
+            "raw": "ReactNode"
+          },
+          {
+            "name": "signature",
+            "type": "function",
+            "raw": "(v: ValidationResult) => ReactNode",
+            "signature": {
+              "arguments": [
+                {
+                  "name": "v",
+                  "type": {
+                    "name": "ValidationResult"
+                  },
+                  "rest": false
+                }
+              ],
+              "return": {
+                "name": "ReactNode"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hideTimeZone": {
+      "description": "Whether to hide the time zone abbreviation.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "hourCycle": {
+      "description": "Whether to display the time in 12 or 24 hour format. By default, this is determined by the user's locale.",
+      "required": false,
+      "tsType": {
+        "name": "union",
+        "raw": "12 \\| 24",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "12"
+          },
+          {
+            "name": "literal",
+            "value": "24"
+          }
+        ]
+      }
+    },
+    "id": {
+      "description": "The element's unique identifier. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id).",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "isDisabled": {
+      "description": "Whether the input is disabled.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "isInvalid": {
+      "description": "Whether the input value is invalid.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "isOpen": {
+      "description": "Whether the overlay is open by default (controlled).",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "isReadOnly": {
+      "description": "Whether the input can be selected but not changed by the user.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "isRequired": {
+      "description": "Whether user input is required on the input before form submission.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "label": {
+      "description": "The content to display as the label.",
+      "required": false,
+      "tsType": {
+        "name": "ReactNode",
+        "elements": [],
+        "raw": "ReactNode"
+      }
+    },
+    "name": {
+      "description": "The name of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "onBlur": {
+      "description": "Handler that is called when the element loses focus.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(e: FocusEvent&#60;Element, Element&#62;) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "e",
+              "type": {
+                "name": "FocusEvent",
+                "elements": [],
+                "raw": "FocusEvent&#60;Element, Element&#62;"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "onFocus": {
+      "description": "Handler that is called when the element receives focus.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(e: FocusEvent&#60;Element, Element&#62;) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "e",
+              "type": {
+                "name": "FocusEvent",
+                "elements": [],
+                "raw": "FocusEvent&#60;Element, Element&#62;"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "onFocusChange": {
+      "description": "Handler that is called when the element's focus status changes.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(isFocused: boolean) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "isFocused",
+              "type": {
+                "name": "boolean"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "onKeyDown": {
+      "description": "Handler that is called when a key is pressed.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(e: KeyboardEvent) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "e",
+              "type": {
+                "name": "KeyboardEvent",
+                "elements": [],
+                "raw": "KeyboardEvent"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "onKeyUp": {
+      "description": "Handler that is called when a key is released.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(e: KeyboardEvent) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "e",
+              "type": {
+                "name": "KeyboardEvent",
+                "elements": [],
+                "raw": "KeyboardEvent"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "onOpenChange": {
+      "description": "Handler that is called when the overlay's open state changes.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(isOpen: boolean) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "isOpen",
+              "type": {
+                "name": "boolean"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "pageBehavior": {
+      "description": "Controls the behavior of paging. Pagination either works by advancing the visible page by visibleDuration (default) or one unit of visibleDuration.",
+      "required": false,
+      "tsType": {
+        "name": "PageBehavior",
+        "elements": [],
+        "raw": "PageBehavior"
+      }
+    },
+    "placeholderValue": {
+      "description": "A placeholder date that influences the format of the placeholder shown when no value is selected. Defaults to today's date at midnight.",
+      "required": false,
+      "tsType": {
+        "name": "union",
+        "raw": "CalendarDate \\| CalendarDateTime",
+        "elements": [
+          {
+            "name": "CalendarDate",
+            "elements": [],
+            "raw": "CalendarDate"
+          },
+          {
+            "name": "CalendarDateTime",
+            "elements": [],
+            "raw": "CalendarDateTime"
+          }
+        ]
+      }
+    },
+    "shouldForceLeadingZeros": {
+      "description": "Whether to always show leading zeros in the month, day, and hour fields.\nBy default, this is determined by the user's locale.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "validate": {
+      "description": "A function that returns an error message if a given value is invalid.\nValidation errors are displayed to the user when the form is submitted\nif `validationBehavior=\"native\"`. For realtime validation, use the `isInvalid`\nprop instead.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(value: CalendarDate \\| CalendarDateTime) => undefined \\| null \\| true \\| ValidationError",
+        "signature": {
+          "arguments": [
+            {
+              "name": "value",
+              "type": {
+                "name": "union",
+                "raw": "CalendarDate \\| CalendarDateTime",
+                "elements": [
+                  {
+                    "name": "CalendarDate"
+                  },
+                  {
+                    "name": "CalendarDateTime"
+                  }
+                ]
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "union",
+            "raw": "undefined \\| null \\| true \\| ValidationError",
+            "elements": [
+              {
+                "name": "undefined"
+              },
+              {
+                "name": "null"
+              },
+              {
+                "name": "true"
+              },
+              {
+                "name": "ValidationError"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "validationBehavior": {
+      "description": "Whether to use native HTML form validation to prevent form submission\nwhen the value is missing or invalid, or mark the field as required\nor invalid via ARIA.",
+      "required": false,
+      "tsType": {
+        "name": "union",
+        "raw": "\"aria\" \\| \"native\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"aria\""
+          },
+          {
+            "name": "literal",
+            "value": "\"native\""
+          }
+        ]
+      }
     }
   }
 }

--- a/www/apps/ui/src/specs/Drawer/Drawer.Body.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Body.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component is used to wrap the body content of the drawer.\nThis component is based on the `div` element and supports all of its props",
   "methods": [],
   "displayName": "Drawer.Body",
   "props": {}

--- a/www/apps/ui/src/specs/Drawer/Drawer.Close.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Close.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component is used to create the close button for the drawer.\nIt accepts props from the [Radix UI Dialog Close](https://www.radix-ui.com/primitives/docs/components/dialog#close) component.",
   "methods": [],
   "displayName": "Drawer.Close",
   "props": {}

--- a/www/apps/ui/src/specs/Drawer/Drawer.Content.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Content.json
@@ -1,6 +1,33 @@
 {
-  "description": "",
+  "description": "This component wraps the content of the drawer.\nIt accepts props from the [Radix UI Dialog Content](https://www.radix-ui.com/primitives/docs/components/dialog#content) component.",
   "methods": [],
   "displayName": "Drawer.Content",
-  "props": {}
+  "props": {
+    "overlayProps": {
+      "required": false,
+      "tsType": {
+        "name": "ReactComponentPropsWithoutRef",
+        "raw": "React.ComponentPropsWithoutRef<typeof DrawerOverlay>",
+        "elements": [
+          {
+            "name": "DrawerOverlay"
+          }
+        ]
+      },
+      "description": "Props for the overlay component.\nIt accepts props from the [Radix UI Dialog Overlay](https://www.radix-ui.com/primitives/docs/components/dialog#overlay) component."
+    },
+    "portalProps": {
+      "required": false,
+      "tsType": {
+        "name": "ReactComponentPropsWithoutRef",
+        "raw": "React.ComponentPropsWithoutRef<typeof DrawerPortal>",
+        "elements": [
+          {
+            "name": "DrawerPortal"
+          }
+        ]
+      },
+      "description": "Props for the portal component that wraps the drawer content.\nIt accepts props from the [Radix UI Dialog Portal](https://www.radix-ui.com/primitives/docs/components/dialog#portal) component."
+    }
+  }
 }

--- a/www/apps/ui/src/specs/Drawer/Drawer.Description.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Description.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component adds accessible description to the drawer.\nIt accepts props from the [Radix UI Dialog Description](https://www.radix-ui.com/primitives/docs/components/dialog#description) component.",
   "methods": [],
   "displayName": "Drawer.Description",
   "props": {}

--- a/www/apps/ui/src/specs/Drawer/Drawer.Footer.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Footer.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component is used to wrap the footer content of the drawer.\nThis component is based on the `div` element and supports all of its props.",
   "methods": [],
   "displayName": "Drawer.Footer",
   "props": {}

--- a/www/apps/ui/src/specs/Drawer/Drawer.Header.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Header.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component is used to wrap the header content of the drawer.\nThis component is based on the `div` element and supports all of its props.",
   "methods": [],
   "displayName": "Drawer.Header",
   "props": {}

--- a/www/apps/ui/src/specs/Drawer/Drawer.Overlay.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Overlay.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component is used to create the overlay for the drawer.\nIt accepts props from the [Radix UI Dialog Overlay](https://www.radix-ui.com/primitives/docs/components/dialog#overlay) component.",
   "methods": [],
   "displayName": "Drawer.Overlay",
   "props": {}

--- a/www/apps/ui/src/specs/Drawer/Drawer.Portal.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Portal.json
@@ -1,5 +1,6 @@
 {
-  "description": "",
+  "description": "The `Drawer.Content` component uses this component to wrap the drawer content.\nIt accepts props from the [Radix UI Dialog Portal](https://www.radix-ui.com/primitives/docs/components/dialog#portal) component.",
   "methods": [],
-  "displayName": "Drawer.Portal"
+  "displayName": "Drawer.Portal",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/Drawer/Drawer.Title.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Title.json
@@ -1,0 +1,6 @@
+{
+  "description": "This component adds an accessible title to the drawer.\nIt accepts props from the [Radix UI Dialog Title](https://www.radix-ui.com/primitives/docs/components/dialog#title) component.",
+  "methods": [],
+  "displayName": "Drawer.Title",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/Drawer/Drawer.Trigger.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.Trigger.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component is used to create the trigger button that opens the drawer.\nIt accepts props from the [Radix UI Dialog Trigger](https://www.radix-ui.com/primitives/docs/components/dialog#trigger) component.",
   "methods": [],
   "displayName": "Drawer.Trigger",
   "props": {}

--- a/www/apps/ui/src/specs/Drawer/Drawer.json
+++ b/www/apps/ui/src/specs/Drawer/Drawer.json
@@ -1,5 +1,6 @@
 {
   "description": "This component is based on the [Radix UI Dialog](https://www.radix-ui.com/primitives/docs/components/dialog) primitives.",
   "methods": [],
-  "displayName": "Drawer"
+  "displayName": "Drawer",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.Group.json
+++ b/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.Group.json
@@ -1,0 +1,6 @@
+{
+  "description": "This component is based on the [Radix UI Dropdown Menu Group](https://www.radix-ui.com/primitives/docs/components/dropdown-menu#group) primitive.",
+  "methods": [],
+  "displayName": "DropdownMenu.Group",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.RadioGroup.json
+++ b/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.RadioGroup.json
@@ -1,0 +1,6 @@
+{
+  "description": "This component is based on the [Radix UI Dropdown Menu RadioGroup](https://www.radix-ui.com/primitives/docs/components/dropdown-menu#radiogroup) primitive.",
+  "methods": [],
+  "displayName": "DropdownMenu.RadioGroup",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.SubMenu.json
+++ b/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.SubMenu.json
@@ -1,0 +1,6 @@
+{
+  "description": "This component is based on the [Radix UI Dropdown Menu Sub](https://www.radix-ui.com/primitives/docs/components/dropdown-menu#sub) primitive.",
+  "methods": [],
+  "displayName": "DropdownMenu.SubMenu",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.Trigger.json
+++ b/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.Trigger.json
@@ -1,0 +1,6 @@
+{
+  "description": "This component is based on the [Radix UI Dropdown Menu Trigger](https://www.radix-ui.com/primitives/docs/components/dropdown-menu#trigger) primitive.",
+  "methods": [],
+  "displayName": "DropdownMenu.Trigger",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.json
+++ b/www/apps/ui/src/specs/DropdownMenu/DropdownMenu.json
@@ -1,0 +1,6 @@
+{
+  "description": "This component is based on the [Radix UI Dropdown Menu](https://www.radix-ui.com/primitives/docs/components/dropdown-menu) primitive.",
+  "methods": [],
+  "displayName": "DropdownMenu",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Body.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Body.json
@@ -1,5 +1,5 @@
 {
-  "description": "This component is based on the `div` element and supports all of its props",
+  "description": "This component is used to wrap the body content of the modal.\nThis component is based on the `div` element and supports all of its props",
   "methods": [],
   "displayName": "FocusModal.Body",
   "props": {}

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Close.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Close.json
@@ -1,0 +1,6 @@
+{
+  "description": "This component is used to create the close button for the modal.\nIt accepts props from the [Radix UI Dialog Close](https://www.radix-ui.com/primitives/docs/components/dialog#close) component.",
+  "methods": [],
+  "displayName": "FocusModal.Close",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Content.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Content.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component wraps the content of the modal.\nIt accepts props from the [Radix UI Dialog Content](https://www.radix-ui.com/primitives/docs/components/dialog#content) component.",
   "methods": [],
   "displayName": "FocusModal.Content",
   "props": {}

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Description.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Description.json
@@ -1,0 +1,6 @@
+{
+  "description": "This component adds accessible description to the modal.\nIt accepts props from the [Radix UI Dialog Description](https://www.radix-ui.com/primitives/docs/components/dialog#description) component.",
+  "methods": [],
+  "displayName": "FocusModal.Description",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Footer.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Footer.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component is used to wrap the footer content of the modal.\nThis component is based on the `div` element and supports all of its props",
   "methods": [],
   "displayName": "FocusModal.Footer",
   "props": {}

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Header.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Header.json
@@ -1,5 +1,5 @@
 {
-  "description": "This component is based on the `div` element and supports all of its props",
+  "description": "This component is used to wrap the header content of the modal.\nThis component is based on the `div` element and supports all of its props",
   "methods": [],
   "displayName": "FocusModal.Header",
   "props": {}

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Overlay.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Overlay.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component is used to create the overlay for the modal.\nIt accepts props from the [Radix UI Dialog Overlay](https://www.radix-ui.com/primitives/docs/components/dialog#overlay) component.",
   "methods": [],
   "displayName": "FocusModal.Overlay",
   "props": {}

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Portal.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Portal.json
@@ -1,5 +1,6 @@
 {
-  "description": "",
+  "description": "The `FocusModal.Content` component uses this component to wrap the modal content.\nIt accepts props from the [Radix UI Dialog Portal](https://www.radix-ui.com/primitives/docs/components/dialog#portal) component.",
   "methods": [],
-  "displayName": "FocusModal.Portal"
+  "displayName": "FocusModal.Portal",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Title.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Title.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "This component adds an accessible title to the modal.\nIt accepts props from the [Radix UI Dialog Title](https://www.radix-ui.com/primitives/docs/components/dialog#title) component.",
   "methods": [],
   "displayName": "FocusModal.Title",
   "props": {}

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.Trigger.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.Trigger.json
@@ -1,5 +1,6 @@
 {
-  "description": "",
+  "description": "This component is used to create the trigger button that opens the modal.\nIt accepts props from the [Radix UI Dialog Trigger](https://www.radix-ui.com/primitives/docs/components/dialog#trigger) component.",
   "methods": [],
-  "displayName": "FocusModal.Trigger"
+  "displayName": "FocusModal.Trigger",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/FocusModal/FocusModal.json
+++ b/www/apps/ui/src/specs/FocusModal/FocusModal.json
@@ -1,5 +1,44 @@
 {
   "description": "This component is based on the [Radix UI Dialog](https://www.radix-ui.com/primitives/docs/components/dialog) primitives.",
   "methods": [],
-  "displayName": "FocusModal"
+  "displayName": "FocusModal",
+  "props": {
+    "defaultOpen": {
+      "description": "Whether the modal is opened by default.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "open": {
+      "description": "Whether the modal is opened.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
+    },
+    "onOpenChange": {
+      "description": "A function to handle when the modal is opened or closed.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(open: boolean) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "open",
+              "type": {
+                "name": "boolean"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    }
+  }
 }

--- a/www/apps/ui/src/specs/Heading/Heading.json
+++ b/www/apps/ui/src/specs/Heading/Heading.json
@@ -9,6 +9,24 @@
         "computed": false
       },
       "description": "The heading level which specifies which heading element is used.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"h1\" \\| \"h2\" \\| \"h3\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"h1\""
+          },
+          {
+            "name": "literal",
+            "value": "\"h2\""
+          },
+          {
+            "name": "literal",
+            "value": "\"h3\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/Hint/Hint.json
+++ b/www/apps/ui/src/specs/Hint/Hint.json
@@ -9,6 +9,20 @@
         "computed": false
       },
       "description": "The hint's style.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"error\" \\| \"info\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"error\""
+          },
+          {
+            "name": "literal",
+            "value": "\"info\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/I18nProvider/I18nProvider.json
+++ b/www/apps/ui/src/specs/I18nProvider/I18nProvider.json
@@ -4,5 +4,23 @@
   "displayName": "I18nProvider",
   "composes": [
     "Props"
-  ]
+  ],
+  "props": {
+    "children": {
+      "description": "Contents that should have the locale applied.",
+      "required": true,
+      "tsType": {
+        "name": "ReactNode",
+        "elements": [],
+        "raw": "ReactNode"
+      }
+    },
+    "locale": {
+      "description": "The locale to apply to the children.",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    }
+  }
 }

--- a/www/apps/ui/src/specs/IconBadge/IconBadge.json
+++ b/www/apps/ui/src/specs/IconBadge/IconBadge.json
@@ -20,6 +20,36 @@
         "computed": false
       },
       "description": "The badge's color.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"green\" \\| \"red\" \\| \"blue\" \\| \"orange\" \\| \"grey\" \\| \"purple\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"green\""
+          },
+          {
+            "name": "literal",
+            "value": "\"red\""
+          },
+          {
+            "name": "literal",
+            "value": "\"blue\""
+          },
+          {
+            "name": "literal",
+            "value": "\"orange\""
+          },
+          {
+            "name": "literal",
+            "value": "\"grey\""
+          },
+          {
+            "name": "literal",
+            "value": "\"purple\""
+          }
+        ]
+      },
       "required": false
     },
     "size": {
@@ -28,6 +58,20 @@
         "computed": false
       },
       "description": "The badge's size.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"base\" \\| \"large\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"base\""
+          },
+          {
+            "name": "literal",
+            "value": "\"large\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/IconButton/IconButton.json
+++ b/www/apps/ui/src/specs/IconButton/IconButton.json
@@ -31,6 +31,20 @@
         "computed": false
       },
       "description": "The button's style.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"primary\" \\| \"transparent\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"primary\""
+          },
+          {
+            "name": "literal",
+            "value": "\"transparent\""
+          }
+        ]
+      },
       "required": false
     },
     "size": {
@@ -39,6 +53,36 @@
         "computed": false
       },
       "description": "The button's size.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"2xsmall\" \\| \"xsmall\" \\| \"small\" \\| \"base\" \\| \"large\" \\| \"xlarge\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"2xsmall\""
+          },
+          {
+            "name": "literal",
+            "value": "\"xsmall\""
+          },
+          {
+            "name": "literal",
+            "value": "\"small\""
+          },
+          {
+            "name": "literal",
+            "value": "\"base\""
+          },
+          {
+            "name": "literal",
+            "value": "\"large\""
+          },
+          {
+            "name": "literal",
+            "value": "\"xlarge\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/Input/Input.json
+++ b/www/apps/ui/src/specs/Input/Input.json
@@ -9,6 +9,20 @@
         "computed": false
       },
       "description": "The input's size.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"small\" \\| \"base\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"small\""
+          },
+          {
+            "name": "literal",
+            "value": "\"base\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/InternalCalendar/InternalCalendar.json
+++ b/www/apps/ui/src/specs/InternalCalendar/InternalCalendar.json
@@ -1,5 +1,6 @@
 {
   "description": "InternalCalendar is the internal implementation of the Calendar component.\nIt's not for public use, but only used for other components like DatePicker.",
   "methods": [],
-  "displayName": "InternalCalendar"
+  "displayName": "InternalCalendar",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/Label/Label.json
+++ b/www/apps/ui/src/specs/Label/Label.json
@@ -9,6 +9,28 @@
         "computed": false
       },
       "description": "The label's size.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"xsmall\" \\| \"small\" \\| \"base\" \\| \"large\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"xsmall\""
+          },
+          {
+            "name": "literal",
+            "value": "\"small\""
+          },
+          {
+            "name": "literal",
+            "value": "\"base\""
+          },
+          {
+            "name": "literal",
+            "value": "\"large\""
+          }
+        ]
+      },
       "required": false
     },
     "weight": {
@@ -17,6 +39,20 @@
         "computed": false
       },
       "description": "The label's font weight.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"regular\" \\| \"plus\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"regular\""
+          },
+          {
+            "name": "literal",
+            "value": "\"plus\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/Popover/Popover.Anchor.json
+++ b/www/apps/ui/src/specs/Popover/Popover.Anchor.json
@@ -1,5 +1,6 @@
 {
   "description": "",
   "methods": [],
-  "displayName": "Popover.Anchor"
+  "displayName": "Popover.Anchor",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/Popover/Popover.Content.json
+++ b/www/apps/ui/src/specs/Popover/Popover.Content.json
@@ -9,6 +9,9 @@
         "computed": false
       },
       "description": "The distance in pixels from the anchor.",
+      "tsType": {
+        "name": "number"
+      },
       "required": false
     },
     "side": {
@@ -17,6 +20,28 @@
         "computed": false
       },
       "description": "The preferred side of the anchor to render against when open.\nWill be reversed when collisions occur and `avoidCollisions` is enabled.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"top\" \\| \"right\" \\| \"bottom\" \\| \"left\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"top\""
+          },
+          {
+            "name": "literal",
+            "value": "\"right\""
+          },
+          {
+            "name": "literal",
+            "value": "\"bottom\""
+          },
+          {
+            "name": "literal",
+            "value": "\"left\""
+          }
+        ]
+      },
       "required": false
     },
     "align": {
@@ -25,6 +50,24 @@
         "computed": false
       },
       "description": "The preferred alignment against the anchor. May change when collisions occur.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"center\" \\| \"end\" \\| \"start\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"center\""
+          },
+          {
+            "name": "literal",
+            "value": "\"end\""
+          },
+          {
+            "name": "literal",
+            "value": "\"start\""
+          }
+        ]
+      },
       "required": false
     }
   }

--- a/www/apps/ui/src/specs/Popover/Popover.Trigger.json
+++ b/www/apps/ui/src/specs/Popover/Popover.Trigger.json
@@ -1,5 +1,6 @@
 {
   "description": "",
   "methods": [],
-  "displayName": "Popover.Trigger"
+  "displayName": "Popover.Trigger",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/Popover/Popover.json
+++ b/www/apps/ui/src/specs/Popover/Popover.json
@@ -1,5 +1,6 @@
 {
   "description": "This component is based on the [Radix UI Popover](https://www.radix-ui.com/primitives/docs/components/popover) primitves.",
   "methods": [],
-  "displayName": "Popover"
+  "displayName": "Popover",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/ProgressAccordion/ProgressAccordion.Header.json
+++ b/www/apps/ui/src/specs/ProgressAccordion/ProgressAccordion.Header.json
@@ -6,7 +6,22 @@
     "status": {
       "required": false,
       "tsType": {
-        "name": "ProgressStatus"
+        "name": "union",
+        "raw": "\"not-started\" \\| \"in-progress\" \\| \"completed\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"not-started\""
+          },
+          {
+            "name": "literal",
+            "value": "\"in-progress\""
+          },
+          {
+            "name": "literal",
+            "value": "\"completed\""
+          }
+        ]
       },
       "description": "The current status.",
       "defaultValue": {

--- a/www/apps/ui/src/specs/ProgressAccordion/ProgressAccordion.ProgressIndicator.json
+++ b/www/apps/ui/src/specs/ProgressAccordion/ProgressAccordion.ProgressIndicator.json
@@ -6,7 +6,22 @@
     "status": {
       "required": true,
       "tsType": {
-        "name": "ProgressStatus"
+        "name": "union",
+        "raw": "\"not-started\" \\| \"in-progress\" \\| \"completed\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"not-started\""
+          },
+          {
+            "name": "literal",
+            "value": "\"in-progress\""
+          },
+          {
+            "name": "literal",
+            "value": "\"completed\""
+          }
+        ]
       },
       "description": "The current status."
     }

--- a/www/apps/ui/src/specs/ProgressAccordion/ProgressAccordion.json
+++ b/www/apps/ui/src/specs/ProgressAccordion/ProgressAccordion.json
@@ -1,5 +1,6 @@
 {
   "description": "This component is based on the [Radix UI Accordion](https://radix-ui.com/primitives/docs/components/accordion) primitves.",
   "methods": [],
-  "displayName": "ProgressAccordion"
+  "displayName": "ProgressAccordion",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/ProgressTabs/ProgressTabs.ProgressIndicator.json
+++ b/www/apps/ui/src/specs/ProgressTabs/ProgressTabs.ProgressIndicator.json
@@ -6,7 +6,22 @@
     "status": {
       "required": false,
       "tsType": {
-        "name": "ProgressStatus"
+        "name": "union",
+        "raw": "\"not-started\" \\| \"in-progress\" \\| \"completed\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"not-started\""
+          },
+          {
+            "name": "literal",
+            "value": "\"in-progress\""
+          },
+          {
+            "name": "literal",
+            "value": "\"completed\""
+          }
+        ]
       },
       "description": "The current status."
     }

--- a/www/apps/ui/src/specs/ProgressTabs/ProgressTabs.Trigger.json
+++ b/www/apps/ui/src/specs/ProgressTabs/ProgressTabs.Trigger.json
@@ -6,7 +6,22 @@
     "status": {
       "required": false,
       "tsType": {
-        "name": "ProgressStatus"
+        "name": "union",
+        "raw": "\"not-started\" \\| \"in-progress\" \\| \"completed\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"not-started\""
+          },
+          {
+            "name": "literal",
+            "value": "\"in-progress\""
+          },
+          {
+            "name": "literal",
+            "value": "\"completed\""
+          }
+        ]
       },
       "description": "",
       "defaultValue": {

--- a/www/apps/ui/src/specs/ProgressTabs/ProgressTabs.json
+++ b/www/apps/ui/src/specs/ProgressTabs/ProgressTabs.json
@@ -1,5 +1,89 @@
 {
   "description": "This component is based on the [Radix UI Tabs](https://radix-ui.com/primitives/docs/components/tabs) primitves.",
   "methods": [],
-  "displayName": "ProgressTabs"
+  "displayName": "ProgressTabs",
+  "props": {
+    "activationMode": {
+      "description": "Whether a tab is activated automatically or manually.",
+      "required": false,
+      "tsType": {
+        "name": "union",
+        "raw": "\"manual\" \\| \"automatic\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"manual\""
+          },
+          {
+            "name": "literal",
+            "value": "\"automatic\""
+          }
+        ]
+      }
+    },
+    "defaultValue": {
+      "description": "The value of the tab to select by default, if uncontrolled",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "dir": {
+      "description": "The direction of navigation between toolbar items.",
+      "required": false,
+      "tsType": {
+        "name": "Direction",
+        "elements": [],
+        "raw": "Direction"
+      }
+    },
+    "onValueChange": {
+      "description": "A function called when a new tab is selected",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(value: string) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "value",
+              "type": {
+                "name": "string"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "orientation": {
+      "description": "The orientation the tabs are layed out.\nMainly so arrow navigation is done accordingly (left & right vs. up & down)",
+      "required": false,
+      "tsType": {
+        "name": "union",
+        "raw": "\"horizontal\" \\| \"vertical\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"horizontal\""
+          },
+          {
+            "name": "literal",
+            "value": "\"vertical\""
+          }
+        ]
+      }
+    },
+    "value": {
+      "description": "The value for the selected tab, if controlled",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    }
+  }
 }

--- a/www/apps/ui/src/specs/Prompt/Prompt.Portal.json
+++ b/www/apps/ui/src/specs/Prompt/Prompt.Portal.json
@@ -1,5 +1,6 @@
 {
   "description": "",
   "methods": [],
-  "displayName": "Prompt.Portal"
+  "displayName": "Prompt.Portal",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/Prompt/Prompt.Trigger.json
+++ b/www/apps/ui/src/specs/Prompt/Prompt.Trigger.json
@@ -1,6 +1,6 @@
 {
   "description": "",
   "methods": [],
-  "displayName": "Popover.Close",
+  "displayName": "Prompt.Trigger",
   "props": {}
 }

--- a/www/apps/ui/src/specs/Select/Select.Content.json
+++ b/www/apps/ui/src/specs/Select/Select.Content.json
@@ -1,5 +1,5 @@
 {
-  "description": "",
+  "description": "The content that appears when the select is open.\nIt's based on [Radix UI Select Content](https://www.radix-ui.com/primitives/docs/components/select#content).",
   "methods": [],
   "displayName": "Select.Content",
   "props": {
@@ -8,7 +8,21 @@
         "value": "\"popper\"",
         "computed": false
       },
-      "description": "",
+      "description": "Whether to show the select items below (`popper`) or over (`item-aligned`) the select input.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"item-aligned\" \\| \"popper\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"item-aligned\""
+          },
+          {
+            "name": "literal",
+            "value": "\"popper\""
+          }
+        ]
+      },
       "required": false
     },
     "sideOffset": {
@@ -16,7 +30,10 @@
         "value": "8",
         "computed": false
       },
-      "description": "",
+      "description": "The distance of the content pop-up in pixels from the select input. Only available when position is set to popper.",
+      "tsType": {
+        "name": "number"
+      },
       "required": false
     },
     "collisionPadding": {
@@ -24,7 +41,21 @@
         "value": "24",
         "computed": false
       },
-      "description": "",
+      "description": "The distance in pixels from the boundary edges where collision detection should occur. Only available when position is set to popper.",
+      "tsType": {
+        "name": "union",
+        "raw": "number \\| Partial&#60;Record&#60;\"top\" \\| \"right\" \\| \"bottom\" \\| \"left\", number&#62;&#62;",
+        "elements": [
+          {
+            "name": "number"
+          },
+          {
+            "name": "Partial",
+            "elements": [],
+            "raw": "Partial&#60;Record&#60;\"top\" \\| \"right\" \\| \"bottom\" \\| \"left\", number&#62;&#62;"
+          }
+        ]
+      },
       "required": false
     }
   }

--- a/www/apps/ui/src/specs/Select/Select.Group.json
+++ b/www/apps/ui/src/specs/Select/Select.Group.json
@@ -1,0 +1,6 @@
+{
+  "description": "Groups multiple items together.",
+  "methods": [],
+  "displayName": "Select.Group",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/Select/Select.Label.json
+++ b/www/apps/ui/src/specs/Select/Select.Label.json
@@ -1,5 +1,5 @@
 {
-  "description": "Used to label a group of items.",
+  "description": "Used to label a group of items.\nIt's based on [Radix UI Select Label](https://www.radix-ui.com/primitives/docs/components/select#label).",
   "methods": [],
   "displayName": "Select.Label",
   "props": {}

--- a/www/apps/ui/src/specs/Select/Select.Trigger.json
+++ b/www/apps/ui/src/specs/Select/Select.Trigger.json
@@ -1,5 +1,5 @@
 {
-  "description": "The trigger that toggles the select.",
+  "description": "The trigger that toggles the select.\nIt's based on [Radix UI Select Trigger](https://www.radix-ui.com/primitives/docs/components/select#trigger).",
   "methods": [],
   "displayName": "Select.Trigger",
   "props": {}

--- a/www/apps/ui/src/specs/Select/Select.Value.json
+++ b/www/apps/ui/src/specs/Select/Select.Value.json
@@ -1,0 +1,6 @@
+{
+  "description": "Displays the selected value, or a placeholder if no value is selected.\nIt's based on [Radix UI Select Value](https://www.radix-ui.com/primitives/docs/components/select#value).",
+  "methods": [],
+  "displayName": "Select.Value",
+  "props": {}
+}

--- a/www/apps/ui/src/specs/StatusBadge/StatusBadge.json
+++ b/www/apps/ui/src/specs/StatusBadge/StatusBadge.json
@@ -9,6 +9,36 @@
         "computed": false
       },
       "description": "The status's color.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"green\" \\| \"red\" \\| \"blue\" \\| \"orange\" \\| \"grey\" \\| \"purple\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"green\""
+          },
+          {
+            "name": "literal",
+            "value": "\"red\""
+          },
+          {
+            "name": "literal",
+            "value": "\"blue\""
+          },
+          {
+            "name": "literal",
+            "value": "\"orange\""
+          },
+          {
+            "name": "literal",
+            "value": "\"grey\""
+          },
+          {
+            "name": "literal",
+            "value": "\"purple\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/Switch/Switch.json
+++ b/www/apps/ui/src/specs/Switch/Switch.json
@@ -9,6 +9,20 @@
         "computed": false
       },
       "description": "The switch's size.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"small\" \\| \"base\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"small\""
+          },
+          {
+            "name": "literal",
+            "value": "\"base\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/Tabs/Tabs.json
+++ b/www/apps/ui/src/specs/Tabs/Tabs.json
@@ -1,5 +1,89 @@
 {
   "description": "This component is based on the [Radix UI Tabs](https://radix-ui.com/primitives/docs/components/tabs) primitves",
   "methods": [],
-  "displayName": "Tabs"
+  "displayName": "Tabs",
+  "props": {
+    "activationMode": {
+      "description": "Whether a tab is activated automatically or manually.",
+      "required": false,
+      "tsType": {
+        "name": "union",
+        "raw": "\"manual\" \\| \"automatic\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"manual\""
+          },
+          {
+            "name": "literal",
+            "value": "\"automatic\""
+          }
+        ]
+      }
+    },
+    "defaultValue": {
+      "description": "The value of the tab to select by default, if uncontrolled",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "dir": {
+      "description": "The direction of navigation between toolbar items.",
+      "required": false,
+      "tsType": {
+        "name": "Direction",
+        "elements": [],
+        "raw": "Direction"
+      }
+    },
+    "onValueChange": {
+      "description": "A function called when a new tab is selected",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(value: string) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "value",
+              "type": {
+                "name": "string"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "orientation": {
+      "description": "The orientation the tabs are layed out.\nMainly so arrow navigation is done accordingly (left & right vs. up & down)",
+      "required": false,
+      "tsType": {
+        "name": "union",
+        "raw": "\"horizontal\" \\| \"vertical\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"horizontal\""
+          },
+          {
+            "name": "literal",
+            "value": "\"vertical\""
+          }
+        ]
+      }
+    },
+    "value": {
+      "description": "The value for the selected tab, if controlled",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    }
+  }
 }

--- a/www/apps/ui/src/specs/Text/Text.json
+++ b/www/apps/ui/src/specs/Text/Text.json
@@ -46,6 +46,32 @@
         "computed": false
       },
       "description": "The text's size.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"xsmall\" \\| \"small\" \\| \"base\" \\| \"large\" \\| \"xlarge\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"xsmall\""
+          },
+          {
+            "name": "literal",
+            "value": "\"small\""
+          },
+          {
+            "name": "literal",
+            "value": "\"base\""
+          },
+          {
+            "name": "literal",
+            "value": "\"large\""
+          },
+          {
+            "name": "literal",
+            "value": "\"xlarge\""
+          }
+        ]
+      },
       "required": false
     },
     "weight": {
@@ -54,6 +80,20 @@
         "computed": false
       },
       "description": "The text's font weight.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"regular\" \\| \"plus\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"regular\""
+          },
+          {
+            "name": "literal",
+            "value": "\"plus\""
+          }
+        ]
+      },
       "required": false
     },
     "family": {
@@ -62,6 +102,20 @@
         "computed": false
       },
       "description": "The text's font family.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"sans\" \\| \"mono\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"sans\""
+          },
+          {
+            "name": "literal",
+            "value": "\"mono\""
+          }
+        ]
+      },
       "required": false
     },
     "leading": {
@@ -70,6 +124,20 @@
         "computed": false
       },
       "description": "The text's line height.",
+      "tsType": {
+        "name": "union",
+        "raw": "\"normal\" \\| \"compact\"",
+        "elements": [
+          {
+            "name": "literal",
+            "value": "\"normal\""
+          },
+          {
+            "name": "literal",
+            "value": "\"compact\""
+          }
+        ]
+      },
       "required": false
     }
   },

--- a/www/apps/ui/src/specs/TimeInput/TimeInput.json
+++ b/www/apps/ui/src/specs/TimeInput/TimeInput.json
@@ -1,5 +1,6 @@
 {
   "description": "",
   "methods": [],
-  "displayName": "TimeInput"
+  "displayName": "TimeInput",
+  "props": {}
 }

--- a/www/apps/ui/src/specs/Toast/Toast.json
+++ b/www/apps/ui/src/specs/Toast/Toast.json
@@ -30,7 +30,64 @@
     "action": {
       "required": false,
       "tsType": {
-        "name": "ToastAction"
+        "name": "signature",
+        "type": "object",
+        "raw": "&#123; altText: string ; label: string ; onClick: () => void \\| Promise&#60;void&#62; ; variant?: ToastActionVariant  &#125;",
+        "signature": {
+          "properties": [
+            {
+              "key": "altText",
+              "value": {
+                "name": "string"
+              },
+              "description": "The button's alt text."
+            },
+            {
+              "key": "label",
+              "value": {
+                "name": "string"
+              },
+              "description": "The button's text."
+            },
+            {
+              "key": "onClick",
+              "value": {
+                "name": "signature",
+                "type": "function",
+                "raw": "() => void \\| Promise&#60;void&#62;",
+                "signature": {
+                  "arguments": [],
+                  "return": {
+                    "name": "void \\| Promise&#60;void&#62;"
+                  }
+                }
+              },
+              "description": "The function to execute when the button is clicked."
+            },
+            {
+              "key": "variant",
+              "value": {
+                "name": "ToastActionVariant",
+                "elements": [
+                  {
+                    "name": "union",
+                    "raw": "\"default\" \\| \"destructive\"",
+                    "elements": [
+                      {
+                        "name": "\"default\""
+                      },
+                      {
+                        "name": "\"destructive\""
+                      }
+                    ]
+                  }
+                ],
+                "raw": "ToastActionVariant"
+              },
+              "description": "The button's variant."
+            }
+          ]
+        }
       },
       "description": "The toast's action buttons."
     }

--- a/www/apps/ui/src/specs/Toaster/Toaster.json
+++ b/www/apps/ui/src/specs/Toaster/Toaster.json
@@ -9,6 +9,11 @@
         "computed": false
       },
       "description": "The position of the created toasts.",
+      "tsType": {
+        "name": "Position",
+        "elements": [],
+        "raw": "Position"
+      },
       "required": false
     },
     "gap": {
@@ -17,6 +22,9 @@
         "computed": false
       },
       "description": "The gap between the toast components.",
+      "tsType": {
+        "name": "number"
+      },
       "required": false
     },
     "offset": {
@@ -25,10 +33,29 @@
         "computed": false
       },
       "description": "The space from the edges of the screen.",
+      "tsType": {
+        "name": "union",
+        "raw": "string \\| number",
+        "elements": [
+          {
+            "name": "string"
+          },
+          {
+            "name": "number"
+          }
+        ]
+      },
       "required": false
     },
     "duration": {
-      "description": "The time in milliseconds that a toast is shown before it's\nautomatically dismissed.\n\n@defaultValue 4000"
+      "description": "The time in milliseconds that a toast is shown before it's\nautomatically dismissed.\n\n",
+      "tsType": {
+        "name": "number"
+      },
+      "defaultValue": {
+        "value": "4000",
+        "computed": false
+      }
     }
   },
   "composes": [

--- a/www/apps/ui/src/specs/Tooltip/Tooltip.json
+++ b/www/apps/ui/src/specs/Tooltip/Tooltip.json
@@ -3,53 +3,6 @@
   "methods": [],
   "displayName": "Tooltip",
   "props": {
-    "content": {
-      "required": true,
-      "tsType": {
-        "name": "ReactReactNode",
-        "raw": "React.ReactNode"
-      },
-      "description": ""
-    },
-    "onClick": {
-      "required": false,
-      "tsType": {
-        "name": "ReactMouseEventHandler",
-        "raw": "React.MouseEventHandler<HTMLButtonElement>",
-        "elements": [
-          {
-            "name": "HTMLButtonElement"
-          }
-        ]
-      },
-      "description": ""
-    },
-    "side": {
-      "required": false,
-      "tsType": {
-        "name": "union",
-        "raw": "\"bottom\" | \"left\" | \"top\" | \"right\"",
-        "elements": [
-          {
-            "name": "literal",
-            "value": "\"bottom\""
-          },
-          {
-            "name": "literal",
-            "value": "\"left\""
-          },
-          {
-            "name": "literal",
-            "value": "\"top\""
-          },
-          {
-            "name": "literal",
-            "value": "\"right\""
-          }
-        ]
-      },
-      "description": ""
-    },
     "maxWidth": {
       "required": false,
       "tsType": {
@@ -61,13 +14,77 @@
         "computed": false
       }
     },
-    "sideOffset": {
-      "defaultValue": {
-        "value": "8",
-        "computed": false
-      },
-      "description": "",
-      "required": false
+    "aria-label": {
+      "description": "A more descriptive label for accessibility purpose",
+      "required": false,
+      "tsType": {
+        "name": "string"
+      }
+    },
+    "delayDuration": {
+      "description": "The duration from when the pointer enters the trigger until the tooltip gets opened. This will\noverride the prop with the same name passed to Provider.",
+      "required": false,
+      "tsType": {
+        "name": "number"
+      }
+    },
+    "forceMount": {
+      "description": "Used to force mounting when more control is needed. Useful when\ncontrolling animation with React animation libraries.",
+      "required": false,
+      "tsType": {
+        "name": "literal",
+        "value": "true"
+      }
+    },
+    "onEscapeKeyDown": {
+      "description": "Event handler called when the escape key is down.\nCan be prevented.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(event: KeyboardEvent) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "event",
+              "type": {
+                "name": "KeyboardEvent",
+                "elements": [],
+                "raw": "KeyboardEvent"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
+    },
+    "onPointerDownOutside": {
+      "description": "Event handler called when the a `pointerdown` event happens outside of the `Tooltip`.\nCan be prevented.",
+      "required": false,
+      "tsType": {
+        "name": "signature",
+        "type": "function",
+        "raw": "(event: PointerDownOutsideEvent) => void",
+        "signature": {
+          "arguments": [
+            {
+              "name": "event",
+              "type": {
+                "name": "PointerDownOutsideEvent",
+                "elements": [],
+                "raw": "PointerDownOutsideEvent"
+              },
+              "rest": false
+            }
+          ],
+          "return": {
+            "name": "void"
+          }
+        }
+      }
     }
   },
   "composes": [

--- a/www/apps/ui/src/specs/TooltipProvider/TooltipProvider.json
+++ b/www/apps/ui/src/specs/TooltipProvider/TooltipProvider.json
@@ -8,7 +8,10 @@
         "value": "100",
         "computed": false
       },
-      "description": "",
+      "description": "The duration from when the pointer enters the trigger until the tooltip gets opened.",
+      "tsType": {
+        "name": "number"
+      },
       "required": false
     },
     "skipDelayDuration": {
@@ -16,8 +19,18 @@
         "value": "300",
         "computed": false
       },
-      "description": "",
+      "description": "How much time a user has to enter another trigger without incurring a delay again.",
+      "tsType": {
+        "name": "number"
+      },
       "required": false
+    },
+    "disableHoverableContent": {
+      "description": "When `true`, trying to hover the content will result in the tooltip closing as the pointer leaves the trigger.",
+      "required": false,
+      "tsType": {
+        "name": "boolean"
+      }
     }
   }
 }

--- a/www/apps/ui/src/types/props.ts
+++ b/www/apps/ui/src/types/props.ts
@@ -20,6 +20,12 @@ export type FunctionType = {
   signature: string
 }
 
+export type PartialType = {
+  type: "partial"
+  elements: unknown[]
+  raw: string
+}
+
 // Keeping this as it's still used by hooks
 export type PropType =
   | "string"

--- a/www/packages/docs-ui/src/components/MainNav/Version/index.tsx
+++ b/www/packages/docs-ui/src/components/MainNav/Version/index.tsx
@@ -37,7 +37,11 @@ export const MainNavVersion = () => {
 
   return (
     <>
-      <Link href={version.releaseUrl} target="_blank">
+      <Link
+        href={version.releaseUrl}
+        target="_blank"
+        className={clsx(version.hide && "hidden")}
+      >
         <Tooltip html="View the release notes<br/>on GitHub">
           <span
             className="relative text-compact-small-plus"
@@ -56,7 +60,9 @@ export const MainNavVersion = () => {
           </span>
         </Tooltip>
       </Link>
-      <span className="text-compact-small">&#183;</span>
+      <span className={clsx("text-compact-small", version.hide && "hidden")}>
+        &#183;
+      </span>
     </>
   )
 }

--- a/www/packages/types/src/config.ts
+++ b/www/packages/types/src/config.ts
@@ -19,6 +19,7 @@ export declare type DocsConfig = {
   version: {
     number: string
     releaseUrl: string
+    hide?: boolean
   }
   reportIssueLink?: string
   logo: string

--- a/www/utils/packages/react-docs-generator/package.json
+++ b/www/utils/packages/react-docs-generator/package.json
@@ -2,7 +2,7 @@
   "name": "react-docs-generator",
   "license": "MIT",
   "scripts": {
-    "dev": "ts-node src/index.ts",
+    "dev": "node --loader ts-node/esm src/index.ts",
     "start": "node dist/index.js",
     "generate:ui": "yarn start --src ../../../../packages/design-system/ui/src --output ../../../apps/ui/src/specs --clean",
     "build": "tsc",

--- a/www/utils/packages/react-docs-generator/src/commands/generate.ts
+++ b/www/utils/packages/react-docs-generator/src/commands/generate.ts
@@ -100,6 +100,10 @@ export default async function ({
           mkdirSync(filePath)
         }
 
+        if (spec.displayName === "Drawer.Content") {
+          console.log("here", spec)
+        }
+
         // write spec to output path
         writeFileSync(
           path.join(filePath, `${spec.displayName}.json`),

--- a/www/utils/packages/react-docs-generator/src/handlers/argsPropHandler.ts
+++ b/www/utils/packages/react-docs-generator/src/handlers/argsPropHandler.ts
@@ -52,7 +52,7 @@ function resolveDocumentation(
       // set type if missing
       if (!propDescriptor.tsType && typedocManager) {
         const typeAnnotation = utils.getTypeAnnotation(path)
-        if (typeAnnotation?.isTSTypeReference) {
+        if (typeAnnotation?.isTSTypeReference()) {
           const typeName = typeAnnotation.get("typeName")
           if (
             !Array.isArray(typeName) &&

--- a/www/utils/packages/typedoc-config/ui.json
+++ b/www/utils/packages/typedoc-config/ui.json
@@ -7,5 +7,8 @@
   "exclude": [
     "../../../../packages/design-system/ui/dist", 
     "../../../../packages/design-system/ui/node_modules"
-  ]
+  ],
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
 }


### PR DESCRIPTION
- Fix error in docs generator that lead to vague types in generated specs
- Re-generate specs
- Include in the docs the props of some missing components
- Add new example to `Select` component
- Other: hide version number in UI docs + fix config for main docs

Closes DX-1232