### PR TITLE
fix(Dashboard): Add dynamic dir attribute support.

### DIFF
--- a/packages/admin/dashboard/src/providers/i18n-provider/i18n-provider.tsx
+++ b/packages/admin/dashboard/src/providers/i18n-provider/i18n-provider.tsx
@@ -1,5 +1,5 @@
 import { I18nProvider as Provider } from "@medusajs/ui"
-import { PropsWithChildren } from "react"
+import { PropsWithChildren, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { languages } from "../../i18n/languages"
 
@@ -12,9 +12,16 @@ const formatLocaleCode = (code: string) => {
 export const I18nProvider = ({ children }: I18nProviderProps) => {
   const { i18n } = useTranslation()
 
-  const locale =
-    languages.find((lan) => lan.code === i18n.language)?.code ||
-    languages[0].code
+  const language =
+    languages.find((lan) => lan.code === i18n.language) || languages[0]
+  const locale = language.code
+
+  useEffect(() => {
+    const html = document.querySelector("html")
+    if (html) {
+      html.dir = language.ltr ? "ltr" : "rtl"
+    }
+  }, [language])
 
   return <Provider locale={formatLocaleCode(locale)}>{children}</Provider>
 }


### PR DESCRIPTION
### What:

- Added functionality to dynamically set the `dir` attribute on the `<html> `tag based on the locale's `rtl` property.
- Implemented a `useEffect` hook in the `i18n-provider` to update the `dir` attribute whenever the language changes.

### Related Issue:
issue #11672