### PR TITLE
feat: Add support for generating a production-ready config out of the…

### DIFF
--- a/packages/core/utils/src/common/__tests__/define-config.spec.ts
+++ b/packages/core/utils/src/common/__tests__/define-config.spec.ts
@@ -958,4 +958,188 @@ describe("defineConfig", function () {
       }
     `)
   })
+
+  it("should include cloud-based modules when in cloud execution context", function () {
+    const originalEnv = { ...process.env }
+
+    process.env.EXECUTION_CONTEXT = "medusa-cloud"
+    process.env.REDIS_URL = "redis://localhost:6379"
+    process.env.S3_FILE_URL = "https://s3.amazonaws.com/medusa-cloud-test"
+    process.env.S3_PREFIX = "test"
+    process.env.S3_REGION = "us-east-1"
+    process.env.S3_BUCKET = "medusa-cloud-test"
+    process.env.S3_ENDPOINT = "https://s3.amazonaws.com"
+    const res = defineConfig({})
+
+    process.env = { ...originalEnv }
+
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "admin": {
+          "backendUrl": "/",
+          "path": "/app",
+        },
+        "featureFlags": {},
+        "modules": {
+          "api_key": {
+            "resolve": "@medusajs/medusa/api-key",
+          },
+          "auth": {
+            "options": {
+              "providers": [
+                {
+                  "id": "emailpass",
+                  "resolve": "@medusajs/medusa/auth-emailpass",
+                },
+              ],
+            },
+            "resolve": "@medusajs/medusa/auth",
+          },
+          "cache": {
+            "options": {
+              "redisUrl": "redis://localhost:6379",
+            },
+            "resolve": "@medusajs/medusa/cache-redis",
+          },
+          "cart": {
+            "resolve": "@medusajs/medusa/cart",
+          },
+          "currency": {
+            "resolve": "@medusajs/medusa/currency",
+          },
+          "customer": {
+            "resolve": "@medusajs/medusa/customer",
+          },
+          "event_bus": {
+            "options": {
+              "redisUrl": "redis://localhost:6379",
+            },
+            "resolve": "@medusajs/medusa/event-bus-redis",
+          },
+          "file": {
+            "options": {
+              "providers": [
+                {
+                  "id": "s3",
+                  "options": {
+                    "authentication_method": "s3-iam-role",
+                    "bucket": "medusa-cloud-test",
+                    "endpoint": "https://s3.amazonaws.com",
+                    "file_url": "https://s3.amazonaws.com/medusa-cloud-test",
+                    "prefix": "test",
+                    "region": "us-east-1",
+                  },
+                  "resolve": "@medusajs/medusa/file-s3",
+                },
+              ],
+            },
+            "resolve": "@medusajs/medusa/file",
+          },
+          "fulfillment": {
+            "options": {
+              "providers": [
+                {
+                  "id": "manual",
+                  "resolve": "@medusajs/medusa/fulfillment-manual",
+                },
+              ],
+            },
+            "resolve": "@medusajs/medusa/fulfillment",
+          },
+          "inventory": {
+            "resolve": "@medusajs/medusa/inventory",
+          },
+          "locking": {
+            "options": {
+              "redisUrl": "redis://localhost:6379",
+            },
+            "resolve": "@medusajs/medusa/locking-redis",
+          },
+          "notification": {
+            "options": {
+              "providers": [
+                {
+                  "id": "local",
+                  "options": {
+                    "channels": [
+                      "feed",
+                    ],
+                    "name": "Local Notification Provider",
+                  },
+                  "resolve": "@medusajs/medusa/notification-local",
+                },
+              ],
+            },
+            "resolve": "@medusajs/medusa/notification",
+          },
+          "order": {
+            "resolve": "@medusajs/medusa/order",
+          },
+          "payment": {
+            "resolve": "@medusajs/medusa/payment",
+          },
+          "pricing": {
+            "resolve": "@medusajs/medusa/pricing",
+          },
+          "product": {
+            "resolve": "@medusajs/medusa/product",
+          },
+          "promotion": {
+            "resolve": "@medusajs/medusa/promotion",
+          },
+          "region": {
+            "resolve": "@medusajs/medusa/region",
+          },
+          "sales_channel": {
+            "resolve": "@medusajs/medusa/sales-channel",
+          },
+          "stock_location": {
+            "resolve": "@medusajs/medusa/stock-location",
+          },
+          "store": {
+            "resolve": "@medusajs/medusa/store",
+          },
+          "tax": {
+            "resolve": "@medusajs/medusa/tax",
+          },
+          "user": {
+            "options": {
+              "jwt_secret": "supersecret",
+            },
+            "resolve": "@medusajs/medusa/user",
+          },
+          "workflows": {
+            "options": {
+              "redis": {
+                "url": "redis://localhost:6379",
+              },
+            },
+            "resolve": "@medusajs/medusa/workflow-engine-redis",
+          },
+        },
+        "plugins": [],
+        "projectConfig": {
+          "databaseUrl": "postgres://localhost/medusa-starter-default",
+          "http": {
+            "adminCors": "http://localhost:7000,http://localhost:7001,http://localhost:5173",
+            "authCors": "http://localhost:7000,http://localhost:7001,http://localhost:5173",
+            "cookieSecret": "supersecret",
+            "jwtSecret": "supersecret",
+            "restrictedFields": {
+              "store": [
+                ${DEFAULT_STORE_RESTRICTED_FIELDS.map((v) => `"${v}"`).join(
+                  ",\n                "
+                )},
+              ],
+            },
+            "storeCors": "http://localhost:8000",
+          },
+          "redisOptions": {
+            "retryStrategy": [Function],
+          },
+          "redisUrl": "redis://localhost:6379",
+        },
+      }
+    `)
+  })
 })

