### PR TITLE
docs: Include `shipping_profile_id` in product creation request

### DIFF
--- a/www/apps/book/app/learn/customization/extend-features/extend-create-product/page.mdx
+++ b/www/apps/book/app/learn/customization/extend-features/extend-create-product/page.mdx
@@ -230,13 +230,14 @@ curl -X POST 'http://localhost:9000/admin/products' \
         "values": ["Default option value"]
       }
     ],
+    "shipping_profile_id": "{shipping_profile_id}",
     "additional_data": {
         "brand_id": "{brand_id}"
     }
 }'
 ```
 
-Make sure to replace `{token}` with the token you received from the previous request, and  `{brand_id}` with the ID of a brand in your application.
+Make sure to replace `{token}` with the token you received from the previous request, `shipping_profile_id` with the ID of a shipping profile in your application, and `{brand_id}` with the ID of a brand in your application.
 
 The request creates a product and returns it.
 


### PR DESCRIPTION
- Fixed missing `shipping_profile_id` field in product creation request, which caused "Invalid request: Field 'shipping_profile_id' is required" errors.
- Updated the request payload to include `shipping_profile_id`.
- Edited documentation to reflect this change.