### PR TITLE
[Fix] Update Repository Directory Paths for All Packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist/**
 .vscode
 
 **/tsconfig.tsbuildinfo
+
+# Cache File
+/packages/**/.cache

--- a/packages/cli/create-medusa-app/package.json
+++ b/packages/cli/create-medusa-app/package.json
@@ -58,7 +58,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa.git",
-    "directory": "packages/create-medusa-app"
+    "directory": "packages/cli/create-medusa-app"
   },
   "author": "Medusa",
   "publishConfig": {

--- a/packages/cli/medusa-cli/package.json
+++ b/packages/cli/medusa-cli/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/medusa-cli"
+    "directory": "packages/cli/medusa-cli"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/medusa-dev-cli/package.json
+++ b/packages/cli/medusa-dev-cli/package.json
@@ -51,7 +51,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa.git",
-    "directory": "packages/medusa-dev-cli"
+    "directory": "packages/cli/medusa-dev-cli"
   },
   "scripts": {
     "test": "jest --passWithNoTests -- src",

--- a/packages/cli/oas/medusa-oas-cli/package.json
+++ b/packages/cli/oas/medusa-oas-cli/package.json
@@ -13,7 +13,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/oas/medusa-oas-cli"
+    "directory": "packages/cli/oas/medusa-oas-cli"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/oas/oas-github-ci/package.json
+++ b/packages/cli/oas/oas-github-ci/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/oas/oas-github-ci"
+    "directory": "packages/cli/oas/oas-github-ci"
   },
   "private": true,
   "author": "Medusa",

