### PR TITLE
chore(types): change payment provider types to interfaces

### DIFF
--- a/.changeset/brown-buttons-buy.md
+++ b/.changeset/brown-buttons-buy.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": patch
+---
+
+chore(types): change payment provider types to interfaces

--- a/packages/core/types/src/http/inventory-level/admin/payloads.ts
+++ b/packages/core/types/src/http/inventory-level/admin/payloads.ts
@@ -28,23 +28,6 @@ export interface AdminBatchCreateInventoryItemLocationLevels {
   incoming_quantity?: number
 }
 
-export interface AdminBatchCreateInventoryItemLocationLevels {
-  /**
-   * The ID of the associated stock location.
-   */
-  location_id: string
-  /**
-   * The associated inventory item's stocked quantity in the
-   * associated stock location.
-   */
-  stocked_quantity?: number
-  /**
-   * The associated inventory item's incoming quantity in the
-   * associated stock location.
-   */
-  incoming_quantity?: number
-}
-
 export interface AdminBatchUpdateInventoryItemLocationLevels
   extends AdminBatchCreateInventoryItemLocationLevels {
   /**

--- a/packages/core/types/src/payment/provider.ts
+++ b/packages/core/types/src/payment/provider.ts
@@ -95,12 +95,10 @@ export type PaymentProviderInput = {
 }
 
 /**
- * @interface
- *
  * The data used initiate a payment in a provider when a payment
  * session is created.
  */
-export type InitiatePaymentInput = PaymentProviderInput & {
+export interface InitiatePaymentInput extends PaymentProviderInput {
   /**
    * The amount to be authorized.
    */
@@ -113,11 +111,9 @@ export type InitiatePaymentInput = PaymentProviderInput & {
 }
 
 /**
- * @interface
- *
  * The attributes to update a payment related to a payment session in a provider.
  */
-export type UpdatePaymentInput = PaymentProviderInput & {
+export interface UpdatePaymentInput extends PaymentProviderInput {
   /**
    * The payment session's amount.
    */
@@ -130,32 +126,24 @@ export type UpdatePaymentInput = PaymentProviderInput & {
 }
 
 /**
- * @interface
- *
  * The data to delete a payment.
  */
-export type DeletePaymentInput = PaymentProviderInput
+export interface DeletePaymentInput extends PaymentProviderInput {}
 
 /**
- * @interface
- *
  * The data to authorize a payment.
  */
-export type AuthorizePaymentInput = PaymentProviderInput
+export interface AuthorizePaymentInput extends PaymentProviderInput {}
 
 /**
- * @interface
- *
  * The data to capture a payment.
  */
-export type CapturePaymentInput = PaymentProviderInput
+export interface CapturePaymentInput extends PaymentProviderInput {}
 
 /**
- * @interface
- *
  * The data to refund a payment.
  */
-export type RefundPaymentInput = PaymentProviderInput & {
+export interface RefundPaymentInput extends PaymentProviderInput {
   /**
    * The amount to refund.
    */
@@ -163,25 +151,19 @@ export type RefundPaymentInput = PaymentProviderInput & {
 }
 
 /**
- * @interface
- *
  * The data to retrieve a payment.
  */
-export type RetrievePaymentInput = PaymentProviderInput
+export interface RetrievePaymentInput extends PaymentProviderInput {}
 
 /**
- * @interface
- *
  * The data to cancel a payment.
  */
-export type CancelPaymentInput = PaymentProviderInput
+export interface CancelPaymentInput extends PaymentProviderInput {}
 
 /**
- * @interface
- *
  * The data to create an account holder.
  */
-export type CreateAccountHolderInput = PaymentProviderInput & {
+export interface CreateAccountHolderInput extends PaymentProviderInput {
   /**
    * The context of creating the account holder.
    */
@@ -193,7 +175,7 @@ export type CreateAccountHolderInput = PaymentProviderInput & {
   }
 }
 
-export type UpdateAccountHolderInput = PaymentProviderInput & {
+export interface UpdateAccountHolderInput extends PaymentProviderInput {
   /**
    * The context of updating the account holder.
    */
@@ -206,11 +188,9 @@ export type UpdateAccountHolderInput = PaymentProviderInput & {
 }
 
 /**
- * @interface
- *
  * The data to delete an account holder.
  */
-export type DeleteAccountHolderInput = PaymentProviderInput & {
+export interface DeleteAccountHolderInput extends Omit<PaymentProviderInput, "context"> {
   /**
    * The context of deleting the account holder.
    */
@@ -223,25 +203,19 @@ export type DeleteAccountHolderInput = PaymentProviderInput & {
 }
 
 /**
- * @interface
- *
  * The data to list payment methods.
  */
-export type ListPaymentMethodsInput = PaymentProviderInput
+export interface ListPaymentMethodsInput extends PaymentProviderInput {}
 
 /**
- * @interface
- *
  * The data to save a payment method.
  */
-export type SavePaymentMethodInput = PaymentProviderInput
+export interface SavePaymentMethodInput extends PaymentProviderInput {}
 
 /**
- * @interface
- *
  * The data to get the payment status.
  */
-export type GetPaymentStatusInput = PaymentProviderInput
+export interface GetPaymentStatusInput extends PaymentProviderInput {}
 
 /**
  * @interface
@@ -256,11 +230,9 @@ export type PaymentProviderOutput = {
 }
 
 /**
- * @interface
- *
  * The successful result of initiating a payment session using a third-party payment provider.
  */
-export type InitiatePaymentOutput = PaymentProviderOutput & {
+export interface InitiatePaymentOutput extends PaymentProviderOutput {
   /**
    * The ID of the payment session in the payment provider.
    */
@@ -268,11 +240,9 @@ export type InitiatePaymentOutput = PaymentProviderOutput & {
 }
 
 /**
- * @interface
- *
  * The successful result of authorizing a payment session using a payment provider.
  */
-export type AuthorizePaymentOutput = PaymentProviderOutput & {
+export interface AuthorizePaymentOutput extends PaymentProviderOutput {
   /**
    * The status of the payment, which will be stored in the payment session's `status` field.
    */
@@ -280,54 +250,40 @@ export type AuthorizePaymentOutput = PaymentProviderOutput & {
 }
 
 /**
- * @interface
- *
  * The result of updating a payment.
  */
-export type UpdatePaymentOutput = PaymentProviderOutput
+export interface UpdatePaymentOutput extends PaymentProviderOutput {}
 
 /**
- * @interface
- *
  * The result of deleting a payment.
  */
-export type DeletePaymentOutput = PaymentProviderOutput
+export interface DeletePaymentOutput extends PaymentProviderOutput {}
 
 /**
- * @interface
- *
  * The result of capturing the payment.
  */
-export type CapturePaymentOutput = PaymentProviderOutput
+export interface CapturePaymentOutput extends PaymentProviderOutput {}
 
 /**
- * @interface
- *
  * The result of refunding the payment.
  */
-export type RefundPaymentOutput = PaymentProviderOutput
+export interface RefundPaymentOutput extends PaymentProviderOutput {}
 
 /**
- * @interface
- *
  * The result of retrieving the payment.
  */
-export type RetrievePaymentOutput = PaymentProviderOutput
+export interface RetrievePaymentOutput extends PaymentProviderOutput {}
 
 /**
- * @interface
- *
  * The result of canceling the payment.
  */
-export type CancelPaymentOutput = PaymentProviderOutput
+export interface CancelPaymentOutput extends PaymentProviderOutput {}
 
 /**
- * @interface
- *
  * The result of creating an account holder in the third-party payment provider. The `data`
  * property is stored as-is in Medusa's account holder's `data` property.
  */
-export type CreateAccountHolderOutput = PaymentProviderOutput & {
+export interface CreateAccountHolderOutput extends PaymentProviderOutput {
   /**
    * The ID of the account holder in the payment provider.
    * This is stored in Medusa's account holder in the `external_id` property.
@@ -336,38 +292,30 @@ export type CreateAccountHolderOutput = PaymentProviderOutput & {
 }
 
 /**
- * @interface
- * 
  * The result of updating an account holder in the third-party payment provider. The `data`
  * property is stored as-is in Medusa's account holder's `data` property.
  */
-export type UpdateAccountHolderOutput = PaymentProviderOutput
+export interface UpdateAccountHolderOutput extends PaymentProviderOutput {}
 
 /**
- * @interface
- * 
  * The result of deleting an account holder in the third-party payment provider.
  */
-export type DeleteAccountHolderOutput = PaymentProviderOutput
+export interface DeleteAccountHolderOutput extends PaymentProviderOutput {}
 
 /**
- * @interface
- * 
  * The result of listing payment methods for an account holder in the third-party payment provider.
  */
-export type ListPaymentMethodsOutput = (PaymentProviderOutput & {
+export interface ListPaymentMethodsOutput extends Array<PaymentProviderOutput & {
   /**
    * The ID of the payment method in the payment provider.
    */
   id: string
-})[]
+}> {}
 
 /**
- * @interface
- *
  * The result of saving a payment method.
  */
-export type SavePaymentMethodOutput = PaymentProviderOutput & {
+export interface SavePaymentMethodOutput extends PaymentProviderOutput {
   /**
    * The ID of the payment method in the payment provider.
    */
@@ -375,11 +323,9 @@ export type SavePaymentMethodOutput = PaymentProviderOutput & {
 }
 
 /**
- * @interface
- *
  * The result of getting the payment status.
  */
-export type GetPaymentStatusOutput = PaymentProviderOutput & {
+export interface GetPaymentStatusOutput extends PaymentProviderOutput {
   /**
    * The status of the payment, which will be stored in the payment session's `status` field.
    */


### PR DESCRIPTION
Since most payment types, such as `CapturePaymentInput` are just equal to `PaymentProviderInput`, the generated documentation uses the `PaymentProviderInput`type instead of the `CapturePaymentInput`. This can cause some confusion as seen in issue #11590

To resolve this, we can convert those types to interfaces, which retains the types in the generated documentation.

Other: remove duplicate inventory type