### PR TITLE
chore: small tsdoc changes for remoteLink and remoteQueryConfig

### DIFF
--- a/packages/core/framework/src/http/types.ts
+++ b/packages/core/framework/src/http/types.ts
@@ -111,6 +111,8 @@ export interface MedusaRequest<
 
   /**
    * An object containing fields and variables to be used with the remoteQuery
+   * 
+   * @version 2.1.4
    */
   queryConfig: {
     fields: string[]
@@ -118,7 +120,7 @@ export interface MedusaRequest<
   }
 
   /**
-   * @deprecated. Instead use "req.queryConfig"
+   * @deprecated Use {@link queryConfig} instead.
    */
   remoteQueryConfig: MedusaRequest["queryConfig"]
 

--- a/packages/core/framework/src/types/container.ts
+++ b/packages/core/framework/src/types/container.ts
@@ -36,9 +36,12 @@ import { AwilixContainer, ResolveOptions } from "awilix"
 declare module "@medusajs/types" {
   export interface ModuleImplementations {
     /**
-     * @deprecated. Instead use "link"
+     * @deprecated use {@link ContainerRegistrationKeys.LINK} instead.
      */
     [ContainerRegistrationKeys.REMOTE_LINK]: Link
+    /**
+     * @version 2.1.4
+     */
     [ContainerRegistrationKeys.LINK]: Link
     [ContainerRegistrationKeys.CONFIG_MODULE]: ConfigModule
     [ContainerRegistrationKeys.PG_CONNECTION]: Knex<any>

--- a/packages/core/utils/src/common/container.ts
+++ b/packages/core/utils/src/common/container.ts
@@ -6,9 +6,12 @@ export const ContainerRegistrationKeys = {
   REMOTE_QUERY: "remoteQuery",
   QUERY: "query",
   /**
-   * @deprecated. Instead use "ContainerRegistrationKeys.LINK"
+   * @deprecated use {@link ContainerRegistrationKeys.LINK} instead.
    */
   REMOTE_LINK: "remoteLink",
+  /**
+   * @version 2.1.4
+   */
   LINK: "link",
   FEATURE_FLAG_ROUTER: "featureFlagRouter",
 } as const


### PR DESCRIPTION
Small tsdoc changes to the deprecation tag message + adding `@version` tag to the new namings