### PR TITLE
fix(workflow-engine-inmemory): Fail trap for integration tests

### DIFF
--- a/packages/modules/workflow-engine-inmemory/integration-tests/__tests__/index.spec.ts
+++ b/packages/modules/workflow-engine-inmemory/integration-tests/__tests__/index.spec.ts
@@ -28,9 +28,20 @@ import {
   workflowEventGroupIdStep1Mock,
   workflowEventGroupIdStep2Mock,
 } from "../__fixtures__/workflow_event_group_id"
+import { setTimeout as setTimeoutSync } from "timers"
 import { createScheduled } from "../__fixtures__/workflow_scheduled"
 
 jest.setTimeout(3000000)
+
+const failTrap = (done) => {
+  setTimeoutSync(() => {
+    // REF:https://stackoverflow.com/questions/78028715/jest-async-test-with-event-emitter-isnt-ending
+    console.warn(
+      "Jest is breaking the event emit with its debouncer. This allows to continue the test by managing the timeout of the test manually."
+    )
+    done()
+  }, 5000)
+}
 
 moduleIntegrationTestRunner<IWorkflowEngineService>({
   moduleName: Modules.WORKFLOW_ENGINE,
@@ -307,6 +318,8 @@ moduleIntegrationTestRunner<IWorkflowEngineService>({
             },
             throwOnError: true,
           })
+
+          failTrap(done)
         })
 
         it("should not run conditional steps if condition is false", (done) => {
@@ -327,6 +340,8 @@ moduleIntegrationTestRunner<IWorkflowEngineService>({
             },
             throwOnError: true,
           })
+
+          failTrap(done)
         })
       })
 

--- a/packages/modules/workflow-engine-inmemory/integration-tests/__tests__/race.spec.ts
+++ b/packages/modules/workflow-engine-inmemory/integration-tests/__tests__/race.spec.ts
@@ -14,6 +14,16 @@ import "../__fixtures__"
 
 jest.setTimeout(3000000)
 
+const failTrap = (done) => {
+  setTimeoutSync(() => {
+    // REF:https://stackoverflow.com/questions/78028715/jest-async-test-with-event-emitter-isnt-ending
+    console.warn(
+      "Jest is breaking the event emit with its debouncer. This allows to continue the test by managing the timeout of the test manually."
+    )
+    done()
+  }, 5000)
+}
+
 moduleIntegrationTestRunner<IWorkflowEngineService>({
   moduleName: Modules.WORKFLOW_ENGINE,
   resolve: __dirname + "/../..",
@@ -87,6 +97,8 @@ moduleIntegrationTestRunner<IWorkflowEngineService>({
             expect(result).toBe("result from step 0")
           })
           .catch((e) => e)
+
+        failTrap(done)
       })
 
       it("should prevent race continuation of the workflow compensation during retryIntervalAwaiting in background execution", (done) => {
@@ -176,6 +188,8 @@ moduleIntegrationTestRunner<IWorkflowEngineService>({
             expect(result).toBe("result from step 0")
           })
           .catch((e) => e)
+
+        failTrap(done)
       })
     })
   },


### PR DESCRIPTION
**What**
Jest is patching the event emitter meaning that sometimes it can lead to flacky behaviors and block the test execution if the done callback is never reached. To prevent that from happening, the fail trap will call the done callback after a given time and warn that the test could not be concluded because of jest blocking it