### PR TITLE
feat: Add support for idempotency key in payments

### DIFF
--- a/packages/core/types/src/payment/provider.ts
+++ b/packages/core/types/src/payment/provider.ts
@@ -76,6 +76,11 @@ export type PaymentProviderContext = {
    * The customer information from Medusa.
    */
   customer?: PaymentCustomerDTO
+
+  /**
+   * Idempotency key for the request, if the payment provider supports it. It will be ignored otherwise.
+   */
+  idempotency_key?: string
 }
 
 export type PaymentProviderInput = {

--- a/packages/modules/payment/src/services/payment-module.ts
+++ b/packages/modules/payment/src/services/payment-module.ts
@@ -347,7 +347,10 @@ export default class PaymentModuleService
       providerPaymentSession = await this.paymentProviderService_.createSession(
         input.provider_id,
         {
-          context: input.context,
+          context: {
+            idempotency_key: paymentSession!.id,
+            ...input.context,
+          },
           data: { ...input.data, session_id: paymentSession!.id },
           amount: input.amount,
           currency_code: input.currency_code,
@@ -421,6 +424,7 @@ export default class PaymentModuleService
         data: data.data,
         amount: data.amount,
         currency_code: data.currency_code,
+        context: data.context,
       }
     )
 
@@ -490,7 +494,7 @@ export default class PaymentModuleService
       session.provider_id,
       {
         data: session.data,
-        context,
+        context: { idempotency_key: session.id, ...context },
       }
     )
 
@@ -515,6 +519,10 @@ export default class PaymentModuleService
     } catch (error) {
       await this.paymentProviderService_.cancelPayment(session.provider_id, {
         data,
+        context: {
+          idempotency_key: payment?.id,
+          ...context,
+        },
       })
 
       throw error
@@ -623,6 +631,7 @@ export default class PaymentModuleService
     try {
       await this.capturePaymentFromProvider_(
         payment,
+        capture,
         isFullyCaptured,
         sharedContext
       )
@@ -703,6 +712,7 @@ export default class PaymentModuleService
   @InjectManager()
   private async capturePaymentFromProvider_(
     payment: InferEntityType<typeof Payment>,
+    capture: InferEntityType<typeof Capture> | undefined,
     isFullyCaptured: boolean,
     @MedusaContext() sharedContext: Context = {}
   ) {
@@ -710,6 +720,9 @@ export default class PaymentModuleService
       payment.provider_id,
       {
         data: payment.data!,
+        context: {
+          idempotency_key: capture?.id,
+        },
       }
     )
 
@@ -818,6 +831,9 @@ export default class PaymentModuleService
       {
         data: payment.data!,
         amount: refund.raw_amount as BigNumberInput,
+        context: {
+          idempotency_key: refund.id,
+        },
       }
     )
 
@@ -842,6 +858,9 @@ export default class PaymentModuleService
 
     await this.paymentProviderService_.cancelPayment(payment.provider_id, {
       data: payment.data!,
+      context: {
+        idempotency_key: payment.id,
+      },
     })
 
     await this.paymentService_.update(
@@ -984,7 +1003,12 @@ export default class PaymentModuleService
     providerAccountHolder =
       await this.paymentProviderService_.createAccountHolder(
         input.provider_id,
-        { context: input.context }
+        {
+          context: {
+            idempotency_key: input.context?.customer?.id,
+            ...input.context,
+          },
+        }
       )
 
     // This can be empty when either the method is not supported or an account holder wasn't created


### PR DESCRIPTION
This PR makes changes to the payment module so an idempotency key is passed to the payment provider, and in cases where the payment provider supports it, it is used to guarantee idempotency of requests (eg. Stripe is one that does support idempotency keys).

CLOSES CLO-408