### PR TITLE
docs-util: collapse types in references

### DIFF
--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/utils/reflection-type-parameters.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/utils/reflection-type-parameters.ts
@@ -108,14 +108,27 @@ export function getReflectionTypeParameters({
             return
           }
 
+          const reflectionTypeParameters = getReflectionTypeParameters({
+            reflectionType: reflectionTypeArg,
+            project,
+            level: level + 1,
+            maxLevel,
+            isReturn: false,
+          })
+
+          if (
+            typeArgs.length === 1 &&
+            reflectionTypeArg.type === "reference" &&
+            reflectionTypeParameters.length === 1
+          ) {
+            componentItem[parentKey - 1].children?.push(
+              ...(reflectionTypeParameters[0].children || [])
+            )
+            return
+          }
+
           componentItem[parentKey - 1].children?.push(
-            ...getReflectionTypeParameters({
-              reflectionType: reflectionTypeArg,
-              project,
-              level: level + 1,
-              maxLevel,
-              isReturn: false,
-            })
+            ...reflectionTypeParameters
           )
         })
       }

--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/utils/reflection-type-parameters.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/utils/reflection-type-parameters.ts
@@ -185,11 +185,20 @@ export function getReflectionTypeParameters({
       const elementTypeItem = getReflectionTypeParameters({
         reflectionType: reflectionType.elementType,
         project,
-        level: level + 1,
+        level,
         maxLevel,
         isReturn: false,
       })
-      componentItem[parentKey - 1].children?.push(...elementTypeItem)
+      if (
+        reflectionType.elementType.type === "reference" &&
+        elementTypeItem.length === 1
+      ) {
+        componentItem[parentKey - 1].children?.push(
+          ...(elementTypeItem[0].children || [])
+        )
+      } else {
+        componentItem[parentKey - 1].children?.push(...elementTypeItem)
+      }
     }
   } else if (reflectionType.type === "tuple") {
     let pushTo: Parameter[] = []


### PR DESCRIPTION
Collaps types in generated reference for type arguments and arrays

**Before**

Promise<FileDTO> -> FileDTO -> id, url, etc...
Promise<FileDTO[]> -> FileDTO[] -> FileDTO

**After**

Promise<FileDTO> -> id, url, ...
Promise<FileDTO[]> -> FileDTO[] -> id, url, ...

Closes DX-1451