### PR TITLE
feat: Change customer to account_holder to be one-to-many

### DIFF
--- a/packages/modules/link-modules/src/definitions/customer-account-holder.ts
+++ b/packages/modules/link-modules/src/definitions/customer-account-holder.ts
@@ -42,13 +42,17 @@ export const CustomerAccountHolder: ModuleJoinerConfig = {
       serviceName: Modules.CUSTOMER,
       entity: "Customer",
       fieldAlias: {
-        account_holder: "account_holder_link.account_holder",
+        account_holders: {
+          path: "account_holder_link.account_holder",
+          isList: true,
+        },
       },
       relationship: {
         serviceName: LINKS.CustomerAccountHolder,
         primaryKey: "customer_id",
         foreignKey: "id",
         alias: "account_holder_link",
+        isList: true,
       },
     },
     {


### PR DESCRIPTION
This adds support for a customer to be able to have multiple account holders, therefore supporting multiple payment providers at the same time.

BREAKING: If you were using `customer.account_holder` in your custom implementation, you will need to change it to `customer.account_holders` and choose the relevant one for the provider_id you want to use. If you haven't done anything custom with payments and account holders, there are no breaking changes