### PR TITLE
chore(cli): Prevent swallowing error in non production env

### DIFF
--- a/packages/cli/medusa-cli/cli.js
+++ b/packages/cli/medusa-cli/cli.js
@@ -3,6 +3,14 @@
 try {
   require("ts-node").register({})
   require("tsconfig-paths").register({})
-} catch {}
+} catch (e) {
+  const isProduction = process.env.NODE_ENV === "production"
+  if (!isProduction) {
+    console.warn(
+      "ts-node cannot be loaded and used, if you are running in production don't forget to set your NODE_ENV to production"
+    )
+    console.warn(e)
+  }
+}
 require("dotenv").config()
 require("./dist/index.js")


### PR DESCRIPTION
**What**
It happened many times that people can't run their project locally because an error is thrown during the config file loading. It occurs that this error can often happen because of some missing deps such as `swc/core`. But since the error is being swallowed, the import API will look for the js file which often does not exists (as it has not been built) and lead to hard debugging situation.

In order to prevent that, we could warn about any error that might occur when running the CLI as long as we are not in production. this error can be ignored if ts-node is not of any use in particular scenarios