### PR TITLE
fix: Remove unnecessary swc production dependency

### DIFF
--- a/packages/medusa/package.json
+++ b/packages/medusa/package.json
@@ -52,7 +52,9 @@
     "@opentelemetry/sdk-node": "^0.53.0",
     "@opentelemetry/sdk-trace-node": "^1.26.0",
     "@swc/core": "^1.7.28",
+    "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.36",
+    "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^8.5.9",
     "@types/lodash": "^4.14.191",
     "@types/multer": "^1.4.7",
@@ -107,9 +109,6 @@
     "@medusajs/user": "^2.5.0",
     "@medusajs/workflow-engine-inmemory": "^2.5.0",
     "@medusajs/workflow-engine-redis": "^2.5.0",
-    "@swc/core": "1.5.7",
-    "@swc/helpers": "^0.5.11",
-    "@types/express": "^4.17.17",
     "boxen": "^5.0.1",
     "chalk": "^4.0.0",
     "chokidar": "^3.4.2",
@@ -132,11 +131,15 @@
     "@mikro-orm/knex": "6.4.3",
     "@mikro-orm/migrations": "6.4.3",
     "@mikro-orm/postgresql": "6.4.3",
+    "@swc/core": "^1.7.28",
     "awilix": "^8.0.1",
     "react-dom": "^18.0.0",
     "yalc": "1.0.0-pre.53"
   },
   "peerDependenciesMeta": {
+    "@swc/core": {
+      "optional": true
+    },
     "react-dom": {
       "optional": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6119,7 +6119,7 @@ __metadata:
     "@opentelemetry/sdk-node": ^0.53.0
     "@opentelemetry/sdk-trace-node": ^1.26.0
     "@swc/core": ^1.7.28
-    "@swc/helpers": ^0.5.11
+    "@swc/helpers": ^0.5.0
     "@swc/jest": ^0.2.36
     "@types/express": ^4.17.17
     "@types/jsonwebtoken": ^8.5.9
@@ -6150,10 +6150,13 @@ __metadata:
     "@mikro-orm/knex": 6.4.3
     "@mikro-orm/migrations": 6.4.3
     "@mikro-orm/postgresql": 6.4.3
+    "@swc/core": ^1.7.28
     awilix: ^8.0.1
     react-dom: ^18.0.0
     yalc: 1.0.0-pre.53
   peerDependenciesMeta:
+    "@swc/core":
+      optional: true
     react-dom:
       optional: true
     yalc:
@@ -13335,7 +13338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:^0.5.0, @swc/helpers@npm:^0.5.11":
+"@swc/helpers@npm:^0.5.0":
   version: 0.5.11
   resolution: "@swc/helpers@npm:0.5.11"
   dependencies:


### PR DESCRIPTION
We move `@swc/core` to a peer dependency so production builds don't include it in their node_modules, which shaves off 55MB of dependencies. The package is only required when developing plugins.