### PR TITLE
Update configuration.mdx

### DIFF
--- a/www/apps/docs/content/admin/configuration.mdx
+++ b/www/apps/docs/content/admin/configuration.mdx
@@ -61,8 +61,8 @@ const plugins = [
     name: "backend",
     type: "string",
     optional: true,
-    defaultValue: "",
-    description: "The URL of the Medusa backend. Its value is only used if the `serve` option is set to `false`.",
+    defaultValue: "http://localhost:9000",
+    description: "The URL of the Medusa backend.",
     expandable: false,
     children: []
   },


### PR DESCRIPTION
I changed the description of the backend field of admin dashboard config. 

Originally It said that it is only used if serve is false. This is not accurate as you can put a value there with server true and the admin dashboard will direct requests to the set url. 

In my opinion this should also remain as you need to change the backend value if your dev environment is on a remote server and I would much prefer if this worked while the server option is true