### PR TITLE
fix(core-flows): Allow create shipping methods through order edits

### DIFF
--- a/packages/core/core-flows/src/order/utils/prepare-shipping-method.ts
+++ b/packages/core/core-flows/src/order/utils/prepare-shipping-method.ts
@@ -18,7 +18,7 @@ export function prepareShippingMethod(relatedEntityField?: string) {
       data: option.data ?? {},
       name: option.name,
       version: orderChange.version,
-      order_id: data.relatedEntity.order_id,
+      order_id: data.input.order_id,
     } as any
 
     if (relatedEntityField) {

--- a/packages/core/core-flows/src/order/workflows/order-edit/update-order-edit-shipping-method.ts
+++ b/packages/core/core-flows/src/order/workflows/order-edit/update-order-edit-shipping-method.ts
@@ -120,7 +120,7 @@ export const updateOrderEditShippingMethodWorkflow = createWorkflow(
     input: WorkflowData<OrderWorkflow.UpdateOrderEditShippingMethodWorkflowInput>
   ): WorkflowResponse<OrderPreviewDTO> {
     const order: OrderDTO = useRemoteQueryStep({
-      entry_point: "order_claim",
+      entry_point: "orders",
       fields: ["id", "currency_code"],
       variables: { id: input.order_id },
       list: false,


### PR DESCRIPTION
Fixes for #11559 and #11558

Noticed there's a recent pull request https://github.com/medusajs/medusa/pull/11504 which fixes what's passed to `prepare-shipping-method`.

As for updating the query for `CreateOrderEditShippingMethodWorkflowInput` entry point from `order_claim` to `orders`, it seems like this has already been fixed?? 

For my own education, how can github say I'm two commits ahead from the main `develop` branch but show what I'm merging into is different from the codebase...
See:
https://github.com/medusajs/medusa/pull/11560/commits/9fb265c169834bb74f220745b6a0a08dfea79be1


I can't even seem to find when this line was changed:
[/packages/core/core-flows/src/order/workflows/order-edit/create-order-edit-shipping-method.ts#L118](https://github.com/medusajs/medusa/blob/develop/packages/core/core-flows/src/order/workflows/order-edit/create-order-edit-shipping-method.ts#L118)

What has happened?