### PR TITLE
fix(types,medusa): calculate taxes for original price

### DIFF
--- a/.changeset/chilled-kings-flow.md
+++ b/.changeset/chilled-kings-flow.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+fix(types,medusa): calculate taxes for original price

--- a/packages/core/types/src/http/pricing/common.ts
+++ b/packages/core/types/src/http/pricing/common.ts
@@ -47,6 +47,16 @@ export interface BaseCalculatedPriceSet {
   original_amount: number | null
 
   /**
+   * The amount of the original price with taxes included. If the original price is tax inclusive, this field will be the same as `original_amount`.
+   */
+  original_amount_with_tax: number | null
+
+  /**
+   * The amount of the original price without taxes included. If the original price is tax exclusive, this field will be the same as `original_amount`.
+   */
+  original_amount_without_tax: number | null
+
+  /**
    * The currency code of the calculated price, or null if there isn't a calculated price.
    */
   currency_code: string | null

--- a/packages/medusa/src/api/store/products/helpers.ts
+++ b/packages/medusa/src/api/store/products/helpers.ts
@@ -77,6 +77,19 @@ export const wrapProductsWithTaxPrices = async <T>(
 
       variant.calculated_price.calculated_amount_with_tax = priceWithTax
       variant.calculated_price.calculated_amount_without_tax = priceWithoutTax
+
+      const {
+        priceWithTax: originalPriceWithTax,
+        priceWithoutTax: originalPriceWithoutTax,
+      } = calculateAmountsWithTax({
+        taxLines: taxRatesForVariant,
+        amount: variant.calculated_price!.original_amount!,
+        includesTax: variant.calculated_price!.is_original_price_tax_inclusive!,
+      })
+
+      variant.calculated_price.original_amount_with_tax = originalPriceWithTax
+      variant.calculated_price.original_amount_without_tax =
+        originalPriceWithoutTax
     })
   })
 }


### PR DESCRIPTION
what:

- adds a with/without_tax fields to original price

FIXES https://github.com/medusajs/medusa/issues/11684