### PR TITLE
docs: typo on homePage codeTabs notificationModuleService

### DIFF
--- a/www/apps/book/components/Homepage/CodeTabs/index.tsx
+++ b/www/apps/book/components/Homepage/CodeTabs/index.tsx
@@ -231,11 +231,11 @@ export default defineLink(
         source: `async function orderPlaced({
   container,
 }: SubscriberArgs) {
-  const notificaitonModuleService = container.resolve(
+  const notificationModuleService = container.resolve(
     Modules.NOTIFICATION
   )
 
-  await notificaitonModuleService.createNotifications({
+  await notificationModuleService.createNotifications({
     to: "customer@gmail.com",
     channel: "email",
     template: "order-placed"
@@ -253,7 +253,7 @@ export const config: SubscriberConfig = {
           ],
           [
             "4",
-            "notificaitonModuleService",
+            "notificationModuleService",
             "Resolve a module's main service\nto use its methods.",
           ],
           ["8", "createNotification", "Send an email to a customer."],


### PR DESCRIPTION
**What - what changes are in this PR**
Typo on the homepage in the codeTabs

**Why - why are these changes relevant**
Simple typo that might be bothering more people than just me!

**How - how have the changes been implemented**
Fixed the typo from: `notificaitonModuleService` to `notificationModuleService`

**Testing - how has the changes been tested or how can the reviewer test the feature**
Should be simple enough not to require full testing locally!