### PR TITLE
feat: add indeterminate payment state handling with webhook reconciliation

### DIFF
--- a/packages/core/types/src/payment/provider.ts
+++ b/packages/core/types/src/payment/provider.ts
@@ -237,6 +237,10 @@ export interface InitiatePaymentOutput extends PaymentProviderOutput {
    * The ID of the payment session in the payment provider.
    */
   id: string
+  /**
+   * A flag to represent an indeterminate state after attempting to initiate payment.
+   */
+  indeterminate?: boolean;
 }
 
 /**

--- a/packages/medusa/src/subscribers/payment-webhook.ts
+++ b/packages/medusa/src/subscribers/payment-webhook.ts
@@ -34,6 +34,7 @@ export default async function paymentWebhookhandler({
   }
 
   const processedEvent = await paymentService.getWebhookActionAndData(input)
+  await paymentService.validatePaymentSessionForWebhook(processedEvent, input.payload.data)
 
   if (
     processedEvent?.action === PaymentActions.NOT_SUPPORTED ||

--- a/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
+++ b/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
@@ -267,9 +267,13 @@ abstract class StripeBase extends AbstractPaymentProvider<StripeOptions> {
         idempotencyKey: context?.idempotency_key,
       })
     )
-    const isPaymentIntent = 'id' in sessionData;
+
+    // If "indeterminate_due_to" exists set the "indeterminate" flag to true, 
+    // Otherwise, return the payment intent
+    const isIndeterminate = 'indeterminate_due_to' in sessionData
     return {
-      id: isPaymentIntent ? sessionData.id : (data?.session_id as string),
+      indeterminate: isIndeterminate,
+      id: isIndeterminate ? (data?.session_id as string) : sessionData.id,
       data: sessionData as unknown as Record<string, unknown>,
     }
   }


### PR DESCRIPTION
Resolves #11848 

## Issue
When a payment intent creation returns an indeterminate state (like with StripeAPIError), the payment module doesn't provide a clear way to handle these cases. This can lead to "ghost payments" when webhooks arrive later for sessions that were considered failed.

## Solution
This PR implements a comprehensive solution for handling indeterminate payment states:

1. Add an indeterminate flag to InitiatePaymentOutput type to track indeterminate states
2. Set this flag when providers encounter API errors that should be treated as indeterminate per Stripe's best practices
3. Update createPaymentSession to soft delete payment sessions with indeterminate states
4. Add validatePaymentSessionForWebhook method to properly handle webhooks for deleted sessions
5. Automatically cancel or refund payments that arrive via webhook for deleted sessions

This approach completes the implementation of handling indeterminate payment initiation states while maintaining data integrity.

## Benefits
- Alignment with payment industry best practices for handling indeterminate states
- Improved data integrity by maintaining soft-deleted records for audit purposes
- Automatic prevention of "ghost payments" through webhook reconciliation
- Better representation of the relationship between local records and provider state

Note: I'm happy to help update the documentation to include information about indeterminate payment states  if this approach is approved.