### PR TITLE
docs-util: add exceptions for routes with custom auth middleware

### DIFF
--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -17443,7 +17443,7 @@ paths:
       operationId: GetInvites
       summary: List Invites
       description: Retrieve a list of invites. The invites can be filtered by fields such as `id`. The invites can also be sorted or paginated.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: fields
           in: query
@@ -17950,11 +17950,15 @@ paths:
           $ref: '#/components/responses/invalid_request_error'
         '500':
           $ref: '#/components/responses/500_error'
+      security:
+        - api_token: []
+        - cookie_auth: []
+        - jwt_token: []
     post:
       operationId: PostInvites
       summary: Create Invite
       description: Create a invite.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: fields
           in: query
@@ -18014,6 +18018,10 @@ paths:
         '500':
           $ref: '#/components/responses/500_error'
       x-workflow: createInvitesWorkflow
+      security:
+        - api_token: []
+        - cookie_auth: []
+        - jwt_token: []
   /admin/invites/accept:
     post:
       operationId: PostInvitesAccept
@@ -18021,7 +18029,7 @@ paths:
       description: |
         Accept an invite and create a new user.
         Since the user isn't created yet, the JWT token used in the authorization header is retrieved from the `/auth/user/emailpass/register` API route (or a provider other than `emailpass`). The user can then authenticate using the `/auth/user/emailpass` API route.
-      x-authenticated: false
+      x-authenticated: true
       requestBody:
         content:
           application/json:
@@ -18091,12 +18099,15 @@ paths:
         '500':
           $ref: '#/components/responses/500_error'
       x-workflow: acceptInviteWorkflow
+      security:
+        - cookie_auth: []
+        - jwt_token: []
   /admin/invites/{id}:
     get:
       operationId: GetInvitesId
       summary: Get an Invite
       description: Retrieve an invite by its ID. You can expand the invite's relations or select the fields that should be returned.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: id
           in: path
@@ -18139,11 +18150,15 @@ paths:
           $ref: '#/components/responses/invalid_request_error'
         '500':
           $ref: '#/components/responses/500_error'
+      security:
+        - api_token: []
+        - cookie_auth: []
+        - jwt_token: []
     delete:
       operationId: DeleteInvitesId
       summary: Delete Invite
       description: Delete an invite.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: id
           in: path
@@ -18196,12 +18211,16 @@ paths:
         '500':
           $ref: '#/components/responses/500_error'
       x-workflow: deleteInvitesWorkflow
+      security:
+        - api_token: []
+        - cookie_auth: []
+        - jwt_token: []
   /admin/invites/{id}/resend:
     post:
       operationId: PostInvitesIdResend
       summary: Refresh Invite Token
       description: Refresh the token of an invite.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: id
           in: path
@@ -18245,6 +18264,10 @@ paths:
         '500':
           $ref: '#/components/responses/500_error'
       x-workflow: refreshInviteTokensWorkflow
+      security:
+        - api_token: []
+        - cookie_auth: []
+        - jwt_token: []
   /admin/notifications:
     get:
       operationId: GetNotifications
@@ -41910,7 +41933,7 @@ paths:
       operationId: GetUsers
       summary: List Users
       description: Retrieve a list of users. The users can be filtered by fields such as `id`. The users can also be sorted or paginated.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: fields
           in: query
@@ -42379,12 +42402,15 @@ paths:
           $ref: '#/components/responses/invalid_request_error'
         '500':
           $ref: '#/components/responses/500_error'
+      security:
+        - cookie_auth: []
+        - jwt_token: []
   /admin/users/me:
     get:
       operationId: GetUsersMe
       summary: Get Logged-In User
       description: Retrieve the logged-in user's details.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: fields
           in: query
@@ -42421,12 +42447,15 @@ paths:
           $ref: '#/components/responses/invalid_request_error'
         '500':
           $ref: '#/components/responses/500_error'
+      security:
+        - cookie_auth: []
+        - jwt_token: []
   /admin/users/{id}:
     get:
       operationId: GetUsersId
       summary: Get a User
       description: Retrieve a user by its ID. You can expand the user's relations or select the fields that should be returned.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: id
           in: path
@@ -42469,11 +42498,14 @@ paths:
           $ref: '#/components/responses/invalid_request_error'
         '500':
           $ref: '#/components/responses/500_error'
