### PR TITLE
chore: Use local CLI version in CI

### DIFF
--- a/.github/workflows/test-cli-with-database.yml
+++ b/.github/workflows/test-cli-with-database.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create Medusa project
         run: |
-          medusa new cli-test --skip-db --branch ci
+          medusa new cli-test --skip-db --v2 --branch ci
         working-directory: ..
 
       - name: run medusa dev

--- a/.github/workflows/test-cli-with-database.yml
+++ b/.github/workflows/test-cli-with-database.yml
@@ -47,11 +47,11 @@ jobs:
           node-version: 20
 
       - name: Install Medusa cli
-        run: npm i -g @medusajs/cli@preview
+        run: npm i -g @medusajs/cli@latest
 
       - name: Create Medusa project
         run: |
-          medusa new cli-test --skip-db --v2 --branch ci
+          medusa new cli-test --skip-db --branch ci
         working-directory: ..
 
       - name: run medusa dev
@@ -59,22 +59,22 @@ jobs:
         working-directory: ../cli-test
 
       - name: Run migrations
-        run: medusa db:migrate
+        run: npx medusa db:migrate
         working-directory: ../cli-test
 
       - name: Create admin user
-        run: medusa user -e test@test.com -p password -i admin_123
+        run: npx medusa user -e test@test.com -p password -i admin_123
         working-directory: ../cli-test
 
       - name: Run development server
-        run: medusa develop &
+        run: npx medusa develop &
         working-directory: ../cli-test
 
       - name: Testing development server
         uses: ./.github/actions/test-server
 
       - name: Starting medusa
-        run: medusa start &
+        run: npx medusa start &
         working-directory: ../cli-test
 
       - name: Testing server


### PR DESCRIPTION
**What**

Use `npx` to resolve the locally installed version of `@medusajs/cli` instead of the global one

**Why**

The version mismatch between the globally installed CLI package and the local packages in the project was causing an issue related to loading `medusa-config.ts`. The exact reason for this is still unclear, but this should at least unblock merging PRs. 

We can tackle a larger clean-up of the workflow separately.

---

Sidenote: Using `npx` brings another improvement that is the changes made to `@medusajs/cli` in a PR will now be tested in the CI instead of the global package.