### PR TITLE
feat: added hook for createPriceListPricesWorkflow

### DIFF
--- a/packages/core/core-flows/src/price-list/workflows/create-price-list-prices.ts
+++ b/packages/core/core-flows/src/price-list/workflows/create-price-list-prices.ts
@@ -5,6 +5,7 @@ import {
 import {
   WorkflowData,
   WorkflowResponse,
+  createHook,
   createWorkflow,
   parallelize,
 } from "@medusajs/framework/workflows-sdk"
@@ -66,11 +67,16 @@ export const createPriceListPricesWorkflow = createWorkflow(
       validateVariantPriceLinksStep(input.data)
     )
 
-    return new WorkflowResponse(
-      createPriceListPricesStep({
-        data: input.data,
-        variant_price_map: variantPriceMap,
-      })
-    )
+    const priceLists = createPriceListPricesStep({
+      data: input.data,
+      variant_price_map: variantPriceMap,
+    })
+    const priceListsCreated = createHook("priceListsCreated", {
+      priceLists,
+    })
+
+    return new WorkflowResponse(priceLists, {
+      hooks: [priceListsCreated],
+    })
   }
 )


### PR DESCRIPTION
What
This commit introduces the `priceListsCreated` hook to the `createPriceListPricesWorkflow`.

Why
The hook was missing and necessary to improve the workflow's extensibility.

How
Added the `priceListsCreated` hook and updated related logic within the workflow.

Testing

1. Create new medusa project via create-medusa-app
2. Connect this custom branch of medusa to it
3. Create `src/workflows/hooks/price-lists-created.ts` file with the following content:

```
import { createPriceListPricesWorkflow } from "@medusajs/medusa/core-flows"

createPriceListPricesWorkflow.hooks.priceListsCreated(
  (async ({ priceLists, additional_data }, { container }) => {
    console.log({priceLists})
  })
)
```
4. Create new admin account and create there a new price list
5. The log should be displayed in terminal