### PR TITLE
fix(dashboard): V2 admin loader's outDir option rewrite(#11582)

### DIFF
--- a/packages/medusa/src/loaders/admin.ts
+++ b/packages/medusa/src/loaders/admin.ts
@@ -43,7 +43,7 @@ export default async function adminLoader({
     disable: false,
     sources,
     ...admin,
-    outDir: path.join(rootDirectory, ADMIN_RELATIVE_OUTPUT_DIR),
+    outDir: path.join(rootDirectory, admin.outDir ?? ADMIN_RELATIVE_OUTPUT_DIR),
   }
 
   if (adminOptions?.disable) {


### PR DESCRIPTION
fix(dashboard): make admin's outDir can be replaced

issue is in #11582 