### PR TITLE
fix(medusa): Re throw error in instrumentation after reporting it

### DIFF
--- a/.changeset/wicked-roses-appear.md
+++ b/.changeset/wicked-roses-appear.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): Re throw error in instrumentation after reporting it

--- a/packages/medusa/src/instrumentation/index.ts
+++ b/packages/medusa/src/instrumentation/index.ts
@@ -154,6 +154,7 @@ export function instrumentRemoteQuery() {
               code: SpanStatusCode.ERROR,
               message: error.message,
             })
+            throw error
           })
           .finally(() => span.end())
       }
@@ -182,6 +183,7 @@ export function instrumentRemoteQuery() {
               code: SpanStatusCode.ERROR,
               message: error.message,
             })
+            throw error
           })
           .finally(() => span.end())
       }
@@ -207,6 +209,7 @@ export function instrumentRemoteQuery() {
               code: SpanStatusCode.ERROR,
               message: error.message,
             })
+            throw error
           })
           .finally(() => span.end())
       }
@@ -251,6 +254,7 @@ export function instrumentWorkflows() {
           span.setAttribute(`workflow.step.${key}`, value)
         })
 
+        // TODO: should we report error and re throw it?
         return await stepHandler().finally(() => span.end())
       }
     )

--- a/packages/medusa/src/instrumentation/index.ts
+++ b/packages/medusa/src/instrumentation/index.ts
@@ -148,15 +148,17 @@ export function instrumentRemoteQuery() {
         span.setAttributes({
           "query.fields": queryOptions.fields,
         })
-        return await queryFn()
-          .catch((error) => {
-            span.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: error.message,
-            })
-            throw error
+        try {
+          return await queryFn()
+        } catch (err) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: err.message,
           })
-          .finally(() => span.end())
+          throw err
+        } finally {
+          span.end()
+        }
       }
     )
   })
@@ -177,15 +179,18 @@ export function instrumentRemoteQuery() {
         span.setAttributes({
           "query.fields": "fields" in queryOptions ? queryOptions.fields : [],
         })
-        return await queryFn()
-          .catch((error) => {
-            span.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: error.message,
-            })
-            throw error
+
+        try {
+          return await queryFn()
+        } catch (error) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error.message,
           })
-          .finally(() => span.end())
+          throw error
+        } finally {
+          span.end()
+        }
       }
     )
   })
@@ -203,15 +208,18 @@ export function instrumentRemoteQuery() {
           "fetch.select": options.select,
           "fetch.relations": options.relations,
         })
-        return await fetchFn()
-          .catch((error) => {
-            span.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: error.message,
-            })
-            throw error
+
+        try {
+          return await fetchFn()
+        } catch (error) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error.message,
           })
-          .finally(() => span.end())
+          throw error
+        } finally {
+          span.end()
+        }
       }
     )
   })


### PR DESCRIPTION
FIXES FRMW-2914

**What**
Currently, when the instrumentation is enabled, some instrument catches the errors in order to set the span status and info, unfortunately, these errors are not re throw leading to swallow them and return nothing in the end leading to potential breaks in flows