### PR TITLE
Feat/complete cart order created hook

### DIFF
--- a/packages/core/core-flows/src/cart/workflows/complete-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/complete-cart.ts
@@ -1,4 +1,5 @@
 import {
+  AdditionalData,
   CartCreditLineDTO,
   CartWorkflowDTO,
   UsageComputedActions,
@@ -49,7 +50,7 @@ export type CompleteCartWorkflowInput = {
    * The ID of the cart to complete.
    */
   id: string
-}
+} & AdditionalData
 
 export type CompleteCartWorkflowOutput = {
   /**
@@ -337,6 +338,7 @@ export const completeCartWorkflow = createWorkflow(
       createHook("orderCreated", {
         order_id: createdOrder.id,
         cart_id: cart.id,
+        additional_data: input.additional_data
       })
 
       return createdOrder

--- a/packages/medusa/src/api/store/carts/[id]/complete/route.ts
+++ b/packages/medusa/src/api/store/carts/[id]/complete/route.ts
@@ -1,7 +1,7 @@
 import { completeCartWorkflow } from "@medusajs/core-flows"
 import { prepareRetrieveQuery } from "@medusajs/framework"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { HttpTypes } from "@medusajs/framework/types"
+import { AdditionalData, HttpTypes } from "@medusajs/framework/types"
 import {
   ContainerRegistrationKeys,
   MedusaError,
@@ -10,13 +10,14 @@ import { refetchCart } from "../../helpers"
 import { defaultStoreCartFields } from "../../query-config"
 
 export const POST = async (
-  req: MedusaRequest,
+  req: MedusaRequest<HttpTypes.StoreCompleteCart & AdditionalData>,
   res: MedusaResponse<HttpTypes.StoreCompleteCartResponse>
 ) => {
   const cart_id = req.params.id
+  const { additional_data } = req.validatedBody
 
   const { errors, result } = await completeCartWorkflow(req.scope).run({
-    input: { id: cart_id },
+    input: { id: cart_id, additional_data },
     context: { transactionId: cart_id },
     throwOnError: false,
   })

--- a/packages/medusa/src/api/store/carts/middlewares.ts
+++ b/packages/medusa/src/api/store/carts/middlewares.ts
@@ -13,6 +13,7 @@ import {
   StoreAddCartPromotions,
   StoreAddCartShippingMethods,
   StoreCalculateCartTaxes,
+  StoreCompleteCart,
   StoreCreateCart,
   StoreGetCartsCart,
   StoreRemoveCartPromotions,
@@ -148,6 +149,7 @@ export const storeCartRoutesMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/store/carts/:id/complete",
     middlewares: [
+      validateAndTransformBody(StoreCompleteCart),
       validateAndTransformQuery(
         StoreGetOrderParams,
         OrderQueryConfig.retrieveTransformQueryConfig

--- a/packages/medusa/src/api/store/carts/validators.ts
+++ b/packages/medusa/src/api/store/carts/validators.ts
@@ -96,3 +96,7 @@ export type StoreUpdateCartCustomerType = z.infer<
   typeof StoreUpdateCartCustomer
 >
 export const StoreUpdateCartCustomer = z.object({}).strict()
+
+export const CompleteCart = z.object({})
+export type StoreCompleteCartType = z.infer<typeof CompleteCart>
+export const StoreCompleteCart = WithAdditionalData(CompleteCart)


### PR DESCRIPTION
When i first started this branch, the idea was to:

- add missing orderCreated hook to completeCartWorkflow
- add additional_data validator to complete cart route
- pass additional_data to completeCartWorkflow to have it available for validate and orderCreated hooks

Since starting the branch, today i merged the latest from develop and see the missing orderCreated hook is now available. Though, the workflow still doesn't receive the additional_data from the route, so i added it.

Additional ref: https://github.com/medusajs/medusa/issues/10965

Fixes #11880