### PR TITLE
fix(medusa, types): fix promotion HTTP types in cart

### DIFF
--- a/.changeset/friendly-jars-matter.md
+++ b/.changeset/friendly-jars-matter.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+fix(medusa, types): fix promotion HTTP types in cart

--- a/packages/core/types/src/http/cart/store/entities.ts
+++ b/packages/core/types/src/http/cart/store/entities.ts
@@ -1,3 +1,4 @@
+import { ApplicationMethodTypeValues } from "../../../promotion"
 import { StorePaymentCollection } from "../../payment"
 import { StoreProduct, StoreProductVariant } from "../../product"
 import { StoreRegion } from "../../region"
@@ -37,6 +38,10 @@ export interface StoreCart extends Omit<BaseCart, "items"> {
    * The cart's region
    */
   region?: StoreRegion
+  /**
+   * The promotions applied to the cart.
+   */
+  promotions: StoreCartPromotion[]
 }
 export interface StoreCartLineItem
   extends Omit<BaseCartLineItem, "product" | "variant" | "cart"> {
@@ -79,4 +84,38 @@ export interface StoreCartShippingMethod extends BaseCartShippingMethod {
   adjustments?: (BaseShippingMethodAdjustment & {
     shipping_method: StoreCartShippingMethod
   })[]
+}
+export interface StoreCartPromotion {
+  /**
+   * The promotion's ID.
+   */
+  id: string
+  /**
+   * The promotion's code.
+   */
+  code?: string
+  /**
+   * Whether the promotion is applied automatically (without the customer needing to enter a code).
+   */
+  is_automatic?: boolean
+  /**
+   * How the promotion is applied.
+   */
+  application_method?: {
+    /**
+     * The amount to be discounted.
+     */
+    value: string
+    /**
+     * The application method's type. If it's `fixed`, the promotion discounts a fixed amount. 
+     * If it's `percentage`, the promotion discounts a percentage.
+     */
+    type: ApplicationMethodTypeValues
+    /**
+     * The currency code of the discount.
+     * 
+     * @example usd
+     */
+    currency_code: string
+  }
 }

--- a/packages/core/types/src/http/cart/store/payloads.ts
+++ b/packages/core/types/src/http/cart/store/payloads.ts
@@ -172,3 +172,17 @@ export interface StoreAddAddress {
    */
   metadata?: Record<string, unknown> | null
 }
+
+export interface StoreCartRemovePromotion {
+  /**
+   * The promotion codes to remove from the cart.
+   */
+  promo_codes: string[]
+}
+
+export interface StoreCartAddPromotion {
+  /**
+   * The promotion codes to add to the cart.
+   */
+  promo_codes: string[]
+}

--- a/packages/medusa/src/api/store/carts/[id]/promotions/route.ts
+++ b/packages/medusa/src/api/store/carts/[id]/promotions/route.ts
@@ -2,14 +2,10 @@ import { updateCartPromotionsWorkflow } from "@medusajs/core-flows"
 import { PromotionActions } from "@medusajs/framework/utils"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { refetchCart } from "../../helpers"
-import {
-  StoreAddCartPromotionsType,
-  StoreRemoveCartPromotionsType,
-} from "../../validators"
 import { HttpTypes } from "@medusajs/framework/types"
 
 export const POST = async (
-  req: MedusaRequest<StoreAddCartPromotionsType>,
+  req: MedusaRequest<HttpTypes.StoreCartAddPromotion>,
   res: MedusaResponse<HttpTypes.StoreCartResponse>
 ) => {
   const workflow = updateCartPromotionsWorkflow(req.scope)
@@ -33,7 +29,7 @@ export const POST = async (
 }
 
 export const DELETE = async (
-  req: MedusaRequest<StoreRemoveCartPromotionsType>,
+  req: MedusaRequest<HttpTypes.StoreCartRemovePromotion>,
   res: MedusaResponse<{
     cart: HttpTypes.StoreCart
   }>


### PR DESCRIPTION
- Add missing `promotions` property to `StoreCart`
- Add HTTP type payloads for add / remove promotion from cart routes

Closes #11299
Closes SUP-790