### PR TITLE
fix(medusa): Allow filtering by handle and title as arrays

### DIFF
--- a/.changeset/loud-pets-own.md
+++ b/.changeset/loud-pets-own.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): Allow filtering products by handle and title as either string or array of strings

--- a/integration-tests/http/__tests__/product/store/product.spec.ts
+++ b/integration-tests/http/__tests__/product/store/product.spec.ts
@@ -862,6 +862,34 @@ medusaIntegrationTestRunner({
         ])
       })
 
+      it("returns a list of products with one of the given handles", async () => {
+        const response = await api.get(
+          `/store/products?handle[]=${product.handle}&handle[]=${product2.handle}`,
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.count).toEqual(2)
+        expect(response.data.products).toEqual([
+          expect.objectContaining({ id: product.id }),
+          expect.objectContaining({ id: product2.id }),
+        ])
+      })
+
+      it("returns a list of products with one of the given titles", async () => {
+        const response = await api.get(
+          `/store/products?title[]=${product.title}&title[]=${product2.title}`,
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.count).toEqual(2)
+        expect(response.data.products).toEqual([
+          expect.objectContaining({ id: product.id }),
+          expect.objectContaining({ id: product2.id }),
+        ])
+      })
+
       // TODO: Not implemented yet
       it.skip("returns gift card product", async () => {
         const response = await api

--- a/packages/medusa/src/api/utils/common-validators/products/index.ts
+++ b/packages/medusa/src/api/utils/common-validators/products/index.ts
@@ -9,8 +9,8 @@ export const ProductStatusEnum = z.nativeEnum(ProductStatus)
 export const StoreGetProductParamsDirectFields = z.object({
   q: z.string().optional(),
   id: z.union([z.string(), z.array(z.string())]).optional(),
-  title: z.string().optional(),
-  handle: z.string().optional(),
+  title: z.union([z.string(), z.array(z.string())]).optional(),
+  handle: z.union([z.string(), z.array(z.string())]).optional(),
   is_giftcard: booleanString().optional(),
   category_id: z.union([z.string(), z.array(z.string())]).optional(),
   external_id: z.union([z.string(), z.array(z.string())]).optional(),


### PR DESCRIPTION
**What**
- Allows filtering products in the Store API with an array value for both `handle` and `title`.

RESOLVES SUP-893