### PR TITLE
fix(pricing): add null conditions for deleted at during price calculations

### DIFF
--- a/.changeset/nasty-poets-pretend.md
+++ b/.changeset/nasty-poets-pretend.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/pricing": patch
+---
+
+fix(pricing): add null conditions for deleted at during price calculations

--- a/packages/modules/pricing/src/repositories/pricing.ts
+++ b/packages/modules/pricing/src/repositories/pricing.ts
@@ -107,6 +107,7 @@ export class PricingRepository
         min_quantity: "price.min_quantity",
         max_quantity: "price.max_quantity",
         currency_code: "price.currency_code",
+        deleted_at: "price.deleted_at",
         price_set_id: "price.price_set_id",
         rules_count: "price.rules_count",
         price_list_id: "price.price_list_id",
@@ -268,7 +269,7 @@ export class PricingRepository
       .join(priceSubQueryKnex.as("price"), "price.price_set_id", "ps.id")
       .whereIn("ps.id", pricingFilters.id)
       .andWhere("price.currency_code", "=", currencyCode)
-
+      .whereNull("price.deleted_at")
       .orderBy([
         { column: "price.has_price_list", order: "asc" },
         { column: "all_rules_count", order: "desc" },


### PR DESCRIPTION
what:

The pricing calculations are currently returning deleted prices when calculating prices. This PR fixes that by scoping the query by the price's deleted_at

RESOLVES CMRC-832
FIXES https://github.com/medusajs/medusa/issues/10844