### PR TITLE
feat: map container types for core services to interface

### DIFF
--- a/.changeset/witty-lies-burn.md
+++ b/.changeset/witty-lies-burn.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/types": patch
+"@medusajs/utils": patch
+---
+
+feat: map container types for core services to interface

--- a/packages/core/types/src/common/common.ts
+++ b/packages/core/types/src/common/common.ts
@@ -66,7 +66,7 @@ export interface FindConfig<Entity> {
   /**
    * An array of strings, each being attribute names of the entity to retrieve in the result.
    */
-  select?: (keyof Entity | string)[]
+  select?: (keyof Entity | (string & {}))[]
 
   /**
    * A number indicating the number of records to skip before retrieving the results.

--- a/packages/core/utils/src/modules-sdk/__tests__/modules-to-container-types.spec.ts
+++ b/packages/core/utils/src/modules-sdk/__tests__/modules-to-container-types.spec.ts
@@ -14,10 +14,10 @@ describe("generateContainerTypes", function () {
       {
         cache: {
           __definition: {
-            key: "cache",
+            key: "foo-cache",
             label: "Cache",
-            defaultPackage: "@medusajs/foo",
-            resolvePath: "@medusajs/foo",
+            defaultPackage: "@medusajs/foo-cache",
+            resolvePath: "@medusajs/foo-cache",
             defaultModuleDeclaration: {
               scope: "internal",
             },
@@ -34,11 +34,46 @@ describe("generateContainerTypes", function () {
     expect(await fileSystem.exists("modules-bindings.d.ts")).toBeTruthy()
     expect(await fileSystem.contents("modules-bindings.d.ts"))
       .toMatchInlineSnapshot(`
-      "import type Cache from '@medusajs/foo'
+      "import type FooCache from '@medusajs/foo-cache'
 
       declare module '@medusajs/framework/types' {
         interface ModulesImplementations {
-          cache: InstanceType<(typeof Cache)['service']>
+          'foo-cache': InstanceType<(typeof FooCache)['service']>
+        }
+      }"
+    `)
+  })
+
+  it("point inbuilt packages to their interfaces", async function () {
+    await generateContainerTypes(
+      {
+        cache: {
+          __definition: {
+            key: "cache",
+            label: "Cache",
+            defaultPackage: "@medusajs/foo-cache",
+            resolvePath: "@medusajs/foo-cache",
+            defaultModuleDeclaration: {
+              scope: "internal",
+            },
+          },
+          __joinerConfig: {},
+        },
+      },
+      {
+        outputDir: fileSystem.basePath,
+        interfaceName: "ModulesImplementations",
+      }
+    )
+
+    expect(await fileSystem.exists("modules-bindings.d.ts")).toBeTruthy()
+    expect(await fileSystem.contents("modules-bindings.d.ts"))
+      .toMatchInlineSnapshot(`
+      "import type { ICacheService } from '@medusajs/framework/types'
+
+      declare module '@medusajs/framework/types' {
+        interface ModulesImplementations {
+          'cache': ICacheService
         }
       }"
     `)
@@ -47,10 +82,10 @@ describe("generateContainerTypes", function () {
   it("should normalize module path pointing to a relative file", async function () {
     await generateContainerTypes(
       {
-        cache: {
+        bar: {
           __definition: {
-            key: "cache",
-            label: "Cache",
+            key: "bar",
+            label: "Bar",
             defaultPackage: "./foo/bar",
             resolvePath: "./foo/bar",
             defaultModuleDeclaration: {
@@ -69,11 +104,11 @@ describe("generateContainerTypes", function () {
     expect(await fileSystem.exists("modules-bindings.d.ts")).toBeTruthy()
     expect(await fileSystem.contents("modules-bindings.d.ts"))
       .toMatchInlineSnapshot(`
-      "import type Cache from '../../foo/bar'
+      "import type Bar from '../../foo/bar'
 
       declare module '@medusajs/framework/types' {
         interface ModulesImplementations {
-          cache: InstanceType<(typeof Cache)['service']>
+          'bar': InstanceType<(typeof Bar)['service']>
         }
       }"
     `)

--- a/packages/core/utils/src/modules-sdk/modules-to-container-types.ts
+++ b/packages/core/utils/src/modules-sdk/modules-to-container-types.ts
@@ -89,11 +89,13 @@ export async function generateContainerTypes(
          * Key registered within the container
          */
         const key = service.__definition.key
+        const interfaceKey = `'${key}'`
+
         if (SERVICES_INTERFACES[key]) {
           result.imports.push(
             `import type { ${SERVICES_INTERFACES[key]} } from '@medusajs/framework/types'`
           )
-          result.mappings.push(`${key}: ${SERVICES_INTERFACES[key]}`)
+          result.mappings.push(`${interfaceKey}: ${SERVICES_INTERFACES[key]}`)
           return
         }
 
@@ -112,7 +114,7 @@ export async function generateContainerTypes(
 
         result.imports.push(`import type ${serviceName} from '${servicePath}'`)
         result.mappings.push(
-          `${key}: InstanceType<(typeof ${serviceName})['service']>`
+          `${interfaceKey}: InstanceType<(typeof ${serviceName})['service']>`
         )
       })
       return result

