### PR TITLE
docs-util: fix inline code escape in generated references

### DIFF
--- a/www/utils/packages/utils/src/str-utils.ts
+++ b/www/utils/packages/utils/src/str-utils.ts
@@ -7,8 +7,26 @@ export function getHTMLChar(str: string) {
 }
 
 export function escapeChars(str: string, escapeBackticks = true) {
-  const result = getHTMLChar(str).replace(/_/g, "\\_").replace(/\|/g, "\\|")
-  return escapeBackticks ? result.replace(/`/g, "\\`") : result
+  const codeRegex = /(`[^`]*`)/g
+  let result = ""
+  let lastIndex = 0
+
+  str.replace(codeRegex, (match, p1, offset) => {
+    result += getHTMLChar(str.slice(lastIndex, offset))
+      .replace(/\|/g, "\\|")
+      .replace(/`/g, escapeBackticks ? "\\`" : "`")
+      .replace(/_/g, "\\_")
+    result += p1 // keep the inline code block as is
+    lastIndex = offset + match.length
+    return match
+  })
+
+  result += getHTMLChar(str.slice(lastIndex))
+    .replace(/\|/g, "\\|")
+    .replace(/`/g, escapeBackticks ? "\\`" : "`")
+    .replace(/_/g, "\\_")
+
+  return result
 }
 
 export function stripLineBreaks(str: string) {


### PR DESCRIPTION
Will be reflected next time references are generated.

Closes DX-1328