### PR TITLE
fix(order): add data model name in define schema

### DIFF
--- a/.changeset/rotten-trainers-lie.md
+++ b/.changeset/rotten-trainers-lie.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/order": patch
+---
+
+fix(order): add data model name in define schema

--- a/packages/modules/order/src/models/order-summary.ts
+++ b/packages/modules/order/src/models/order-summary.ts
@@ -5,6 +5,7 @@ const _OrderSummary = model
   .define(
     {
       tableName: "order_summary",
+      name: "OrderSummary",
     },
     {
       id: model.id({ prefix: "ordsum" }).primaryKey(),

--- a/packages/modules/order/src/models/return-item.ts
+++ b/packages/modules/order/src/models/return-item.ts
@@ -6,6 +6,7 @@ import { ReturnReason } from "./return-reason"
 const _ReturnItem = model
   .define(
     {
+      name: "ReturnItem",
       tableName: "return_item",
     },
     {

--- a/packages/modules/order/src/models/shipping-method-adjustment.ts
+++ b/packages/modules/order/src/models/shipping-method-adjustment.ts
@@ -5,6 +5,7 @@ const _OrderShippingMethodAdjustment = model
   .define(
     {
       tableName: "order_shipping_method_adjustment",
+      name: "OrderShippingMethodAdjustment",
     },
     {
       id: model.id({ prefix: "ordsmadj" }).primaryKey(),

--- a/packages/modules/order/src/models/shipping-method-tax-line.ts
+++ b/packages/modules/order/src/models/shipping-method-tax-line.ts
@@ -5,6 +5,7 @@ const _OrderShippingMethodTaxLine = model
   .define(
     {
       tableName: "order_shipping_method_tax_line",
+      name: "OrderShippingMethodTaxLine",
     },
     {
       id: model.id({ prefix: "ordsmtxl" }).primaryKey(),


### PR DESCRIPTION
Add missing data model name in `model.define` in the Order Module where missing, as we need to infer the names in the references we generate

Closes DX-1305