--- a/packages/core/utils/src/modules-sdk/modules-to-container-types.ts
+++ b/packages/core/utils/src/modules-sdk/modules-to-container-types.ts
@@ -1,8 +1,42 @@
 import { join } from "path"
+import { Modules } from "./definition"
 import type { LoadedModule } from "@medusajs/types"
 import { FileSystem } from "../common/file-system"
 import { toCamelCase } from "../common/to-camel-case"
 import { upperCaseFirst } from "../common/upper-case-first"
+
+/**
+ * For known services that has interfaces, we will set the container
+ * type to the interface than the actual service implementation.
+ *
+ * The idea is to provide more precise types.
+ */
+const SERVICES_INTERFACES = {
+  [Modules.AUTH]: "IAuthModuleService",
+  [Modules.CACHE]: "ICacheService",
+  [Modules.CART]: "ICartModuleService",
+  [Modules.CUSTOMER]: "ICustomerModuleService",
+  [Modules.EVENT_BUS]: "IEventBusModuleService",
+  [Modules.INVENTORY]: "IInventoryService",
+  [Modules.PAYMENT]: "IPaymentModuleService",
+  [Modules.PRICING]: "IPricingModuleService",
+  [Modules.PRODUCT]: "IProductModuleService",
+  [Modules.PROMOTION]: "IPromotionModuleService",
+  [Modules.SALES_CHANNEL]: "ISalesChannelModuleService",
+  [Modules.TAX]: "ITaxModuleService",
+  [Modules.FULFILLMENT]: "IFulfillmentModuleService",
+  [Modules.STOCK_LOCATION]: "IStockLocationService",
+  [Modules.USER]: "IUserModuleService",
+  [Modules.WORKFLOW_ENGINE]: "IWorkflowEngineService",
+  [Modules.REGION]: "IRegionModuleService",
+  [Modules.ORDER]: "IOrderModuleService",
+  [Modules.API_KEY]: "IApiKeyModuleService",
+  [Modules.STORE]: "IStoreModuleService",
+  [Modules.CURRENCY]: "ICurrencyModuleService",
+  [Modules.FILE]: "IFileModuleService",
+  [Modules.NOTIFICATION]: "INotificationModuleService",
+  [Modules.LOCKING]: "ILockingModule",
+}
 
 /**
  * Modules registered inside the config file points to one
@@ -55,6 +89,13 @@ export async function generateContainerTypes(
          * Key registered within the container
          */
         const key = service.__definition.key
