### PR TITLE
docs-util: fixes to OAS generator + generate OAS

### DIFF
--- a/www/apps/api-reference/specs/admin/components/schemas/AdminOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminOrder.yaml
@@ -5,6 +5,7 @@ required:
   - payment_collections
   - items
   - shipping_methods
+  - status
   - currency_code
   - id
   - version
@@ -235,3 +236,7 @@ properties:
     type: number
     title: original_shipping_tax_total
     description: The tax total of the order's shipping excluding promotions.
+  status:
+    type: string
+    title: status
+    description: The order's status.

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminOrderPreview.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminOrderPreview.yaml
@@ -6,6 +6,7 @@ x-schemaName: AdminOrderPreview
 required:
   - return_requested_total
   - order_change
+  - status
   - currency_code
   - id
   - version
@@ -643,3 +644,7 @@ properties:
     $ref: ./AdminCustomer.yaml
   sales_channel:
     $ref: ./AdminSalesChannel.yaml
+  status:
+    type: string
+    title: status
+    description: The order's status.

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseOrder.yaml
@@ -9,6 +9,7 @@ required:
   - sales_channel_id
   - email
   - currency_code
+  - status
   - items
   - shipping_methods
   - payment_status
@@ -230,3 +231,7 @@ properties:
     type: number
     title: original_shipping_tax_total
     description: The tax total of the order's shipping excluding promotions.
+  status:
+    type: string
+    title: status
+    description: The order's status.

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreOrder.yaml
@@ -4,6 +4,7 @@ x-schemaName: StoreOrder
 required:
   - items
   - shipping_methods
+  - status
   - currency_code
   - id
   - region_id
@@ -228,3 +229,7 @@ properties:
     description: The order's transactions.
     items:
       $ref: ./BaseOrderTransaction.yaml
+  status:
+    type: string
+    title: status
+    description: The order's status.

--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -43329,7 +43329,10 @@ paths:
             schema:
               type: object
               title: input
-              description: The input data necessary for authentication. For example, for email-pass authentication, pass `email` and `password` properties.
+              description: |
+                The input data necessary for authentication. 
+                For example, for email-pass authentication, pass `email` and `password` properties. 
+                For the Google and GitHub authentication providers, you can pass `callback_url` to indicate the URL in the frontend that the user should be redirected to after completing their authentication. This will override the provider's `callbackUrl` configurations in `medusa-config.ts`.
       x-codeSamples:
         - lang: Shell
           label: EmailPass Provider
@@ -47909,6 +47912,7 @@ components:
         - payment_collections
         - items
         - shipping_methods
+        - status
         - currency_code
         - id
         - version
@@ -48139,6 +48143,10 @@ components:
           type: number
           title: original_shipping_tax_total
           description: The tax total of the order's shipping excluding promotions.
+        status:
+          type: string
+          title: status
+          description: The order's status.
     AdminOrderAddress:
       type: object
       description: An order address.
@@ -48830,6 +48838,7 @@ components:
       required:
         - return_requested_total
         - order_change
+        - status
         - currency_code
         - id
         - version
@@ -49441,6 +49450,10 @@ components:
           $ref: '#/components/schemas/AdminCustomer'
         sales_channel:
           $ref: '#/components/schemas/AdminSalesChannel'
+        status:
+          type: string
+          title: status
+          description: The order's status.
     AdminOrderPreviewResponse:
       type: object
       description: The preview of an order.
@@ -55927,6 +55940,7 @@ components:
         - sales_channel_id
         - email
         - currency_code
+        - status
         - items
         - shipping_methods
         - payment_status
@@ -56148,6 +56162,10 @@ components:
           type: number
           title: original_shipping_tax_total
           description: The tax total of the order's shipping excluding promotions.
+        status:
+          type: string
+          title: status
+          description: The order's status.
     BaseOrderAddress:
       type: object
       description: An order address.
@@ -62108,6 +62126,7 @@ components:
       required:
         - items
         - shipping_methods
+        - status
         - currency_code
         - id
         - region_id
@@ -62332,6 +62351,10 @@ components:
           description: The order's transactions.
           items:
             $ref: '#/components/schemas/BaseOrderTransaction'
+        status:
+          type: string
+          title: status
+          description: The order's status.
     StoreOrderAddress:
       type: object
       description: An order address

