### PR TITLE
Update page.mdx

### DIFF
--- a/www/apps/resources/app/js-sdk/page.mdx
+++ b/www/apps/resources/app/js-sdk/page.mdx
@@ -45,6 +45,7 @@ For admin customizations, create this file at `src/admin/lib/config.ts`.
   <CodeTab label="Admin" value="admin">
 
 ```ts title="src/admin/lib/config.ts"
+/// <reference types="vite/types/importMeta.d.ts" />
 import Medusa from "@medusajs/js-sdk"
 
 export const sdk = new Medusa({


### PR DESCRIPTION
This fixes some type issues that it will throw , so the  /// <reference types="vite/types/importMeta.d.ts" /> will fix this issue which is Property 'env' does not exist on type 'ImportMeta'.ts