### PR TITLE
fix(types): fix shipping profile type optional in create type / method

### DIFF
--- a/packages/core/types/src/fulfillment/mutations/shipping-profile.ts
+++ b/packages/core/types/src/fulfillment/mutations/shipping-profile.ts
@@ -10,7 +10,7 @@ export interface CreateShippingProfileDTO {
   /**
    * The type of the shipping profile.
    */
-  type?: string
+  type: string
 
   /**
    * Holds custom data in key-value pairs.

--- a/packages/core/types/src/fulfillment/service.ts
+++ b/packages/core/types/src/fulfillment/service.ts
@@ -1625,9 +1625,11 @@ export interface IFulfillmentModuleService extends IModuleService {
    *   await fulfillmentModuleService.createShippingProfiles([
    *     {
    *       name: "Default",
+   *       type: "default"
    *     },
    *     {
    *       name: "Digital",
+   *       type: "digital"
    *     },
    *   ])
    */

--- a/packages/core/types/src/fulfillment/service.ts
+++ b/packages/core/types/src/fulfillment/service.ts
@@ -1649,6 +1649,7 @@ export interface IFulfillmentModuleService extends IModuleService {
    * const shippingProfile =
    *   await fulfillmentModuleService.createShippingProfiles({
    *     name: "Default",
+   *     type: "default"
    *   })
    */
   createShippingProfiles(


### PR DESCRIPTION
The `type` property is marked optional in the `CreateShippingProfileDTO` type, which is used as a type parameter of the `createShippingProfiles`. Not passing `type` results in an error requiring `type` to be passed, likely because it's not optional in the `ShippingProfile` data model.