### PR TITLE
fix: Put routes loader error inline

### DIFF
--- a/packages/medusa/src/loaders/api.ts
+++ b/packages/medusa/src/loaders/api.ts
@@ -65,8 +65,7 @@ export default async ({ app, container, plugins }: Options) => {
     }).load()
   } catch (err) {
     throw Error(
-      "An error occurred while registering API Routes. See error in logs for more details.",
-      { cause: err }
+      `An error occurred while registering API Routes. Error: ${err.message}`
     )
   }
 


### PR DESCRIPTION
This is the only place where we used `cause`, which caused the error to be swallowed in Cloud due to it not being output in the same way to stderr. This PR simply puts the error inline, which is how we handle errors in most of the places in the codebase.