+      security:
+        - cookie_auth: []
+        - jwt_token: []
     post:
       operationId: PostUsersId
       summary: Update a User
       description: Update a user's details.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: id
           in: path
@@ -42529,11 +42561,14 @@ paths:
         '500':
           $ref: '#/components/responses/500_error'
       x-workflow: updateUsersWorkflow
+      security:
+        - cookie_auth: []
+        - jwt_token: []
     delete:
       operationId: DeleteUsersId
       summary: Delete a User
       description: Delete a user.
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: id
           in: path
@@ -42567,6 +42602,9 @@ paths:
         '500':
           $ref: '#/components/responses/500_error'
       x-workflow: removeUserAccountWorkflow
+      security:
+        - cookie_auth: []
+        - jwt_token: []
   /admin/workflows-executions:
     get:
       operationId: GetWorkflowsExecutions

--- a/www/apps/api-reference/specs/admin/paths/admin_invites.yaml
+++ b/www/apps/api-reference/specs/admin/paths/admin_invites.yaml
@@ -4,7 +4,7 @@ get:
   description: >-
     Retrieve a list of invites. The invites can be filtered by fields such as
     `id`. The invites can also be sorted or paginated.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: fields
       in: query
@@ -589,11 +589,15 @@ get:
       $ref: ../components/responses/invalid_request_error.yaml
     '500':
       $ref: ../components/responses/500_error.yaml
+  security:
+    - api_token: []
+    - cookie_auth: []
+    - jwt_token: []
 post:
   operationId: PostInvites
   summary: Create Invite
   description: Create a invite.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: fields
       in: query
@@ -657,3 +661,7 @@ post:
     '500':
       $ref: ../components/responses/500_error.yaml
   x-workflow: createInvitesWorkflow
+  security:
+    - api_token: []
+    - cookie_auth: []
+    - jwt_token: []

--- a/www/apps/api-reference/specs/admin/paths/admin_invites_accept.yaml
+++ b/www/apps/api-reference/specs/admin/paths/admin_invites_accept.yaml
@@ -8,7 +8,7 @@ post:
     header is retrieved from the `/auth/user/emailpass/register` API route (or a
     provider other than `emailpass`). The user can then authenticate using the
     `/auth/user/emailpass` API route.
-  x-authenticated: false
+  x-authenticated: true
   requestBody:
     content:
       application/json:
@@ -72,3 +72,6 @@ post:
     '500':
       $ref: ../components/responses/500_error.yaml
   x-workflow: acceptInviteWorkflow
+  security:
+    - cookie_auth: []
+    - jwt_token: []

--- a/www/apps/api-reference/specs/admin/paths/admin_invites_{id}.yaml
+++ b/www/apps/api-reference/specs/admin/paths/admin_invites_{id}.yaml
@@ -4,7 +4,7 @@ get:
   description: >-
     Retrieve an invite by its ID. You can expand the invite's relations or
     select the fields that should be returned.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: id
       in: path
@@ -56,11 +56,15 @@ get:
       $ref: ../components/responses/invalid_request_error.yaml
     '500':
       $ref: ../components/responses/500_error.yaml
+  security:
+    - api_token: []
+    - cookie_auth: []
+    - jwt_token: []
 delete:
   operationId: DeleteInvitesId
   summary: Delete Invite
   description: Delete an invite.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: id
       in: path
@@ -114,3 +118,7 @@ delete:
     '500':
       $ref: ../components/responses/500_error.yaml
   x-workflow: deleteInvitesWorkflow
+  security:
+    - api_token: []
+    - cookie_auth: []
+    - jwt_token: []

--- a/www/apps/api-reference/specs/admin/paths/admin_invites_{id}_resend.yaml
+++ b/www/apps/api-reference/specs/admin/paths/admin_invites_{id}_resend.yaml
@@ -2,7 +2,7 @@ post:
   operationId: PostInvitesIdResend
   summary: Refresh Invite Token
   description: Refresh the token of an invite.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: id
       in: path
@@ -55,3 +55,7 @@ post:
     '500':
       $ref: ../components/responses/500_error.yaml
   x-workflow: refreshInviteTokensWorkflow
+  security:
+    - api_token: []
+    - cookie_auth: []
+    - jwt_token: []

