### PR TITLE
fix(promotion): don't evaluate rule condition if conditions to evaluate is empty

### DIFF
--- a/.changeset/selfish-coats-drop.md
+++ b/.changeset/selfish-coats-drop.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/promotion": patch
+---
+
+fix(promotion): don't evaluate rule condition if conditions to evaluate is empty

--- a/packages/modules/promotion/integration-tests/__tests__/services/promotion-module/compute-actions.spec.ts
+++ b/packages/modules/promotion/integration-tests/__tests__/services/promotion-module/compute-actions.spec.ts
@@ -132,6 +132,40 @@ moduleIntegrationTestRunner({
                 code: "PROMOTION_TEST",
               },
             ])
+
+            const resultWithoutCustomer = await service.computeActions(
+              ["PROMOTION_TEST"],
+              {
+                items: [
+                  {
+                    id: "item_cotton_tshirt",
+                    quantity: 1,
+                    subtotal: 100,
+                    product_category: {
+                      id: "catg_cotton",
+                    },
+                    product: {
+                      id: "prod_tshirt",
+                    },
+                  },
+                  {
+                    id: "item_cotton_sweater",
+                    quantity: 5,
+                    subtotal: 750,
+                    product_category: {
+                      id: "catg_cotton",
+                    },
+                    product: {
+                      id: "prod_sweater",
+                    },
+                  },
+                ],
+              }
+            )
+
+            expect(JSON.parse(JSON.stringify(resultWithoutCustomer))).toEqual(
+              []
+            )
           })
 
           it("should compute the correct item amendments when there are multiple promotions to apply", async () => {

--- a/packages/modules/promotion/src/utils/validations/promotion-rule.ts
+++ b/packages/modules/promotion/src/utils/validations/promotion-rule.ts
@@ -115,6 +115,10 @@ export function evaluateRuleValueCondition(
     ruleValuesToCheck = [ruleValuesToCheck]
   }
 
+  if (!ruleValuesToCheck.length) {
+    return false
+  }
+
   return ruleValuesToCheck.every((ruleValueToCheck: string) => {
     if (operator === "in" || operator === "eq") {
       return ruleValues.some((ruleValue) => ruleValue === ruleValueToCheck)


### PR DESCRIPTION
what:

- fixes case where empty arrays are evaluated truthy

FIXES https://github.com/medusajs/medusa/issues/10783
RESOLVES CMRC-822