### PR TITLE
fix(types, medusa): remove fulfillment and payment status filters from validator + http types

### DIFF
--- a/.changeset/big-spiders-cheat.md
+++ b/.changeset/big-spiders-cheat.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+fix(types, medusa): remove fulfillment and payment status filters from validator + http types

--- a/packages/core/types/src/http/order/admin/queries.ts
+++ b/packages/core/types/src/http/order/admin/queries.ts
@@ -1,5 +1,4 @@
 import { OperatorMap } from "../../../dal"
-import { FulfillmentStatus, PaymentStatus } from "../../../order"
 import { FindParams } from "../../common"
 import { BaseOrderChangesFilters, BaseOrderFilters } from "../common"
 
@@ -12,14 +11,6 @@ export interface AdminOrderFilters extends FindParams, BaseOrderFilters {
    * Filter by sales channel IDs to retrieve their associated orders.
    */
   sales_channel_id?: string[]
-  /**
-   * Filter by fulfillment statuses.
-   */
-  fulfillment_status?: FulfillmentStatus[]
-  /**
-   * Filter by payment statuses.
-   */
-  payment_status?: PaymentStatus[]
   /**
    * Filter by region IDs to retrieve their associated orders.
    */

--- a/packages/medusa/src/api/admin/orders/validators.ts
+++ b/packages/medusa/src/api/admin/orders/validators.ts
@@ -50,8 +50,6 @@ export const AdminGetOrdersParams = createFindParams({
       .optional(),
     name: z.union([z.string(), z.array(z.string())]).optional(),
     sales_channel_id: z.array(z.string()).optional(),
-    fulfillment_status: z.array(z.string()).optional(),
-    payment_status: z.array(z.string()).optional(),
     region_id: z.union([z.string(), z.array(z.string())]).optional(),
     customer_id: z.union([z.string(), z.array(z.string())]).optional(),
     q: z.string().optional(),


### PR DESCRIPTION
We don't allow filtering by these fields, so this PR removes them from the Zod validator + HTTP type.

Closes SUP-993