### PR TITLE
fix(core-flows): support 0 as a valid unit price for custom line items

### DIFF
--- a/.changeset/olive-clocks-sort.md
+++ b/.changeset/olive-clocks-sort.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): support 0 as a valid unit price for custom line items

--- a/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
@@ -756,6 +756,16 @@ medusaIntegrationTestRunner({
                   },
                   quantity: 1,
                 },
+                {
+                  title: "zero price item",
+                  subtitle: "zero price item",
+                  thumbnail: "some-url",
+                  requires_shipping: false,
+                  is_discountable: false,
+                  is_tax_inclusive: false,
+                  unit_price: 0,
+                  quantity: 1,
+                },
               ],
               cart_id: cart.id,
             },
@@ -841,6 +851,12 @@ medusaIntegrationTestRunner({
                   variant_sku: null,
                   variant_title: null,
                 },
+                expect.objectContaining({
+                  title: "zero price item",
+                  subtitle: "zero price item",
+                  is_custom_price: true,
+                  unit_price: 0,
+                }),
               ],
             })
           )

--- a/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
@@ -124,7 +124,7 @@ export const addToCartWorkflow = createWorkflow(
           isCustomPrice: isDefined(item?.unit_price),
         }
 
-        if (variant && !input.unitPrice) {
+        if (variant && !isDefined(input.unitPrice)) {
           input.unitPrice = variant.calculated_price?.calculated_amount
         }
 


### PR DESCRIPTION
what:

- fixes case where unit price for a custom line item can be 0
