### PR TITLE
chore(core-flows): pass cart as reference to subflows

### DIFF
--- a/.changeset/eight-buckets-think.md
+++ b/.changeset/eight-buckets-think.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+chore(core-flows): pass cart as reference to subflows

--- a/packages/core/core-flows/src/cart/workflows/refresh-cart-items.ts
+++ b/packages/core/core-flows/src/cart/workflows/refresh-cart-items.ts
@@ -149,11 +149,11 @@ export const refreshCartItemsWorkflow = createWorkflow(
     }).config({ name: "refetch–cart" })
 
     refreshCartShippingMethodsWorkflow.runAsStep({
-      input: { cart_id: input.cart_id },
+      input: { cart: refetchedCart },
     })
 
     updateTaxLinesWorkflow.runAsStep({
-      input: { cart_id: input.cart_id },
+      input: { cart: refetchedCart },
     })
 
     const cartPromoCodes = transform(
@@ -176,7 +176,7 @@ export const refreshCartItemsWorkflow = createWorkflow(
     })
 
     refreshPaymentCollectionForCartWorkflow.runAsStep({
-      input: { cart: refetchedCart },
+      input: { cart_id: input.cart_id },
     })
 
     return new WorkflowResponse(refetchedCart)


### PR DESCRIPTION
What:
 - Pass the cart already fetched to subflows, and refetch it on the payment collection update, that might have new totals after taxes/promotions.