### PR TITLE
chore(admin-sdk): Pin Zod version

### DIFF
--- a/.changeset/few-ravens-mix.md
+++ b/.changeset/few-ravens-mix.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/admin-sdk": patch
+---
+
+chore(admin-sdk): Pin zod in admin-sdk

--- a/packages/admin/admin-sdk/package.json
+++ b/packages/admin/admin-sdk/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@medusajs/admin-shared": "^2.5.0",
-    "zod": "^3.22"
+    "zod": "3.22.4"
   },
   "packageManager": "yarn@3.2.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5280,7 +5280,7 @@ __metadata:
     "@types/react": ^18.3.2
     tsup: ^8.0.1
     typescript: ^5.3.3
-    zod: ^3.22
+    zod: 3.22.4
   languageName: unknown
   linkType: soft
 
@@ -34040,12 +34040,5 @@ __metadata:
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
   checksum: 7578ab283dac0eee66a0ad0fc4a7f28c43e6745aadb3a529f59a4b851aa10872b3890398b3160f257f4b6817b4ce643debdda4fb21a2c040adda7862cab0a587
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.22":
-  version: 3.23.8
-  resolution: "zod@npm:3.23.8"
-  checksum: 8f14c87d6b1b53c944c25ce7a28616896319d95bc46a9660fe441adc0ed0a81253b02b5abdaeffedbeb23bdd25a0bf1c29d2c12dd919aef6447652dd295e3e69
   languageName: node
   linkType: hard


### PR DESCRIPTION
**What**
In order to prevent multiple version to exists and that might not be compatible with one another, we fix the zod package version in the admin-sdk in complement to the starter