### PR TITLE
chore(medusa): Add handler path to the http tracing to be able to group by

### DIFF
--- a/.changeset/itchy-walls-call.md
+++ b/.changeset/itchy-walls-call.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+chore(medusa): Add handler path to the http tracing to be able to group by

--- a/.changeset/nine-dolphins-melt.md
+++ b/.changeset/nine-dolphins-melt.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+chore(medusa): Add handler path to the http tracing to be able to group by

--- a/.changeset/nine-dolphins-melt.md
+++ b/.changeset/nine-dolphins-melt.md
@@ -1,5 +1,0 @@
----
-"@medusajs/medusa": patch
----
-
-chore(medusa): Add handler path to the http tracing to be able to group by

--- a/packages/medusa/src/commands/start.ts
+++ b/packages/medusa/src/commands/start.ts
@@ -19,6 +19,7 @@ import { logger } from "@medusajs/framework/logger"
 import loaders from "../loaders"
 import { MedusaModule } from "@medusajs/framework/modules-sdk"
 import { MedusaContainer } from "@medusajs/framework/types"
+import { parse } from "url"
 
 const EVERY_SIXTH_HOUR = "0 */6 * * *"
 const CRON_SCHEDULE = EVERY_SIXTH_HOUR
@@ -148,7 +149,7 @@ async function start(args: {
         if (traceRequestHandler) {
           const expressHandlerPath = findExpressRoutePath({
             stack,
-            url: req.url!,
+            url: parse(req.url!, false).pathname!,
           })
           void traceRequestHandler(
             async () => {

--- a/packages/medusa/src/commands/start.ts
+++ b/packages/medusa/src/commands/start.ts
@@ -108,18 +108,22 @@ function findexpressRoutePath({
   stack: ExpressStack[]
   url: string
 }): string | void {
-  const boundDispatchTarget = stack.find(
-    (layer) => layer.name === "bound dispatch" && layer.match(url)
-  )
+  const stackToProcess = [...stack]
 
-  if (boundDispatchTarget) {
-    return boundDispatchTarget.route.path
+  while (stackToProcess.length > 0) {
+    const layer = stackToProcess.pop()!
+
+    if (layer.name === "bound dispatch" && layer.match(url)) {
+      return layer.route.path
+    }
+
+    // Add nested stack items to be processed if they exist
+    if (layer.handle?.stack?.length) {
+      stackToProcess.push(...layer.handle.stack)
+    }
   }
 
-  return findexpressRoutePath({
-    stack: stack.flatMap((layer) => layer.handle.stack).filter(Boolean),
-    url,
-  })
+  return undefined
 }
 
 async function start(args: {

--- a/packages/medusa/src/commands/start.ts
+++ b/packages/medusa/src/commands/start.ts
@@ -101,7 +101,7 @@ type ExpressStack = {
  * @param url - The input url
  * @returns The route path
  */
-function findexpressRoutePath({
+function findExpressRoutePath({
   stack,
   url,
 }: {
@@ -143,7 +143,7 @@ async function start(args: {
 
     const http_ = http.createServer(async (req, res) => {
       const stack = app._router.stack
-      const expressHandlerPath = findexpressRoutePath({ stack, url: req.url! })
+      const expressHandlerPath = findExpressRoutePath({ stack, url: req.url! })
 
       await new Promise((resolve) => {
         res.on("finish", resolve)

--- a/packages/medusa/src/commands/start.ts
+++ b/packages/medusa/src/commands/start.ts
@@ -143,11 +143,13 @@ async function start(args: {
 
     const http_ = http.createServer(async (req, res) => {
       const stack = app._router.stack
-      const expressHandlerPath = findExpressRoutePath({ stack, url: req.url! })
-
       await new Promise((resolve) => {
         res.on("finish", resolve)
         if (traceRequestHandler) {
+          const expressHandlerPath = findExpressRoutePath({
+            stack,
+            url: req.url!,
+          })
           void traceRequestHandler(
             async () => {
               app(req, res)

--- a/packages/medusa/src/instrumentation/index.ts
+++ b/packages/medusa/src/instrumentation/index.ts
@@ -28,7 +28,12 @@ export function instrumentHttpLayer() {
   const HTTPTracer = new Tracer("@medusajs/http", "2.0.0")
   const { SpanStatusCode } = require("@opentelemetry/api")
 
-  startCommand.traceRequestHandler = async (requestHandler, req, res) => {
+  startCommand.traceRequestHandler = async (
+    requestHandler,
+    req,
+    res,
+    handlerPath
+  ) => {
     if (shouldExcludeResource(req.url!)) {
       return await requestHandler()
     }
@@ -36,6 +41,7 @@ export function instrumentHttpLayer() {
     const traceName = `${req.method} ${req.url}`
     await HTTPTracer.trace(traceName, async (span) => {
       span.setAttributes({
+        handler: handlerPath,
         "http.url": req.url,
         "http.method": req.method,
         ...req.headers,

--- a/packages/medusa/src/instrumentation/index.ts
+++ b/packages/medusa/src/instrumentation/index.ts
@@ -41,7 +41,7 @@ export function instrumentHttpLayer() {
     const traceName = handlerPath ?? `${req.method} ${req.url}`
     await HTTPTracer.trace(traceName, async (span) => {
       span.setAttributes({
-        route: handlerPath,
+        "http.route": handlerPath,
         "http.url": req.url,
         "http.method": req.method,
         ...req.headers,
@@ -72,7 +72,8 @@ export function instrumentHttpLayer() {
         return await handler(req, res)
       }
 
-      const traceName = `route: ${req.method} ${req.originalUrl}`
+      const label = req.route?.path ?? `${req.method} ${req.originalUrl}`
+      const traceName = `route handler: ${label}`
 
       await HTTPTracer.trace(traceName, async (span) => {
         try {

--- a/packages/medusa/src/instrumentation/index.ts
+++ b/packages/medusa/src/instrumentation/index.ts
@@ -38,10 +38,10 @@ export function instrumentHttpLayer() {
       return await requestHandler()
     }
 
-    const traceName = `${req.method} ${req.url}`
+    const traceName = handlerPath ?? `${req.method} ${req.url}`
     await HTTPTracer.trace(traceName, async (span) => {
       span.setAttributes({
-        handler: handlerPath,
+        route: handlerPath,
         "http.url": req.url,
         "http.method": req.method,
         ...req.headers,


### PR DESCRIPTION
RESOLVES FRMW-2835

In this PR, we trace HTTP requests using the route pattern and not the request URL. This allows us to aggregate all HTTP requests under a single route.

In terms of implementation, we have to self find the route for a given request, since there is no API in express to do the same and we begin tracing even before the request is handed over to Express.

Since, the route matching happens via RegExp matches, we ensure that this does not add much performance overhead. The matching takes between 0.8ms-1.5ms for various different routes