### PR TITLE
docs: fix overflowing content on small devices

### DIFF
--- a/www/packages/docs-ui/src/components/AiAssistant/ChatWindow/index.tsx
+++ b/www/packages/docs-ui/src/components/AiAssistant/ChatWindow/index.tsx
@@ -152,7 +152,8 @@ export const AiAssistantChatWindow = () => {
           "shadow-elevation-modal dark:shadow-elevation-modal-dark",
           "bg-medusa-bg-base rounded-docs_DEFAULT overflow-x-hidden",
           "flex-col justify-between m-docs_0.25 max-w-ai-assistant",
-          chatOpened && ["!right-0"]
+          chatOpened && ["!right-0"],
+          !chatOpened && ["!fixed"]
         )}
         style={{
           height,

--- a/www/packages/docs-ui/src/providers/Layout/index.tsx
+++ b/www/packages/docs-ui/src/providers/Layout/index.tsx
@@ -24,11 +24,7 @@ export const LayoutProvider = ({
   const [showCollapsedNavbar, setShowCollapsedNavbar] = useState(false)
 
   useResizeObserver(mainContentRef as React.RefObject<HTMLDivElement>, () => {
-    if (disableResizeObserver) {
-      setShowCollapsedNavbar(false)
-      return
-    }
-    if (window.innerWidth < 992) {
+    if (disableResizeObserver || window.innerWidth < 992) {
       setShowCollapsedNavbar(false)
       return
     }


### PR DESCRIPTION
Fix content overflowing on small devices