### PR TITLE
fix(dashboard): bust variant inventory cache on inventory update

### DIFF
--- a/.changeset/quiet-numbers-bow.md
+++ b/.changeset/quiet-numbers-bow.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): bust variant inventory cache on inventory update

--- a/packages/admin/dashboard/src/hooks/api/inventory.tsx
+++ b/packages/admin/dashboard/src/hooks/api/inventory.tsx
@@ -205,6 +205,9 @@ export const useUpdateInventoryLevel = (
       queryClient.invalidateQueries({
         queryKey: inventoryItemLevelsQueryKeys.detail(inventoryItemId),
       })
+      queryClient.invalidateQueries({
+        queryKey: variantsQueryKeys.details(),
+      })
       options?.onSuccess?.(data, variables, context)
     },
     ...options,


### PR DESCRIPTION
what:

- busts variant cache on inventory level update

FIXES https://github.com/medusajs/medusa/issues/11686