### PR TITLE
Filtering products by external id column is possible but not in the interface/type

### DIFF
--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -379,6 +379,10 @@ export interface BaseProductListParams
    */
   is_giftcard?: boolean
   /**
+   * Filter by external id(s).
+   */
+  external_id?: string | string[]
+  /**
    * Filter by the product's tag(s).
    */
   tags?: string | string[]


### PR DESCRIPTION
Filtering products by external id column is possible but not in the interface/type, i think there are a few more places you can add it