### PR TITLE
docs: update fulfillment provider module docs to reflect CalculatedShippingOptionPrice

### DIFF
--- a/packages/core/utils/src/fulfillment/provider.ts
+++ b/packages/core/utils/src/fulfillment/provider.ts
@@ -229,20 +229,21 @@ export class AbstractFulfillmentProviderService
    * @returns The calculated price's details.
    *
    * @example
+   * import { CalculateShippingOptionPriceDTO } from "@medusajs/framework/types"
    * class MyFulfillmentProviderService extends AbstractFulfillmentProviderService {
    *   // ...
    *   async calculatePrice(
-   *     optionData: Record<string, unknown>,
-   *     data: Record<string, unknown>,
-   *     context: any
+   *     optionData: CalculateShippingOptionPriceDTO["optionData"],
+   *     data: CalculateShippingOptionPriceDTO["data"],
+   *     context: CalculateShippingOptionPriceDTO["context"]
    *   ): Promise<CalculatedShippingOptionPrice> {
    *     // assuming the client can calculate the price using
    *     // the third-party service
    *     const price = await this.client.calculate(data)
    *     return {
    *       calculated_amount: price,
-   *       is_calculated_price_tax_inclusive: true,
    *       // Update this boolean value based on your logic
+   *       is_calculated_price_tax_inclusive: true,
    *     }
    *   }
    * }