--- a/www/apps/api-reference/specs/admin/paths/auth_user_{auth_provider}.yaml
+++ b/www/apps/api-reference/specs/admin/paths/auth_user_{auth_provider}.yaml
@@ -28,9 +28,17 @@ post:
         schema:
           type: object
           title: input
-          description: >-
-            The input data necessary for authentication. For example, for
-            email-pass authentication, pass `email` and `password` properties.
+          description: >
+            The input data necessary for authentication. 
+
+            For example, for email-pass authentication, pass `email` and
+            `password` properties. 
+
+            For the Google and GitHub authentication providers, you can pass
+            `callback_url` to indicate the URL in the frontend that the user
+            should be redirected to after completing their authentication. This
+            will override the provider's `callbackUrl` configurations in
+            `medusa-config.ts`.
   x-codeSamples:
     - lang: Shell
       label: EmailPass Provider

--- a/www/apps/api-reference/specs/store/components/schemas/AdminOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminOrder.yaml
@@ -5,6 +5,7 @@ required:
   - payment_collections
   - items
   - shipping_methods
+  - status
   - currency_code
   - id
   - version
@@ -235,3 +236,7 @@ properties:
     type: number
     title: original_shipping_tax_total
     description: The tax total of the order's shipping excluding promotions.
+  status:
+    type: string
+    title: status
+    description: The order's status.

--- a/www/apps/api-reference/specs/store/components/schemas/AdminOrderPreview.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminOrderPreview.yaml
@@ -6,6 +6,7 @@ x-schemaName: AdminOrderPreview
 required:
   - return_requested_total
   - order_change
+  - status
   - currency_code
   - id
   - version
@@ -643,3 +644,7 @@ properties:
     $ref: ./AdminCustomer.yaml
   sales_channel:
     $ref: ./AdminSalesChannel.yaml
+  status:
+    type: string
+    title: status
+    description: The order's status.

--- a/www/apps/api-reference/specs/store/components/schemas/BaseOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseOrder.yaml
@@ -9,6 +9,7 @@ required:
   - sales_channel_id
   - email
   - currency_code
+  - status
   - items
   - shipping_methods
   - payment_status
@@ -230,3 +231,7 @@ properties:
     type: number
     title: original_shipping_tax_total
     description: The tax total of the order's shipping excluding promotions.
+  status:
+    type: string
+    title: status
+    description: The order's status.

--- a/www/apps/api-reference/specs/store/components/schemas/StoreOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreOrder.yaml
@@ -4,6 +4,7 @@ x-schemaName: StoreOrder
 required:
   - items
   - shipping_methods
+  - status
   - currency_code
   - id
   - region_id
@@ -228,3 +229,7 @@ properties:
     description: The order's transactions.
     items:
       $ref: ./BaseOrderTransaction.yaml
+  status:
+    type: string
+    title: status
+    description: The order's status.

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -174,7 +174,10 @@ paths:
             schema:
               type: object
               title: input
-              description: The input data necessary for authentication. For example, for email-pass authentication, pass `email` and `password` properties.
+              description: |
+                The input data necessary for authentication. 
+                For example, for email-pass authentication, pass `email` and `password` properties. 
+                For the Google and GitHub authentication providers, you can pass `callback_url` to indicate the URL in the frontend that the customer should be redirected to after completing their authentication. This will override the provider's `callbackUrl` configurations in `medusa-config.ts`.
       x-codeSamples:
         - lang: Shell
           label: EmailPass Provider
@@ -10530,6 +10533,7 @@ components:
         - payment_collections
         - items
         - shipping_methods
+        - status
         - currency_code
         - id
         - version
@@ -10760,6 +10764,10 @@ components:
           type: number
           title: original_shipping_tax_total
           description: The tax total of the order's shipping excluding promotions.
+        status:
+          type: string
+          title: status
+          description: The order's status.
     AdminOrderAddress:
       type: object
       description: An order address.
@@ -11451,6 +11459,7 @@ components:
       required:
         - return_requested_total
         - order_change
+        - status
         - currency_code
         - id
         - version
@@ -12062,6 +12071,10 @@ components:
           $ref: '#/components/schemas/AdminCustomer'
         sales_channel:
           $ref: '#/components/schemas/AdminSalesChannel'
+        status:
+          type: string
+          title: status
+          description: The order's status.
     AdminOrderPreviewResponse:
       type: object
       description: The preview of an order.