+        if (SERVICES_INTERFACES[key]) {
+          result.imports.push(
+            `import type { ${SERVICES_INTERFACES[key]} } from '@medusajs/framework/types'`
+          )
+          result.mappings.push(`${key}: ${SERVICES_INTERFACES[key]}`)
+          return
+        }
 
         /**
          * @todo. The property should exist on "LoadedModule"

--- a/packages/core/utils/src/modules-sdk/types/medusa-service.ts
+++ b/packages/core/utils/src/modules-sdk/types/medusa-service.ts
@@ -120,7 +120,7 @@ export type AbstractModuleService<
     TModelName
   >}`]: (
     id: string,
-    config?: FindConfig<any>,
+    config?: FindConfig<TModelsDtoConfig[TModelName]["dto"]>,
     sharedContext?: Context
   ) => Promise<TModelsDtoConfig[TModelName]["dto"]>
 } & {
@@ -129,7 +129,7 @@ export type AbstractModuleService<
     TModelName
   >}`]: (
     filters?: any,
-    config?: FindConfig<any>,
+    config?: FindConfig<TModelsDtoConfig[TModelName]["dto"]>,
     sharedContext?: Context
   ) => Promise<TModelsDtoConfig[TModelName]["dto"][]>
 } & {
@@ -137,9 +137,11 @@ export type AbstractModuleService<
     TModelsDtoConfig,
     TModelName
   >}`]: {
-    (filters?: any, config?: FindConfig<any>, sharedContext?: Context): Promise<
-      [TModelsDtoConfig[TModelName]["dto"][], number]
-    >
+    (
+      filters?: any,
+      config?: FindConfig<TModelsDtoConfig[TModelName]["dto"]>,
+      sharedContext?: Context
+    ): Promise<[TModelsDtoConfig[TModelName]["dto"][], number]>
   }
 } & {
   [TModelName in keyof TModelsDtoConfig as `delete${ExtractPluralName<


### PR DESCRIPTION
Improves intellisense for service methods to retrieve, list and count entities via the auto-generated methods from DML.

Also, updates the container types generation to point to interface for core services. This way, we get accurate intellisense.

Fixes: FRMW-2902

---

Sample container types output.

```ts
import type { ICacheService } from '@medusajs/framework/types'
import type { IEventBusModuleService } from '@medusajs/framework/types'
import type { IWorkflowEngineService } from '@medusajs/framework/types'
import type { ILockingModule } from '@medusajs/framework/types'
import type { IStockLocationService } from '@medusajs/framework/types'
import type { IInventoryService } from '@medusajs/framework/types'
import type { IProductModuleService } from '@medusajs/framework/types'
import type { IPricingModuleService } from '@medusajs/framework/types'
import type { IPromotionModuleService } from '@medusajs/framework/types'
import type { ICustomerModuleService } from '@medusajs/framework/types'
import type { ISalesChannelModuleService } from '@medusajs/framework/types'
import type { ICartModuleService } from '@medusajs/framework/types'
import type { IRegionModuleService } from '@medusajs/framework/types'
import type { IApiKeyModuleService } from '@medusajs/framework/types'
import type { IStoreModuleService } from '@medusajs/framework/types'
import type { ITaxModuleService } from '@medusajs/framework/types'
import type { ICurrencyModuleService } from '@medusajs/framework/types'
import type { IPaymentModuleService } from '@medusajs/framework/types'
import type { IOrderModuleService } from '@medusajs/framework/types'
import type { IAuthModuleService } from '@medusajs/framework/types'
import type { IUserModuleService } from '@medusajs/framework/types'
import type { IFileModuleService } from '@medusajs/framework/types'
import type { IFulfillmentModuleService } from '@medusajs/framework/types'
import type { INotificationModuleService } from '@medusajs/framework/types'
import type Blog from '@blog/index'

declare module '@medusajs/framework/types' {
  interface ModuleImplementations {
    cache: ICacheService,
    event_bus: IEventBusModuleService,
    workflows: IWorkflowEngineService,
    locking: ILockingModule,
    stock_location: IStockLocationService,
    inventory: IInventoryService,
    product: IProductModuleService,
    pricing: IPricingModuleService,
    promotion: IPromotionModuleService,
    customer: ICustomerModuleService,
    sales_channel: ISalesChannelModuleService,
    cart: ICartModuleService,
    region: IRegionModuleService,
    api_key: IApiKeyModuleService,
    store: IStoreModuleService,
    tax: ITaxModuleService,
    currency: ICurrencyModuleService,
    payment: IPaymentModuleService,
    order: IOrderModuleService,
    auth: IAuthModuleService,
    user: IUserModuleService,
    file: IFileModuleService,
    fulfillment: IFulfillmentModuleService,
    notification: INotificationModuleService,
    blog: InstanceType<(typeof Blog)['service']>
  }
}
```