### PR TITLE
Added currency symbol for Turkish lira

### DIFF
--- a/packages/core/utils/src/defaults/currencies.ts
+++ b/packages/core/utils/src/defaults/currencies.ts
@@ -946,9 +946,9 @@ export const defaultCurrencies: Record<string, Currency> = {
     name_plural: "Tongan paʻanga",
   },
   TRY: {
-    symbol: "TL",
+    symbol: "₺",
     name: "Turkish Lira",
-    symbol_native: "TL",
+    symbol_native: "₺",
     decimal_digits: 2,
     rounding: 0,
     code: "TRY",


### PR DESCRIPTION
### Added missing currency symbol for Turkish lira

Relates to issue #11149 

Ref: https://en.wikipedia.org/wiki/Turkish_lira_sign
Symbol added:

# ₺


**What** - Added another currency to the list of currencies
**Why** - For those developing a Medusa app targeting the Turkish market
**How** - Updated the `symbol` key in the relevant file
**Testing** - Currency symbol was added following the same format of the previous currencies
