### PR TITLE
chore: admin product list transform filter

### DIFF
--- a/.changeset/nine-owls-cheer.md
+++ b/.changeset/nine-owls-cheer.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/index": patch
+"@medusajs/medusa": patch
+---
+
+chore: transform filter before query.index

--- a/packages/medusa/src/api/admin/products/route.ts
+++ b/packages/medusa/src/api/admin/products/route.ts
@@ -60,19 +60,20 @@ async function getProductsWithIndexEngine(
 ) {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  const transformedFilters = {}
-  for (const [key, value] of Object.entries(req.filterableFields)) {
-    if (key === "sales_channel_id") {
-      transformedFilters["sales_channels.id"] = value
-    } else {
-      transformedFilters[key] = value
-    }
+  const filters: Record<string, any> = req.filterableFields
+  if (isPresent(filters.sales_channel_id)) {
+    const salesChannelIds = filters.sales_channel_id
+
+    filters["sales_channels"] ??= {}
+    filters["sales_channels"]["id"] = salesChannelIds
+
+    delete filters.sales_channel_id
   }
 
   const { data: products, metadata } = await query.index({
     entity: "product",
     fields: req.queryConfig.fields ?? [],
-    filters: transformedFilters,
+    filters: filters,
     pagination: req.queryConfig.pagination,
   })
 

--- a/packages/medusa/src/api/admin/products/route.ts
+++ b/packages/medusa/src/api/admin/products/route.ts
@@ -1,23 +1,25 @@
 import { createProductsWorkflow } from "@medusajs/core-flows"
-import { AdditionalData, HttpTypes } from "@medusajs/framework/types"
+import { featureFlagRouter } from "@medusajs/framework"
 import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
   refetchEntities,
   refetchEntity,
 } from "@medusajs/framework/http"
-import { remapKeysForProduct, remapProductResponse } from "./helpers"
-import IndexEngineFeatureFlag from "../../../loaders/feature-flags/index-engine"
-import { featureFlagRouter } from "@medusajs/framework"
+import { AdditionalData, HttpTypes } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys, isPresent } from "@medusajs/framework/utils"
+import IndexEngineFeatureFlag from "../../../loaders/feature-flags/index-engine"
+import { remapKeysForProduct, remapProductResponse } from "./helpers"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest<HttpTypes.AdminProductListParams>,
   res: MedusaResponse<HttpTypes.AdminProductListResponse>
 ) => {
   if (featureFlagRouter.isFeatureEnabled(IndexEngineFeatureFlag.key)) {
-    // TODO: These filters are not supported by the index engine yet
+    // Use regular list when no filters are provided
+    // TODO: Tags and categories are not supported by the index engine yet
     if (
+      Object.keys(req.filterableFields).length === 0 ||
       isPresent(req.filterableFields.tags) ||
       isPresent(req.filterableFields.categories)
     ) {
@@ -58,10 +60,19 @@ async function getProductsWithIndexEngine(
 ) {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
+  const transformedFilters = {}
+  for (const [key, value] of Object.entries(req.filterableFields)) {
+    if (key === "sales_channel_id") {
+      transformedFilters["sales_channels.id"] = value
+    } else {
+      transformedFilters[key] = value
+    }
+  }
+
   const { data: products, metadata } = await query.index({
     entity: "product",
     fields: req.queryConfig.fields ?? [],
-    filters: req.filterableFields,
+    filters: transformedFilters,
     pagination: req.queryConfig.pagination,
   })
 

--- a/packages/modules/index/src/utils/query-builder.ts
+++ b/packages/modules/index/src/utils/query-builder.ts
@@ -1,6 +1,7 @@
 import { IndexTypes } from "@medusajs/framework/types"
 import {
   GraphQLUtils,
+  isDefined,
   isObject,
   isPresent,
   isString,
@@ -276,13 +277,17 @@ export class QueryBuilder {
 
         value = this.transformValueToType(attr, field, value)
         if (Array.isArray(value)) {
+          if (value.length === 0) {
+            return
+          }
+
           const castType = this.getPostgresCastType(attr, field).cast
           const inPlaceholders = value.map(() => "?").join(",")
           builder.whereRaw(
             `(${aliasMapping[attr]}.data${nested}->>?)${castType} IN (${inPlaceholders})`,
             [...field, ...value]
           )
-        } else {
+        } else if (isDefined(value)) {
           const operator = value === null ? "IS" : "="
 
           if (operator === "=") {


### PR DESCRIPTION
What:
 - Medusa: When using the index engine, the sales channel filter is located somewhere else, it has to be transformed before querying it.
 - Index Module: Avoid where clauses with empty values

FIXES: SUP-1127