### PR TITLE
fix(dashboard): Format i18n schema with Prettier

### DIFF
--- a/.changeset/dirty-dancers-cough.md
+++ b/.changeset/dirty-dancers-cough.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): Format i18n schema with Prettier


### PR DESCRIPTION
**What**
- Formats the schema that is generated by `yarn i18n:schema`. 
- Ensures we don't end up with huge diffs if one team member forgets to format the schema in one PR, and the schema is then updated and formatted later on.