### PR TITLE
fix(types): add missing inventory_items to input of createProductsWorkflow

### DIFF
--- a/.changeset/angry-jobs-prove.md
+++ b/.changeset/angry-jobs-prove.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": patch
+---
+
+fix(types): add missing inventory_items to input of createProductsWorkflow

--- a/packages/core/types/src/product/common.ts
+++ b/packages/core/types/src/product/common.ts
@@ -1239,6 +1239,16 @@ export interface UpdateProductOptionValueDTO {
 
 /**
  * @interface
+ * 
+ * Inventory kit for creating a product variant.
+ */
+export interface CreateProductVariantInventoryKit {
+  inventory_item_id: string
+  required_quantity?: number
+}
+
+/**
+ * @interface
  *
  * A product variant to create.
  */
@@ -1275,6 +1285,11 @@ export interface CreateProductVariantDTO {
    *  Whether the product variant's inventory should be managed by the core system.
    */
   manage_inventory?: boolean
+  /**
+   * The variant's inventory items. It's only
+   * available if `manage_inventory` is enabled.
+   */
+  inventory_items?: CreateProductVariantInventoryKit[]
   /**
    * The HS Code of the product variant.
    */


### PR DESCRIPTION
The `createProductsWorkflow` allows passing an `inventory_items` property to assign the inventory items of a product variant, and we even pass it in the `/admin/products` API route when creating a variant, but the workflow's input type doesn't include that property. This PR adds it to the workflow's input type.