### PR TITLE
fix(core-flows): add no_notification to shipment created event

### DIFF
--- a/packages/core/core-flows/src/order/workflows/create-shipment.ts
+++ b/packages/core/core-flows/src/order/workflows/create-shipment.ts
@@ -195,7 +195,7 @@ export const createOrderShipmentWorkflow = createWorkflow(
 
     emitEventStep({
       eventName: FulfillmentEvents.SHIPMENT_CREATED,
-      data: { id: shipment.id },
+      data: { id: shipment.id, no_notification: input.no_notification },
     })
 
     const shipmentCreated = createHook("shipmentCreated", {


### PR DESCRIPTION
What:

- passes no notification toggle to shipment created event


Fixes https://github.com/medusajs/medusa/issues/11505