--- a/www/apps/api-reference/specs/admin/paths/admin_users.yaml
+++ b/www/apps/api-reference/specs/admin/paths/admin_users.yaml
@@ -4,7 +4,7 @@ get:
   description: >-
     Retrieve a list of users. The users can be filtered by fields such as `id`.
     The users can also be sorted or paginated.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: fields
       in: query
@@ -547,3 +547,6 @@ get:
       $ref: ../components/responses/invalid_request_error.yaml
     '500':
       $ref: ../components/responses/500_error.yaml
+  security:
+    - cookie_auth: []
+    - jwt_token: []

--- a/www/apps/api-reference/specs/admin/paths/admin_users_me.yaml
+++ b/www/apps/api-reference/specs/admin/paths/admin_users_me.yaml
@@ -2,7 +2,7 @@ get:
   operationId: GetUsersMe
   summary: Get Logged-In User
   description: Retrieve the logged-in user's details.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: fields
       in: query
@@ -48,3 +48,6 @@ get:
       $ref: ../components/responses/invalid_request_error.yaml
     '500':
       $ref: ../components/responses/500_error.yaml
+  security:
+    - cookie_auth: []
+    - jwt_token: []

--- a/www/apps/api-reference/specs/admin/paths/admin_users_{id}.yaml
+++ b/www/apps/api-reference/specs/admin/paths/admin_users_{id}.yaml
@@ -4,7 +4,7 @@ get:
   description: >-
     Retrieve a user by its ID. You can expand the user's relations or select the
     fields that should be returned.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: id
       in: path
@@ -56,11 +56,14 @@ get:
       $ref: ../components/responses/invalid_request_error.yaml
     '500':
       $ref: ../components/responses/500_error.yaml
+  security:
+    - cookie_auth: []
+    - jwt_token: []
 post:
   operationId: PostUsersId
   summary: Update a User
   description: Update a user's details.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: id
       in: path
@@ -118,11 +121,14 @@ post:
     '500':
       $ref: ../components/responses/500_error.yaml
   x-workflow: updateUsersWorkflow
+  security:
+    - cookie_auth: []
+    - jwt_token: []
 delete:
   operationId: DeleteUsersId
   summary: Delete a User
   description: Delete a user.
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: id
       in: path
@@ -157,3 +163,6 @@ delete:
     '500':
       $ref: ../components/responses/500_error.yaml
   x-workflow: removeUserAccountWorkflow
+  security:
+    - cookie_auth: []
+    - jwt_token: []

--- a/www/utils/generated/oas-output/operations/admin/delete_admin_invites_[id].ts
+++ b/www/utils/generated/oas-output/operations/admin/delete_admin_invites_[id].ts
@@ -3,7 +3,7 @@
  * operationId: DeleteInvitesId
  * summary: Delete Invite
  * description: Delete an invite.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: id
  *     in: path
@@ -56,6 +56,10 @@
  *   "500":
  *     $ref: "#/components/responses/500_error"
  * x-workflow: deleteInvitesWorkflow
+ * security:
+ *   - api_token: []
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/delete_admin_users_[id].ts
+++ b/www/utils/generated/oas-output/operations/admin/delete_admin_users_[id].ts
@@ -3,7 +3,7 @@
  * operationId: DeleteUsersId
  * summary: Delete a User
  * description: Delete a user.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: id
  *     in: path
@@ -37,6 +37,9 @@
  *   "500":
  *     $ref: "#/components/responses/500_error"
  * x-workflow: removeUserAccountWorkflow
+ * security:
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/get_admin_invites.ts
+++ b/www/utils/generated/oas-output/operations/admin/get_admin_invites.ts
@@ -3,7 +3,7 @@
  * operationId: GetInvites
  * summary: List Invites
  * description: Retrieve a list of invites. The invites can be filtered by fields such as `id`. The invites can also be sorted or paginated.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: fields
  *     in: query
@@ -512,6 +512,10 @@
  *     $ref: "#/components/responses/invalid_request_error"
  *   "500":
  *     $ref: "#/components/responses/500_error"
+ * security:
+ *   - api_token: []
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/get_admin_invites_[id].ts
+++ b/www/utils/generated/oas-output/operations/admin/get_admin_invites_[id].ts
@@ -3,7 +3,7 @@
  * operationId: GetInvitesId
  * summary: Get an Invite
  * description: Retrieve an invite by its ID. You can expand the invite's relations or select the fields that should be returned.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: id
  *     in: path
