### PR TITLE
chore(js-sdk): Remove create user method from SDK

### DIFF
--- a/packages/core/js-sdk/src/admin/user.ts
+++ b/packages/core/js-sdk/src/admin/user.ts
@@ -14,19 +14,6 @@ export class User {
     this.client = client
   }
 
-  async create(
-    body: HttpTypes.AdminCreateUser,
-    query?: HttpTypes.AdminUserParams,
-    headers?: ClientHeaders
-  ) {
-    return this.client.fetch<HttpTypes.AdminUserResponse>(`/admin/users`, {
-      method: "POST",
-      headers,
-      body,
-      query,
-    })
-  }
-
   async update(
     id: string,
     body: HttpTypes.AdminUpdateUser,


### PR DESCRIPTION
Endpoint doesn't exist. Admin users can only be created through invites at the HTTP level.