### PR TITLE
docs: fix incorrect link in tax-inclusive-pricing

### DIFF
--- a/www/apps/resources/app/commerce-modules/pricing/tax-inclusive-pricing/page.mdx
+++ b/www/apps/resources/app/commerce-modules/pricing/tax-inclusive-pricing/page.mdx
@@ -16,7 +16,7 @@ For example, if a product’s price is $50, the tax rate is 2%, and tax-inclusiv
 
 ## How is Tax-Inclusive Pricing Set?
 
-The [PricePreference data model](/references/pricing/PricePreference) holds the tax-inclusive setting for a context. It has two properties that indicate the context:
+The [PricePreference data model](/references/pricing/models/PricePreference) holds the tax-inclusive setting for a context. It has two properties that indicate the context:
 
 - `attribute`: The name of the attribute to compare against. For example, `region_id` or `currency_code`.
 - `value`: The attribute’s value. For example, `reg_123` or `usd`.


### PR DESCRIPTION
Closes #11596