### PR TITLE
fix: hooks auto-generated types to have precise input options

### DIFF
--- a/.changeset/fifty-badgers-punch.md
+++ b/.changeset/fifty-badgers-punch.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/workflows-sdk": patch
+---
+
+fix: hooks auto-generated types to have precise input options

--- a/packages/core/workflows-sdk/src/utils/composer/helpers/workflow-response.ts
+++ b/packages/core/workflows-sdk/src/utils/composer/helpers/workflow-response.ts
@@ -4,7 +4,10 @@ import { WorkflowData, WorkflowDataProperties } from "../type"
 /**
  * Workflow response class encapsulates the return value of a workflow
  */
-export class WorkflowResponse<TResult, THooks = []> {
+export class WorkflowResponse<
+  TResult,
+  const THooks extends readonly unknown[] = []
+> {
   __type: typeof OrchestrationUtils.SymbolMedusaWorkflowResponse =
     OrchestrationUtils.SymbolMedusaWorkflowResponse
 


### PR DESCRIPTION
Fixes: FRMW-2933

**Types before**

![CleanShot 2025-03-18 at 14 53 40@2x](https://github.com/user-attachments/assets/6f779cbe-6db2-4953-ae65-5c207d8503b8)

**Types after**
![CleanShot 2025-03-18 at 14 57 08@2x](https://github.com/user-attachments/assets/16331e85-d478-4e2a-a27f-92b891f7c287)
