### PR TITLE
docs: fix code tabs in production

### DIFF
--- a/www/packages/docs-ui/src/components/CodeTabs/index.tsx
+++ b/www/packages/docs-ui/src/components/CodeTabs/index.tsx
@@ -117,8 +117,8 @@ export const CodeTabs = ({
 
       if (
         typeof codeBlock.type !== "string" &&
-        "name" in codeBlock.type &&
-        codeBlock.type.name === "CodeBlock"
+        (("name" in codeBlock.type && codeBlock.type.name === "CodeBlock") ||
+          "source" in codeBlockProps)
       ) {
         codeBlockProps = {
           ...codeBlockProps,


### PR DESCRIPTION
Fix code tabs showing default title in production