### PR TITLE
fix(create-medusa-app): --db-url keep asking db credentials

### DIFF
--- a/.changeset/chatty-badgers-visit.md
+++ b/.changeset/chatty-badgers-visit.md
@@ -1,0 +1,5 @@
+---
+"create-medusa-app": patch
+---
+
+Fix issue where create-medusa-app repeatedly asked for database credentials even when --db-url was specified. The logic in MedusaProjectCreator->create()->initializeProject()->setupDatabase() always defines a dbName. Updated the getDbClientAndCredentials() method to check db-url first

--- a/packages/cli/create-medusa-app/src/utils/create-db.ts
+++ b/packages/cli/create-medusa-app/src/utils/create-db.ts
@@ -225,7 +225,7 @@ export async function getDbClientAndCredentials({
   dbConnectionString: string
   verbose?: boolean
 }> {
-  // check db-url first cause dbName is always be define in MedusaProjectCreator->create()->initializeProject()->setupDatabase()
+  // Check the db-url first, because the dbName is always defined in MedusaProjectCreator->create()->initializeProject()->setupDatabase()
   if (dbUrl) {
     return await getForDbUrl({
       dbUrl,

--- a/packages/cli/create-medusa-app/src/utils/create-db.ts
+++ b/packages/cli/create-medusa-app/src/utils/create-db.ts
@@ -225,14 +225,15 @@ export async function getDbClientAndCredentials({
   dbConnectionString: string
   verbose?: boolean
 }> {
-  if (dbName) {
-    return await getForDbName({
-      dbName,
+  // check db-url first cause dbName is always be define in MedusaProjectCreator->create()->initializeProject()->setupDatabase()
+  if (dbUrl) {
+    return await getForDbUrl({
+      dbUrl,
       verbose,
     })
   } else {
-    return await getForDbUrl({
-      dbUrl,
+    return await getForDbName({
+      dbName,
       verbose,
     })
   }

--- a/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
+++ b/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
@@ -44,7 +44,6 @@ export class MedusaProjectCreator
 
   async create(): Promise<void> {
     track("CREATE_CLI_CMA")
-
     try {
       await this.initializeProject()
       await this.setupProject()
@@ -111,6 +110,8 @@ export class MedusaProjectCreator
         dbUrl: this.options.dbUrl,
         verbose: this.options.verbose,
       })
+    
+    
 
     this.client = client
     this.dbConnectionString = dbConnectionString

--- a/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
+++ b/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
@@ -44,6 +44,7 @@ export class MedusaProjectCreator
 
   async create(): Promise<void> {
     track("CREATE_CLI_CMA")
+
     try {
       await this.initializeProject()
       await this.setupProject()
@@ -110,8 +111,6 @@ export class MedusaProjectCreator
         dbUrl: this.options.dbUrl,
         verbose: this.options.verbose,
       })
-    
-    
 
     this.client = client
     this.dbConnectionString = dbConnectionString


### PR DESCRIPTION
issue #11033: it keeps asking for the database credentials even after specifying --db-url #11033

fix: dbName is always define. Checking for dbName first in getDbClientAndCredentials() was always skiping getForDbUrl case