### PR TITLE
fix: preserve payment sessions during certain Stripe errors for webhook reconciliation

### DIFF
--- a/packages/modules/payment/src/services/payment-module.ts
+++ b/packages/modules/payment/src/services/payment-module.ts
@@ -504,6 +504,11 @@ export default class PaymentModuleService
       status !== PaymentSessionStatus.AUTHORIZED &&
       status !== PaymentSessionStatus.CAPTURED
     ) {
+      await this.paymentSessionService_.update({
+        id: session.id,
+        status,
+        data,
+    }, sharedContext);
       throw new MedusaError(
         MedusaError.Types.NOT_ALLOWED,
         `Session: ${session.id} was not authorized with the provider.`

--- a/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
+++ b/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
@@ -263,14 +263,9 @@ abstract class StripeBase extends AbstractPaymentProvider<StripeOptions> {
         idempotencyKey: context?.idempotency_key,
       })
     )
-    if (sessionData === null) {
-      return {
-        id: data?.session_id as string,
-      }
-    }
 
     return {
-      id: sessionData.id,
+      id: sessionData?.id ?? data?.session_id as string,
       data: sessionData as unknown as Record<string, unknown>,
     }
   }

--- a/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
+++ b/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
@@ -50,12 +50,10 @@ import {
   getSmallestUnit,
 } from "../utils/get-smallest-unit"
 
-type FailedCommunicationState = {
+type StripeIndeterminateState = {
   indeterminate_due_to: string,
 }
-
-type StripeErrorData = Stripe.PaymentIntent | FailedCommunicationState
-
+type StripeErrorData = Stripe.PaymentIntent | StripeIndeterminateState
 type HandledErrorType =
   | { retry: true; }
   | { retry: false; data: StripeErrorData };
@@ -128,9 +126,9 @@ abstract class StripeBase extends AbstractPaymentProvider<StripeOptions> {
   handleStripeError(error: any): HandledErrorType {
     switch (error.type) {
       case 'StripeCardError':
-        // For card errors, Stripe has already created a payment intent but it failed
+        // Stripe has created a payment intent but it failed
         // Extract and return paymentIntent object to be stored in payment_session
-        // This allows for reference to the failed intent and potential webhook reconciliation
+        // Allows for reference to the failed intent and potential webhook reconciliation
         const stripeError = error.raw as Stripe.errors.StripeCardError
         if (stripeError.payment_intent) {
           return {
@@ -157,7 +155,7 @@ abstract class StripeBase extends AbstractPaymentProvider<StripeOptions> {
         return {
           retry: false,
           data: {
-            indeterminate_due_to: "StripeAPIError"
+            indeterminate_due_to: "stripe_api_error"
           }
         }
       }

--- a/packages/modules/providers/payment-stripe/src/types/index.ts
+++ b/packages/modules/providers/payment-stripe/src/types/index.ts
@@ -1,5 +1,3 @@
-import Stripe from "stripe"
-
 export interface StripeOptions {
   /**
    * The API key for the Stripe account

--- a/packages/modules/providers/payment-stripe/src/types/index.ts
+++ b/packages/modules/providers/payment-stripe/src/types/index.ts
@@ -1,3 +1,5 @@
+import Stripe from "stripe"
+
 export interface StripeOptions {
   /**
    * The API key for the Stripe account
@@ -20,6 +22,10 @@ export interface StripeOptions {
    */
   paymentDescription?: string
 }
+
+export type HandledErrorType = 
+| { retry: true; data: null } 
+| { retry: false; data: Stripe.PaymentIntent };
 
 export interface PaymentIntentOptions {
   capture_method?: "automatic" | "manual"

--- a/packages/modules/providers/payment-stripe/src/types/index.ts
+++ b/packages/modules/providers/payment-stripe/src/types/index.ts
@@ -23,10 +23,6 @@ export interface StripeOptions {
   paymentDescription?: string
 }
 
-export type HandledErrorType = 
-| { retry: true; data: null } 
-| { retry: false; data: Stripe.PaymentIntent };
-
 export interface PaymentIntentOptions {
   capture_method?: "automatic" | "manual"
   setup_future_usage?: "on_session" | "off_session"


### PR DESCRIPTION
### Issue
When creating a payment intent with specific parameters (off_session: true, confirm: true, capture_method: "automatic"), the payment module throws errors on certain Stripe responses. This triggers a cleanup function that deletes the payment session.

This creates a significant problem in the payment flow: if the issue resolves and a webhook event is later received from Stripe, the payment session no longer exists to be matched and updated.

Additionally, the payment module currently doesn't update the payment_session status when calling authorizePaymentSession, which creates inconsistency in the payment state.

### Solution
This PR implements several improvements to make payment processing more robust:

1. **Better error handling**: Errors from Stripe are now handled appropriately:
   - If the error is retry-able (network errors, rate limits), a retry is triggered
   - If the issue can't be solved instantly, the error details are stored in payment_session.data
   - This preserves the payment_session for webhook reconciliation or future resolution

2. **Retry mechanism**: Added automatic retry with exponential backoff for errors that might be fixed after retry (connection issues, rate limits)

3. **Status consistency**: Modified authorizePaymentSession method to update payment_session.status regardless of whether the authorization is successful

## Benefits
This change improves payment reliability by:
- Preventing data loss during transient errors
- Maintaining a consistent record for webhook reconciliation 
- Enabling better debugging of payment issues
- Ensuring payment status is always reflected accurately

Note: I haven't included tests yet as I wanted to get feedback on the approach first. I'm happy to add tests once the solution direction is confirmed.
