### PR TITLE
change devDependencies in packages

### DIFF
--- a/packages/core/framework/package.json
+++ b/packages/core/framework/package.json
@@ -69,6 +69,7 @@
     "pg": "^8.13.0",
     "rimraf": "^3.0.2",
     "supertest": "^4.0.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.6.2",
     "vite": "^5.4.14"
   },
@@ -93,7 +94,6 @@
     "jsonwebtoken": "^9.0.2",
     "lodash": "4.17.21",
     "morgan": "^1.9.1",
-    "tsconfig-paths": "^4.2.0",
     "zod": "3.22.4"
   },
   "peerDependencies": {

--- a/packages/medusa/package.json
+++ b/packages/medusa/package.json
@@ -44,6 +44,7 @@
     "test:integration": "jest --forceExit -- src/**/integration-tests/**/__tests__/**/*.ts"
   },
   "devDependencies": {
+    "@medusajs/admin-bundler": "^2.5.0",
     "@medusajs/framework": "^2.5.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/instrumentation": "^0.53.0",
@@ -66,7 +67,6 @@
   "dependencies": {
     "@inquirer/checkbox": "^2.3.11",
     "@inquirer/input": "^2.2.9",
-    "@medusajs/admin-bundler": "^2.5.0",
     "@medusajs/api-key": "^2.5.0",
     "@medusajs/auth": "^2.5.0",
     "@medusajs/auth-emailpass": "^2.5.0",


### PR DESCRIPTION
I've built my first application with Medusa, and the docker image is surprisingly large. I've gone through the dependencies declared in the core packages and I have found two that are not needed as production dependencies. This is specially the case of `@medusajs/admin-bundler` which brings in a lot of dev packages.

This PR simply moves those dependencies as `devDependencies`