### PR TITLE
fix(medusa, types): allow passing require_shipping override flag

### DIFF
--- a/integration-tests/http/__tests__/cart/store/cart.spec.ts
+++ b/integration-tests/http/__tests__/cart/store/cart.spec.ts
@@ -1123,6 +1123,108 @@ medusaIntegrationTestRunner({
             )
           })
 
+          it("should successfully complete cart without shipping for products without inventory management", async () => {
+            const product = (
+              await api.post(
+                `/admin/products`,
+                {
+                  title: "Product without inventory management",
+                  description: "test",
+                  options: [
+                    {
+                      title: "Size",
+                      values: ["S", "M", "L", "XL"],
+                    },
+                  ],
+                  variants: [
+                    {
+                      title: "S / Black",
+                      sku: "special-shirt",
+                      options: {
+                        Size: "S",
+                      },
+                      manage_inventory: false,
+                      prices: [
+                        {
+                          amount: 1500,
+                          currency_code: "usd",
+                        },
+                      ],
+                    },
+                  ],
+                  shipping_profile_id: shippingProfile.id,
+                },
+                adminHeaders
+              )
+            ).data.product
+
+            let cart = (
+              await api.post(
+                `/store/carts`,
+                {
+                  currency_code: "usd",
+                  sales_channel_id: salesChannel.id,
+                  region_id: region.id,
+                  shipping_address: shippingAddressData,
+                  // items: [
+                  //   {
+                  //     variant_id: product.variants[0].id,
+                  //     quantity: 1,
+                  //     requires_shipping: false,
+                  //   },
+                  // ],
+                },
+                storeHeadersWithCustomer
+              )
+            ).data.cart
+
+            cart = (
+              await api.post(
+                `/store/carts/${cart.id}/line-items`,
+                {
+                  variant_id: product.variants[0].id,
+                  quantity: 1,
+                  requires_shipping: false,
+                },
+                storeHeaders
+              )
+            ).data.cart
+
+            const paymentCollection = (
+              await api.post(
+                `/store/payment-collections`,
+                { cart_id: cart.id },
+                storeHeaders
+              )
+            ).data.payment_collection
+
+            await api.post(
+              `/store/payment-collections/${paymentCollection.id}/payment-sessions`,
+              { provider_id: "pp_system_default" },
+              storeHeaders
+            )
+
+            expect(cart.items[0].requires_shipping).toEqual(false)
+
+            const response = await api.post(
+              `/store/carts/${cart.id}/complete`,
+              {},
+              storeHeaders
+            )
+
+            expect(response.status).toEqual(200)
+            expect(response.data.order).toEqual(
+              expect.objectContaining({
+                shipping_methods: [],
+                items: expect.arrayContaining([
+                  expect.objectContaining({
+                    requires_shipping: false,
+                  }),
+                ]),
+              })
+            )
+          })
+
           describe("with sale price lists", () => {
             let priceList
 

--- a/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
@@ -35,12 +35,12 @@ const cartFields = ["completed_at"].concat(cartFieldsForPricingContext)
 
 export const addToCartWorkflowId = "add-to-cart"
 /**
- * This workflow adds a product variant to a cart as a line item. It's executed by the 
+ * This workflow adds a product variant to a cart as a line item. It's executed by the
  * [Add Line Item Store API Route](https://docs.medusajs.com/api/store#carts_postcartsidlineitems).
- * 
+ *
  * You can use this workflow within your own customizations or custom workflows, allowing you to wrap custom logic around adding an item to the cart.
  * For example, you can use this workflow to add a line item to the cart with a custom price.
- * 
+ *
  * @example
  * const { result } = await addToCartWorkflow(container)
  * .run({
@@ -59,11 +59,11 @@ export const addToCartWorkflowId = "add-to-cart"
  *     ]
  *   }
  * })
- * 
+ *
  * @summary
- * 
+ *
  * Add a line item to a cart.
- * 
+ *
  * @property hooks.validate - This hook is executed before all operations. You can consume this hook to perform any custom validation. If validation fails, you can throw an error to stop the workflow execution.
  */
 export const addToCartWorkflow = createWorkflow(

--- a/packages/core/types/src/http/cart/store/payloads.ts
+++ b/packages/core/types/src/http/cart/store/payloads.ts
@@ -83,6 +83,11 @@ export interface StoreAddCartLineItem {
    */
   quantity: number
   /**
+   * Whether the line item requires shipping.
+   * Overrides the flag from inventory item if the product has managed inventory.
+   */
+  requires_shipping?: boolean
+  /**
    * Key-value pairs of custom data.
    */
   metadata?: Record<string, unknown>

--- a/packages/medusa/src/api/store/carts/validators.ts
+++ b/packages/medusa/src/api/store/carts/validators.ts
@@ -8,6 +8,7 @@ export const StoreGetCartsCart = createSelectParams()
 const ItemSchema = z.object({
   variant_id: z.string(),
   quantity: z.number(),
+  requires_shipping: z.boolean().optional(),
   metadata: z.record(z.unknown()).nullish(),
 })
 
@@ -66,6 +67,7 @@ export type StoreAddCartLineItemType = z.infer<typeof StoreAddCartLineItem>
 export const StoreAddCartLineItem = z.object({
   variant_id: z.string(),
   quantity: z.number(),
+  requires_shipping: z.boolean().optional(),
   metadata: z.record(z.unknown()).nullish(),
 })
 


### PR DESCRIPTION
**What**
- allow passing the `require_shipping` flag when adding items to a cart

**Why**
- useful for variants that don't have managed inventory to override the default `require_shipping: true` flag