@@ -18548,6 +18561,7 @@ components:
         - sales_channel_id
         - email
         - currency_code
+        - status
         - items
         - shipping_methods
         - payment_status
@@ -18769,6 +18783,10 @@ components:
           type: number
           title: original_shipping_tax_total
           description: The tax total of the order's shipping excluding promotions.
+        status:
+          type: string
+          title: status
+          description: The order's status.
     BaseOrderAddress:
       type: object
       description: An order address.
@@ -24729,6 +24747,7 @@ components:
       required:
         - items
         - shipping_methods
+        - status
         - currency_code
         - id
         - region_id
@@ -24953,6 +24972,10 @@ components:
           description: The order's transactions.
           items:
             $ref: '#/components/schemas/BaseOrderTransaction'
+        status:
+          type: string
+          title: status
+          description: The order's status.
     StoreOrderAddress:
       type: object
       description: An order address

--- a/www/apps/api-reference/specs/store/paths/auth_customer_{auth_provider}.yaml
+++ b/www/apps/api-reference/specs/store/paths/auth_customer_{auth_provider}.yaml
@@ -28,9 +28,17 @@ post:
         schema:
           type: object
           title: input
-          description: >-
-            The input data necessary for authentication. For example, for
-            email-pass authentication, pass `email` and `password` properties.
+          description: >
+            The input data necessary for authentication. 
+
+            For example, for email-pass authentication, pass `email` and
+            `password` properties. 
+
+            For the Google and GitHub authentication providers, you can pass
+            `callback_url` to indicate the URL in the frontend that the customer
+            should be redirected to after completing their authentication. This
+            will override the provider's `callbackUrl` configurations in
+            `medusa-config.ts`.
   x-codeSamples:
     - lang: Shell
       label: EmailPass Provider

--- a/www/utils/generated/oas-output/operations/admin/post_auth_[actor_type]_[auth_provider].ts
+++ b/www/utils/generated/oas-output/operations/admin/post_auth_[actor_type]_[auth_provider].ts
@@ -26,7 +26,12 @@
  *       schema:
  *         type: object
  *         title: input
- *         description: The input data necessary for authentication. For example, for email-pass authentication, pass `email` and `password` properties.
+ *         description: >
+ *           The input data necessary for authentication. 
+ * 
+ *           For example, for email-pass authentication, pass `email` and `password` properties. 
+ * 
+ *           For the Google and GitHub authentication providers, you can pass `callback_url` to indicate the URL in the frontend that the user should be redirected to after completing their authentication. This will override the provider's `callbackUrl` configurations in `medusa-config.ts`.
  * x-codeSamples:
  *   - lang: Shell
  *     label: EmailPass Provider

--- a/www/utils/generated/oas-output/operations/store/post_auth_[actor_type]_[auth_provider].ts
+++ b/www/utils/generated/oas-output/operations/store/post_auth_[actor_type]_[auth_provider].ts
@@ -26,7 +26,12 @@
  *       schema:
  *         type: object
  *         title: input
- *         description: The input data necessary for authentication. For example, for email-pass authentication, pass `email` and `password` properties.
+ *         description: >
+ *           The input data necessary for authentication. 
+ * 
+ *           For example, for email-pass authentication, pass `email` and `password` properties. 
+ * 
+ *           For the Google and GitHub authentication providers, you can pass `callback_url` to indicate the URL in the frontend that the customer should be redirected to after completing their authentication. This will override the provider's `callbackUrl` configurations in `medusa-config.ts`.
  * x-codeSamples:
  *   - lang: Shell
  *     label: EmailPass Provider

--- a/www/utils/generated/oas-output/schemas/AdminOrder.ts
+++ b/www/utils/generated/oas-output/schemas/AdminOrder.ts
@@ -7,6 +7,7 @@
  *   - payment_collections
  *   - items
  *   - shipping_methods
+ *   - status
  *   - currency_code
  *   - id
  *   - version
@@ -237,6 +238,10 @@
  *     type: number
  *     title: original_shipping_tax_total
  *     description: The tax total of the order's shipping excluding promotions.
+ *   status:
+ *     type: string
+ *     title: status
+ *     description: The order's status.
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminOrderPreview.ts
+++ b/www/utils/generated/oas-output/schemas/AdminOrderPreview.ts
@@ -6,6 +6,7 @@
  * required:
  *   - return_requested_total
  *   - order_change
