### PR TITLE
fix(framework): add missing storefrontUrl from configuration type

### DIFF
--- a/.changeset/dull-tigers-dress.md
+++ b/.changeset/dull-tigers-dress.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/framework": patch
+---
+
+fix(framework): add missing storefrontUrl from configuration type

--- a/packages/core/framework/src/config/types.ts
+++ b/packages/core/framework/src/config/types.ts
@@ -88,6 +88,24 @@ export type AdminOptions = {
    */
   backendUrl?: string
   /**
+   * The URL of your Medusa storefront application. This URL is used as a prefix to some
+   * links in the admin that require performing actions in the storefront. For example,
+   * this URL is used as a prefix to shareable payment links for orders with
+   * outstanding amounts.
+   *
+   * @example
+   * ```js title="medusa-config.js"
+   * module.exports = defineConfig({
+   *   admin: {
+   *     storefrontUrl: process.env.MEDUSA_STOREFRONT_URL ||
+   *       "http://localhost:9000"
+   *   },
+   *   // ...
+   * })
+   * ```
+   */
+  storefrontUrl?: string
+  /**
    * Configure the Vite configuration for the admin dashboard. This function receives the default Vite configuration
    * and returns the modified configuration. The default value is `undefined`.
    *
@@ -771,7 +789,13 @@ export type ProjectConfigOptions = {
 /**
  * @interface
  *
- * The configurations for your Medusa application are in `medusa-config.ts` located in the root of your Medusa project. The configurations include configurations for database, modules, and more.
+ * The configurations for your Medusa application are set in `medusa-config.ts` located in the root of your Medusa project. The configurations include configurations for database, modules, and more.
+ * 
+ * :::note
+ * 
+ * Some Medusa configurations are set through environment variables, which you can find in [this documentation](https://docs.medusajs.com/learn/fundamentals/environment-variables#predefined-medusa-environment-variables).
+ * 
+ * :::
  *
  * `medusa-config.ts` exports the value returned by the `defineConfig` utility function imported from `@medusajs/framework/utils`.
  *

--- a/packages/core/framework/src/config/types.ts
+++ b/packages/core/framework/src/config/types.ts
@@ -98,7 +98,7 @@ export type AdminOptions = {
    * module.exports = defineConfig({
    *   admin: {
    *     storefrontUrl: process.env.MEDUSA_STOREFRONT_URL ||
-   *       "http://localhost:9000"
+   *       "http://localhost:8000"
    *   },
    *   // ...
    * })


### PR DESCRIPTION
The `storefrontUrl` is defined in the `packages/core/types/src/common/config-module.ts` file, but for many purposes, including the documentation, we use the types defined in `packages/core/framework/src/config/types.ts`. This PR adds the `storefrontUrl` to the framework type