@@ -48,6 +48,10 @@
  *     $ref: "#/components/responses/invalid_request_error"
  *   "500":
  *     $ref: "#/components/responses/500_error"
+ * security:
+ *   - api_token: []
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/get_admin_users.ts
+++ b/www/utils/generated/oas-output/operations/admin/get_admin_users.ts
@@ -3,7 +3,7 @@
  * operationId: GetUsers
  * summary: List Users
  * description: Retrieve a list of users. The users can be filtered by fields such as `id`. The users can also be sorted or paginated.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: fields
  *     in: query
@@ -474,6 +474,9 @@
  *     $ref: "#/components/responses/invalid_request_error"
  *   "500":
  *     $ref: "#/components/responses/500_error"
+ * security:
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/get_admin_users_[id].ts
+++ b/www/utils/generated/oas-output/operations/admin/get_admin_users_[id].ts
@@ -3,7 +3,7 @@
  * operationId: GetUsersId
  * summary: Get a User
  * description: Retrieve a user by its ID. You can expand the user's relations or select the fields that should be returned.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: id
  *     in: path
@@ -48,6 +48,9 @@
  *     $ref: "#/components/responses/invalid_request_error"
  *   "500":
  *     $ref: "#/components/responses/500_error"
+ * security:
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/get_admin_users_me.ts
+++ b/www/utils/generated/oas-output/operations/admin/get_admin_users_me.ts
@@ -3,7 +3,7 @@
  * operationId: GetUsersMe
  * summary: Get Logged-In User
  * description: Retrieve the logged-in user's details.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: fields
  *     in: query
@@ -42,6 +42,9 @@
  *     $ref: "#/components/responses/invalid_request_error"
  *   "500":
  *     $ref: "#/components/responses/500_error"
+ * security:
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/post_admin_invites.ts
+++ b/www/utils/generated/oas-output/operations/admin/post_admin_invites.ts
@@ -3,7 +3,7 @@
  * operationId: PostInvites
  * summary: Create Invite
  * description: Create a invite.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: fields
  *     in: query
@@ -65,6 +65,10 @@
  *   "500":
  *     $ref: "#/components/responses/500_error"
  * x-workflow: createInvitesWorkflow
+ * security:
+ *   - api_token: []
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/post_admin_invites_[id]_resend.ts
+++ b/www/utils/generated/oas-output/operations/admin/post_admin_invites_[id]_resend.ts
@@ -3,7 +3,7 @@
  * operationId: PostInvitesIdResend
  * summary: Refresh Invite Token
  * description: Refresh the token of an invite.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: id
  *     in: path
@@ -49,6 +49,10 @@
  *   "500":
  *     $ref: "#/components/responses/500_error"
  * x-workflow: refreshInviteTokensWorkflow
+ * security:
+ *   - api_token: []
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/post_admin_invites_accept.ts
+++ b/www/utils/generated/oas-output/operations/admin/post_admin_invites_accept.ts
@@ -6,7 +6,7 @@
  *   Accept an invite and create a new user.
  * 
  *   Since the user isn't created yet, the JWT token used in the authorization header is retrieved from the `/auth/user/emailpass/register` API route (or a provider other than `emailpass`). The user can then authenticate using the `/auth/user/emailpass` API route.
- * x-authenticated: false
+ * x-authenticated: true
  * requestBody:
  *   content:
  *     application/json:
@@ -76,6 +76,9 @@
  *   "500":
  *     $ref: "#/components/responses/500_error"
  * x-workflow: acceptInviteWorkflow
+ * security:
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/admin/post_admin_users_[id].ts
+++ b/www/utils/generated/oas-output/operations/admin/post_admin_users_[id].ts
@@ -3,7 +3,7 @@
  * operationId: PostUsersId
  * summary: Update a User
  * description: Update a user's details.
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: id
  *     in: path
@@ -61,6 +61,9 @@
  *   "500":
  *     $ref: "#/components/responses/500_error"
  * x-workflow: updateUsersWorkflow
+ * security:
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 


### PR DESCRIPTION
Routes like admin user and invite routes have custom authentication middleware applied on them. As we can't detect the applied middleware, we add exceptions to generate accurate OAS for them instead.