### PR TITLE
fix(utils): Handle 0 correctly in build query

### DIFF
--- a/packages/core/utils/src/modules-sdk/__tests__/build-query.spec.ts
+++ b/packages/core/utils/src/modules-sdk/__tests__/build-query.spec.ts
@@ -64,6 +64,18 @@ describe("buildQuery", () => {
     })
   })
 
+  test("should build pagination with values of 0", () => {
+    const config: FindConfig<any> = {
+      take: 0,
+      skip: 0,
+    }
+    const result = buildQuery({}, config)
+    expect(result.options).toMatchObject({
+      limit: 0,
+      offset: 0,
+    })
+  })
+
   test("should handle withDeleted flag", () => {
     const filters = { deleted_at: "some-value" }
     const result = buildQuery(filters)

--- a/packages/core/utils/src/modules-sdk/build-query.ts
+++ b/packages/core/utils/src/modules-sdk/build-query.ts
@@ -26,11 +26,11 @@ export function buildQuery<const T = any>(
     populate: deduplicate(config.relations ?? []),
     fields: config.select as string[],
     limit:
-      Number.isSafeInteger(config.take) && config.take !== null
+      Number.isSafeInteger(config.take) && config.take != null
         ? config.take
         : undefined,
     offset:
-      Number.isSafeInteger(config.skip) && config.skip !== null
+      Number.isSafeInteger(config.skip) && config.skip != null
         ? config.skip
         : undefined,
   }

--- a/packages/core/utils/src/modules-sdk/build-query.ts
+++ b/packages/core/utils/src/modules-sdk/build-query.ts
@@ -25,8 +25,14 @@ export function buildQuery<const T = any>(
   const findOptions: DAL.FindOptions<T>["options"] = {
     populate: deduplicate(config.relations ?? []),
     fields: config.select as string[],
-    limit: (Number.isSafeInteger(config.take) && config.take) || undefined,
-    offset: (Number.isSafeInteger(config.skip) && config.skip) || undefined,
+    limit:
+      Number.isSafeInteger(config.take) && config.take !== null
+        ? config.take
+        : undefined,
+    offset:
+      Number.isSafeInteger(config.skip) && config.skip !== null
+        ? config.skip
+        : undefined,
   }
 
   if (config.order) {


### PR DESCRIPTION
**What**

Remove truthy/falsy check for `take` and `skip`

**Why**

To ensure `{ take: 0, skip: 0 }` is not converted to `{ take: undefined, skip: undefined }`