--- a/packages/core/utils/src/fulfillment/provider.ts
+++ b/packages/core/utils/src/fulfillment/provider.ts
@@ -8,7 +8,7 @@ import {
 /**
  * ### constructor
  *
- * The constructor allows you to access resources from the [module's container](https://docs.medusajs.com/learn/fundamentals/modules/container) 
+ * The constructor allows you to access resources from the [module's container](https://docs.medusajs.com/learn/fundamentals/modules/container)
  * using the first parameter, and the module's options using the second parameter.
  *
  * :::note
@@ -48,7 +48,7 @@ import {
  *
  *     this.logger_ = logger
  *     this.options_ = options
- * 
+ *
  *     // TODO initialize your client
  *   }
  * }
@@ -96,7 +96,7 @@ export class AbstractFulfillmentProviderService
    * This method retrieves a list of fulfillment options that this provider supports. Admin users will then choose from these options when
    * they're creating a shipping option. The chosen fulfillment option's object is then stored within the created shipping option's `data` property.
    * The `data` property is useful to store data relevant for the third-party provider to later process the fulfillment.
-   * 
+   *
    * This method is useful if your third-party provider allows you to retrieve support options, carriers, or services from an API. You can then
    * retrieve those and return then in the method, allowing the admin user to choose from the services provided by the third-party provider.
    *
@@ -112,7 +112,7 @@ export class AbstractFulfillmentProviderService
    *   async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
    *     // assuming you have a client
    *     const services = await this.client.getServices()
-   * 
+   *
    *     return services.map((service) => ({
    *       id: service.service_id,
    *       name: service.name,
@@ -190,7 +190,7 @@ export class AbstractFulfillmentProviderService
   /**
    * This method validates whether a shippin option's price can be calculated during checkout. It's executed when the admin user creates a shipping
    * option of type `calculated`. If this method returns `false`, an error is thrown as the shipping option's price can't be calculated.
-   * 
+   *
    * You can perform the checking using the third-party provider if applicable. The `data` parameter will hold the shipping option's `data` property, which
    * includes the data of a fulfillment option returned by {@link getFulfillmentOptions}.
    *
@@ -231,11 +231,19 @@ export class AbstractFulfillmentProviderService
    * @example
    * class MyFulfillmentProviderService extends AbstractFulfillmentProviderService {
    *   // ...
-   *   async calculatePrice(optionData: any, data: any, context: any): Promise<number> {
+   *   async calculatePrice(
+    optionData: Record<string, unknown>,
+    data: Record<string, unknown>,
+    context: any
+  ): Promise<CalculatedShippingOptionPrice> {
    *     // assuming the client can calculate the price using
    *     // the third-party service
    *     const price = await this.client.calculate(data)
-   *     return price
+   *     return {
+   *       calculated_amount: price,
+   *       is_calculated_price_tax_inclusive: true,
+   *       // Update this boolean value based on your logic
+   *     }
    *   }
    * }
    */
@@ -346,7 +354,7 @@ export class AbstractFulfillmentProviderService
    * `data` property, it's stored in the fulfillment's `data` property.
    *
    * The `data` property is useful when handling the fulfillment later,
-   * as you can access information useful for your integration. For example, you 
+   * as you can access information useful for your integration. For example, you
    * can store an ID for the fulfillment in the third-party service.
    *
    * Use this method to perform actions necessary in the third-party fulfillment service, such as

--- a/packages/core/utils/src/fulfillment/provider.ts
+++ b/packages/core/utils/src/fulfillment/provider.ts
@@ -8,7 +8,7 @@ import {
 /**
  * ### constructor
  *
- * The constructor allows you to access resources from the [module's container](https://docs.medusajs.com/learn/fundamentals/modules/container)
+ * The constructor allows you to access resources from the [module's container](https://docs.medusajs.com/learn/fundamentals/modules/container) 
  * using the first parameter, and the module's options using the second parameter.
  *
  * :::note
@@ -48,7 +48,7 @@ import {
  *
  *     this.logger_ = logger
  *     this.options_ = options
- *
+ * 
  *     // TODO initialize your client
  *   }
  * }
@@ -96,7 +96,7 @@ export class AbstractFulfillmentProviderService
    * This method retrieves a list of fulfillment options that this provider supports. Admin users will then choose from these options when
    * they're creating a shipping option. The chosen fulfillment option's object is then stored within the created shipping option's `data` property.
    * The `data` property is useful to store data relevant for the third-party provider to later process the fulfillment.
-   *
+   * 
    * This method is useful if your third-party provider allows you to retrieve support options, carriers, or services from an API. You can then
    * retrieve those and return then in the method, allowing the admin user to choose from the services provided by the third-party provider.
    *
@@ -112,7 +112,7 @@ export class AbstractFulfillmentProviderService
    *   async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
    *     // assuming you have a client
    *     const services = await this.client.getServices()
-   *
+   * 
    *     return services.map((service) => ({
    *       id: service.service_id,
    *       name: service.name,
@@ -190,7 +190,7 @@ export class AbstractFulfillmentProviderService
   /**
    * This method validates whether a shippin option's price can be calculated during checkout. It's executed when the admin user creates a shipping
    * option of type `calculated`. If this method returns `false`, an error is thrown as the shipping option's price can't be calculated.
-   *
+   * 
    * You can perform the checking using the third-party provider if applicable. The `data` parameter will hold the shipping option's `data` property, which
    * includes the data of a fulfillment option returned by {@link getFulfillmentOptions}.
    *
@@ -232,10 +232,10 @@ export class AbstractFulfillmentProviderService
    * class MyFulfillmentProviderService extends AbstractFulfillmentProviderService {
    *   // ...
    *   async calculatePrice(
-    optionData: Record<string, unknown>,
-    data: Record<string, unknown>,
-    context: any
-  ): Promise<CalculatedShippingOptionPrice> {
+   *     optionData: Record<string, unknown>,
+   *     data: Record<string, unknown>,
+   *     context: any
+   *   ): Promise<CalculatedShippingOptionPrice> {
    *     // assuming the client can calculate the price using
    *     // the third-party service
    *     const price = await this.client.calculate(data)

--- a/www/apps/resources/references/fulfillment_provider/classes/fulfillment_provider.AbstractFulfillmentProviderService/page.mdx
+++ b/www/apps/resources/references/fulfillment_provider/classes/fulfillment_provider.AbstractFulfillmentProviderService/page.mdx
@@ -251,8 +251,8 @@ class MyFulfillmentProviderService extends AbstractFulfillmentProviderService {
     const price = await this.client.calculate(data)
     return {
       calculated_amount: price,
-      is_calculated_price_tax_inclusive: true
       // update this boolean value based on your logic
+      is_calculated_price_tax_inclusive: true
     }
   }
 }

--- a/www/apps/resources/references/fulfillment_provider/classes/fulfillment_provider.AbstractFulfillmentProviderService/page.mdx
+++ b/www/apps/resources/references/fulfillment_provider/classes/fulfillment_provider.AbstractFulfillmentProviderService/page.mdx
@@ -241,11 +241,19 @@ you can retrieve the calculated price of the shipping method.
 ```ts
 class MyFulfillmentProviderService extends AbstractFulfillmentProviderService {
   // ...
-  async calculatePrice(optionData: any, data: any, context: any): Promise<number> {
+  async calculatePrice(
+    optionData: Record<string, unknown>,
+    data: Record<string, unknown>,
+    context: any
+  ): Promise<CalculatedShippingOptionPrice> {
     // assuming the client can calculate the price using
     // the third-party service
     const price = await this.client.calculate(data)
-    return price
+    return {
+      calculated_amount: price,
+      is_calculated_price_tax_inclusive: true
+      // update this boolean value based on your logic
+    }
   }
 }
 ```

--- a/www/apps/resources/references/fulfillment_provider/classes/fulfillment_provider.AbstractFulfillmentProviderService/page.mdx
+++ b/www/apps/resources/references/fulfillment_provider/classes/fulfillment_provider.AbstractFulfillmentProviderService/page.mdx
@@ -242,9 +242,9 @@ you can retrieve the calculated price of the shipping method.
 class MyFulfillmentProviderService extends AbstractFulfillmentProviderService {
   // ...
   async calculatePrice(
-    optionData: Record<string, unknown>,
-    data: Record<string, unknown>,
-    context: any
+    optionData: CalculateShippingOptionPriceDTO["optionData"],
+    data: CalculateShippingOptionPriceDTO["data"],
+    context: CalculateShippingOptionPriceDTO["context"]
   ): Promise<CalculatedShippingOptionPrice> {
     // assuming the client can calculate the price using
     // the third-party service


### PR DESCRIPTION
The return value below the example for the `calculatePrice` method is shown correctly as `CalculatedShippingOptionPrice` but the example is not updated in the guide "How to Create a Fulfillment Provider Module"

This PR updates the example in the guide and the TS doc