### PR TITLE
Preserve model.enum case in generated query-entry-points.d.ts

### DIFF
--- a/packages/core/utils/src/dml/helpers/graphql-builder/get-attribute.ts
+++ b/packages/core/utils/src/dml/helpers/graphql-builder/get-attribute.ts
@@ -43,7 +43,7 @@ export function getGraphQLAttributeFromDMLPropety(
       const enumName = toPascalCase(modelName + "_" + field.fieldName + "Enum")
       const enumValues = field.dataType
         .options!.choices.map((value) => {
-          const enumValue = value.replace(/[^a-z0-9_]/gi, "_").toUpperCase()
+          const enumValue = value.replace(/[^a-z0-9_]/gi, "_")
           return `  ${enumValue}`
         })
         .join("\n")


### PR DESCRIPTION
A field defined using `model.enum` does not have it's case preserved in the corresponding generated TS types in `/.medusa/types/query-entry-points.d.ts`, resulting in:
* if a value corresponding with the values in `model.enum` is used in `query.graph`, a compile error is thrown.
* if a value corresponding to the values generated in `query-entry-points.d.ts` is used, the downstream graphql query generated is incorrect.