### PR TITLE
fix: exit process with a status code when build fails

### DIFF
--- a/.changeset/nice-actors-juggle.md
+++ b/.changeset/nice-actors-juggle.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/medusa": patch
+"@medusajs/framework": patch
+---
+
+fix: exit process with a status code when build fails

--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -315,12 +315,12 @@ export class Compiler {
       this.#logger.warn(
         `Backend build completed with errors (${tracker.getSeconds()}s)`
       )
-    } else {
-      this.#logger.info(
-        `Backend build completed successfully (${tracker.getSeconds()}s)`
-      )
+      return false
     }
 
+    this.#logger.info(
+      `Backend build completed successfully (${tracker.getSeconds()}s)`
+    )
     return true
   }
 
@@ -359,7 +359,7 @@ export class Compiler {
       this.#logger.info(
         "Skipping admin build, since its disabled inside the medusa-config file"
       )
-      return false
+      return true
     }
 
     /**
@@ -435,12 +435,12 @@ export class Compiler {
       this.#logger.warn(
         `Plugin build completed with errors (${tracker.getSeconds()}s)`
       )
-    } else {
-      this.#logger.info(
-        `Plugin build completed successfully (${tracker.getSeconds()}s)`
-      )
+      return false
     }
 
+    this.#logger.info(
+      `Plugin build completed successfully (${tracker.getSeconds()}s)`
+    )
     return true
   }
 

--- a/packages/medusa/src/commands/build.ts
+++ b/packages/medusa/src/commands/build.ts
@@ -7,23 +7,28 @@ export default async function build({
 }: {
   directory: string
   adminOnly: boolean
-}): Promise<boolean> {
+}) {
   logger.info("Starting build...")
   const compiler = new Compiler(directory, logger)
 
   const tsConfig = await compiler.loadTSConfigFile()
   if (!tsConfig) {
     logger.error("Unable to compile application")
-    return false
+    process.exit(1)
   }
 
-  const promises: Promise<any>[] = []
+  const promises: Promise<boolean>[] = []
   if (!adminOnly) {
     promises.push(compiler.buildAppBackend(tsConfig))
   }
 
   const bundler = await import("@medusajs/admin-bundler")
   promises.push(compiler.buildAppFrontend(adminOnly, tsConfig, bundler))
-  await Promise.all(promises)
-  return true
+  const responses = await Promise.all(promises)
+
+  if (responses.every((response) => response === true)) {
+    process.exit(0)
+  } else {
+    process.exit(1)
+  }
 }

--- a/packages/medusa/src/commands/plugin/build.ts
+++ b/packages/medusa/src/commands/plugin/build.ts
@@ -1,21 +1,24 @@
 import { Compiler } from "@medusajs/framework/build-tools"
 import { logger } from "@medusajs/framework/logger"
-export default async function build({
-  directory,
-}: {
-  directory: string
-}): Promise<boolean> {
+export default async function build({ directory }: { directory: string }) {
   logger.info("Starting build...")
   const compiler = new Compiler(directory, logger)
 
   const tsConfig = await compiler.loadTSConfigFile()
   if (!tsConfig) {
     logger.error("Unable to compile plugin")
-    return false
+    process.exit(1)
   }
 
   const bundler = await import("@medusajs/admin-bundler")
-  await compiler.buildPluginBackend(tsConfig)
-  await compiler.buildPluginAdminExtensions(bundler)
-  return true
+  const responses = await Promise.all([
+    compiler.buildPluginBackend(tsConfig),
+    compiler.buildPluginAdminExtensions(bundler),
+  ])
+
+  if (responses.every((response) => response === true)) {
+    process.exit(0)
+  } else {
+    process.exit(1)
+  }
 }


### PR DESCRIPTION
Fixes: FRMW-2897
CLOSES CLO-434

Still need the frontend Admin bundler to provide some way to know if the build has failed or not.