--- a/packages/core/modules-sdk/package.json
+++ b/packages/core/modules-sdk/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/modules-sdk"
+    "directory": "packages/core/modules-sdk"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/orchestration/package.json
+++ b/packages/core/orchestration/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/orchestration"
+    "directory": "packages/core/orchestration"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -10,7 +10,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/types"
+    "directory": "packages/core/types"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/utils"
+    "directory": "packages/core/utils"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/core/workflows-sdk/package.json
+++ b/packages/core/workflows-sdk/package.json
@@ -10,7 +10,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/workflows"
+    "directory": "packages/core/workflows-sdk"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/modules/api-key/package.json
+++ b/packages/modules/api-key/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/api-key"
+    "directory": "packages/modules/api-key"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/auth/package.json
+++ b/packages/modules/auth/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/auth"
+    "directory": "packages/modules/auth"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/cache-inmemory/package.json
+++ b/packages/modules/cache-inmemory/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/cache-inmemory"
+    "directory": "packages/modules/cache-inmemory"
   },
   "engines": {
     "node": ">=20"

--- a/packages/modules/cache-redis/package.json
+++ b/packages/modules/cache-redis/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/cache-redis"
+    "directory": "packages/modules/cache-redis"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/cart/package.json
+++ b/packages/modules/cart/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/cart"
+    "directory": "packages/modules/cart"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/currency/package.json
+++ b/packages/modules/currency/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/currency"
+    "directory": "packages/modules/currency"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/customer/package.json
+++ b/packages/modules/customer/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/customer"
+    "directory": "packages/modules/customer"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/event-bus-local/package.json
+++ b/packages/modules/event-bus-local/package.json
@@ -12,7 +12,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/event-bus-local"
+    "directory": "packages/modules/event-bus-local"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/event-bus-redis/package.json
+++ b/packages/modules/event-bus-redis/package.json
@@ -12,7 +12,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/event-bus-redis"
+    "directory": "packages/modules/event-bus-redis"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/file/package.json
+++ b/packages/modules/file/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/file"
+    "directory": "packages/modules/file"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/fulfillment/package.json
+++ b/packages/modules/fulfillment/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/fulfillment"
+    "directory": "packages/modules/fulfillment"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/index/package.json
+++ b/packages/modules/index/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/index"
+    "directory": "packages/modules/index"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/inventory/package.json
+++ b/packages/modules/inventory/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/inventory"
+    "directory": "packages/modules/inventory"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/link-modules/package.json
+++ b/packages/modules/link-modules/package.json
@@ -13,7 +13,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/link-modules"
+    "directory": "packages/modules/link-modules"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/locking/package.json
+++ b/packages/modules/locking/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/locking"
+    "directory": "packages/modules/locking"
   },
   "files": [
     "dist",

--- a/packages/modules/order/package.json
+++ b/packages/modules/order/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/order"
+    "directory": "packages/modules/order"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/payment/package.json
+++ b/packages/modules/payment/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/payment"
+    "directory": "packages/modules/payment"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/pricing/package.json
+++ b/packages/modules/pricing/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/pricing"
+    "directory": "packages/modules/pricing"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/product/package.json
+++ b/packages/modules/product/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/product"
+    "directory": "packages/modules/product"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/promotion/package.json
+++ b/packages/modules/promotion/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/promotion"
+    "directory": "packages/modules/promotion"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/providers/file-local/package.json
+++ b/packages/modules/providers/file-local/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/file-local"
+    "directory": "packages/modules/providers/file-local"
   },
   "files": [
     "dist",

--- a/packages/modules/providers/file-s3/package.json
+++ b/packages/modules/providers/file-s3/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/file-local"
+    "directory": "packages/file-s3"
   },
   "files": [
     "dist",

--- a/packages/modules/providers/file-s3/package.json
+++ b/packages/modules/providers/file-s3/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/file-s3"
+    "directory": "packages/modules/providers/file-s3"
   },
   "files": [
     "dist",

--- a/packages/modules/providers/fulfillment-manual/package.json
+++ b/packages/modules/providers/fulfillment-manual/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/fulfillment-manual"
+    "directory": "packages/modules/providers/fulfillment-manual"
   },
   "files": [
     "dist",

--- a/packages/modules/providers/locking-postgres/package.json
+++ b/packages/modules/providers/locking-postgres/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/locking-postgres"
+    "directory": "packages/modules/providers/locking-postgres"
   },
   "files": [
     "dist",

--- a/packages/modules/providers/locking-redis/package.json
+++ b/packages/modules/providers/locking-redis/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/locking-redis"
+    "directory": "packages/modules/providers/locking-redis"
   },
   "files": [
     "dist",

--- a/packages/modules/providers/payment-stripe/package.json
+++ b/packages/modules/providers/payment-stripe/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/payment-stripe"
+    "directory": "packages/modules/providers/payment-stripe"
   },
   "files": [
     "dist",

--- a/packages/modules/region/package.json
+++ b/packages/modules/region/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/region"
+    "directory": "packages/modules/region"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/sales-channel/package.json
+++ b/packages/modules/sales-channel/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/sales-channel"
+    "directory": "packages/modules/sales-channel"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/stock-location/package.json
+++ b/packages/modules/stock-location/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/stock-location"
+    "directory": "packages/modules/stock-location"
   },
   "engines": {
     "node": ">=20"

--- a/packages/modules/store/package.json
+++ b/packages/modules/store/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/store"
+    "directory": "packages/modules/store"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/tax/package.json
+++ b/packages/modules/tax/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/tax"
+    "directory": "packages/modules/tax"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/user/package.json
+++ b/packages/modules/user/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/user"
+    "directory": "packages/modules/user"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/workflow-engine-inmemory/package.json
+++ b/packages/modules/workflow-engine-inmemory/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/workflow-engine-inmemory"
+    "directory": "packages/modules/workflow-engine-inmemory"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/workflow-engine-redis/package.json
+++ b/packages/modules/workflow-engine-redis/package.json
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/workflow-engine-redis"
+    "directory": "packages/modules/workflow-engine-redis"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR updates the `repository.directory` field in the package.json files of all packages to include the correct directory paths, reflecting the structure within the Medusa repository.

### Changes:
- Updated the repository.directory paths for all packages to include the modules folder where applicable.

> Example: "directory": "packages/api-key" was changed to "directory": "packages/modules/api-key".

This ensures accurate references to the package locations within the repository for better clarity and maintainability. Please review and merge.




