### PR TITLE
fix(admin): loadConfig does not allow `serve` to be truly configurable

### DIFF
--- a/.changeset/stale-ghosts-carry.md
+++ b/.changeset/stale-ghosts-carry.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/admin": patch
+---
+
+fix(admin): loadConfig does not allow serve to be truly configurable

--- a/packages/admin/src/utils/load-config.ts
+++ b/packages/admin/src/utils/load-config.ts
@@ -35,7 +35,6 @@ export const loadConfig = (isDev?: boolean): PluginOptions | null => {
   if (isDev) {
     config = {
       ...config,
-      serve: false,
       path: "/",
       backend: "http://localhost:9000",
     }
@@ -45,7 +44,7 @@ export const loadConfig = (isDev?: boolean): PluginOptions | null => {
     const options = (plugin as { options: PluginOptions }).options ?? {}
 
     config = {
-      serve: isDev ? false : options.serve ?? config.serve,
+      serve: options.serve ?? config.serve,
       autoRebuild: options.autoRebuild ?? config.autoRebuild,
       path: options.path ?? config.path,
       outDir: options.outDir ?? config.outDir,


### PR DESCRIPTION
## Related to https://github.com/medusajs/medusa/issues/11237

## Solution that PR introduce
- `serve` is always `true` allowing to always start the Admin UI with the new logic in the `develop.js` command file in `@medusajs/medusa`
- `loadConfig` in the `@medusajs/admin` is no longer overriding the `serve` function to false, allowing to fix the current bug we have in v1.20.11 where the Admin UI cannot be launched at all

## Quick preview of the new behavior on a project
In this preview, I try with the different values and how it behaves with the fix.
- No `serve` option -> Default to `true`; Trigger the admin develop
- `serve` set to `false` -> Ignore the admin develop command
- `serve` set to `true` -> Trigger the admin develop

https://github.com/user-attachments/assets/33fdb428-b3ae-466a-9095-b7f8ba0dd822