--- a/packages/core/utils/src/modules-sdk/definition.ts
+++ b/packages/core/utils/src/modules-sdk/definition.ts
@@ -64,11 +64,25 @@ export const REVERSED_MODULE_PACKAGE_NAMES = Object.entries(
 }, {})
 
 // TODO: temporary fix until the event bus, cache and workflow engine are migrated to use providers and therefore only a single resolution will be good
-REVERSED_MODULE_PACKAGE_NAMES["@medusajs/medusa/event-bus-redis"] =
-  Modules.EVENT_BUS
-REVERSED_MODULE_PACKAGE_NAMES["@medusajs/medusa/cache-redis"] = Modules.CACHE
-REVERSED_MODULE_PACKAGE_NAMES["@medusajs/medusa/workflow-engine-redis"] =
-  Modules.WORKFLOW_ENGINE
+export const TEMPORARY_REDIS_MODULE_PACKAGE_NAMES = {
+  [Modules.EVENT_BUS]: "@medusajs/medusa/event-bus-redis",
+  [Modules.CACHE]: "@medusajs/medusa/cache-redis",
+  [Modules.WORKFLOW_ENGINE]: "@medusajs/medusa/workflow-engine-redis",
+  [Modules.LOCKING]: "@medusajs/medusa/locking-redis",
+}
+
+REVERSED_MODULE_PACKAGE_NAMES[
+  TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.EVENT_BUS]
+] = Modules.EVENT_BUS
+REVERSED_MODULE_PACKAGE_NAMES[
+  TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.CACHE]
+] = Modules.CACHE
+REVERSED_MODULE_PACKAGE_NAMES[
+  TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.WORKFLOW_ENGINE]
+] = Modules.WORKFLOW_ENGINE
+REVERSED_MODULE_PACKAGE_NAMES[
+  TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.LOCKING]
+] = Modules.LOCKING
 
 /**
  * Making modules be referenced as a type as well.


### PR DESCRIPTION
Our default config generation includes in-memory modules, which are not production ready.

This PR adds a production-ready config that is used as the default when running in a cloud environment