### PR TITLE
fix: Flaky behavior of Yalc

### DIFF
--- a/.changeset/seven-cooks-drop.md
+++ b/.changeset/seven-cooks-drop.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/medusa": patch
+"@medusajs/framework": patch
+---
+
+fix: Flaky behavior of Yalc

--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import { getConfigFile } from "@medusajs/utils"
 import type { AdminOptions, ConfigModule, Logger } from "@medusajs/types"
-import { rm, access, constants, copyFile, writeFile } from "fs/promises"
+import { rm, access, constants, copyFile, writeFile, mkdir } from "fs/promises"
 import type tsStatic from "typescript"
 
 /**
@@ -138,6 +138,16 @@ export class Compiler {
    */
   async #clean(path: string) {
     await rm(path, { recursive: true }).catch(() => {})
+  }
+
+  /**
+   * Ensures a directory exists
+   */
+  async #ensureDir(path: string, clean?: boolean) {
+    if (clean) {
+      await this.#clean(path)
+    }
+    await mkdir(path, { recursive: true })
   }
 
   /**
@@ -463,6 +473,7 @@ export class Compiler {
    * a file has changed.
    */
   async developPluginBackend(onFileChange?: () => void) {
+    await this.#ensureDir(this.#pluginsDistFolder, true)
     await this.#createPluginOptionsFile()
     const ts = await this.#loadTSCompiler()
 


### PR DESCRIPTION
Fixes: FRMW-2882

Yalc is meant to be used as a binary. However, we are importing it as a package and re-calling the same `publishPackage` function on every change. This makes Yalc behave flaky and therefore this PR calls `yalc` as a command.

We do not have to make the same changes in other commands, since they are not long-lived like the `plugin:develop` command.