### PR TITLE
fix(create-medusa-app): fix database name from input not used in setup

### DIFF
--- a/.changeset/light-fireants-attend.md
+++ b/.changeset/light-fireants-attend.md
@@ -1,0 +1,5 @@
+---
+"create-medusa-app": patch
+---
+
+fix(create-medusa-app): fix database name from input not used in setup

--- a/packages/cli/create-medusa-app/src/utils/create-db.ts
+++ b/packages/cli/create-medusa-app/src/utils/create-db.ts
@@ -224,6 +224,7 @@ export async function getDbClientAndCredentials({
   client: pg.Client
   dbConnectionString: string
   verbose?: boolean
+  dbName?: string
 }> {
   if (dbName) {
     return await getForDbName({

--- a/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
+++ b/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
@@ -104,7 +104,7 @@ export class MedusaProjectCreator
   }
 
   private async setupDatabase(): Promise<void> {
-    const dbName = `medusa-${slugify(this.projectName)}`
+    let dbName = `medusa-${slugify(this.projectName)}`
     const { client, dbConnectionString, ...rest } =
       await getDbClientAndCredentials({
         dbName,
@@ -115,11 +115,12 @@ export class MedusaProjectCreator
     this.client = client
     this.dbConnectionString = dbConnectionString
     this.isDbInitialized = true
+    dbName = rest.dbName || dbName
 
     if (!this.options.dbUrl) {
       this.factBoxOptions.interval = displayFactBox({
         ...this.factBoxOptions,
-        title: "Creating database...",
+        message: "Creating database...",
       })
 
       this.client = await runCreateDb({


### PR DESCRIPTION
When the default database name already exists, the user is asked to enter a new name. However, the new name wasn't being used. This PR fixes the issue.

Closes #11064
Closes SUP-641