### PR TITLE
feat(auth-google,auth-github): Allow passing a custom callbackUrl to …

### DIFF
--- a/packages/core/modules-sdk/src/definitions.ts
+++ b/packages/core/modules-sdk/src/definitions.ts
@@ -92,7 +92,7 @@ export const ModulesDefinition: {
     label: upperCaseFirst(Modules.AUTH),
     isRequired: false,
     isQueryable: true,
-    dependencies: [ContainerRegistrationKeys.LOGGER],
+    dependencies: [ContainerRegistrationKeys.LOGGER, Modules.CACHE],
     defaultModuleDeclaration: {
       scope: MODULE_SCOPE.INTERNAL,
     },

--- a/packages/core/types/src/auth/common/provider.ts
+++ b/packages/core/types/src/auth/common/provider.ts
@@ -59,6 +59,10 @@ export type AuthenticationInput = {
 
   /**
    * Body of the incoming authentication request.
+   *
+   * One of the arguments that is suggested to be treated in a standard manner is a `callback_url` field.
+   * The field specifies where the user is redirected to after a successful authentication in the case of Oauth auhentication.
+   * If not passed, the provider will fallback to the callback_url provided in the provider options.
    */
   body?: Record<string, string>
 

--- a/packages/core/types/src/auth/provider.ts
+++ b/packages/core/types/src/auth/provider.ts
@@ -20,6 +20,9 @@ export interface AuthIdentityProviderService {
       user_metadata?: Record<string, unknown>
     }
   ) => Promise<AuthIdentityDTO>
+  // These methods are used for OAuth providers to store and retrieve state
+  setState: (key: string, value: Record<string, unknown>) => Promise<void>
+  getState: (key: string) => Promise<Record<string, unknown> | null>
 }
 
 /**

--- a/packages/modules/auth/src/services/auth-module.ts
+++ b/packages/modules/auth/src/services/auth-module.ts
@@ -5,6 +5,7 @@ import {
   AuthTypes,
   Context,
   DAL,
+  ICacheService,
   InferEntityType,
   InternalModuleDeclaration,
   Logger,
@@ -27,6 +28,7 @@ type InjectedDependencies = {
   providerIdentityService: ModulesSdkTypes.IMedusaInternalService<any>
   authProviderService: AuthProviderService
   logger?: Logger
+  cache?: ICacheService
 }
 export default class AuthModuleService
   extends MedusaService<{
@@ -43,13 +45,14 @@ export default class AuthModuleService
     InferEntityType<typeof ProviderIdentity>
   >
   protected readonly authProviderService_: AuthProviderService
-
+  protected readonly cache_: ICacheService | undefined
   constructor(
     {
       authIdentityService,
       providerIdentityService,
       authProviderService,
       baseRepository,
+      cache,
     }: InjectedDependencies,
     protected readonly moduleDeclaration: InternalModuleDeclaration
   ) {
@@ -60,6 +63,7 @@ export default class AuthModuleService
     this.authIdentityService_ = authIdentityService
     this.authProviderService_ = authProviderService
     this.providerIdentityService_ = providerIdentityService
+    this.cache_ = cache
   }
 
   __joinerConfig(): ModuleJoinerConfig {
@@ -371,6 +375,27 @@ export default class AuthModuleService
         ]
 
         return serializedResponse
+      },
+      setState: async (key: string, value: Record<string, unknown>) => {
+        if (!this.cache_) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_ARGUMENT,
+            "Cache module dependency is required when using OAuth providers that require state"
+          )
+        }
+
+        // 20 minutes. Can be made configurable if necessary, but this is a good default.
+        this.cache_.set(key, value, 1200)
+      },
+      getState: async (key: string) => {
+        if (!this.cache_) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_ARGUMENT,
+            "Cache module dependency is required when using OAuth providers that require state"
+          )
+        }
+
+        return await this.cache_.get(key)
       },
     }
   }

--- a/packages/modules/providers/auth-github/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/auth-github/integration-tests/__tests__/services.spec.ts
@@ -118,6 +118,17 @@ describe("Github auth provider", () => {
     })
   })
 
+  it("returns a custom redirect_uri on authenticate", async () => {
+    const res = await githubService.authenticate({
+      body: { callback_url: "https://someotherurl.com" },
+    })
+    expect(res).toEqual({
+      success: true,
+      location:
+        "https://github.com/login/oauth/authorize?redirect_uri=https%3A%2F%2Fsomeotherurl.com&client_id=test&response_type=code",
+    })
+  })
+
   it("validate callback should return an error on empty code", async () => {
     const res = await githubService.validateCallback(
       {

--- a/packages/modules/providers/auth-github/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/auth-github/integration-tests/__tests__/services.spec.ts
@@ -1,4 +1,4 @@
-import { generateJwtToken, MedusaError } from "@medusajs/framework/utils"
+import { MedusaError } from "@medusajs/framework/utils"
 import { GithubAuthService } from "../../src/services/github"
 import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
@@ -20,7 +20,9 @@ const sampleIdPayload = {
 }
 
 const baseUrl = "https://someurl.com"
-const callbackUrl = "https%3A%2F%2Fsomeurl.com%2Fauth%2Fgithub%2Fcallback"
+const callbackUrl = encodeURIComponent(
+  "https://someurl.com/auth/github/callback"
+)
 
 let state = {}
 const defaultSpies = {

--- a/packages/modules/providers/auth-github/src/services/github.ts
+++ b/packages/modules/providers/auth-github/src/services/github.ts
@@ -59,16 +59,19 @@ export class GithubAuthService extends AbstractAuthModuleProvider {
     req: AuthenticationInput,
     authIdentityService: AuthIdentityProviderService
   ): Promise<AuthenticationResponse> {
-    if (req.query?.error) {
+    const query: Record<string, string> = req.query ?? {}
+    const body: Record<string, string> = req.body ?? {}
+
+    if (query.error) {
       return {
         success: false,
-        error: `${req.query.error_description}, read more at: ${req.query.error_uri}`,
+        error: `${query.error_description}, read more at: ${query.error_uri}`,
       }
     }
 
     const stateKey = crypto.randomBytes(32).toString("hex")
     const state = {
-      callback_url: req.body?.callback_url ?? this.config_.callbackUrl,
+      callback_url: body?.callback_url ?? this.config_.callbackUrl,
     }
 
     await authIdentityService.setState(stateKey, state)
@@ -79,19 +82,22 @@ export class GithubAuthService extends AbstractAuthModuleProvider {
     req: AuthenticationInput,
     authIdentityService: AuthIdentityProviderService
   ): Promise<AuthenticationResponse> {
-    if (req.query && req.query.error) {
+    const query: Record<string, string> = req.query ?? {}
+    const body: Record<string, string> = req.body ?? {}
+
+    if (query.error) {
       return {
         success: false,
-        error: `${req.query.error_description}, read more at: ${req.query.error_uri}`,
+        error: `${query.error_description}, read more at: ${query.error_uri}`,
       }
     }
 
-    const code = req.query?.code ?? req.body?.code
+    const code = query?.code ?? body?.code
     if (!code) {
       return { success: false, error: "No code provided" }
     }
 
-    const state = await authIdentityService.getState(req.query?.state as string)
+    const state = await authIdentityService.getState(query?.state as string)
     if (!state) {
       return { success: false, error: "No state provided, or session expired" }
     }
@@ -203,18 +209,11 @@ export class GithubAuthService extends AbstractAuthModuleProvider {
   }
 
   private getRedirect(clientId: string, callbackUrl: string, stateKey: string) {
-    const redirectUrlParam = `redirect_uri=${encodeURIComponent(callbackUrl)}`
-    const clientIdParam = `client_id=${clientId}`
-    const responseTypeParam = "response_type=code"
-    const stateKeyParam = `state=${stateKey}`
-    const authUrl = new URL(
-      `https://github.com/login/oauth/authorize?${[
-        redirectUrlParam,
-        clientIdParam,
-        responseTypeParam,
-        stateKeyParam,
-      ].join("&")}`
-    )
+    const authUrl = new URL(`https://github.com/login/oauth/authorize`)
+    authUrl.searchParams.set("redirect_uri", callbackUrl)
+    authUrl.searchParams.set("client_id", clientId)
+    authUrl.searchParams.set("response_type", "code")
+    authUrl.searchParams.set("state", stateKey)
 
     return { success: true, location: authUrl.toString() }
   }

--- a/packages/modules/providers/auth-github/src/services/github.ts
+++ b/packages/modules/providers/auth-github/src/services/github.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto"
 import {
   AuthenticationInput,
   AuthenticationResponse,
@@ -16,7 +17,6 @@ type InjectedDependencies = {
 
 interface LocalServiceConfig extends GithubAuthProviderOptions {}
 
-// TODO: Add state param that is stored in Redis, to prevent CSRF attacks
 export class GithubAuthService extends AbstractAuthModuleProvider {
   static identifier = "github"
   static DISPLAY_NAME = "Github Authentication"
@@ -56,7 +56,8 @@ export class GithubAuthService extends AbstractAuthModuleProvider {
   }
 
   async authenticate(
-    req: AuthenticationInput
+    req: AuthenticationInput,
+    authIdentityService: AuthIdentityProviderService
   ): Promise<AuthenticationResponse> {
     if (req.query?.error) {
       return {
@@ -65,10 +66,13 @@ export class GithubAuthService extends AbstractAuthModuleProvider {
       }
     }
 
-    return this.getRedirect(
-      this.config_.clientId,
-      req.body?.callback_url ?? this.config_.callbackUrl
-    )
+    const stateKey = crypto.randomBytes(32).toString("hex")
+    const state = {
+      callback_url: req.body?.callback_url ?? this.config_.callbackUrl,
+    }
+
+    await authIdentityService.setState(stateKey, state)
+    return this.getRedirect(this.config_.clientId, state.callback_url, stateKey)
   }
 
   async validateCallback(
@@ -87,9 +91,12 @@ export class GithubAuthService extends AbstractAuthModuleProvider {
       return { success: false, error: "No code provided" }
     }
 
-    // We can add redirect_uri=${encodeURIComponent(this.config_.callbackUrl)} here as well for enhanced security, although effect is minimal due to having to preconfigure allowed redirect URLs in Github.
-    // We need to store state in Redis to enable that first, see TODO above.
-    const params = `client_id=${this.config_.clientId}&client_secret=${this.config_.clientSecret}&code=${code}`
+    const state = await authIdentityService.getState(req.query?.state as string)
+    if (!state) {
+      return { success: false, error: "No state provided, or session expired" }
+    }
+
+    const params = `client_id=${this.config_.clientId}&client_secret=${this.config_.clientSecret}&code=${code}&redirect_uri=${state.callback_url}`
 
     const exchangeTokenUrl = new URL(
       `https://github.com/login/oauth/access_token?${params}`
@@ -195,16 +202,17 @@ export class GithubAuthService extends AbstractAuthModuleProvider {
     }
   }
 
-  private getRedirect(clientId: string, callbackUrl: string) {
+  private getRedirect(clientId: string, callbackUrl: string, stateKey: string) {
     const redirectUrlParam = `redirect_uri=${encodeURIComponent(callbackUrl)}`
     const clientIdParam = `client_id=${clientId}`
     const responseTypeParam = "response_type=code"
-
+    const stateKeyParam = `state=${stateKey}`
     const authUrl = new URL(
       `https://github.com/login/oauth/authorize?${[
         redirectUrlParam,
         clientIdParam,
         responseTypeParam,
+        stateKeyParam,
       ].join("&")}`
     )
 

--- a/packages/modules/providers/auth-google/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/auth-google/integration-tests/__tests__/services.spec.ts
@@ -28,7 +28,9 @@ const encodedIdToken = generateJwtToken(sampleIdPayload, {
 })
 
 const baseUrl = "https://someurl.com"
-const callbackUrl = "https%3A%2F%2Fsomeurl.com%2Fauth%2Fgoogle%2Fcallback"
+const callbackUrl = encodeURIComponent(
+  "https://someurl.com/auth/google/callback"
+)
 
 let state = {}
 const defaultSpies = {

--- a/packages/modules/providers/auth-google/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/auth-google/integration-tests/__tests__/services.spec.ts
@@ -117,6 +117,17 @@ describe("Google auth provider", () => {
     })
   })
 
+  it("returns a custom redirect_uri on authenticate", async () => {
+    const res = await googleService.authenticate({
+      body: { callback_url: "https://someotherurl.com" },
+    })
+    expect(res).toEqual({
+      success: true,
+      location:
+        "https://accounts.google.com/o/oauth2/v2/auth?redirect_uri=https%3A%2F%2Fsomeotherurl.com&client_id=test&response_type=code&scope=email+profile+openid",
+    })
+  })
+
   it("validate callback should return an error on empty code", async () => {
     const res = await googleService.validateCallback(
       {


### PR DESCRIPTION
This is necessary so we can support different login pages based on the actor. This is also an intended approach to implementing oauth, where the client can control the callbackUrl (but the allowed redirects are limited within the Oauth app configuration)

For example, you might have a `user/github/callback` page and a `customer/github/callback` page, and where you redirect to would depend on which actor is doing the authentication.

The PR also adds the `state` parameter as defined in the Oauth protocol.

Note: If you have overridden the auth module definition in your medusa config, you will need to pass `Modules.CACHE` as a dependency. This can be considered a breaking change due to that fact.

We can also make it non-breaking by not storing the state and always returning the default callbackUrl as the state value. This reduces the security of the implementation, but can be an acceptable fallback.