### PR TITLE
fix: Exclude the health endpoint from being logged

### DIFF
--- a/packages/core/framework/src/http/express-loader.ts
+++ b/packages/core/framework/src/http/express-loader.ts
@@ -11,6 +11,8 @@ import { MedusaRequest, MedusaResponse } from "./types"
 
 const NOISY_ENDPOINTS_CHUNKS = ["@fs", "@id", "@vite", "@react", "node_modules"]
 
+const isHealthCheck = (req: MedusaRequest) => req.path === "/health"
+
 export async function expressLoader({ app }: { app: Express }): Promise<{
   app: Express
   shutdown: () => Promise<void>
@@ -69,6 +71,7 @@ export async function expressLoader({ app }: { app: Express }): Promise<{
   function shouldSkipHttpLog(req: MedusaRequest, res: MedusaResponse) {
     return (
       isTest ||
+      isHealthCheck(req) ||
       NOISY_ENDPOINTS_CHUNKS.some((chunk) => req.url.includes(chunk)) ||
       !logger.shouldLog("http")
     )


### PR DESCRIPTION
The health endpoint is almost exclusively used by the infrastructure and there is very little value in logging it. 

Let me know if you think we should handle this differently, or if we should make it configurable.