+ *   - status
  *   - currency_code
  *   - id
  *   - version
@@ -617,6 +618,10 @@
  *     $ref: "#/components/schemas/AdminCustomer"
  *   sales_channel:
  *     $ref: "#/components/schemas/AdminSalesChannel"
+ *   status:
+ *     type: string
+ *     title: status
+ *     description: The order's status.
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/BaseOrder.ts
+++ b/www/utils/generated/oas-output/schemas/BaseOrder.ts
@@ -11,6 +11,7 @@
  *   - sales_channel_id
  *   - email
  *   - currency_code
+ *   - status
  *   - items
  *   - shipping_methods
  *   - payment_status
@@ -232,6 +233,10 @@
  *     type: number
  *     title: original_shipping_tax_total
  *     description: The tax total of the order's shipping excluding promotions.
+ *   status:
+ *     type: string
+ *     title: status
+ *     description: The order's status.
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/StoreOrder.ts
+++ b/www/utils/generated/oas-output/schemas/StoreOrder.ts
@@ -6,6 +6,7 @@
  * required:
  *   - items
  *   - shipping_methods
+ *   - status
  *   - currency_code
  *   - id
  *   - region_id
@@ -230,6 +231,10 @@
  *     description: The order's transactions.
  *     items:
  *       $ref: "#/components/schemas/BaseOrderTransaction"
+ *   status:
+ *     type: string
+ *     title: status
+ *     description: The order's status.
  * 
 */
 

--- a/www/utils/packages/docs-generator/src/classes/kinds/oas.ts
+++ b/www/utils/packages/docs-generator/src/classes/kinds/oas.ts
@@ -483,7 +483,7 @@ class OasKindGenerator extends FunctionKindGenerator {
     oas.parameters = this.updateParameters({
       oldParameters: oas.parameters as OpenAPIV3.ParameterObject[],
       newParameters: newPathParameters,
-      type: "path",
+      types: ["path", "header"],
     })
 
     // retrieve updated query and request schemas
@@ -498,7 +498,7 @@ class OasKindGenerator extends FunctionKindGenerator {
     oas.parameters = this.updateParameters({
       oldParameters: oas.parameters as OpenAPIV3.ParameterObject[],
       newParameters: queryParameters,
-      type: "query",
+      types: ["query"],
     })
 
     if (!oas.parameters.length) {
@@ -1913,7 +1913,7 @@ class OasKindGenerator extends FunctionKindGenerator {
   updateParameters({
     oldParameters,
     newParameters,
-    type,
+    types,
   }: {
     /**
      * The old list of parameters.
@@ -1926,13 +1926,13 @@ class OasKindGenerator extends FunctionKindGenerator {
     /**
      * The type of parameters.
      */
-    type: ParameterType
+    types: ParameterType[]
   }): OpenAPIV3.ParameterObject[] {
     if (!oldParameters) {
       return newParameters || []
     }
     const oppositeParamType = ["path", "query", "header"].filter(
-      (item) => item !== type
+      (item) => !types.includes(item as ParameterType)
     ) as ParameterType[]
     const oppositeParams: OpenAPIV3.ParameterObject[] =
       oldParameters?.filter((param) =>
@@ -1940,7 +1940,9 @@ class OasKindGenerator extends FunctionKindGenerator {
       ) || []
     // check and update/add parameters if necessary
     const existingParams: OpenAPIV3.ParameterObject[] =
-      oldParameters?.filter((param) => param.in === type) || []
+      oldParameters?.filter((param) =>
+        types.includes(param.in as ParameterType)
+      ) || []
     const paramsToRemove = new Set<string>()
 
     existingParams.forEach((parameter) => {
@@ -2405,8 +2407,8 @@ class OasKindGenerator extends FunctionKindGenerator {
     const fnText = node.getText()
 
     return {
-      shouldAddFields: fnText.includes(`req.remoteQueryConfig.fields`),
-      shouldAddPagination: fnText.includes(`req.remoteQueryConfig.pagination`),
+      shouldAddFields: fnText.includes(`req.queryConfig.fields`),
+      shouldAddPagination: fnText.includes(`req.queryConfig.pagination`),
     }
   }
 


### PR DESCRIPTION
- Fix how header parameters are updated
- replace `remoteQueryConfig` usage with `queryConfig`
- regenerate OAS for new release