### PR TITLE
fix: add reservations for current line item to available quantity

### DIFF
--- a/packages/admin-ui/ui/src/domain/orders/details/create-fulfillment/item-table.tsx
+++ b/packages/admin-ui/ui/src/domain/orders/details/create-fulfillment/item-table.tsx
@@ -88,7 +88,7 @@ const FulfillmentLine = ({
   const { reservations, isLoading: isReservationsLoading } =
     useAdminReservations({
       location_id: locationId,
-      line_item_id: item.id,
+      line_item_id: [item.id],
     })
 
   const isLoading = isInventoryLoading || isReservationsLoading


### PR DESCRIPTION
When attempting to create a fulfillment with the last remaining item in stock, the reservation of the item blocks you from creating the fulfillment. This PR adds the quantity of any reservations for the specific line item and location to the available quantity for fulfillment.

Fixes #9821