### PR TITLE
feat(utils): add error message when manager is not found in context

### DIFF
--- a/.changeset/smooth-pans-drive.md
+++ b/.changeset/smooth-pans-drive.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+feat(utils): add error message when manager is not found

--- a/packages/core/utils/src/modules-sdk/decorators/inject-manager.ts
+++ b/packages/core/utils/src/modules-sdk/decorators/inject-manager.ts
@@ -1,4 +1,5 @@
 import { Context } from "@medusajs/types"
+import { isPresent } from "../../common"
 import { MedusaContextType } from "./context-parameter"
 
 export function InjectManager(managerProperty?: string): MethodDecorator {
@@ -39,6 +40,15 @@ export function InjectManager(managerProperty?: string): MethodDecorator {
       const resourceWithManager = !managerProperty
         ? this
         : this[managerProperty]
+
+      if (
+        !isPresent(resourceWithManager) &&
+        !isPresent(originalContext.manager)
+      ) {
+        throw new Error(
+          `Could not find a manager in the context. Ensure that ${this.managerProperty} is set on your service that points to a repository.`
+        )
+      }
 
       copiedContext.manager =
         originalContext.manager ?? resourceWithManager.getFreshManager()


### PR DESCRIPTION
what:

- when a manger is not found in the context, throw an error instead of moving forward.

ADDS to https://github.com/medusajs/medusa/issues/11678