### PR TITLE
docs: clarify condition / variable manipulation restriction for workflows and steps

### DIFF
--- a/www/apps/book/app/learn/fundamentals/workflows/conditions/page.mdx
+++ b/www/apps/book/app/learn/fundamentals/workflows/conditions/page.mdx
@@ -14,6 +14,12 @@ So, you can't use an if-condition that checks a variable's value, as the conditi
 
 Instead, use when-then from the Workflows SDK. It allows you to perform steps in a workflow only if a condition that you specify is satisfied.
 
+<Note title="Tip">
+
+Restrictions for conditions is only applicable in a workflow's definition. You can still use if-conditions in your step's code.
+
+</Note>
+
 ---
 
 ## How to use When-Then?

--- a/www/apps/book/app/learn/fundamentals/workflows/variable-manipulation/page.mdx
+++ b/www/apps/book/app/learn/fundamentals/workflows/variable-manipulation/page.mdx
@@ -16,6 +16,12 @@ So, you can only pass variables as parameters to steps. But, in a workflow, you 
 
 Instead, use `transform` from the Workflows SDK.
 
+<Note title="Tip">
+
+Restrictions for variable manipulation is only applicable in a workflow's definition. You can still manipulate variables in your step's code.
+
+</Note>
+
 ---
 
 ## What is the transform Utility?


### PR DESCRIPTION
Clarify that restrictions on using conditions and manipulating variables applies to workflows only, and not steps in the workflow.

Closes DX-1284