### PR TITLE
feat(dashboard): add support for Lithuanian language

### DIFF
--- a/packages/admin/dashboard/src/i18n/languages.ts
+++ b/packages/admin/dashboard/src/i18n/languages.ts
@@ -19,7 +19,8 @@ import {
   faIR,
   cs,
   ru,
-  el
+  el,
+  lt,
 } from "date-fns/locale"
 import { Language } from "./types"
 
@@ -149,5 +150,11 @@ export const languages: Language[] = [
     display_name: "Русский",
     ltr: true,
     date_locale: ru,
+  },
+  {
+    code: "lt",
+    display_name: "Lietuviškai",
+    ltr: true,
+    date_locale: lt,
   },
 ]

--- a/packages/admin/dashboard/src/i18n/translations/index.ts
+++ b/packages/admin/dashboard/src/i18n/translations/index.ts
@@ -19,6 +19,7 @@ import zhCN from "./zhCN.json"
 import fa from "./fa.json"
 import cs from "./cs.json"
 import ru from "./ru.json"
+import lt from "./lt.json"
 
 export default {
   bg: {
@@ -83,5 +84,8 @@ export default {
   },
   ru: {
     translation: ru,
+  },
+  lt: {
+    translation: lt,
   },
 }

--- a/packages/admin/dashboard/src/i18n/translations/lt.json
+++ b/packages/admin/dashboard/src/i18n/translations/lt.json
@@ -1,0 +1,3003 @@
+{
+  "$schema": "./$schema.json",
+  "general": {
+    "ascending": "Didėjančia tvarka",
+    "descending": "Mažėjančia tvarka",
+    "add": "Pridėti",
+    "start": "Pradžia",
+    "end": "Pabaiga",
+    "open": "Atidaryti",
+    "close": "Uždaryti",
+    "apply": "Taikyti",
+    "range": "Intervalas",
+    "search": "Paieška",
+    "of": "iš",
+    "results": "rezultatai",
+    "pages": "puslapiai",
+    "next": "Kitas",
+    "prev": "Praeitas",
+    "is": "yra",
+    "timeline": "Laiko juosta",
+    "success": "Payvko",
+    "warning": "Įspėjimas",
+    "tip": "Patarimas",
+    "error": "Klaida",
+    "select": "Pasirinkite",
+    "selected": "Pasirinktas",
+    "enabled": "Įjungtas",
+    "disabled": "Išjungtas",
+    "expired": "Pasibaigęs",
+    "active": "Aktyvus",
+    "revoked": "Atšauktas",
+    "new": "Naujas",
+    "modified": "Pakeistas",
+    "added": "Pridėtas",
+    "removed": "Pašalintas",
+    "admin": "Administratorius",
+    "store": "Parduotuvė",
+    "details": "Aprašymas",
+    "items_one": "{{count}} daiktas",
+    "items_other": "{{count}} daiktai",
+    "countSelected": "{{count}} pasirinkta",
+    "countOfTotalSelected": "{{count}} iš {{total}} pasirinkta",
+    "plusCount": "+ {{count}}",
+    "plusCountMore": "+ {{count}} dar",
+    "areYouSure": "Jūs įsitikinę?",
+    "areYouSureDescription": "Ketinate pašalinti {{entity}} {{title}}. Šis veiksmas neatstatomas.",
+    "noRecordsFound": "Įrašų nerasta",
+    "typeToConfirm": "Įveskite {val} patvirtinimui:",
+    "noResultsTitle": "Rezultatų nėra",
+    "noResultsMessage": "Pabandykite pakeisti paieškos kriterijus",
+    "noSearchResults": "Paieškos rezultatų nėra",
+    "noSearchResultsFor": "Paieškos rezultatų nėra pagal <0>'{{query}}'</0>",
+    "noRecordsTitle": "Įrašų nėra",
+    "noRecordsMessage": "Nėra įrašų parodymui",
+    "unsavedChangesTitle": "Tikrai norite išeiti iš šios formos?",
+    "unsavedChangesDescription": "Turite neišsaugotų pakeitimų, kurie bus prarasti jei išeisite iš šios formos.",
+    "includesTaxTooltip": "Kainos šiame stulpelyje nurodytos su mokesčiais.",
+    "excludesTaxTooltip": "Kainos šiame stulpelyje nurodytos be mokesčių.",
+    "noMoreData": "Daugiau duomenų nėra"
+  },
+  "json": {
+    "header": "JSON",
+    "numberOfKeys_one": "{{count}} įrašas",
+    "numberOfKeys_other": "{{count}} įrašų",
+    "drawer": {
+      "header_one": "JSON <0>· {{count}} įrašas</0>",
+      "header_other": "JSON <0>· {{count}} įrašų</0>",
+      "description": "Peržiūrėkite šio objekto JSON duomenis"
+    }
+  },
+  "metadata": {
+    "header": "Metaduomenys",
+    "numberOfKeys_one": "{{count}} įrašas",
+    "numberOfKeys_other": "{{count}} įrašų",
+    "edit": {
+      "header": "Keisti Metaduomenis",
+      "description": "Keisti šio objekto metaduomenis.",
+      "successToast": "Metaduomenyss sėkmingai atnaujinti.",
+      "actions": {
+        "insertRowAbove": "Įterpti eilutę virš",
+        "insertRowBelow": "Įterpti eilutę po",
+        "deleteRow": "Pašalinti eiltuę"
+      },
+      "labels": {
+        "key": "įrašas",
+        "value": "reikšmė"
+      },
+      "complexRow": {
+        "label": "Kai kurios eilutės išjungtos",
+        "description": "Šiame objekte yra neprimityvių metaduomenų, pvz., masyvų ar objektų, kurių čia redaguoti čia negalima. Norėdami pakeisti išjungtas eilutes, naudokite API tiesiogiai.",
+        "tooltip": "Eilutė išjungta, nes joje yra neprimityvių duomenų."
+      }
+    }
+  },
+  "validation": {
+    "mustBeInt": "Reikšmė turi būti sveikasis skaičius.",
+    "mustBePositive": "Reikšmė turi būti teigiamas skaičius."
+  },
+  "actions": {
+    "save": "Išsaugoti",
+    "saveAsDraft": "Išsaugoti kaip juodraštį",
+    "copy": "Kopijuoti",
+    "copied": "Nukopijuota",
+    "duplicate": "Dubliuoti",
+    "publish": "Publikuoti",
+    "create": "Sukurti",
+    "delete": "Ištrinti",
+    "remove": "Pašalinti",
+    "revoke": "Atšaukti",
+    "cancel": "Atšaukti",
+    "forceConfirm": "Priverstinai patvirtinti",
+    "continueEdit": "Tęsti redagavimą",
+    "enable": "Įjungti",
+    "disable": "Išjungti",
+    "undo": "Atstatyti",
+    "complete": "Baigtas",
+    "viewDetails": "Peržiūrėti informaciją",
+    "back": "Atgal",
+    "close": "Uždaryti",
+    "showMore": "Rodyti daugiau",
+    "continue": "Tęsti",
+    "continueWithEmail": "Tęstu su el. paštu",
+    "idCopiedToClipboard": "ID nukopijuotas į atmintį",
+    "addReason": "Pridėti priežastį",
+    "addNote": "Pridėti pastabą",
+    "reset": "Atstatyti",
+    "confirm": "Patvirtinti",
+    "edit": "Keisti",
+    "addItems": "Pridėti",
+    "download": "Parsisiųsti",
+    "clear": "Išvalyti",
+    "clearAll": "Išvalyti visus",
+    "apply": "Pritaikyti",
+    "add": "Pridėti",
+    "select": "Pasirinkti",
+    "browse": "Naršyti",
+    "logout": "Atsijungti",
+    "hide": "Paslėpti",
+    "export": "Eksportuoti",
+    "import": "Importuoti",
+    "cannotUndo": "Šio veiksmo pasekmės neatstatomos"
+  },
+  "operators": {
+    "in": "Iš"
+  },
+  "app": {
+    "search": {
+      "label": "Ieškoti",
+      "title": "Paieška",
+      "description": "Paieška visoje parduotuvėje: tarp užsakymų, prekių, klientų, kt.",
+      "allAreas": "Vios sritys",
+      "navigation": "Navigacija",
+      "openResult": "Atidaryti rezultatą",
+      "showMore": "Rodyti daugiau",
+      "placeholder": "Peršok arba rask bet ką...",
+      "noResultsTitle": "Rezultatų nerasta",
+      "noResultsMessage": "Mes neradome nieko, atitinkančio Jūsų piešką.",
+      "emptySearchTitle": "Paieškai, įveskite",
+      "emptySearchMessage": "Įveskite paieškos žodį ar frazę.",
+      "loadMore": "Užkrauti dar {{count}}",
+      "groups": {
+        "all": "Visos sritys",
+        "customer": "Klientai",
+        "customerGroup": "Klientų grupės",
+        "product": "Prekės",
+        "productVariant": "Prekių variantai",
+        "inventory": "Atsargos",
+        "reservation": "Rezervacijos",
+        "category": "Kategorijos",
+        "collection": "Kolekcijos",
+        "order": "Užsakymai",
+        "promotion": "Akcijos",
+        "campaign": "Kampanijos",
+        "priceList": "Kainoraščiai",
+        "user": "Administratoriai",
+        "region": "Regionai",
+        "taxRegion": "Mokesčių regionai",
+        "returnReason": "Grąžinimo priežastys",
+        "salesChannel": "Pardavimų kanalai",
+        "productType": "Prekių tipai",
+        "productTag": "Prekių žymos",
+        "location": "Sandėliavimo vietos",
+        "shippingProfile": "Siuntimo tipas",
+        "publishableApiKey": "Vieši API raktai",
+        "secretApiKey": "Slapti API raktai",
+        "command": "Komandos",
+        "navigation": "Navigacija"
+      }
+    },
+    "keyboardShortcuts": {
+      "pageShortcut": "Peršokti į",
+      "settingShortcut": "Nustatymai",
+      "commandShortcut": "Komandos",
+      "then": "tada",
+      "navigation": {
+        "goToOrders": "Užsakymai",
+        "goToProducts": "Prekės",
+        "goToCollections": "Kolekcijos",
+        "goToCategories": "Kategorijos",
+        "goToCustomers": "Klientai",
+        "goToCustomerGroups": "Klientų grupės",
+        "goToInventory": "Atsargos",
+        "goToReservations": "Rezervacijos",
+        "goToPriceLists": "Kainoraščiai",
+        "goToPromotions": "Akcijos",
+        "goToCampaigns": "Kampanijos"
+      },
+      "settings": {
+        "goToSettings": "Nustatymai",
+        "goToStore": "Parduotuvė",
+        "goToUsers": "Administratoriai",
+        "goToRegions": "Regionai",
+        "goToTaxRegions": "Mokesčių regionai",
+        "goToSalesChannels": "Pardavimų kanalai",
+        "goToProductTypes": "Prekių tipai",
+        "goToLocations": "Vietos",
+        "goToPublishableApiKeys": "Vieši API raktai",
+        "goToSecretApiKeys": "Slapti API raktai",
+        "goToWorkflows": "Darbo eigos",
+        "goToProfile": "Paskyra",
+        "goToReturnReasons": "Grąžinimo priežastys"
+      }
+    },
+    "menus": {
+      "user": {
+        "documentation": "Dokumentacija",
+        "changelog": "Pakeitimų žurnalas",
+        "shortcuts": "Spartieji klavišai",
+        "profileSettings": "Paskyros nustatymai",
+        "theme": {
+          "label": "Tema",
+          "dark": "Tamsi",
+          "light": "Šviesi",
+          "system": "Sistemos"
+        }
+      },
+      "store": {
+        "label": "Parduotuvė",
+        "storeSettings": "Parduotuvės nustatymai"
+      },
+      "actions": {
+        "logout": "Atsijungti"
+      }
+    },
+    "nav": {
+      "accessibility": {
+        "title": "Navigacija",
+        "description": "Darbastalio meniu."
+      },
+      "common": {
+        "extensions": "Plėtiniai"
+      },
+      "main": {
+        "store": "Parduotuvė",
+        "storeSettings": "Parduotuvės nustatymai"
+      },
+      "settings": {
+        "header": "Nustatymai",
+        "general": "Bendrieji",
+        "developer": "Kūrėjo",
+        "myAccount": "Mano Paskyra"
+      }
+    }
+  },
+  "dataGrid": {
+    "columns": {
+      "view": "Žiūrėti",
+      "resetToDefault": "Atstatyti numatytuosius",
+      "disabled": "Matomų stulpelių keitimas išjungtas."
+    },
+    "shortcuts": {
+      "label": "Spartieji klavišai",
+      "commands": {
+        "undo": "Atstatyti",
+        "redo": "Perdaryti",
+        "copy": "Kopijuoti",
+        "paste": "Įklijuoti",
+        "edit": "Keisti",
+        "delete": "Šalinti",
+        "clear": "Išvalyti",
+        "moveUp": "Eiti aukštyn",
+        "moveDown": "Eiti žemyn",
+        "moveLeft": "Eiti karėn",
+        "moveRight": "Eiti dešinėn",
+        "moveTop": "Eiti į viršų",
+        "moveBottom": "Eitį į apačią",
+        "selectDown": "Pasirinkti žemiau",
+        "selectUp": "Pasirinkti aukščiau",
+        "selectColumnDown": "Pasirinkti stulpelį žemyn",
+        "selectColumnUp": "Pasirinkti stulpelį aukštyn",
+        "focusToolbar": "Pereitį į įrankių juostą",
+        "focusCancel": "Pereiti prie atšaukimo"
+      }
+    },
+    "errors": {
+      "fixError": "Pataisykite klaidą",
+      "count_one": "{{count}} klaida",
+      "count_other": "{{count}} klaidos"
+    }
+  },
+  "filters": {
+    "sortLabel": "Rūšiuoti",
+    "filterLabel": "Filtruoti",
+    "searchLabel": "Ieškoti",
+    "date": {
+      "today": "Šiandien",
+      "lastSevenDays": "Per paskutines 7 dienas",
+      "lastThirtyDays": "Per paskutines 30 dienų",
+      "lastNinetyDays": "Per paskutines 90 dienų",
+      "lastTwelveMonths": "Per paskutinius 12 mėnesių",
+      "custom": "Nustatytas",
+      "from": "Nuo",
+      "to": "Iki",
+      "starting": "Pradedant",
+      "ending": "Baigiant"
+    },
+    "compare": {
+      "lessThan": "Mažiau už",
+      "greaterThan": "Daugiau už",
+      "exact": "Tiksliai",
+      "range": "Rėžis",
+      "lessThanLabel": "mažiau už {{value}}",
+      "greaterThanLabel": "daugiau už {{value}}",
+      "andLabel": "ir"
+    },
+    "sorting": {
+      "alphabeticallyAsc": "A iki Z",
+      "alphabeticallyDesc": "Z iki A",
+      "dateAsc": "Naujausi viršuje",
+      "dateDesc": "Seniausi viršuje"
+    },
+    "radio": {
+      "yes": "Taip",
+      "no": "Ne",
+      "true": "Tiesa",
+      "false": "Netiesa"
+    },
+    "addFilter": "Pridėti filtrą"
+  },
+  "errorBoundary": {
+    "badRequestTitle": "400 - Bloga užklausa",
+    "badRequestMessage": "Serveris negali suprasti užklausos dėl neteisingos sintaksės.",
+    "notFoundTitle": "404 - Šiuo adresu puslapio nėra",
+    "notFoundMessage": "Patikrinkite adresą ir bandykite dar kartą arba pasinaudokite paieška.",
+    "internalServerErrorTitle": "500 - Vidinė serverio klaida",
+    "internalServerErrorMessage": "Serveryje įvyko netikėta klaida. Bandykite vėliau.",
+    "defaultTitle": "Įvyko klaida",
+    "defaultMessage": "Pateikiant šį puslapį įvyko netikėta klaida.",
+    "noMatchMessage": "Jūsų ieškomas puslapis neegzistuoja.",
+    "backToDashboard": "Atgal į darbastalį"
+  },
+  "addresses": {
+    "title": "Adresai",
+    "shippingAddress": {
+      "header": "Pristatymo adresas",
+      "editHeader": "Keisti pristatymo adresą",
+      "editLabel": "Pristatymo adresas",
+      "label": "Pristatymo adresas"
+    },
+    "billingAddress": {
+      "header": "Adresas sąskaitoms",
+      "editHeader": "Keisti adresą sąskaitoms",
+      "editLabel": "Adresas sąskaitoms",
+      "label": "Adresas sąskaitoms",
+      "sameAsShipping": "Sutampa su pristatymo adresu"
+    },
+    "contactHeading": "Kontaktai",
+    "locationHeading": "Vieta"
+  },
+  "email": {
+    "editHeader": "Keisti el. paštą",
+    "editLabel": "El. paštas",
+    "label": "El. paštas"
+  },
+  "transferOwnership": {
+    "header": "Perleisti nuosavybės teisę",
+    "label": "Perleisti nuosavybės teisę",
+    "details": {
+      "order": "Užsakymas",
+      "draft": "Juodraštis"
+    },
+    "currentOwner": {
+      "label": "Dabartinis savininkas",
+      "hint": "Dabartinis užsakymo savininkas."
+    },
+    "newOwner": {
+      "label": "Naujas savininkas",
+      "hint": "Naujas savininkas, kuriam bus perkeltas užsakymas."
+    },
+    "validation": {
+      "mustBeDifferent": "Naujas savininkas turi būti kitas nei dabartinis.",
+      "required": "Naujas savininkas privalomas."
+    }
+  },
+  "sales_channels": {
+    "availableIn": "Galima įsigyti <0>{{x}}</0> iš <1>{{y}}</1> pardavimo kanalų"
+  },
+  "products": {
+    "domain": "Prekės",
+    "list": {
+      "noRecordsMessage": "Sukurkite pirmą savo prekę, kad pradėtumėte parduoti."
+    },
+    "edit": {
+      "header": "Keisti prekę",
+      "description": "Keikite prekės aprašymą",
+      "successToast": "Prekė {{title}} sėmingai pakeista."
+    },
+    "create": {
+      "title": "Sukurti prekę",
+      "description": "Sukurkite naują prekę.",
+      "header": "Bendra informacija",
+      "tabs": {
+        "details": "Aprašymas",
+        "organize": "Skirstymas",
+        "variants": "Variantai",
+        "inventory": "Atsargų rinkiniai"
+      },
+      "errors": {
+        "variants": "Pasirinkite bent vieną variantą.",
+        "options": "Sukurkite bent vieną pasirinkimą.",
+        "uniqueSku": "SKU turi būti unikalus."
+      },
+      "inventory": {
+        "heading": "Atsargų rinkiniai",
+        "label": "Pridėti atsargas prie varianto atsargų rinkinio.",
+        "itemPlaceholder": "Pasirinkite atsargą",
+        "quantityPlaceholder": "Koks kiekis reikalingas rinkiniui?"
+      },
+      "variants": {
+        "header": "Variantai",
+        "subHeadingTitle": "Taip, tai prekė su variantais",
+        "subHeadingDescription": "Jei nepažymėta, mes sukursime numatytąjį variantą už jus.",
+        "optionTitle": {
+          "placeholder": "Dydis"
+        },
+        "optionValues": {
+          "placeholder": "Mažas, Vidutinis, Didelis"
+        },
+        "productVariants": {
+          "label": "Prekės variantai",
+          "hint": "Šis reitingas turės įtakos variantų reikiavimui parduotuvėje.",
+          "alert": "Pridėkite pasirinkimų, kad sukurtumėte variantų.",
+          "tip": "Nepažymėti variantai nebus sukurti. Jūs galite bet kada sukurti ar keisti variantus, bet šis sąrašas aitinka variantus su jūsų prekės pasrinkimais."
+        },
+        "productOptions": {
+          "label": "Prekės pasirinkimai",
+          "hint": "Apibrėžkite prekės parinktis, pvz. spalva, dydis ir kt."
+        }
+      },
+      "successToast": "Prekė {{title}} sėkmingai sukurta."
+    },
+    "export": {
+      "header": "Esportuoti prekių sąrašą",
+      "description": "Išesportuokite prekių sąrašą į CSV bylą.",
+      "success": {
+        "title": "Apdorojame jūsų eksportą",
+        "description": "Duomenų eksportavimas gali užtrukti kelias minutes. Pranešime kai baigsis."
+      },
+      "filters": {
+        "title": "Filtrai",
+        "description": "Pritaikyti filtrus lentelės peržiūrai"
+      },
+      "columns": {
+        "title": "Stulpeliai",
+        "description": "Pritaikykite išeksporuotus duomenis savo poreikiams"
+      }
+    },
+    "import": {
+      "header": "Importuoti prekių sąrašą",
+      "uploadLabel": "Importuoti prekes",
+      "uploadHint": "Atvilkite CSV bylą arba spustelėkite, kad įkeltumėte",
+      "description": "Importuokite produktus pateikdami CSV bylą iš anksto nustatytu formatu",
+      "template": {
+        "title": "Nežinote, kaip sutvarkyti sąrašą?",
+        "description": "Atsisiųskite pateiktą šabloną, kad įsitikintumėte, jog laikotės tinkamo formato."
+      },
+      "upload": {
+        "title": "Įkelti CSV bylą",
+        "description": "Importuodami galite pridėti arba atnaujinti produktus. Norėdami atnaujinti esamus produktus, turite naudoti esamą nuorodą ir ID, o esamiems variantams atnaujinti turite naudoti esamą ID. Prieš importuojant produktus, jūsų bus paprašyta patvirtinti.",
+        "preprocessing": "Apdorojame...",
+        "productsToCreate": "Prekės, kurios bus sukurtos",
+        "productsToUpdate": "Prekės, kurios bus atnaujintos"
+      },
+      "success": {
+        "title": "Apdorojame Jūsų importą",
+        "description": "Duomenų importavimas gali užtrukti kelias minutes. Pranešime kai baigsis."
+      }
+    },
+    "deleteWarning": "Ketinate pašalinti prekę {{title}}. Šis veiksmas neatstatomas.",
+    "variants": {
+      "header": "Variantai",
+      "empty": {
+        "heading": "Variantų nėra",
+        "description": "Nėra rodomų variantų."
+      },
+      "filtered": {
+        "heading": "Rezultatų nėra",
+        "description": "Nė vienas variantas neatitinka dabartinių filtro kriterijų."
+      }
+    },
+    "attributes": "Požymiai",
+    "editAttributes": "Keisi požymius",
+    "editOptions": "Keisti pasirinkimus",
+    "editPrices": "Keisti kainas",
+    "media": {
+      "label": "Nuotraukos",
+      "editHint": "Pridėkite prekės nuotraukas, kad pateikti jas parduotuvėje.",
+      "makeThumbnail": "Pagaminti miniatūrą",
+      "uploadImagesLabel": "Įkelti nuotraukas",
+      "uploadImagesHint": "Atvilkite nuotraukas čia arba spustelkite įkėlimui.",
+      "invalidFileType": "'{{name}}' nepalaikomas bylos tipas. Palaikomi bylų tipai: {{types}}.",
+      "failedToUpload": "Nepavyko įkelti pridėtų nuotraukų. Bandykite dar kartą.",
+      "deleteWarning_one": "Ketinate pašalinti {{count}} nuotrauką. Šis veiksmas neatstatomas.",
+      "deleteWarning_other": "Ketinate pašalinti {{count}} nuotraukų. Šis veiksmas neatstatomas.",
+      "deleteWarningWithThumbnail_one": "Ketinate pašalinti {{count}} nuotrauką ir jos miniatūrą. Šis veiksmas neatstatomas.",
+      "deleteWarningWithThumbnail_other": "Ketinate pašalinti {{count}} nuotraukų ir jų miniatūrų. Šis veiksmas neatstatomas.",
+      "thumbnailTooltip": "Miniatūra",
+      "galleryLabel": "Galerija",
+      "downloadImageLabel": "Parsisiųsti nuotrauką",
+      "deleteImageLabel": "Pašalinti nuotrauką",
+      "emptyState": {
+        "header": "Nuotraukų dar nėra",
+        "description": "Pridėkite prekės nuotraukas kad parodyti jas parduotuvėje",
+        "action": "Pridėti nuotraukas"
+      },
+      "successToast": "Nuotraukos sėkmingai atnaujintos."
+    },
+    "discountableHint": "Jei nepažymėta, nuolaidos prekei netaikomos.",
+    "noSalesChannels": "Nėra nei vienam pardavimo kanale",
+    "variantCount_one": "{{count}} variantas",
+    "variantCount_other": "{{count}} variantai",
+    "deleteVariantWarning": "Ketinate pašalinti prekės variantą {{title}}. Šis veiksmas neatstatomas.",
+    "productStatus": {
+      "draft": "Juodraštis",
+      "published": "Publikuojama",
+      "proposed": "Pasiūlyta",
+      "rejected": "Atmesta"
+    },
+    "fields": {
+      "title": {
+        "label": "Pavadinimas",
+        "hint": "Pavadinkite prekę trumpai ir aiškiai.<0/>50-60 simbolių yra rekomenduojamas ilgis paieškos sistemoms."
+      },
+      "subtitle": {
+        "label": "Paantraštė"
+      },
+      "handle": {
+        "label": "Nuoroda",
+        "tooltip": "Nuoroda naudojama norint nurodyti prekės adresą jūsų parduotuvėje. Jei nenurodyta, nuoroda bus sugeneruota iš prekės pavadinimo."
+      },
+      "description": {
+        "label": "Aprašymas",
+        "hint": "Aprašykite prekę trumpai ir aiškiai.<0/>120-160 simbolių yra rekomenduojamas ilgis paieškos sistemoms."
+      },
+      "discountable": {
+        "label": "Nukainuojama",
+        "hint": "Jei nepažymėta, nuolaidos šiai prekei netaikomos"
+      },
+      "shipping_profile": {
+        "label": "Pristatymo eiga",
+        "hint": "Priskirkite prekės pristatymo eigą"
+      },
+      "type": {
+        "label": "Tipas"
+      },
+      "collection": {
+        "label": "Kolekcija"
+      },
+      "categories": {
+        "label": "Kategorijos"
+      },
+      "tags": {
+        "label": "Žymos"
+      },
+      "sales_channels": {
+        "label": "Pardavimų kanalai",
+        "hint": "Jei nenurodysite kitaip, ši prekė bus prieinama tik pagrindiniam pardavimo kanale."
+      },
+      "countryOrigin": {
+        "label": "Kilmės šalis"
+      },
+      "material": {
+        "label": "Medžiaga"
+      },
+      "width": {
+        "label": "Plotis"
+      },
+      "length": {
+        "label": "Length"
+      },
+      "height": {
+        "label": "Aukštis"
+      },
+      "weight": {
+        "label": "Svoris"
+      },
+      "options": {
+        "label": "Prekės pasirinkimai",
+        "hint": "Pasirinkimai naudojami norint apibrėžti prekės spalvą, dydį ir pan.",
+        "add": "Pridėti pasirinkimą",
+        "optionTitle": "Pasirinkimo pavadinimas",
+        "optionTitlePlaceholder": "Spalva",
+        "variations": "Pasirinkimai (atskirti kableliu)",
+        "variantionsPlaceholder": "Raudona, Mėlyna, Žalia"
+      },
+      "variants": {
+        "label": "Prekės variantai",
+        "hint": "Nepažymėti variantai nebus sukurti. Šis reitingavimas įtakos variantų rikiavimą parduotuvėje."
+      },
+      "mid_code": {
+        "label": "Gamintojo kodas"
+      },
+      "hs_code": {
+        "label": "HS kodas"
+      }
+    },
+    "variant": {
+      "edit": {
+        "header": "Keisti variantą",
+        "success": "Prekės variantas sėkmingai pakeistas"
+      },
+      "create": {
+        "header": "Prekės variantas"
+      },
+      "deleteWarning": "Tikrai norite pašalinti šį variantą?",
+      "pricesPagination": "1 - {{current}} iš {{total}} kainų",
+      "tableItemAvailable": "{{availableCount}} laisva",
+      "tableItem_one": "{{availableCount}} laisva {{locationCount}} vietoje",
+      "tableItem_other": "{{availableCount}} laisvų {{locationCount}} vietose",
+      "inventory": {
+        "notManaged": "Nevaldomos",
+        "manageItems": "Tvarkyti atsargas",
+        "notManagedDesc": "Šio varianto atsargos netvarkomos. Įjunkite „Tvarkyti atsargas“, kad galėtumėte sekti varianto atsargas.",
+        "manageKit": "Tvarkyti atsargų rinkinį",
+        "navigateToItem": "Eiti į atsargas",
+        "actions": {
+          "inventoryItems": "Eiti į atsargas",
+          "inventoryKit": "Rodyti atsargas"
+        },
+        "inventoryKit": "Atsargų rinkinys",
+        "inventoryKitHint": "Ar šis variantas susideda iš kelių atargų?",
+        "validation": {
+          "itemId": "Pasirinkite atsargas",
+          "quantity": "Kiekis privalomas. Įveskite teigiamą skaičių."
+        },
+        "header": "Atsargos ir likučiai",
+        "editItemDetails": "Keisti",
+        "manageInventoryLabel": "Tvarkyti atsargas",
+        "manageInventoryHint": "Kai įjungta, mes pakeisime atargų likučius kai užsakymai ar grąžinimai sukuriami.",
+        "allowBackordersLabel": "Leisti užsakyti kai nėra",
+        "allowBackordersHint": "Kai įjungta, klientai gali pirkti variantą net jei neturime reikiamo kiekio.",
+        "toast": {
+          "levelsBatch": "Atsargų likučiai atnaujinti.",
+          "update": "Atsargos sėkmingai atnaujintos.",
+          "updateLevel": "Likučiai sėkmingai atnaujinti.",
+          "itemsManageSuccess": "Atsargos sėkmingai pakeistos."
+        }
+      }
+    },
+    "options": {
+      "header": "Pasirinkimai",
+      "edit": {
+        "header": "Keisti pasirinkimą",
+        "successToast": "Pasirinkimas {{title}} sėkmingai pakeistas."
+      },
+      "create": {
+        "header": "Sukurti pasirinkimą",
+        "successToast": "Pasirinkimas {{title}} sėkmingai sukurtas."
+      },
+      "deleteWarning": "Ketinate pašalinti prekės pasirinkimą: {{title}}. Šis veiksmas neatstatomas."
+    },
+    "organization": {
+      "header": "Išdėstymas",
+      "edit": {
+        "header": "Keisti išdėstymą",
+        "toasts": {
+          "success": "{{title}} išdėstymas sėkmingai pakeistas."
+        }
+      }
+    },
+    "stock": {
+      "heading": "Tvarkykite atsargų likučius ir vietas",
+      "description": "Pakeiskite atsargų likučius visiems prekės variantams.",
+      "loading": "Palaukite, gali šiek tiek užtrukti...",
+      "tooltips": {
+        "alreadyManaged": "Šios atsargos jau yar redaguojamos prie {{title}}.",
+        "alreadyManagedWithSku": "Šios atsargos jau yar redaguojamos prie {{title}} ({{sku}})."
+      }
+    },
+    "shippingProfile": {
+      "header": "Siuntimo nustatymai",
+      "edit": {
+        "header": "Siuntimo nustatymai",
+        "toasts": {
+          "success": "Siuntimo nustatymai {{title}} sėkmingai atnaujinti."
+        }
+      },
+      "create": {
+        "errors": {
+          "required": "Siuntimo paskyra privaloma"
+        }
+      }
+    },
+    "toasts": {
+      "delete": {
+        "success": {
+          "header": "Prekė pašalinta",
+          "description": "{{title}} sėkmingai pašalinta."
+        },
+        "error": {
+          "header": "Nepavyko pašalinti prekės"
+        }
+      }
+    }
+  },
+  "collections": {
+    "domain": "Kolekcijos",
+    "subtitle": "Suskirstykite prekes į kolekcijas.",
+    "createCollection": "Sukurti kolekciją",
+    "createCollectionHint": "Sukurkite naują kolekciją prekių skirstymui.",
+    "createSuccess": "Kolekcija sėkmingai sukurta.",
+    "editCollection": "Keisti kolekciją",
+    "handleTooltip": "Nuordoda naudojama norint nurodyti kolekcijos adresą parduotuvėje. Jei nenurodyta, nuoroda bus sugenruota iš kolekcijos pavadinimo.",
+    "deleteWarning": "Ketinate pašalinti kolekciją {{title}}. Šis veiksmas neatstatomas.",
+    "removeSingleProductWarning": "Ketinate pašalinti prekę {{title}} iš kolekcijos. Šis veiksmas neatstatomas.",
+    "removeProductsWarning_one": "Ketinate pašalinti {{count}} prekę iš kolekcijos. Šis veiksmas neatstatomas.",
+    "removeProductsWarning_other": "Ketinate pašalinti {{count}} prekių iš kolekcijos. Šis veiksmas neatstatomas.",
+    "products": {
+      "list": {
+        "noRecordsMessage": "Kolekcijoje prekių nėra"
+      },
+      "add": {
+        "successToast_one": "Prekė sėkmingai pridėta į kolekciją.",
+        "successToast_other": "Prekės sėmingai pridėtos į kolekciją."
+      },
+      "remove": {
+        "successToast_one": "Prekė sėkmingai pašalinta iš kolekcijos.",
+        "successToast_other": "Prekės sėkmingai pašalintos iš kolekcijos."
+      }
+    }
+  },
+  "categories": {
+    "domain": "Kategorijos",
+    "subtitle": "Suskirstykite prekes į katęgorijas, kurias galite rikiuoti ir išdėstyti hierarchiškai.",
+    "create": {
+      "header": "Sukurti kategoriją",
+      "hint": "Sukurkite naują kategoriją prekių skirstymui.",
+      "tabs": {
+        "details": "Nustatymai",
+        "organize": "Tvarkyti eiliškumą"
+      },
+      "successToast": "Kategorija {{name}} sėkmingai sukurta."
+    },
+    "edit": {
+      "header": "Keisti kategoriją",
+      "description": "Pakeistite kategorijos nustatymus ar rikiavimą.",
+      "successToast": "Kategorija sėkmingai pakeista."
+    },
+    "delete": {
+      "confirmation": "Ketinate pašalinti kategoriją {{name}}. Šis veiksmas neatstatomas.",
+      "successToast": "Kategorija {{name}} sėkmingai pašalinta."
+    },
+    "products": {
+      "add": {
+        "disabledTooltip": "Prekė jau yra šioje kategorijoje.",
+        "successToast_one": "Pridėta {{count}} prekė į kategoriją.",
+        "successToast_other": "Pridėta {{count}} prekių į kategoriją."
+      },
+      "remove": {
+        "confirmation_one": "Ketinate pašalinti {{count}} prekę iš kategorijos. Šis veiksmas neatstatomas.",
+        "confirmation_other": "Ketinate pašalinti {{count}} prekių iš kategorijos. Šis veiksmas neatstatomas.",
+        "successToast_one": "Pašalinta {{count}} prekė iš kategorijos.",
+        "successToast_other": "Pašalinta {{count}} prekių iš kategorijos."
+      },
+      "list": {
+        "noRecordsMessage": "Kategorijoje prekių nėra."
+      }
+    },
+    "organize": {
+      "header": "Tvarkyti",
+      "action": "Keisti rikiavimą"
+    },
+    "fields": {
+      "visibility": {
+        "label": "Matomumas",
+        "internal": "Vidinis",
+        "public": "Viešas"
+      },
+      "status": {
+        "label": "Būsena",
+        "active": "Įjungta",
+        "inactive": "Išjungta"
+      },
+      "path": {
+        "label": "Kelias",
+        "tooltip": "Rodyti pilną kategorijos kelią."
+      },
+      "children": {
+        "label": "Vaikai"
+      },
+      "new": {
+        "label": "Nauja"
+      }
+    }
+  },
+  "inventory": {
+    "domain": "Atsargos",
+    "subtitle": "Tvarkykite savo turimas atsargas",
+    "reserved": "Rezervuota",
+    "available": "Laisva",
+    "locationLevels": "Vietos",
+    "associatedVariants": "Susiję variantai",
+    "manageLocations": "Tvarkyti vietas",
+    "deleteWarning": "Ketinate pašalinti atsargas. Šis veiksmas neatstatomas.",
+    "editItemDetails": "Keisti atsargas",
+    "create": {
+      "title": "Sukurti atsargas",
+      "details": "Nustatymai",
+      "availability": "Prieinamumas",
+      "locations": "Vietos",
+      "attributes": "Požymiai",
+      "requiresShipping": "Reikalingas siuntimas",
+      "requiresShippingHint": "Ar šioms atsargoms reikalingas siuntimas?",
+      "successToast": "Atsargos sėkmingai sukurtos."
+    },
+    "reservation": {
+      "header": "{{itemName}} rezervacija",
+      "editItemDetails": "Keisti rezervaciją",
+      "lineItemId": "Užsakymo eilutės ID",
+      "orderID": "Užsakymo ID",
+      "description": "Aprašymas",
+      "location": "Sandėliavimo vieta",
+      "inStockAtLocation": "Sandėlyje šioje vietoje",
+      "availableAtLocation": "Laiva šioje vietoje",
+      "reservedAtLocation": "Rezervuota šioje vietoje",
+      "reservedAmount": "Rezervuoti kiekį",
+      "create": "Sukurti rezervaciją",
+      "itemToReserve": "Rezervuojama prekė",
+      "quantityPlaceholder": "Kiek norite rezervuoti?",
+      "descriptionPlaceholder": "Koks šios rezervacijos tipas?",
+      "successToast": "Rezervacija sėkmingai sukurta.",
+      "updateSuccessToast": "Rezervacija sėkmingai pakeista.",
+      "deleteSuccessToast": "Rezervacija sėkmingai pašalinta.",
+      "errors": {
+        "noAvaliableQuantity": "Vietos sandėlyje nėra pakankamo laisvo kiekio.",
+        "quantityOutOfRange": "Mažiausias kiekis yra 1, o didžiausias kiekis yra {{max}}"
+      }
+    },
+    "adjustInventory": {
+      "errors": {
+        "stockedQuantity": "Kiekis sandėlyje negali būti mažesnis nei rezervuotas kiekis {{quantity}}."
+      }
+    },
+    "toast": {
+      "updateLocations": "Vietos sėkmingai atnaujintos.",
+      "updateLevel": "Atsargų kiekis sėkmingai pakeistas.",
+      "updateItem": "Atsargos sėkmingai atnaujintos."
+    },
+    "stock": {
+      "title": "Keisti atsargų likučius",
+      "description": "Pakeiskite pasirinktų atargų likučius.",
+      "action": "Keisti likučius",
+      "placeholder": "Išjungta",
+      "disablePrompt_one": "Ketinate išjungti {{count}} vietos likutį. Šis veiksmas neatstatomas.",
+      "disablePrompt_other": "Ketinate išjungti {{count}} vietos likučius. Šis veiksmas neatstatomas.",
+      "disabledToggleTooltip": "Neina išjungti: išvalykite užsakytus ir/arba rezervuotus likučius prieš išjungiant.",
+      "successToast": "Atsargų likučiai sėkmingai atnaujinti."
+    }
+  },
+  "giftCards": {
+    "domain": "Dovanų kortelės",
+    "editGiftCard": "Keisti dovanų kortelę",
+    "createGiftCard": "Sukurti dovanų kortelę",
+    "createGiftCardHint": "Sukurkite dovanų kortelę, kuri gali būti panaudota atsiskaitymui parduotuvėje.",
+    "selectRegionFirst": "Pirma pasirinkite regioną",
+    "deleteGiftCardWarning": "Ketinate pašalinti dovanų kortelę {{code}}. Šis veiksmas neatstatomas.",
+    "balanceHigherThanValue": "Likutis negali būti didesnis nei pradinė suma.",
+    "balanceLowerThanZero": "Likutis negali būti neigiamas.",
+    "expiryDateHint": "Šalyse galioja skirtingi įstatymai dėl dovanų kortelių galiojimo pabaigos. Prieš nustatydami galiojimo datą, peržiūrėkite vietines taisykles.",
+    "regionHint": "Pakeitus dovanų kortelės regioną, gali pasikeis ir jos valiuta, o tai gali turėti įtakos kortelės vertei.",
+    "enabledHint": "Nurodykite, ar dovanų kortelė įjungta, ar išjungta.",
+    "balance": "Likutis",
+    "currentBalance": "Esamas likutis",
+    "initialBalance": "Pradinis likutis",
+    "personalMessage": "Asmeninė žinutė",
+    "recipient": "Gavėjas"
+  },
+  "customers": {
+    "domain": "Klientai",
+    "list": {
+      "noRecordsMessage": "Jūsų klientai bus rodomi čia."
+    },
+    "create": {
+      "header": "Sukurti klientą",
+      "hint": "Sukurkite naują klientą ir tvarkykite jo duomenis.",
+      "successToast": "Klientas {{email}} sėkmingai sukurtas."
+    },
+    "groups": {
+      "label": "Klientų grupės",
+      "remove": "Tikrai norite pašalinti klientą iš \"{{name}}\" klientų grupės?",
+      "removeMany": "Tikrai norite pašalinti klientą iš šių klientų grupių: {{groups}}?",
+      "alreadyAddedTooltip": "Klientas jau yra šioje klientų grupėje.",
+      "list": {
+        "noRecordsMessage": "Šis klientas nepriklauso nei vienai klientų grupei."
+      },
+      "add": {
+        "success": "Klientas priskirtas prie: {{groups}}.",
+        "list": {
+          "noRecordsMessage": "Prašome pirma sukurti klientų grupę."
+        }
+      },
+      "removed": {
+        "success": "Klientas pašalintas iš: {{groups}}.",
+        "list": {
+          "noRecordsMessage": "Prašome pirma sukurti klientų grupę."
+        }
+      }
+    },
+    "edit": {
+      "header": "Keisti klientą",
+      "emailDisabledTooltip": "El. paštas negali būti pakeistas užsiregistravusiems klientams.",
+      "successToast": "Klientas {{email}} sėkmingai pakeistas."
+    },
+    "delete": {
+      "title": "Pašalinti klientą",
+      "description": "Ketinate pašalinti klientą {{email}}. Šis veiksmas neatstatomas.",
+      "successToast": "Klientas {{email}} sėkmingai pašalintas."
+    },
+    "fields": {
+      "guest": "Svečias",
+      "registered": "Užsiregistravęs",
+      "groups": "Grupės"
+    },
+    "registered": "Užsiregistravęs",
+    "guest": "Svečias",
+    "hasAccount": "Turi paskyrą",
+    "addresses": {
+      "title": "Adresai",
+      "fields": {
+        "addressName": "Adreso pavadinimas",
+        "address1": "Adreso eilutė 1",
+        "address2": "Adreso eilutė 2",
+        "city": "Miestas",
+        "province": "Provincija",
+        "postalCode": "Pašto kodas",
+        "country": "Šalis",
+        "phone": "Telefonas",
+        "company": "Įmonė",
+        "countryCode": "Šalies kodas",
+        "provinceCode": "Provincijos kodas"
+      },
+      "create": {
+        "header": "Sukurti adresą",
+        "hint": "Sukurkite naują adresą klientui.",
+        "successToast": "Addresas sėkmingai sukurtas."
+      }
+    }
+  },
+  "customerGroups": {
+    "domain": "Klientų grupės",
+    "subtitle": "Skirstykite klientus į grupes. Grupės gali turėti skirtingas akcijas ir kainas.",
+    "list": {
+      "empty": {
+        "heading": "Klientų grupių nėra",
+        "description": "Nėra klientų grupių parodymui."
+      },
+      "filtered": {
+        "heading": "Rezultatų nėra",
+        "description": "Nei viena klientų grupė neatitinka nustatyto filtro."
+      }
+    },
+    "create": {
+      "header": "Sukurti klientų grupę",
+      "hint": "Sukurkite naują klientų grupę klientų segmentavimui.",
+      "successToast": "Klientų grupė {{name}} sėkmingai sukurta."
+    },
+    "edit": {
+      "header": "Keisti klientų grupę",
+      "successToast": "Klientų grupė {{name}} sėkmingai pakeista."
+    },
+    "delete": {
+      "title": "Pašalinti klientų grupę",
+      "description": "Ketinate pašalinti klientų grupę {{name}}. Šis veiksmas neatstatomas.",
+      "successToast": "Klientų grupė {{name}} sėkmingai pašalinta."
+    },
+    "customers": {
+      "alreadyAddedTooltip": "Klientas jau priskirtas prie grupės.",
+      "add": {
+        "successToast_one": "Klientas sėkmingai priskirtas prie grupės.",
+        "successToast_other": "Klientai sėkmingai priskirti prie grupės.",
+        "list": {
+          "noRecordsMessage": "Pirma sukurkite klientą."
+        }
+      },
+      "remove": {
+        "title_one": "Pašalinti klientą",
+        "title_other": "Pašalinti klientus",
+        "description_one": "Ketinate pašalinti {{count}} klientą iš klientų grupės. Šis veiksmas neatstatomas.",
+        "description_other": "Ketinate pašalinti {{count}} klientus iš klientų grupės. Šis veiksmas neatstatomas."
+      },
+      "list": {
+        "noRecordsMessage": "Ši grupė neturi klientų."
+      }
+    }
+  },
+  "orders": {
+    "domain": "Užsakymai",
+    "claim": "Pretenzijos",
+    "exchange": "Keitimai",
+    "return": "Grąžinimai",
+    "cancelWarning": "Ketinate atšaukti užsakymą {{id}}. Šis veiksmas neatstatomas.",
+    "orderCanceled": "Užsakymas sėkmingai atšauktas",
+    "onDateFromSalesChannel": "{{date}} iš {{salesChannel}}",
+    "list": {
+      "noRecordsMessage": "Jūsų užsakymai bus rodomi čia."
+    },
+    "status": {
+      "not_paid": "Neapmokėtas",
+      "pending": "Laukia",
+      "completed": "Įvykdytas",
+      "draft": "Juodraštis",
+      "archived": "Archyvuotas",
+      "canceled": "Atšauktas",
+      "requires_action": "Reikia veiksmų"
+    },
+    "summary": {
+      "requestReturn": "Prašyti grąžinimo",
+      "allocateItems": "Priskirti atsargas",
+      "editOrder": "Keisti užsakymą",
+      "editOrderContinue": "Tęsti užsakymo keitimą",
+      "inventoryKit": "Susideda iš {{count}}x atsargų",
+      "itemTotal": "Prekės iš viso",
+      "shippingTotal": "Siuntimas iš viso",
+      "discountTotal": "Nuolaida iš viso",
+      "taxTotalIncl": "Mokesčiai iš viso (įskaičiuoti)",
+      "itemSubtotal": "Prekės viso",
+      "shippingSubtotal": "Siuntimas viso",
+      "discountSubtotal": "Nuolaida viso",
+      "taxTotal": "Mokesčiai viso"
+    },
+    "transfer": {
+      "title": "Perleisti nuosavybę",
+      "requestSuccess": "Užsakymo nuosavybės perleidimo prašymas išsiųstas į {{email}}.",
+      "currentOwner": "Dabartinis savininkas",
+      "newOwner": "Naujas savininkas",
+      "currentOwnerDescription": "Pirkėjas jau susietas su šiuo užsakymu.",
+      "newOwnerDescription": "Pirkėjas kuriam perleidžiamos užsakymmo nuosavybė."
+    },
+    "payment": {
+      "title": "Apmokėjimas",
+      "isReadyToBeCaptured": "Mokėjimas <0/> paruoštas nuskaitymui.",
+      "totalPaidByCustomer": "Viso sumokėjo klientas",
+      "capture": "Nuskaityti mokėjimą",
+      "capture_short": "Nuskaityti",
+      "refund": "Grąžinti",
+      "markAsPaid": "Pažymėti kaip sumokėtą",
+      "statusLabel": "Apmokėjimo būsena",
+      "statusTitle": "Apmokėjimo būsena",
+      "status": {
+        "notPaid": "Neapmokėtas",
+        "authorized": "Patvirtintas",
+        "partiallyAuthorized": "Dalinai patvirtintas",
+        "awaiting": "Laukia",
+        "captured": "Nuskaitytas",
+        "partiallyRefunded": "Dalinai grąžintas",
+        "partiallyCaptured": "Dalinai captured",
+        "refunded": "Grąžintas",
+        "canceled": "Atšauktas",
+        "requiresAction": "Reikia veiksmų"
+      },
+      "capturePayment": "Mokėjimas, kurio suma {{amount}}, bus nuskaitytas.",
+      "capturePaymentSuccess": "Mokėjimas, kurio suma {{amount}}, sėkmingai nuskaitytas",
+      "markAsPaidPayment": "Mokėjimas, kurio suma {{amount}}, bus pažymėtas kaip atliktas.",
+      "markAsPaidPaymentSuccess": "Mokėjimas, kurio suma {{amount}}, sėkmingai pažymėtas kaip atliktas",
+      "createRefund": "Sukurti grąžinimą",
+      "refundPaymentSuccess": "return, kurio suma {{amount}}, sėkmingas",
+      "createRefundWrongQuantity": "Kiekis turi būti skaičius tarp 1 ir {{number}}",
+      "refundAmount": "Grąžinti {{ amount }}",
+      "paymentLink": "Kopijuoti mokėjimo, kurio suma {{ amount }}, nuorodą",
+      "selectPaymentToRefund": "Pasirinkite mokėjimą grąžinimui"
+    },
+    "edits": {
+      "title": "Keisti užsakymą",
+      "confirm": "Patvirtinti pakeitimus",
+      "confirmText": "Ketinate patvirtinti užsakymo keitimą. Šis veiksmas neatstatomas.",
+      "cancel": "Atšaukti keitimą",
+      "currentItems": "Dabartinės prekės",
+      "currentItemsDescription": "Pakeiskite prekės kiekį ar pašalinkite.",
+      "addItemsDescription": "Galite pridėti naujų prekių prie užsakymo.",
+      "addItems": "Pridėti prekių",
+      "amountPaid": "Sumokėta suma",
+      "newTotal": "Nauja suma",
+      "differenceDue": "Skirtumas",
+      "create": "Keisti užsakymą",
+      "currentTotal": "Dabartinė suma",
+      "noteHint": "Pridėkite vidinę užsakymo keitimo pastabą",
+      "cancelSuccessToast": "Užsakymo keitimas atšauktas",
+      "createSuccessToast": "Užsakymo keitimas sėkmingai sukurtas",
+      "activeChangeError": "Jau yra vykdomas užsakymo keitimas (grąžinimas, pretenzija, keitimas, kt.). Užbaikite arba atšaukite keitimą.",
+      "panel": {
+        "title": "Užsakymo keitimas išsiųstas",
+        "titlePending": "Užsakymo keitimas laukia"
+      },
+      "toast": {
+        "canceledSuccessfully": "Užsakymo keitimas atšauktas",
+        "confirmedSuccessfully": "Užsakymo keitimas patvirtintas"
+      },
+      "validation": {
+        "quantityLowerThanFulfillment": "Negalima nustatyti, kad kiekis būtų mažesnis arba lygus įvykdytam kiekiui"
+      }
+    },
+    "edit": {
+      "email": {
+        "title": "Keisti el. paštą",
+        "requestSuccess": "Užsakymo el. paštas pakeitas į {{email}}."
+      },
+      "shippingAddress": {
+        "title": "Keisti pristatymo adresą",
+        "requestSuccess": "Užsakymo pristatymo adresas pakeistas."
+      },
+      "billingAddress": {
+        "title": "Keisti adresą sąskaitai",
+        "requestSuccess": "Užsakymo adresas sąskaitai pakeistas."
+      }
+    },
+    "returns": {
+      "create": "Sukurti grąžinimą",
+      "confirm": "Patvirtinti grąžinimą",
+      "confirmText": "Ketinate patvirtinti grąžinimą. Šis veiksmas neatstatomas.",
+      "inbound": "Įeinantis",
+      "outbound": "Išeinantis",
+      "sendNotification": "Siųsti pranešimą",
+      "sendNotificationHint": "Praneškite klientui apie grąžinimą.",
+      "returnTotal": "Grąžinama viso",
+      "inboundTotal": "Įeinantis viso",
+      "refundAmount": "Pirkėjui grąžinama suma",
+      "outstandingAmount": "Likučio suma",
+      "reason": "Priežastis",
+      "reasonHint": "Pasirinkite kodėl klientas nori grąžinti prekes.",
+      "note": "Pastabaa",
+      "noInventoryLevel": "Nėra likučio",
+      "noInventoryLevelDesc": "Pasirinktoje vietoje nėra pasirinktų atsargų likučio. Grąžinimas gali būti išsiųstas, bet negali būti priimtas kol pasirinktoje vietoje nebus sukurtas likutis.",
+      "noteHint": "Laisvos formos pataba, jei norite ką nors nurodyti.",
+      "location": "Sandėliavimo vieta",
+      "locationHint": "Pasirinkite vietą, į kurią norite grąžinti atsargas.",
+      "inboundShipping": "Grąžinimo siuntimas",
+      "inboundShippingHint": "Pasirinkite norimą siuntimo būdą.",
+      "returnableQuantityLabel": "Grąžinamas kiekis",
+      "refundableAmountLabel": "Grąžinama suma",
+      "returnRequestedInfo": "{{requestedItemsCount}}x prekių grąžinimas išsiųstas",
+      "returnReceivedInfo": "{{requestedItemsCount}}x prekių grąžinimas gautas",
+      "itemReceived": "Gautos prekės",
+      "returnRequested": "return išsiųstas",
+      "damagedItemReceived": "Gauta pažeista prekė",
+      "damagedItemsReturned": "{{quantity}}x pažeistos prekės grąžintos",
+      "activeChangeError": "Jau yra vykdomas užsakymo keitimas (grąžinimas, pretenzija, keitimas, kt.). Užbaikite arba atšaukite keitimą.",
+      "cancel": {
+        "title": "Atšaukti grąžinimą",
+        "description": "Tikrai norite atšaukti grąžinimą?"
+      },
+      "placeholders": {
+        "noReturnShippingOptions": {
+          "title": "Nėra grąžinimo siuntimo variantų",
+          "hint": "Nėra sukurtų siuntimo variantų šiai vietovei. Galite sukurti Galite sukurti jį <LinkComponent>Vietos ir siuntimas</LinkComponent>."
+        },
+        "outboundShippingOptions": {
+          "title": "Nėra išeinančio siuntimo variantų",
+          "hint": "Nėra sukurtų išeinančio siuntimo variantų šiai vietovei. Galite sukurti jį <LinkComponent>Vietos ir siuntimas</LinkComponent>."
+        }
+      },
+      "receive": {
+        "action": "Priimti prekes",
+        "receiveItems": "{{ returnType }} {{ id }}",
+        "restockAll": "Atnaujinti visus likučius",
+        "itemsLabel": "Gautos prekės",
+        "title": "Priimti #{{returnId}} prekes",
+        "sendNotificationHint": "Praneškite klientui apie gautą grąžinimą.",
+        "inventoryWarning": "Atkreipkite dėmesį, kad automatiškai pakeisime likučius pagal tai, ką įvesite aukščiau.",
+        "writeOffInputLabel": "Kiek prekių yra pažeistų?",
+        "toast": {
+          "success": "Gražinimas sėkmingai gautas.",
+          "errorLargeValue": "Kiekis didesnis nei prašomas.",
+          "errorNegativeValue": "Kiekis negali būti neigiamas.",
+          "errorLargeDamagedValue": "Pažeistų prekių kiekis + nepažeistų gautas kiekis didesnis už bedrą grąžinąmą kiekį. Sumažinkite nepažeistų prekių kiekį."
+        }
+      },
+      "toast": {
+        "canceledSuccessfully": "return sekmingai atšauktas",
+        "confirmedSuccessfully": "return sekmingai patvirtintas"
+      },
+      "panel": {
+        "title": "return inicijuotas",
+        "description": "Yra pradėtas grąžinimas, kuris neužbaigtas"
+      }
+    },
+    "claims": {
+      "create": "Sukurti pretenziją",
+      "confirm": "Patvirtinti pretenziją",
+      "confirmText": "Ketinate patvirtinti pretenziją. Šis veiksmas neatstatomas.",
+      "manage": "Tvarkyti pretenziją",
+      "outbound": "Tiekėjui",
+      "outboundItemAdded": "{{itemsCount}}x pridėta prie pretenzijos",
+      "outboundTotal": "Tiekėjui viso",
+      "outboundShipping": "Siuntimas tiėkėjui",
+      "outboundShippingHint": "Pasirinkite norimą siuntimo būdą.",
+      "refundAmount": "Numatomas skirtumas",
+      "activeChangeError": "Jau yra vykdomas užsakymo keitimas (grąžinimas, pretenzija, keitimas, kt.). Užbaikite arba atšaukite keitimą.",
+      "actions": {
+        "cancelClaim": {
+          "successToast": "Pretenzija sėkmingai atšaukta."
+        }
+      },
+      "cancel": {
+        "title": "Atšaukti pretenziją",
+        "description": "Tikrai norite atšaukti pretenziją?"
+      },
+      "tooltips": {
+        "onlyReturnShippingOptions": "Šiame sąraše bus tik grąžinimo siuntimo pasirinkimai."
+      },
+      "toast": {
+        "canceledSuccessfully": "Pretenzija sekmingai atšaukta",
+        "confirmedSuccessfully": "Pretenzija sekmingai patvirtinta"
+      },
+      "panel": {
+        "title": "Pretenzija inicijuota",
+        "description": "Jau yra nagrinėjama pretenzija, kuri turi būti užbaigta"
+      }
+    },
+    "exchanges": {
+      "create": "Sukurti keitimą",
+      "manage": "Tvarkyti keitimą",
+      "confirm": "Patvirtinti keitimą",
+      "confirmText": "Ketinate patvirtinti keitimą. Šis veiksmas neatstatomas.",
+      "outbound": "Tiekėjui",
+      "outboundItemAdded": "{{itemsCount}}x pridėta keitimui",
+      "outboundTotal": "Tiekėjui viso",
+      "outboundShipping": "Siuntimas tiekėjui",
+      "outboundShippingHint": "Pasirinkite norimą siuntimo būdą.",
+      "refundAmount": "Numatomas skirtumas",
+      "activeChangeError": "Jau yra vykdomas užsakymo keitimas (grąžinimas, pretenzija, keitimas, kt.). Užbaikite arba atšaukite keitimą.",
+      "actions": {
+        "cancelExchange": {
+          "successToast": "Keitimas sėkmingai atšauktas."
+        }
+      },
+      "cancel": {
+        "title": "Atšaukti keitimą",
+        "description": "Tikrai norite atšaukti keitimą?"
+      },
+      "tooltips": {
+        "onlyReturnShippingOptions": "Šiame sąraše bus tik grąžinimo siuntimo pasirinkimai."
+      },
+      "toast": {
+        "canceledSuccessfully": "Keitimas sekmingai atšauktas",
+        "confirmedSuccessfully": "Keitimas sekmingai patvirtintas"
+      },
+      "panel": {
+        "title": "Keitimas inicijuotas",
+        "description": "Jau yra nagrinėjamas keitimas, kuris turi būti užbaigtas"
+      }
+    },
+    "reservations": {
+      "allocatedLabel": "Atidėta",
+      "notAllocatedLabel": "Neatidėta"
+    },
+    "allocateItems": {
+      "action": "Atidėti prekes",
+      "title": "Atidėti uždakymo prekes",
+      "locationDescription": "Pasirinkite vietą, kurioje norite atidėti.",
+      "itemsToAllocate": "Prekių atidėjimui",
+      "itemsToAllocateDesc": "Pasirinkite kiek prekių norite atidėti",
+      "search": "Prekių paieška",
+      "consistsOf": "Susideda iš {{num}}x atsargų",
+      "requires": "Reikalinga {{num}} kiekvienam variantui",
+      "toast": {
+        "created": "Prekė sėkmingai atidėta"
+      },
+      "error": {
+        "quantityNotAllocated": "Yra neatidėtų prekių."
+      }
+    },
+    "shipment": {
+      "title": "Žymėti vykdymą išsiųstu",
+      "trackingNumber": "Sekimo numeris",
+      "addTracking": "Pridėti sekimo numerį",
+      "sendNotification": "Siųsti pranešimą",
+      "sendNotificationHint": "Praneškite klientui apie šį siuntimą.",
+      "toastCreated": "Siuntimas sėkmingai sukurtas."
+    },
+    "fulfillment": {
+      "cancelWarning": "Ketinate atšaukti užsakymo vykdymą. Šis veiksmas neatstatomas.",
+      "markAsDeliveredWarning": "Ketinate pažymėti kaip pristatytą. Šis veiksmas neatstatomas.",
+      "differentOptionSelected": "Pasirinktas siuntimo būdas nesutampa su kliento pasirinktu.",
+      "disabledItemTooltip": "Pasirinktas siuntimo būdas neleidžia siųsti šios prekės",
+      "unfulfilledItems": "Neparuoštos prekės",
+      "statusLabel": "Būsena",
+      "statusTitle": "Būsena",
+      "fulfillItems": "Paruošti prekes",
+      "awaitingFulfillmentBadge": "Laukia paruošimo",
+      "requiresShipping": "Reikalingas siuntimas",
+      "number": "Vykdymas #{{number}}",
+      "itemsToFulfill": "Prekės paruošimui",
+      "create": "Sukurti vykdymą",
+      "available": "Yra",
+      "inStock": "Sandėlyje",
+      "markAsShipped": "Žymėti kaip išsiųstą",
+      "markAsPickedUp": "Žymėti kaip paimtą",
+      "markAsDelivered": "Žymėti kaip pristatytą",
+      "itemsToFulfillDesc": "Pasirinkite prekes ir kiekius paruošimui",
+      "locationDescription": "Pasirinkite vietą iš kurios norite paruošti prekes.",
+      "sendNotificationHint": "Praneškite klientui apie sukurtą prekių paruošimą.",
+      "methodDescription": "Pasirinkite kitą siuntimo būdą nei kliento pasirinkas",
+      "error": {
+        "wrongQuantity": "Yra tik viena prekė paruošimui",
+        "wrongQuantity_other": "Kiekis turi būti skaičius tarp 1 ir {{number}}",
+        "noItems": "Nėra prekių paruošimui.",
+        "noShippingOption": "Siuntimo būdas yra privalomas",
+        "noLocation": "Vieta yra privaloma"
+      },
+      "status": {
+        "notFulfilled": "Neįvykdytas",
+        "partiallyFulfilled": "Dalinai įvykdytas",
+        "fulfilled": "Įvykdytas",
+        "partiallyShipped": "Dalinai išsiųstas",
+        "shipped": "Išsiųstas",
+        "delivered": "Pristatytas",
+        "partiallyDelivered": "Dalinai pristatytas",
+        "partiallyReturned": "Dalinai grąžintas",
+        "returned": "Grąžinintas",
+        "canceled": "Atšauktas",
+        "requiresAction": "Reikia veiksmų"
+      },
+      "toast": {
+        "created": "Sėkmingai paruoštas",
+        "canceled": "Paruošimas atšauktas",
+        "fulfillmentShipped": "Negalima atšaukti jau išsiųsto užsakymo",
+        "fulfillmentDelivered": "Sėkmingai pažymėtas kaip pristatytas",
+        "fulfillmentPickedUp": "Sėkmingai pažymėtas kaip paimtas"
+      },
+      "trackingLabel": "Sekimas",
+      "shippingFromLabel": "Siunčiama iš",
+      "itemsLabel": "Prekės"
+    },
+    "refund": {
+      "title": "Sukurti pinigų grąžinimą",
+      "sendNotificationHint": "Praneškite klientui apie sukurtą pinigų grąžinimą.",
+      "systemPayment": "Sisteminis mokėjimas",
+      "systemPaymentDesc": "Vienas ar daugiau jūsų mokėjimų yra sisteminiai. Atminkite, kad Medusa netvarko tokių mokėjimų užfiksavimo ir grąžinimo.",
+      "error": {
+        "amountToLarge": "Negalima grąžinti daugiau nei užsakymo suma.",
+        "amountNegative": "Grąžinimo suma turi būti teigiamas skaičius.",
+        "reasonRequired": "Pasirinkite grąžinimo priežastį."
+      }
+    },
+    "customer": {
+      "contactLabel": "Kontaktai",
+      "editEmail": "Keisti el. paštą",
+      "transferOwnership": "Perleisti nuosavybės teisę",
+      "editBillingAddress": "Keisti adresą sąskaitai",
+      "editShippingAddress": "Keisti pristatymo adresą"
+    },
+    "activity": {
+      "header": "Veikla",
+      "showMoreActivities_one": "Rodyti dar {{count}} veiklą",
+      "showMoreActivities_other": "Rodyti dar {{count}} veiklų",
+      "comment": {
+        "label": "Komentaras",
+        "placeholder": "Palikite komentarą",
+        "addButtonText": "Pridėti komentarą",
+        "deleteButtonText": "Pašalinti komentarą"
+      },
+      "from": "Iš",
+      "to": "Į",
+      "events": {
+        "common": {
+          "toReturn": "Grąžinti",
+          "toSend": "Siųsti"
+        },
+        "placed": {
+          "title": "Užsakymas patalpintas",
+          "fromSalesChannel": "iš {{salesChannel}}"
+        },
+        "canceled": {
+          "title": "Užsakymas atšauktas"
+        },
+        "payment": {
+          "awaiting": "Laukia apmokėjimo",
+          "captured": "Mokėjimas užfiksuotas",
+          "canceled": "Mokėjimas atšauktas",
+          "refunded": "Mokėjimas grąžintas"
+        },
+        "fulfillment": {
+          "created": "Prekės paruoštos",
+          "canceled": "Paruošimas atšauktas",
+          "shipped": "Prekės išsiųstos",
+          "delivered": "Prekės pristatytos",
+          "items_one": "{{count}} prekė",
+          "items_other": "{{count}} prekės"
+        },
+        "return": {
+          "created": "Grąžinimas #{{returnId}} sukurtas",
+          "canceled": "Grąžinimas #{{returnId}} atšauktas",
+          "received": "Grąžinimas #{{returnId}} gautas",
+          "items_one": "{{count}} prekė grąžinta",
+          "items_other": "{{count}} prekių grąžinta"
+        },
+        "note": {
+          "comment": "Komentaras",
+          "byLine": "sukurtas {{author}}"
+        },
+        "claim": {
+          "created": "Pretenzija #{{claimId}} išsiųsta",
+          "canceled": "Pretenzija #{{claimId}} atšaukta",
+          "itemsInbound": "{{count}} prekė grąžinama",
+          "itemsOutbound": "{{count}} prekė išsiuntimui"
+        },
+        "exchange": {
+          "created": "Keitimas #{{exchangeId}} išsiųstas",
+          "canceled": "Keitimas #{{exchangeId}} atšauktas",
+          "itemsInbound": "{{count}} prekė grąžinama",
+          "itemsOutbound": "{{count}} prekė išsiuntimui"
+        },
+        "edit": {
+          "requested": "Užsakymo keitimas #{{editId}} išsiųstas",
+          "confirmed": "Užsakymo keitimas #{{editId}} patvirtintas"
+        },
+        "transfer": {
+          "requested": "Užsakymo nuosavybės teisės perleidimas #{{transferId}} išsiųstas",
+          "confirmed": "Užsakymo nuosavybės teisės perleidimas #{{transferId}} patvirtintas",
+          "declined": "Užsakymo nuosavybės teisės perleidimas #{{transferId}} atmestas"
+        },
+        "update_order": {
+          "shipping_address": "Pristatymo adresas pakeistas",
+          "billing_address": "Adresas sąskaitai pakeistas",
+          "email": "El. paštas pakeistas"
+        }
+      }
+    },
+    "fields": {
+      "displayId": "Rodyti ID",
+      "refundableAmount": "Grąžinama suma",
+      "returnableQuantity": "Grąžinamas kiekis"
+    }
+  },
+  "draftOrders": {
+    "domain": "Užsakymų juodraščiai",
+    "deleteWarning": "Ketinate pašalinti užsakymo juodraštį {{id}}. Šis veiksmas neatstatomas.",
+    "paymentLinkLabel": "Apmokėjimo nuoroda",
+    "cartIdLabel": "Krepšelio ID",
+    "markAsPaid": {
+      "label": "Žymėti kaip apmokėtą",
+      "warningTitle": "Žymėti kaip apmokėtą",
+      "warningDescription": "Ketinate pažymėti užsakymo juodraštį kaip apmokėtą. Šis veiksmas neatstatomas ir apmokėjimas nebus įmanomas vėliau."
+    },
+    "status": {
+      "open": "Atviras",
+      "completed": "Atliktas"
+    },
+    "create": {
+      "createDraftOrder": "Sukurti užsakymo juodraštį",
+      "createDraftOrderHint": "Sukurkite naują užsakymo juodraštį užsakymo tvarkymui prieš jo pateikimą.",
+      "chooseRegionHint": "Pasirinkite regioną",
+      "existingItemsLabel": "Esamos prekės",
+      "existingItemsHint": "Pridėkite esamas prekes prie šio užsakymo juodraščio.",
+      "customItemsLabel": "Inividualios prekės",
+      "customItemsHint": "Pridėkite individualias prekes prie šio užsakymo juodraščio.",
+      "addExistingItemsAction": "Pridėti esamas prekes",
+      "addCustomItemAction": "Pridėti individualias prekes",
+      "noCustomItemsAddedLabel": "Nėra pridėtų individualių prekių",
+      "noExistingItemsAddedLabel": "Nėra pridėtų individualių prekių",
+      "chooseRegionTooltip": "Pasirinkite regioną",
+      "useExistingCustomerLabel": "Naudoti esamą klientą",
+      "addShippingMethodsAction": "Pridėti siuntimo būdus",
+      "unitPriceOverrideLabel": "Vieneto kainos perrašymas",
+      "shippingOptionLabel": "Siuntimo būdas",
+      "shippingOptionHint": "Pasirinkite siuntimo būdą šiam užsakymo juodraščiui.",
+      "shippingPriceOverrideLabel": "Siuntimo kainos perrašymas",
+      "shippingPriceOverrideHint": "Perrašykite kitą siuntimo kainą šiam užsakymo juodraščiui.",
+      "sendNotificationLabel": "Siųsti pranešimą",
+      "sendNotificationHint": "Praneškite klientui apie užsakymo juodraščio sukūrimą."
+    },
+    "validation": {
+      "requiredEmailOrCustomer": "El. paštas ar klientas yra privalomas.",
+      "requiredItems": "Privaloma bent viena prekė.",
+      "invalidEmail": "El. paštas turi būti teisingas."
+    }
+  },
+  "stockLocations": {
+    "domain": "Sandėliavimas ir siuntimas",
+    "list": {
+      "description": "Tvarkykite savo sandėliavimo vietas ir siuntimo būdus."
+    },
+    "create": {
+      "header": "Sukurti sandėliavimo vietą",
+      "hint": "Sandėliavimo vieta yra fizinis adresas, kuriame sandėliuojamos ir iš kurio siunčiamos prekės klientams.",
+      "successToast": "Sandėliavimo vieta {{name}} sėkmingai sukurta."
+    },
+    "edit": {
+      "header": "Keisti sandėliavimo vietą",
+      "viewInventory": "Peržiūrėti atsargas",
+      "successToast": "Sandėliavimo vieta {{name}} sėkmingai pakeista."
+    },
+    "delete": {
+      "confirmation": "Ketinate pašalinti sandėliavimo vietą {{name}}. Šis veiksmas neatstatomas."
+    },
+    "fulfillmentProviders": {
+      "header": "Vykdytojai",
+      "shippingOptionsTooltip": "Čia bus tik vykdytojai įjungti šiai sandėliavimo vietai. Pridėkite juos jei šis pasirinkimas uždraustas.",
+      "label": "Prijungti vykdytojai",
+      "connectedTo": "Prijungta {{count}} iš {{total}} vykdytojų",
+      "noProviders": "Ši sandėliavimo vieta neprijungta nei prie vieno vykdytojo.",
+      "action": "Prijungti vykdytojus",
+      "successToast": "Vykdytojai sėkmingai pakeisti."
+    },
+    "fulfillmentSets": {
+      "pickup": {
+        "header": "Atsiėmimas"
+      },
+      "shipping": {
+        "header": "Siuntimas"
+      },
+      "disable": {
+        "confirmation": "Are you sure that you want to disable {{name}}? This will delete all associated service zones and shipping options, and cannot be undone.",
+        "pickup": "Atsiėmimas sėkmingai išjungtas.",
+        "shipping": "Siuntimas sėkmingai išjungtas."
+      },
+      "enable": {
+        "pickup": "Atsiėmimas sėkmingai įjungtas.",
+        "shipping": "Siuntimas sėkmingai įjungtas."
+      }
+    },
+    "sidebar": {
+      "header": "Siuntimo nustatymai",
+      "shippingProfiles": {
+        "label": "Siuntimo tipai",
+        "description": "Grupuokite prekes pagal siuntimo reikalavimus"
+      }
+    },
+    "salesChannels": {
+      "header": "Pardavimų kanalai",
+      "hint": "Tvarkykite pardavimo kanalus prijungtus prie šios sandėliavimo vietos.",
+      "label": "Prijungti pardavimo kanalai",
+      "connectedTo": "Prijungta {{count}} iš {{total}} pardavimo kanalų",
+      "noChannels": "Ši sandėliavimo vieta neprijungta nei prie vieno pardavimo kanalų.",
+      "action": "Prijungti pardavimo kanalus",
+      "successToast": "Pardavimo kanalai sėkmingai pakeisti."
+    },
+    "pickupOptions": {
+      "edit": {
+        "header": "Keisti atsiėmimo būdą"
+      }
+    },
+    "shippingOptions": {
+      "create": {
+        "shipping": {
+          "header": "Sukurti siuntimo būdą zonai {{zone}}",
+          "hint": "Sukurkite siuntimo būdą kad nustatyti kaip prekės siunčiamos iš šios sandėliavimo vietos.",
+          "label": "Siuntimo būdai",
+          "successToast": "Siuntimo būdas {{name}} sėkmingai sukurtas."
+        },
+        "pickup": {
+          "header": "Sukurti atsiėmimo būdą zonai {{zone}}",
+          "hint": "Sukurkite atsiėmimo būdą kad nustatyti kaip prekės atsiimamos iš šios sandėliavimo vietos.",
+          "label": "Atsiėmimo būdai",
+          "successToast": "Atsiėmimo būdas {{name}} sėkmingai sukurtas."
+        },
+        "returns": {
+          "header": "Sukurti grąžinimo būdą zonai {{zone}}",
+          "hint": "Sukurkite grąžinimo būdą kad nustatyti kaip prekės grąžinimos į šią sandėliavimo vietą.",
+          "label": "Grąžinimo būdai",
+          "successToast": "Grąžinimo būdas {{name}} sėkmingai sukurtas."
+        },
+        "tabs": {
+          "details": "Nustatymai",
+          "prices": "Kainos"
+        },
+        "action": "Sukurti būdą"
+      },
+      "delete": {
+        "confirmation": "Ketinate pašalinti siuntimo būdą {{name}}. Šis veiksmas neatstatomas.",
+        "successToast": "Siuntimo būdas {{name}} sėkmingai pašalintas."
+      },
+      "edit": {
+        "header": "Keisti siuntimo būdą",
+        "action": "Keisti būdą",
+        "successToast": "Siuntimo būdas {{name}} sėkmingai pakeistas."
+      },
+      "pricing": {
+        "action": "Keisti kainas"
+      },
+      "conditionalPrices": {
+        "header": "Sąlyginės {{name}} kainos",
+        "description": "Nustatykite sąlygines kainas šiam siuntimo būdui priklausomai nuo krepšelio sumos.",
+        "attributes": {
+          "cartItemTotal": "Krepšelio suma"
+        },
+        "summaries": {
+          "range": "Jei <0>{{attribute}}</0> yra tarp <1>{{gte}}</1> ir <2>{{lte}}</2>",
+          "greaterThan": "Jei <0>{{attribute}}</0> ≥ <1>{{gte}}</1>",
+          "lessThan": "Jei <0>{{attribute}}</0> ≤ <1>{{lte}}</1>"
+        },
+        "actions": {
+          "addPrice": "Pridėti kainą",
+          "manageConditionalPrices": "Tvarkyti sąlygines kainas"
+        },
+        "rules": {
+          "amount": "Siuntimo kaina",
+          "gte": "Mažiausia krepšelio suma",
+          "lte": "Didžiausia krepšelio suma"
+        },
+        "customRules": {
+          "label": "Inividualios taisyklės",
+          "tooltip": "Ši sąlyginė kaina turi taisyklių, kurios negali būti pakeistos darbastalyje.",
+          "eq": "Krepšelio suma turi būti lygi",
+          "gt": "Krepšelio suma turi būti didesnė už",
+          "lt": "Krepšelio suma turi būti mažesnė už"
+        },
+        "errors": {
+          "amountRequired": "Siuntimo kaina privaloma",
+          "minOrMaxRequired": "Turi būti pateikta bent viena iš mažiausios ar didžiausios krepšelio sumų",
+          "minGreaterThanMax": "Mažiausia krepšelio suma turi būti mažesnė arba lygi didžiausiai krepšelio sumai",
+          "duplicateAmount": "Siuntimo kaina turi būti unikali kiekvienai sąlygai",
+          "overlappingConditions": "Sąlygos turi būti unikaios tarp visų kainų taisyklių"
+        }
+      },
+      "fields": {
+        "count": {
+          "shipping_one": "{{count}} siuntimo būdas",
+          "shipping_other": "{{count}} siuntimo būdai",
+          "pickup_one": "{{count}} atsiėmimo būdas",
+          "pickup_other": "{{count}} atsiėmimo būdai",
+          "returns_one": "{{count}} grąžinimo būdas",
+          "returns_other": "{{count}} grąžinimo būdai"
+        },
+        "priceType": {
+          "label": "Kainos tipas",
+          "options": {
+            "fixed": {
+              "label": "Fiksuota",
+              "hint": "Siuntimo kaina yra fiksuota ir nekinta priklausomai nuo užsakymo turinio."
+            },
+            "calculated": {
+              "label": "Apskaičiuojama",
+              "hint": "Siuntimo kaina yra apskaičiuojama pirkimo metu pagal vykdytoją."
+            }
+          }
+        },
+        "enableInStore": {
+          "label": "Įjungta parduotuvėje",
+          "hint": "Ar klientai gali pasirinkti šį būdą pirkimo metu."
+        },
+        "provider": "Vykdytojas",
+        "profile": "Pristatymo eiga",
+        "fulfillmentOption": "Pristatymo būdas"
+      }
+    },
+    "serviceZones": {
+      "create": {
+        "headerPickup": "Sukurti atsiėmimo iš {{location}} aptarnavimo zoną",
+        "headerShipping": "Sukurti siuntimo iš {{location}} aptarnavimo zoną",
+        "action": "Sukurti aptarnavimo zoną",
+        "successToast": "Aptarnavimo zona {{name}} sėkmingai sukurta."
+      },
+      "edit": {
+        "header": "Keisti aptarnavimo zoną",
+        "successToast": "Aptarnavimo zona {{name}} sėkmingai pakeista."
+      },
+      "delete": {
+        "confirmation": "Ketinate pašalinti aptarnavimo zoną {{name}}. Šis veiksmas neatstatomas.",
+        "successToast": "Aptarnavimo zona {{name}} sėkmingai pašalinta."
+      },
+      "manageAreas": {
+        "header": "Tvarkyti geografines sritis {{name}}",
+        "action": "Tvarkyti geografines sritis",
+        "label": "Geografines sritys",
+        "hint": "Pasirinkite geografines sritis, kurias apima aptarnavimo zona.",
+        "successToast": "{{name}} geografines sritys sėkmingai pakeistos."
+      },
+      "fields": {
+        "noRecords": "Nėra aptarnavimo zonų siuntimo būdų pridėjimui.",
+        "tip": "Aptarnavimo zoną sudaro geografinės sritys. Ji naudojama apriboti siuntimo būdus pagal adresų rinkinius."
+      }
+    }
+  },
+  "shippingProfile": {
+    "domain": "Siuntimo tipai",
+    "subtitle": "Sugrupuokite prekes su panašiais siuntimo reikalavimais į siuntimo tipus.",
+    "create": {
+      "header": "Sukurti siuntimo tipą",
+      "hint": "Sukurkite siuntimo tipą, kad sugrupuoti prekes su panašiais siuntimo reikalavimais.",
+      "successToast": "Siuntimo tipas {{name}} sėkmingai sukurtas."
+    },
+    "delete": {
+      "title": "Pašalinti siuntimo tipą",
+      "description": "Ketinate pašalinti siuntimo tipą {{name}}. Šis veiksmas neatstatomas.",
+      "successToast": "Siuntimo tipas {{name}} sėkmingai pašalintas."
+    },
+    "tooltip": {
+      "type": "Įveskite siuntimo tipą, pavyzdžiui: Sunkus, Negabaritinis, Tik krovinys, t.t."
+    }
+  },
+  "taxRegions": {
+    "domain": "Mokesčių regionai",
+    "list": {
+      "hint": "Nustatykite kiek apmokęstinate klientus kai jie perka iš skirtingų šalių ir regionų."
+    },
+    "delete": {
+      "confirmation": "Ketinate pašalinti mokesčių regioną. Šis veiksmas neatstatomas.",
+      "successToast": "Mokesčių regionas sėkmingai pašalintas."
+    },
+    "create": {
+      "header": "Sukurti mokesčių regioną",
+      "hint": "Sukurkite mokesčių regioną, kad nustatyti mokesčių tarifus konkrečiai šaliai.",
+      "errors": {
+        "rateIsRequired": "Tarifas yra privalomas kai kuriamas numatytasis mokesčių tarifas.",
+        "nameIsRequired": "Pavadinimas yra privalomas kai kuriamas numatytasis mokesčių tarifas."
+      },
+      "successToast": "Mokesčių regionas sėkmingai sukurtas."
+    },
+    "province": {
+      "header": "Provincijos",
+      "create": {
+        "header": "Sukurti provincijos mokesčių regioną",
+        "hint": "Sukurkite provincijos mokesčių regioną jos mokesčių tarifų nustatymui."
+      }
+    },
+    "state": {
+      "header": "Valstijos",
+      "create": {
+        "header": "Sukurti valstijos mokesčių regioną",
+        "hint": "Sukurkite valstijos mokesčių regioną jos mokesčių tarifų nustatymui."
+      }
+    },
+    "stateOrTerritory": {
+      "header": "Valstijos ar teritorijos",
+      "create": {
+        "header": "Sukurti valstijos/teritorijos mokesčių regioną",
+        "hint": "Sukurkite valstijos/teritorijos mokesčių regioną jos mokesčių tarifų nustatymui."
+      }
+    },
+    "county": {
+      "header": "Šalys",
+      "create": {
+        "header": "Sukurti šalies mokesčių regioną",
+        "hint": "Sukurkite šalies mokesčių regioną jos mokesčių tarifų nustatymui."
+      }
+    },
+    "region": {
+      "header": "Regionai",
+      "create": {
+        "header": "Sukurti regiono mokesčių regioną",
+        "hint": "Sukurkite regiono mokesčių regioną jo mokesčių tarifų nustatymui."
+      }
+    },
+    "department": {
+      "header": "Skyriai",
+      "create": {
+        "header": "Sukurti skyriaus mokesčių regioną",
+        "hint": "Sukurkite skyriaus mokesčių regioną jo mokesčių tarifų nustatymui."
+      }
+    },
+    "territory": {
+      "header": "Teritorijos",
+      "create": {
+        "header": "Sukurti teritorijos mokesčių regioną",
+        "hint": "Sukurkite teritorijos mokesčių regioną jos mokesčių tarifų nustatymui."
+      }
+    },
+    "prefecture": {
+      "header": "Prefektūros",
+      "create": {
+        "header": "Sukurti prefektūros mokesčių regioną",
+        "hint": "Sukurkite prefektūros mokesčių regioną jos mokesčių tarifų nustatymui."
+      }
+    },
+    "district": {
+      "header": "Rajonai",
+      "create": {
+        "header": "Sukurti rajono mokesčių regioną",
+        "hint": "Sukurkite rajono mokesčių regioną jo mokesčių tarifų nustatymui."
+      }
+    },
+    "governorate": {
+      "header": "Gubernijos",
+      "create": {
+        "header": "Sukurti gubernijos mokesčių regioną",
+        "hint": "Sukurkite gubernijos mokesčių regioną jos mokesčių tarifų nustatymui."
+      }
+    },
+    "canton": {
+      "header": "Kantonai",
+      "create": {
+        "header": "Sukurti kantono mokesčių regioną",
+        "hint": "Sukurkite kantono mokesčių regioną jo mokesčių tarifų nustatymui."
+      }
+    },
+    "emirate": {
+      "header": "Emyratai",
+      "create": {
+        "header": "Sukurti emyrato mokesčių regioną",
+        "hint": "Sukurkite emyrato mokesčių regioną jos mokesčių tarifų nustatymui."
+      }
+    },
+    "sublevel": {
+      "header": "Polygiai",
+      "create": {
+        "header": "Sukurti polygio mokesčių regioną",
+        "hint": "Sukurkite polygio mokesčių regioną jos mokesčių tarifų nustatymui."
+      }
+    },
+    "taxOverrides": {
+      "header": "Perrašymai",
+      "create": {
+        "header": "Sukurti perrašymą",
+        "hint": "Sukurkite mokesčių tarifą, kuris nustatytomis sąlygomis perrašys numatytuosius mokesčius."
+      },
+      "edit": {
+        "header": "Keisti perrašymą",
+        "hint": "Pakeiskite mokesčių tarifą, kuris nustatytomis sąlygomis perrašys numatytuosius mokesčius."
+      }
+    },
+    "taxRates": {
+      "create": {
+        "header": "Sukurti mokesčių tarifą",
+        "hint": "Sukurkite regiono mokesčio tarifą.",
+        "successToast": "Mokesčių tarifas sėkmingai sukurtas."
+      },
+      "edit": {
+        "header": "Keisti mokesčių tarifą",
+        "hint": "Pakeiskite regiono mokesčio tarifą.",
+        "successToast": "Mokesčių tarifas sėkmingai pakeistas."
+      },
+      "delete": {
+        "confirmation": "Ketinate pašalinti mokesčio tarifą. {{name}}. Šis veiksmas neatstatomas.",
+        "successToast": "Mokesčių tarifas sėkmingai pašalintas."
+      }
+    },
+    "fields": {
+      "isCombinable": {
+        "label": "Derinamas",
+        "hint": "Ar šis mokesčio tarifas gali būti derinamas su numatytuoju mokesčių regiono tarifu.",
+        "true": "Derinamas",
+        "false": "Nederinamas"
+      },
+      "defaultTaxRate": {
+        "label": "Numatytasis mokesčio tarifas",
+        "tooltip": "Numatytasis mokesčio tarifas šiam regionui. Pavyzdžiui, standartinis PVM tarifas šaliai ar regionui.",
+        "action": "Sukurti numatytąjį mokesčio tarifą"
+      },
+      "taxRate": "Mokesčio tarifas",
+      "taxCode": "Mokesčio kodas",
+      "targets": {
+        "label": "Taikymai",
+        "hint": "Pasirinkite kam šis mokestis bus taikomas.",
+        "options": {
+          "product": "Prekės",
+          "productCollection": "Prekių kolekcijos",
+          "productTag": "Prekių žymės",
+          "productType": "Prekių tipai",
+          "customerGroup": "Klientų grupės"
+        },
+        "operators": {
+          "in": "į",
+          "on": "ant",
+          "and": "ir"
+        },
+        "placeholders": {
+          "product": "Prekių paieška",
+          "productCollection": "Prekių kolekcijų paieška",
+          "productTag": "Prekių žymių paieška",
+          "productType": "Prekių tipų paieška",
+          "customerGroup": "Klientų grupių paieška"
+        },
+        "tags": {
+          "product": "Prekė",
+          "productCollection": "Prekių kolekcija",
+          "productTag": "Prekių žymė",
+          "productType": "Prekių tipas",
+          "customerGroup": "Klientų grupė"
+        },
+        "modal": {
+          "header": "Pridėkite taikymus"
+        },
+        "values_one": "{{count}} reikšmė",
+        "values_other": "{{count}} reikšmės",
+        "numberOfTargets_one": "{{count}} taikymas",
+        "numberOfTargets_other": "{{count}} taikymai",
+        "additionalValues_one": "ir dar {{count}} reikšmė",
+        "additionalValues_other": "ir dar {{count}} reikšmių",
+        "action": "Pridėti taikymą"
+      },
+      "sublevels": {
+        "labels": {
+          "province": "Provincija",
+          "state": "Valstija",
+          "region": "Regionas",
+          "stateOrTerritory": "Valstija/Teritorija",
+          "department": "Skyrius",
+          "county": "County",
+          "territory": "Teritorija",
+          "prefecture": "Prefektūra",
+          "district": "Rajonas",
+          "governorate": "Gubernija",
+          "emirate": "Emyratas",
+          "canton": "Kantonas",
+          "sublevel": "Polygio kodas"
+        },
+        "placeholders": {
+          "province": "Pasirinkite provinciją",
+          "state": "Pasirinkite valstija",
+          "region": "Pasirinkite regioną",
+          "stateOrTerritory": "Pasirinkite valstiją/tertoriją",
+          "department": "Pasirinkite skyrių",
+          "county": "Pasirinkite šalį",
+          "territory": "Pasirinkite tertoriją",
+          "prefecture": "Pasirinkite prefektūrą",
+          "district": "Pasirinkite rajoną",
+          "governorate": "Pasirinkite guberniją",
+          "emirate": "Pasirinkite emyratą",
+          "canton": "Pasirinkite kantoną"
+        },
+        "tooltips": {
+          "sublevel": "Įveskite ISO 3166-2 kodą polygio mokesčių regionui.",
+          "notPartOfCountry": "{{province}} nepriklauso {{country}}. Patikrinkite dar kartą ar nurodėte teisingai."
+        },
+        "alert": {
+          "header": "Polygio regionai išjungti šiam mokesčių regionui",
+          "description": "Polygio regionai išjungti šiam mokesčių regionui region pagal nutylėjimą. Galite juos įungti, kad galėtumėte kurti polygius, tokius kaip provincijos, valstijos ar teritorijos.",
+          "action": "Įjungti polygio regionus"
+        }
+      },
+      "noDefaultRate": {
+        "label": "Nėra numatytojo tarifo",
+        "tooltip": "Šis mokesčių regionas neturi numatytojo mokesčio tarifo. Jei yra standartinis tarifas, pvz., šalies PVM, pridėkite jį prie šio regiono."
+      }
+    }
+  },
+  "promotions": {
+    "domain": "Akcijos",
+    "sections": {
+      "details": "Akcijos nustatymai"
+    },
+    "tabs": {
+      "template": "Tipas",
+      "details": "Nustatymai",
+      "campaign": "Kampanija"
+    },
+    "fields": {
+      "type": "Tipas",
+      "value_type": "Reikšmės tipas",
+      "value": "Reikšmė",
+      "campaign": "Kampanija",
+      "method": "Būdas",
+      "allocation": "Paskirstymas",
+      "addCondition": "Pridėti sąlygą",
+      "clearAll": "Išvalyti visus",
+      "amount": {
+        "tooltip": "Pasirinkite valiutos kodą, kad įjungti sumos nustatymą"
+      },
+      "conditions": {
+        "rules": {
+          "title": "Kas gali naudotis šiuo kodu?",
+          "description": "Kuriam klientui leidžiama naudotis šiuo nuolaidos kodu? Jei nepayžymėta, kodu galės naudotis visi klientai."
+        },
+        "target-rules": {
+          "title": "Kokioms prekėms bus taikoma akcija?",
+          "description": "Akcija bus taikoma prekėms, kurios atitinka šias sąlygas."
+        },
+        "buy-rules": {
+          "title": "Kas turi būti krepšelyje, kad galiotų akcija?",
+          "description": "Jei šios sąlygos atitinka, taikome akciją nurodytoms prekėms."
+        }
+      }
+    },
+    "tooltips": {
+      "campaignType": "Valiutos kodas turi būti pasirinktas prie akcijos, kad nustatyti išlaidų biudžetą."
+    },
+    "errors": {
+      "requiredField": "Laukelis privalomas",
+      "promotionTabError": "Prieš tęsdami ištaisykite klaidas skirtuke Akcija"
+    },
+    "toasts": {
+      "promotionCreateSuccess": "Nuolaidos kodas ({{code}}) sėkmingai sukurtas."
+    },
+    "create": {},
+    "edit": {
+      "title": "Keisti akcijos nustatymus",
+      "rules": {
+        "title": "Keisti naudojimo sąlygas"
+      },
+      "target-rules": {
+        "title": "Keisti taikymą prekėms"
+      },
+      "buy-rules": {
+        "title": "Keisti pirkimo taisykles"
+      }
+    },
+    "campaign": {
+      "header": "Kampanija",
+      "edit": {
+        "header": "Keisti kampaniją",
+        "successToast": "Akcijos kampanija sėkmingai atnauinta."
+      },
+      "actions": {
+        "goToCampaign": "Eiti į kampaniją"
+      }
+    },
+    "campaign_currency": {
+      "tooltip": "Tai akcijos valiuta. Pakeiskite ją nustatymų skirtuke."
+    },
+    "form": {
+      "required": "Privaloma",
+      "and": "IR",
+      "selectAttribute": "Pasirinkite požymius",
+      "campaign": {
+        "existing": {
+          "title": "Esama kampanija",
+          "description": "Pridėkite akciją prie esamos kampanijos.",
+          "placeholder": {
+            "title": "Nėra sukurtų kampanijų",
+            "desc": "Galite sukurti ją, kad sekti kelias akcijas ir nustatyti biudžetus."
+          }
+        },
+        "new": {
+          "title": "Nauja kampanija",
+          "description": "Sukurti nauą kampaniją šiai akcijai."
+        },
+        "none": {
+          "title": "Be kampanijos",
+          "description": "Tęsti be akcijos ir kampanijos susiejimo"
+        }
+      },
+      "status": {
+        "label": "Būsena",
+        "draft": {
+          "title": "Juodraštis",
+          "description": "Klientai kol kas negalės naudotis šiuo kodu"
+        },
+        "active": {
+          "title": "Taikoma",
+          "description": "Klientai gali naudotis šiuo kodu"
+        },
+        "inactive": {
+          "title": "Netaikoma",
+          "description": "Klientai daugiau negali naudotis šiuo kodu"
+        }
+      },
+      "method": {
+        "label": "Būdas",
+        "code": {
+          "title": "Nuolaidos kodas",
+          "description": "Klientai turi įvesti šį nuolaidos kodą pirkimo metu"
+        },
+        "automatic": {
+          "title": "Automatiškai",
+          "description": "Klientai mato šią akciją pirkimo metu"
+        }
+      },
+      "max_quantity": {
+        "title": "Didžiausias kiekis",
+        "description": "Didžiausias prekių kiekis, kuriam taikoma ši akcija."
+      },
+      "type": {
+        "standard": {
+          "title": "Standartinė",
+          "description": "Standartinė akcija"
+        },
+        "buyget": {
+          "title": "Pirk gauk",
+          "description": "Pirk X gauk Y akcija"
+        }
+      },
+      "allocation": {
+        "each": {
+          "title": "Kiekvienai",
+          "description": "Taikoma kiekvienai prekei"
+        },
+        "across": {
+          "title": "Visoms",
+          "description": "Taikoma visoms prekėms"
+        }
+      },
+      "code": {
+        "title": "Kodas",
+        "description": "Kodas, kurį klientai įves pirkdami."
+      },
+      "value": {
+        "title": "Vertė"
+      },
+      "value_type": {
+        "fixed": {
+          "title": "Vertė",
+          "description": "Nuskaičiuojama suma, pvz., 100"
+        },
+        "percentage": {
+          "title": "Vertė",
+          "description": "Procentas, nuskaičiuoamas nuo sumos, pvz., 8%"
+        }
+      }
+    },
+    "deleteWarning": "Ketinate pašalinti nuolaidos kodą {{code}}. Šis veiksmas neatstatomas.",
+    "createPromotionTitle": "Sukurti akciją",
+    "type": "Akcijos tipas",
+    "conditions": {
+      "add": "Pridėti sąlygą",
+      "list": {
+        "noRecordsMessage": "Pridėkite sąlygą, kad apriboti kurioms prekėms akcija taikoma."
+      }
+    }
+  },
+  "campaigns": {
+    "domain": "Kampanijos",
+    "details": "Kampanijos nustatymai",
+    "status": {
+      "active": "Aktyvi",
+      "expired": "Pasibaigusi",
+      "scheduled": "Suplanuota"
+    },
+    "delete": {
+      "title": "Jūs tikri?",
+      "description": "Ketinate pašalinti kampaniją '{{name}}'. Šis veiksmas neatstatomas.",
+      "successToast": "Kampanija '{{name}}' sėkmingai sukurta."
+    },
+    "edit": {
+      "header": "Keisti kampanija",
+      "description": "Keiskite kampanios nustatymus.",
+      "successToast": "Kampanija '{{name}}' sėkmingai pakeista."
+    },
+    "configuration": {
+      "header": "Konfigūracija",
+      "edit": {
+        "header": "Keisti kampanijos konfigūraciją",
+        "description": "Keiskite kompanijos konfigūraciją",
+        "successToast": "Kampanijos konfigūracija sėkmingai pakeista."
+      }
+    },
+    "create": {
+      "title": "Sukurti kampaniją",
+      "description": "Sukurkite reklaminę kampaniją.",
+      "hint": "Sukurkite reklaminę kampaniją.",
+      "header": "Sukurti kampaniją",
+      "successToast": "Kampanija '{{name}}' sėkmingai sukurta."
+    },
+    "fields": {
+      "name": "Pavadinimas",
+      "identifier": "Identifikatorius",
+      "start_date": "Pradžios data",
+      "end_date": "Pabaigos data",
+      "total_spend": "Išleistas biudžetas",
+      "total_used": "Panaudotas biudžetas",
+      "budget_limit": "Biudžeto limitas",
+      "campaign_id": {
+        "hint": "Šiame sąraše rodomos tik reklamos kampanijos, kurių valiutos kodas yra toks pat kaip akcijos."
+      }
+    },
+    "budget": {
+      "create": {
+        "hint": "Sukurkite kampanijos biudžetą.",
+        "header": "Kampanijos biudžetas"
+      },
+      "details": "Kampanijos biudžetas",
+      "fields": {
+        "type": "Tipas",
+        "currency": "valiuta",
+        "limit": "Limitas",
+        "used": "Panaudota"
+      },
+      "type": {
+        "spend": {
+          "title": "Išlaidos",
+          "description": "Nustatykite sumą, už kurią gali būti suteikta akcijos nuolaidų."
+        },
+        "usage": {
+          "title": "Panaudojimas",
+          "description": "Nustatykite kiekį, kiek kartų gali būti pasinaudota šia akcija."
+        }
+      },
+      "edit": {
+        "header": "Keisti kampanijos biudžetą"
+      }
+    },
+    "promotions": {
+      "remove": {
+        "title": "Pašalinti akciją iš kampanijos",
+        "description": "Ketinate pašalinti {{count}} akciją(-ų) iš kampanijos(-ų). Šis veiksmas neatstatomas."
+      },
+      "alreadyAdded": "Ši akcija jau pridėta prie kampanijos.",
+      "alreadyAddedDiffCampaign": "Ši akcija jau pridėta prie kitos kampanijos ({{name}}).",
+      "currencyMismatch": "Akcijos ir kampanijos valiuta nesutampa",
+      "toast": {
+        "success": "{{count}} akciją(-ų) sėkmingai pridėta prie kampanijos"
+      },
+      "add": {
+        "list": {
+          "noRecordsMessage": "Pirmiausia sukurkite akciją."
+        }
+      },
+      "list": {
+        "noRecordsMessage": "Kampanijoje akcijų nėra."
+      }
+    },
+    "deleteCampaignWarning": "Ketinate pašalinti kampaniją {{name}}. Šis veiksmas neatstatomas.",
+    "totalSpend": "<0>{{amount}}</0> <1>{{currency}}</1>"
+  },
+  "priceLists": {
+    "domain": "Kainoraščiai",
+    "subtitle": "Sukurkite pardavimo ar perrašymo kainas tam tikroms sąlygoms.",
+    "delete": {
+      "confirmation": "Ketinate pašalinti kainoraštį {{title}}. Šis veiksmas neatstatomas.",
+      "successToast": "Kainoraštis {{title}} sėkmingai pašalintas."
+    },
+    "create": {
+      "header": "Sukurti kainoraštį",
+      "subheader": "Sukurkite kainoraštį jūsų prekių kainų valdymui.",
+      "tabs": {
+        "details": "Nustatymai",
+        "products": "Prekės",
+        "prices": "Kainos"
+      },
+      "successToast": "Kainoraštis {{title}} sėkmingai sukurtas.",
+      "products": {
+        "list": {
+          "noRecordsMessage": "Pirmiausia sukurkite prekę."
+        }
+      }
+    },
+    "edit": {
+      "header": "Keisti kainoraštį",
+      "successToast": "Kainoraštis {{title}} sėkmingai pakeistas."
+    },
+    "configuration": {
+      "header": "Konfigūracija",
+      "edit": {
+        "header": "Keisti kainoraščio konfigūraciją",
+        "description": "Keiskite kainoraščio konfigūraciją.",
+        "successToast": "Kainoraščio konfigūraciją sėkmingai pakeista."
+      }
+    },
+    "products": {
+      "header": "Prekės",
+      "actions": {
+        "addProducts": "Pridėti prekes",
+        "editPrices": "Keisti prices"
+      },
+      "delete": {
+        "confirmation_one": "Ketinate pašalinti kainas {{count}} prekei kainoraštyje. Šis veiksmas neatstatomas.",
+        "confirmation_other": "Ketinate pašalinti kainas {{count}} prekėms kainoraštyje. Šis veiksmas neatstatomas.",
+        "successToast_one": "Kainos {{count}} prekei sėkmingai pašalintos.",
+        "successToast_other": "Kainos {{count}} prekėms sėkmingai pašalintoss."
+      },
+      "add": {
+        "successToast": "Kainos sėkmingai pridėtos prie kainorščio."
+      },
+      "edit": {
+        "successToast": "Kainos sėkmingai pakeistos."
+      }
+    },
+    "fields": {
+      "priceOverrides": {
+        "label": "Kainų perrašymai",
+        "header": "Kainų perrašymai"
+      },
+      "status": {
+        "label": "Būsena",
+        "options": {
+          "active": "Aktyvus",
+          "draft": "Juodraštis",
+          "expired": "Pasibaigęs",
+          "scheduled": "Suplanuotas"
+        }
+      },
+      "type": {
+        "label": "Tipas",
+        "hint": "Pasirinkite kokio tipo kainoraštį norite sukurti.",
+        "options": {
+          "sale": {
+            "label": "Pardavimo",
+            "description": "Pardavimo kainos yra laikini prekių kainų pakeitimai."
+          },
+          "override": {
+            "label": "Perrašymo",
+            "description": "Perrašymo kainos dažniausiai naudojamos norint sukurti specialias kainas klientams."
+          }
+        }
+      },
+      "startsAt": {
+        "label": "Kainoraštis turi pradžios datą?",
+        "hint": "Suplanuokite kainoraščio įjungimą."
+      },
+      "endsAt": {
+        "label": "Kainoraštis turi pabaigos datą?",
+        "hint": "Suplanuokite kainoraščio išjungimą."
+      },
+      "customerAvailability": {
+        "header": "Pasirinkite klientų grupes",
+        "label": "Prieinama klientams",
+        "hint": "Pasirinkite kurioms klientų grupėms turėtų būti taikomas šis kainoraštis.",
+        "placeholder": "Klientų grupių paieška",
+        "attribute": "Klientų grupės"
+      }
+    }
+  },
+  "profile": {
+    "domain": "Paskyra",
+    "manageYourProfileDetails": "Tvarkykite savo paskyros nustatymus.",
+    "fields": {
+      "languageLabel": "Kalka",
+      "usageInsightsLabel": "Naudojimo įžvalgos"
+    },
+    "edit": {
+      "header": "Keisti paskyrą",
+      "languageHint": "Kalba, kurią norite naudoti administravimo aplinkoje. Tai nekeičia jūsų parduotuvės kalbos.",
+      "languagePlaceholder": "Pasirinkite kalbą",
+      "usageInsightsHint": "Pasidalinkite naudojimo įžvalgomis ir padėkite mums tobulinti Medusa. Daugiau apie tai, ką renkame ir kaip tai naudojame, galite perskaityti mūsų <0>dokumentacijoje</0>."
+    },
+    "toast": {
+      "edit": "Paskyros pakeitimai išsaugoti"
+    }
+  },
+  "users": {
+    "domain": "Administratoriai",
+    "editUser": "Keisti administratorių",
+    "inviteUser": "Pakviesti administratorių",
+    "inviteUserHint": "Pakvieskite naują parduotuvės administratorių.",
+    "sendInvite": "Siųsti pakvietimą",
+    "pendingInvites": "Laukiantys pakvietimai",
+    "deleteInviteWarning": "Ketinate pašalinti pakvietimą, išsiųstą {{email}}. Šis veiksmas neatstatomas.",
+    "resendInvite": "Pakartoti pakvietimą",
+    "copyInviteLink": "Kopijuoti pakvietimo nuorodą",
+    "expiredOnDate": "Galioja iki {{date}}",
+    "validFromUntil": "Galioja <0>{{from}}</0> - <1>{{until}}</1>",
+    "acceptedOnDate": "Priimtas {{date}}",
+    "inviteStatus": {
+      "accepted": "Priimtas",
+      "pending": "Laukia",
+      "expired": "Negaliojantis"
+    },
+    "roles": {
+      "admin": "Adkministratorius",
+      "developer": "Kūrėjas",
+      "member": "Narys"
+    },
+    "list": {
+      "empty": {
+        "heading": "Administratorių nėra",
+        "description": "Kai pakviesite, jie bus rodomi čia."
+      },
+      "filtered": {
+        "heading": "Rezultatų nėra",
+        "description": "Nėra administratorių, atitinkačių filtro kriterijus."
+      }
+    },
+    "deleteUserWarning": "Ketinate pašalinti administratorių {{name}}. Šis veiksmas neatstatomas.",
+    "deleteUserSuccess": "Administratorius {{name}} sėkmingai pašalintas",
+    "invite": "Pakvietimas"
+  },
+  "store": {
+    "domain": "Parduotuvė",
+    "manageYourStoresDetails": "Tvarkykite savo parduotuvės nustatymus",
+    "editStore": "Keisti parduotuvę",
+    "defaultCurrency": "Numatytoji valiuta",
+    "defaultRegion": "Numatytasis regionas",
+    "defaultSalesChannel": "Numatytasis pardavimo kanalas",
+    "defaultLocation": "Numatytoji sandėliavimo vieta",
+    "swapLinkTemplate": "Keitimo nuorodos šablonas",
+    "paymentLinkTemplate": "Apmokėjimo nuorodos šablonas",
+    "inviteLinkTemplate": "Pakvietimo nuorodos šablonas",
+    "currencies": "Vaiutos",
+    "addCurrencies": "Pridėti valiutas",
+    "enableTaxInclusivePricing": "Įjungti mokesčių įskaičiavimą kainodaroje",
+    "disableTaxInclusivePricing": "Išjungti mokesčių įskaičiavimą kainodaroje",
+    "removeCurrencyWarning_one": "Ketinate pašalinti {{count}} parduotuvės valiutą. Įsitikinkite, kad pašalinote visas kainas šia valiuta preš tęsiant.",
+    "removeCurrencyWarning_other": "Ketinate pašalinti {{count}} parduotuvės valiutų. Įsitikinkite, kad pašalinote visas kainas šiomis valiutomis preš tęsiant.",
+    "currencyAlreadyAdded": "Valiuta parduotuvėje jau pridėta.",
+    "edit": {
+      "header": "Keisti parduotuvę"
+    },
+    "toast": {
+      "update": "Parduotuvė sėkmingai pakeista",
+      "currenciesUpdated": "Valiutos sėkmingai pakeistos",
+      "currenciesRemoved": "Valiutos sėkmingai pašalintos iš parduotuvės",
+      "updatedTaxInclusivitySuccessfully": "Mokesčių įskaičiavimas kainodaroje sėkmingai pakeistas"
+    }
+  },
+  "regions": {
+    "domain": "Regionai",
+    "subtitle": "Regionas yra sritis, kurioje parduodate produktus. Jis gali apimti kelias šalis ir turi skirtingus mokesčių tarifus, vykdytojus ir valiutą",
+    "createRegion": "Sukurti regioną",
+    "createRegionHint": "Tvarkykite mokesčių tarifus ir vykdytojus šalių rinkiniams.",
+    "addCountries": "Pridėti šalis",
+    "editRegion": "Keisti regioną",
+    "countriesHint": "Pridėkite šalis, priklausančias šiam regionui.",
+    "deleteRegionWarning": "Ketinate pašalinti regioną {{name}}. Šis veiksmas neatstatomas.",
+    "removeCountriesWarning_one": "Ketinate pašalinti {{count}} šalį iš regiono. Šis veiksmas neatstatomas.",
+    "removeCountriesWarning_other": "Ketinate pašalinti {{count}} šalis iš regiono. Šis veiksmas neatstatomas.",
+    "removeCountryWarning": "Ketinate pašalinti šalį {{name}} iš regiono. Šis veiksmas neatstatomas.",
+    "automaticTaxesHint": "Kai įjungta, mokesčiai bus paskaičiuoti pagal pristatymo adresą pirkimo metu.",
+    "taxInclusiveHint": "Kai įjungta, kainos regione bus rodomos su mokesčiais.",
+    "providersHint": "Pridėkite, kurie mokėjimo paslaugų teikėjai galimi šiame regione.",
+    "shippingOptions": "Siuntimo būdai",
+    "deleteShippingOptionWarning": "Ketinate pašalinti siuntimo būdą {{name}}. Šis veiksmas neatstatomas.",
+    "return": "Grąžinimas",
+    "outbound": "Išvykstantis",
+    "priceType": "Kainos tipas",
+    "flatRate": "Fiksuota",
+    "calculated": "Apskaičiuojama",
+    "list": {
+      "noRecordsMessage": "Sukurkite regioną vietovėms, kuriose prekiaujate."
+    },
+    "toast": {
+      "delete": "Regionas sėkmingai pašalintas",
+      "edit": "Regiono pakeitimai išsaugoti",
+      "create": "Regionas sėkmingai sukurtas",
+      "countries": "Regiono šalys sėkmingai pakeistos"
+    },
+    "shippingOption": {
+      "createShippingOption": "Sukurti siuntimo būdą",
+      "createShippingOptionHint": "Sukurkite siuntimo būdą regionui.",
+      "editShippingOption": "Keisti siuntimo būdą",
+      "fulfillmentMethod": "Siuntimo tipas",
+      "type": {
+        "outbound": "Pristatymas",
+        "outboundHint": "Naudokite šį pasirinkimą, jei kuriate siuntimo būdą prekių pristatymui klientui.",
+        "return": "Grąžinimas",
+        "returnHint": "Naudokite šį pasirinkimą, jei kuriate siuntimo būdą prekių grąžinimui iš kliento."
+      },
+      "priceType": {
+        "label": "Kainos tipas",
+        "flatRate": "Fiksuota",
+        "calculated": "Apskaičiuojama"
+      },
+      "availability": {
+        "adminOnly": "Tik administravimo aplinkoje",
+        "adminOnlyHint": "Kai įjungta, siuntimo būdas bus prieinamas tik administravimo apinkoje, o ne parduotuvėje."
+      },
+      "taxInclusiveHint": "Kai įjungta, siuntimo kaina bus su įskaičiuotais mokesčiais.",
+      "requirements": {
+        "label": "Reikalavimai",
+        "hint": "Nurodykite šio siuntimo būdo reikalavimus."
+      }
+    }
+  },
+  "taxes": {
+    "domain": "Mokesčių regionai",
+    "domainDescription": "Tvarkykite savo mokesčių regionus",
+    "countries": {
+      "taxCountriesHint": "Mokesčių nustatymai galioja šalims sąraše."
+    },
+    "settings": {
+      "editTaxSettings": "Keisti mokesčių nustatymus",
+      "taxProviderLabel": "Mokesčių skaičiuotuvas",
+      "systemTaxProviderLabel": "Sistemos mokesčių skaičiuotuvas",
+      "calculateTaxesAutomaticallyLabel": "Apskaičiuoti mokesčius automatiškai",
+      "calculateTaxesAutomaticallyHint": "Kai įjungta, mokesčiai bus apskaičiuoti ir pritaikyti pirkinių krepšeliams automatiškai. Kai išjungta, mokesčiai turi būti skaičiuojami rankiniu būdu atsiskaitant. Neautomatinius mokesčius rekomenduojama naudoti su trečiųjų šalių mokesčių skaičiuotuvais.",
+      "applyTaxesOnGiftCardsLabel": "Taikyti mokesčius dovanų kortelėms",
+      "applyTaxesOnGiftCardsHint": "Kai įjungta, mokesčiai bus pritaikyti dovanų kortelėms pirkimo metu. Kai kuriose šalyse mokesčių teisės aktai reikalauja apmokestinti dovanų korteles perkant.",
+      "defaultTaxRateLabel": "Numatytasis mokesčio tarifas",
+      "defaultTaxCodeLabel": "Numatytasis mokesčio kodas"
+    },
+    "defaultRate": {
+      "sectionTitle": "Numatytasis mokesčių tarifas"
+    },
+    "taxRate": {
+      "sectionTitle": "Mokesčių tarifai",
+      "createTaxRate": "Sukurti mokesčių tarifą",
+      "createTaxRateHint": "Sukurkite mokesčių tarifą regionui.",
+      "deleteRateDescription": "Ketinate pašalinti mokesčių tarifą {{name}}. Šis veiksmas neatstatomas.",
+      "editTaxRate": "Keisti mokesčių tarifą",
+      "editRateAction": "Keisti tarifą",
+      "editOverridesAction": "Keisti perrašymus",
+      "editOverridesTitle": "Keisti mokesčių tarifo perrašymus",
+      "editOverridesHint": "Nurodykite mokesčių tarifo perrašymus.",
+      "deleteTaxRateWarning": "Ketinate pašalinti mokesčių tarifą {{name}}. Šis veiksmas neatstatomas.",
+      "productOverridesLabel": "Prekių perrašymai",
+      "productOverridesHint": "Nurodykite prekių perrašymus šiam mokesčių tarifui.",
+      "addProductOverridesAction": "Pridėti prekių perrašymus",
+      "productTypeOverridesLabel": "Prekių tipo perrašymai",
+      "productTypeOverridesHint": "Nurodykite prekių tipo perrašymus šiam mokesčių tarifui.",
+      "addProductTypeOverridesAction": "Pridėti prekių tipo perrašymus",
+      "shippingOptionOverridesLabel": "Siuntimo būdo perrašymai",
+      "shippingOptionOverridesHint": "Nurodykite siuntimo būdo perrašymus šiam mokesčių tarifui.",
+      "addShippingOptionOverridesAction": "Pridėti siuntimo būdo perrašymus",
+      "productOverridesHeader": "Prekės",
+      "productTypeOverridesHeader": "Prekių tipai",
+      "shippingOptionOverridesHeader": "Siuntimo būdai"
+    }
+  },
+  "locations": {
+    "domain": "Sandėiavimo vietos",
+    "editLocation": "Keisti sandėliavimo vietą",
+    "addSalesChannels": "Pridėti pardavimo kanalą",
+    "noLocationsFound": "Sandėliavimo vietų nėra",
+    "selectLocations": "Pasirinkite prekės sandėliavimo vietas.",
+    "deleteLocationWarning": "Ketinate pašalinti sandėliavimo vietą {{name}}. Šis veiksmas neatstatomas.",
+    "removeSalesChannelsWarning_one": "Ketinate pašalinti {{count}} pardavimo kanalą iš sandėliavimo vietos.",
+    "removeSalesChannelsWarning_other": "Ketinate pašalinti {{count}} pardavimo kanalus iš sandėliavimo vietos.",
+    "toast": {
+      "create": "Sandėliavimo vieta sėkmingai sukurta",
+      "update": "Sandėliavimo vieta sėkmingai pakeista",
+      "removeChannel": "Pardavimų kanalas sėkmingai pašalintas"
+    }
+  },
+  "reservations": {
+    "domain": "Rezervacijos",
+    "subtitle": "Tvarkykite rezervuotų atsargų kiekius.",
+    "deleteWarning": "Ketinate pašalinti rezervaciją. Šis veiksmas neatstatomas."
+  },
+  "salesChannels": {
+    "domain": "Pardavimo kanalai",
+    "subtitle": "Tvarkykite interneto ir fizinius pardavimo kanalus, kuriuose prekiaujate.",
+    "list": {
+      "empty": {
+        "heading": "Pardavimo kanalų nėra",
+        "description": "Kai sukursite pardavimo kanalą, jis bus rodomas čia."
+      },
+      "filtered": {
+        "heading": "Rezultatų nėra",
+        "description": "Nėra pardavimo kanalų, atitinkančių filtro kriterijus."
+      }
+    },
+    "createSalesChannel": "Sukurti pardavimo kanalą",
+    "createSalesChannelHint": "Sukurkite pardavimo kanalą, kuriame prekiaujate.",
+    "enabledHint": "Nurodykite, ar pardavimo kanalas įjungtas.",
+    "removeProductsWarning_one": "Ketinate pašalinti {{count}} prekę iš {{sales_channel}}.",
+    "removeProductsWarning_other": "Ketinate pašalinti {{count}} prekes iš {{sales_channel}}.",
+    "addProducts": "Pridėti prekes",
+    "editSalesChannel": "Keisti pardavimo kanalą",
+    "productAlreadyAdded": "Prekė jau pridėta prekių kanale.",
+    "deleteSalesChannelWarning": "Ketinate pašalinti prekių kanalą {{name}}. Šis veiksmas neatstatomas.",
+    "toast": {
+      "create": "Pardavimo kanalas sėkmingai sukurtas",
+      "update": "Pardavimo kanalas sėkmingai pakeistas",
+      "delete": "Pardavimo kanalas sėkmingai pašalintas"
+    },
+    "tooltip": {
+      "cannotDeleteDefault": "Negalima pašalinti numatytojo pardavimo kanalo"
+    },
+    "products": {
+      "list": {
+        "noRecordsMessage": "Prekių pardavimo kanale nėra."
+      },
+      "add": {
+        "list": {
+          "noRecordsMessage": "Pirmiausia sukurkite prekę."
+        }
+      }
+    }
+  },
+  "apiKeyManagement": {
+    "domain": {
+      "publishable": "Vieši API raktai",
+      "secret": "Slapti API raktai"
+    },
+    "subtitle": {
+      "publishable": "Tvarkykite API raktus, naudojamus parduotuvėse siekiant apriboti užklausų apimtį iki konkrečių pardavimo kanalų.",
+      "secret": "Tvarkykite API raktus, naudojamus autentifikuoti administratorius administravimo programose."
+    },
+    "status": {
+      "active": "Aktyvus",
+      "revoked": "Atšauktas"
+    },
+    "type": {
+      "publishable": "Viešas",
+      "secret": "Slaptas"
+    },
+    "create": {
+      "createPublishableHeader": "Sukurti viešą API raktą",
+      "createPublishableHint": "Sukurkite viešą API raktą, kad apriboti užklausų apimtį iki konkrečių pardavimo kanalų.",
+      "createSecretHeader": "Sukurti slaptą API raktą",
+      "createSecretHint": "Sukurkite slaptą API raktą, kad pasiekti Medusa API kaip autentifikuotas administratorius.",
+      "secretKeyCreatedHeader": "Slaptas raktas sukurtas",
+      "secretKeyCreatedHint": "Jūsų slaptas raktas sugeneruotas. Nusikopijuokite jį dabar ir saugiai išsisaugokite. Tai vienintelis kartas, kai jis bus rodomas.",
+      "copySecretTokenSuccess": "Slaptas raktas nukopijuotas į atmintį.",
+      "copySecretTokenFailure": "Nepavyko nukopijuoti slapto rakto į atmintį.",
+      "successToast": "API raktas sėkmingai sukurtas."
+    },
+    "edit": {
+      "header": "Keisti API raktą",
+      "description": "Keiskite API rakto pavadinimą.",
+      "successToast": "API raktas {{title}} sėkmingai pakeistas."
+    },
+    "salesChannels": {
+      "title": "Pridėti pardavimo kanalus",
+      "description": "Pridėkite pardavimo kanalus, kurie bus prieinami su šiuo API raktu.",
+      "successToast_one": "{{count}} pardavimo kanalas sėkmingai pridėtas prie API rakto.",
+      "successToast_other": "{{count}} pardavimo kanalai sėkmingai pridėti prie API rakto.",
+      "alreadyAddedTooltip": "Pardavimo kanalas jau pridėtas prie API rakto.",
+      "list": {
+        "noRecordsMessage": "API raktas neturi priskirtų pardavimo kanalų."
+      }
+    },
+    "delete": {
+      "warning": "Ketinate pašalinti API raktą {{title}}. Šis veiksmas neatstatomas.",
+      "successToast": "API raktas {{title}} sėkmingai pašalintas."
+    },
+    "revoke": {
+      "warning": "Ketinate atšaukti API raktą {{title}}. Šis veiksmas neatstatomas.",
+      "successToast": "API raktas {{title}} sėkmingai atšauktas."
+    },
+    "addSalesChannels": {
+      "list": {
+        "noRecordsMessage": "Pirmiausia sukurkite pardavimo kanalą."
+      }
+    },
+    "removeSalesChannel": {
+      "warning": "Ketinate pašalinti pardavimo kanalą {{name}}, priskirtą API raktui. Šis veiksmas neatstatomas.",
+      "warningBatch_one": "Ketinate pašalinti {{count}} pardavimo kanalą, priskirtą API raktui. Šis veiksmas neatstatomas.",
+      "warningBatch_other": "Ketinate pašalinti {{count}} pardavimo kanalus, priskirtus API raktui. Šis veiksmas neatstatomas.",
+      "successToast": "Pardavimo kanalas sėkmingai pašalintas nuo API rakto.",
+      "successToastBatch_one": "{{count}} pardavimo kanalas sėkmingai pašalintas nuo API rakto.",
+      "successToastBatch_other": "{{count}} pardavimo kanalass sėkmingai pašalintas nuo API rakto."
+    },
+    "actions": {
+      "revoke": "Atšaukti API raktą",
+      "copy": "Kopijuoti API raktą",
+      "copySuccessToast": "API raktas nukopijuotas į atmintį."
+    },
+    "table": {
+      "lastUsedAtHeader": "Paskutinį kartą naudotas",
+      "createdAtHeader": "Atšauktas"
+    },
+    "fields": {
+      "lastUsedAtLabel": "Paskutinį kartą naudotas",
+      "revokedByLabel": "Atšaukė",
+      "revokedAtLabel": "Atšauktas",
+      "createdByLabel": "Sukūrė"
+    }
+  },
+  "returnReasons": {
+    "domain": "Grąžinimo priežastys",
+    "subtitle": "Tvarkykite prekių grąžinimo priežastis.",
+    "calloutHint": "Tvarkykite prekių grąžinimo priežastis, kad suskirtyti grąžinimus į kategorijas.",
+    "editReason": "Keisti grąžinimo priežastį",
+    "create": {
+      "header": "Pridėti grąžinimo priežastį",
+      "subtitle": "Nurodykite dažniausias grąžinimo priežastis.",
+      "hint": "Sukurkite prekių grąžinimo priežastį, kad suskirtyti grąžinimus į kategorijas.",
+      "successToast": "Grąžinimo priežastis {{label}} sėkmingai sukurta."
+    },
+    "edit": {
+      "header": "Keisti grąžinimo priežastį",
+      "subtitle": "Keiskite grąžinimo priežasties reikšmę.",
+      "successToast": "Grąžinimo priežastis {{label}} sėkmingai pakeista."
+    },
+    "delete": {
+      "confirmation": "Ketinate pašalinti grąžinimo priežastį {{label}}. Šis veiksmas neatstatomas.",
+      "successToast": "Grąžinimo priežastis {{label}} sėkmingai pašalinta."
+    },
+    "fields": {
+      "value": {
+        "label": "Reikšmė",
+        "placeholder": "klaidingas_dydis",
+        "tooltip": "Vertė turėtų būti unikalus grąžinimo priežasties identifikatorius."
+      },
+      "label": { "label": "Antraštė", "placeholder": "Klaidingas dydis" },
+      "description": {
+        "label": "Aprašymas",
+        "placeholder": "Klientas gavo netinkamą dydį"
+      }
+    }
+  },
+  "login": {
+    "forgotPassword": "Pamiršote slaptažodį? - <0>Atstatyti</0>",
+    "title": "Sveiki atvykę į Medusa",
+    "hint": "Prisijunkite, kad pasiektumėte paskyrą"
+  },
+  "invite": {
+    "title": "Sveiki atvykę į Medusa",
+    "hint": "Sukurkite savo paskyrą žemiau",
+    "backToLogin": "Atgal į prisijungimą",
+    "createAccount": "Sukurti paskyrą",
+    "alreadyHaveAccount": "Jau turite paskyrą? - <0>Prisijunkite</0>",
+    "emailTooltip": "Jūsų el. pašto adresas negali būti pakeistas. Jei norite naudoti kitą el. pašto adresą, turite gauti naują kvietimą.",
+    "invalidInvite": "Kvietimas neteisingas arba pasibaigęs.",
+    "successTitle": "Jūsų paskyra sukurta",
+    "successHint": "Pradėkite naudotis Medusa administravimo aplinka nedelsiant.",
+    "successAction": "Paleisti Medusa administravimo aplinką",
+    "invalidTokenTitle": "Jūsų kvietimo prieigos raktas neteisingas",
+    "invalidTokenHint": "Pabandykite paprašyti naujos kvietimo nuorodos.",
+    "passwordMismatch": "Slptažodžiai nesutampa",
+    "toast": {
+      "accepted": "Kvietimas sėkmingai priimtas"
+    }
+  },
+  "resetPassword": {
+    "title": "Slaptažodžio atstatymas",
+    "hint": "Įveskite savo el. pašto adresą ir atsiųsime instrukcijas, kaip iš naujo nustatyti slaptažodį.",
+    "email": "El. paštas",
+    "sendResetInstructions": "Siųsti atstatymo instrukcijas",
+    "backToLogin": "<0>Atgal į prisijungimą</0>",
+    "newPasswordHint": "Pasirinkite naują slaptažodį.",
+    "invalidTokenTitle": "Jūsų atkūrimo prieigos raktas neteisingas",
+    "invalidTokenHint": "Pabandykite užsakyti naują slaptažodžio atstatymo nuorodą.",
+    "expiredTokenTitle": "Jūsų atkūrimo prieigos rakto galiojimas baigėsi",
+    "goToResetPassword": "Eiti į slaptažodžio atstatymą",
+    "resetPassword": "Atstatyti slaptažodį",
+    "newPassword": "Naujas slaptažodis",
+    "repeatNewPassword": "Pakartokite naują slaptažodį",
+    "tokenExpiresIn": "Prieigos rakto galiojimas baigsis už <0>{{time}}</0> minučių",
+    "successfulRequestTitle": "Sėkmingai išsiuntėme jums el. laišką",
+    "successfulRequest": "Išsiuntėme jums el. laišką, kurį galite naudoti naujo slaptažodžio nustatymui. Patikrinkite šlamšto aplanką, jei po kelių minučių jo negavote.",
+    "successfulResetTitle": "Slaptažodis sėkmingai pakeistas",
+    "successfulReset": "Prašome prisijungti prisijungimo puslapyje.",
+    "passwordMismatch": "Slaptažodžiai nesutampa",
+    "invalidLinkTitle": "Jūsų slaptažodžio keitimo nuoroda neteisinga",
+    "invalidLinkHint": "Pabandykite iš naujo atstatyti slaptažodį."
+  },
+  "workflowExecutions": {
+    "domain": "Darbo eigos",
+    "subtitle": "Peržiūrėkite ir sekite darbo eigų vykdymą savo Medusa programoje.",
+    "transactionIdLabel": "Transakcijos ID",
+    "workflowIdLabel": "Darbo eigos ID",
+    "progressLabel": "Progresas",
+    "stepsCompletedLabel_one": "{{completed}} iš {{count}} žingsnio",
+    "stepsCompletedLabel_other": "{{completed}} iš {{count}} žingsnių",
+    "list": {
+      "noRecordsMessage": "Jokia darbo eiga dar nebuvo atlikta."
+    },
+    "history": {
+      "sectionTitle": "Istorija",
+      "runningState": "Vykdoma...",
+      "awaitingState": "Laukia",
+      "failedState": "Nepavyko",
+      "skippedState": "Praleista",
+      "skippedFailureState": "Praleista (nepavyko)",
+      "definitionLabel": "Apibrėžimas",
+      "outputLabel": "Išvestis",
+      "compensateInputLabel": "Kompensuoti įvestį",
+      "revertedLabel": "Atstatyta",
+      "errorLabel": "Klaida"
+    },
+    "state": {
+      "done": "Atlikta",
+      "failed": "Nepavyko",
+      "reverted": "Atstatyta",
+      "invoking": "Pradedama",
+      "compensating": "Kompensuojama",
+      "notStarted": "Nepradėta"
+    },
+    "transaction": {
+      "state": {
+        "waitingToCompensate": "Laukiama kompensacijos"
+      }
+    },
+    "step": {
+      "state": {
+        "skipped": "Praleistas",
+        "skippedFailure": "Praleistas (nepavyko)",
+        "dormant": "Neveikiantis",
+        "timeout": "Nespėjo"
+      }
+    }
+  },
+  "productTypes": {
+    "domain": "Prekių tipai",
+    "subtitle": "Suskirstykite savo prekes į tipus.",
+    "create": {
+      "header": "Sukurti prekių tipą",
+      "hint": "Sukurkite prekių tipą prekių skirstymui.",
+      "successToast": "Prekių tipas {{value}} sėkmingai sukurtas."
+    },
+    "edit": {
+      "header": "Keisti prekių tipą",
+      "successToast": "Prekių tipas {{value}} sėkmingai pakeistas."
+    },
+    "delete": {
+      "confirmation": "Ketinate pašalinti prekių tipą {{value}}. Šis veiksmas neatstatomas.",
+      "successToast": "Prekių tipas {{value}} sėkmingai pašalintas."
+    },
+    "fields": {
+      "value": "Reikšmė"
+    }
+  },
+  "productTags": {
+    "domain": "Prekių žymos",
+    "create": {
+      "header": "Sukurti prekių žymą",
+      "subtitle": "Sukurkite prekių žymą prekių skirstymui.",
+      "successToast": "Prekių žyma {{value}} sėkmingai sukurta."
+    },
+    "edit": {
+      "header": "Keisti prekių žymą",
+      "subtitle": "Keiskite prekių žymos reikšmę.",
+      "successToast": "Prekių žyma {{value}} sėkmingai pakeista."
+    },
+    "delete": {
+      "confirmation": "Ketinate pašalinti prekių žymą {{value}}. Šis veiksmas neatstatomas.",
+      "successToast": "Prekių žyma {{value}} sėkmingai pašalinta."
+    },
+    "fields": {
+      "value": "Reikšmė"
+    }
+  },
+  "notifications": {
+    "domain": "Pranešimai",
+    "emptyState": {
+      "title": "Pranešimų nėra",
+      "description": "Šiuo metu neturite jokių pranešimų, bet kai tik gausite, jie bus čia."
+    },
+    "accessibility": {
+      "description": "Čia bus pateikti pranešimai apie Medusa veiklą"
+    }
+  },
+  "errors": {
+    "serverError": "Serverio klaida - bandykite dar kartą vėliau.",
+    "invalidCredentials": "Klaidingas el. pašto adresas arba slaptažodis"
+  },
+  "statuses": {
+    "scheduled": "Suplanuota",
+    "expired": "Negalioja",
+    "active": "Aktyvus",
+    "inactive": "Neaktyvus",
+    "draft": "Juodraštis",
+    "enabled": "Įjungta",
+    "disabled": "Išjungta"
+  },
+  "labels": {
+    "productVariant": "Prekės variantas",
+    "prices": "Kainos",
+    "available": "Yra",
+    "inStock": "Sandėlyje",
+    "added": "Pridėta",
+    "removed": "Pašalinta",
+    "from": "Nuo",
+    "to": "Iki",
+    "beaware": "Žinokite, kad",
+    "loading": "Kraunama"
+  },
+  "fields": {
+    "amount": "Suma",
+    "refundAmount": "Grąžinama suma",
+    "name": "Pavadinimas",
+    "default": "Numatytasis",
+    "lastName": "Pavardė",
+    "firstName": "Vardas",
+    "title": "Pavadinimas",
+    "customTitle": "Pasirinktinis pavadinimas",
+    "manageInventory": "Tvarkyti atsargas",
+    "inventoryKit": "Turi atsargų rinkinį",
+    "inventoryItems": "Atsargos",
+    "inventoryItem": "Atsargos",
+    "requiredQuantity": "Reikalingas kiekis",
+    "description": "Aprašymas",
+    "email": "El. paštas",
+    "password": "Slaptažodis",
+    "repeatPassword": "Pakartokite slaptažodį",
+    "confirmPassword": "Patvirtinti slaptažodį",
+    "newPassword": "Naujas slaptažodis",
+    "repeatNewPassword": "Pakartokite naują slaptažodį",
+    "categories": "Kategorijos",
+    "shippingMethod": "Siuntimo būdas",
+    "configurations": "Konfigūracijos",
+    "conditions": "Sąlygos",
+    "category": "Kategorija",
+    "collection": "Kolekcija",
+    "discountable": "Nukainuojama",
+    "handle": "Nuoroda",
+    "subtitle": "Paantraštė",
+    "by": "",
+    "item": "Prekė",
+    "qty": "kiekis.",
+    "limit": "Limitas",
+    "tags": "Žymos",
+    "type": "Tipas",
+    "reason": "Priežastis",
+    "none": "jokie",
+    "all": "visi",
+    "search": "Paieška",
+    "percentage": "Procentas",
+    "sales_channels": "Pardavimų kanalai",
+    "customer_groups": "Klientų grupės",
+    "product_tags": "Prekių žymos",
+    "product_types": "Prekių tipai",
+    "product_collections": "Prekių kolekcijos",
+    "status": "Būsena",
+    "code": "Kodas",
+    "value": "Reikšmė",
+    "disabled": "Išjungta",
+    "dynamic": "Dinamiškas",
+    "normal": "Normalus",
+    "years": "Metai",
+    "months": "Mėnesiai",
+    "days": "Dienos",
+    "hours": "Valandos",
+    "minutes": "Minutės",
+    "totalRedemptions": "Bendras išpirkimas",
+    "countries": "Šalys",
+    "paymentProviders": "Mokėjimo paslaugų teikėjai",
+    "refundReason": "Pinigų grąžinimo priežastis",
+    "fulfillmentProviders": "Užsakymo vykdytojai",
+    "fulfillmentProvider": "Užsakymo vykdytojas",
+    "providers": "Teikėjai",
+    "availability": "Prieinamumas",
+    "inventory": "Atsargos",
+    "optional": "Neprivalomas",
+    "note": "Pastaba",
+    "automaticTaxes": "Automatiniai mokesčiai",
+    "taxInclusivePricing": "Kainodara su įskaičiuotais mokesčiais",
+    "currency": "Valiuta",
+    "address": "Adresas",
+    "address2": "Butas, apartamentai, kt.",
+    "city": "Miestas",
+    "postalCode": "Pašto kodas",
+    "country": "Šalis",
+    "state": "Valstija",
+    "province": "Provincija",
+    "company": "Įmonė",
+    "phone": "Telefonas",
+    "metadata": "Metaduomenys",
+    "selectCountry": "Pasirinkite šalį",
+    "products": "Prekės",
+    "variants": "Variantai",
+    "orders": "Užsakymai",
+    "account": "Paskyra",
+    "total": "Užsakymo viso",
+    "paidTotal": "Viso užfiksuota",
+    "totalExclTax": "Viso be mokesčių",
+    "subtotal": "Tarpinė suma",
+    "shipping": "Siuntimas",
+    "outboundShipping": "Pristatymo siuntimas",
+    "returnShipping": "Grąžinimo siuntimas",
+    "tax": "Mokestis",
+    "created": "Sukurtas",
+    "key": "Raktas",
+    "customer": "Klientas",
+    "date": "Data",
+    "order": "Užsakymas",
+    "fulfillment": "Vykdymas",
+    "provider": "Teikėjas",
+    "payment": "Mokėjimas",
+    "items": "Prekės",
+    "salesChannel": "Pardavimo kanalai",
+    "region": "Regionas",
+    "discount": "Nuolaida",
+    "role": "Rolė",
+    "sent": "Išsiųstas",
+    "salesChannels": "Pardavimo kanalai",
+    "product": "Prekė",
+    "createdAt": "Sukurta",
+    "updatedAt": "Atnaujinta",
+    "revokedAt": "Atšaukta",
+    "true": "Taip",
+    "false": "Ne",
+    "giftCard": "Dovanų kortelė",
+    "tag": "Žyma",
+    "dateIssued": "Išdavimo data",
+    "issuedDate": "Išdavimo data",
+    "expiryDate": "Galiojimo laikas",
+    "price": "Kaina",
+    "priceTemplate": "Kaina {{regionOrCurrency}}",
+    "height": "Aukštis",
+    "width": "Plotis",
+    "length": "Ilgis",
+    "weight": "Svoris",
+    "midCode": "MID kodas",
+    "hsCode": "HS kodas",
+    "ean": "EAN",
+    "upc": "UPC",
+    "inventoryQuantity": "Atsargų likutis",
+    "barcode": "Brūkšninis kodas",
+    "countryOfOrigin": "Kilmės šalis",
+    "material": "Medžiaga",
+    "thumbnail": "Miniatūra",
+    "sku": "SKU",
+    "managedInventory": "Valdomos atsargos",
+    "allowBackorder": "Leisti užsakyti kai nėra",
+    "inStock": "Sandėlyje",
+    "location": "Sandėliavimo vieta",
+    "quantity": "Kiekis",
+    "variant": "Variantas",
+    "id": "ID",
+    "parent": "Tėvas",
+    "minSubtotal": "Mažiausia tarpinė suma",
+    "maxSubtotal": "Didžiausia tarpinė suma",
+    "shippingProfile": "Siuntimo tipai",
+    "summary": "Santrauka",
+    "details": "Nustatymai",
+    "label": "Antraštė",
+    "rate": "Tarifas",
+    "requiresShipping": "Reikalingas siuntimas",
+    "unitPrice": "Vieneto kaina",
+    "startDate": "Pradžios data",
+    "endDate": "Pabaigos data",
+    "draft": "Juodraštis",
+    "values": "Reikšmės"
+  },
+  "dateTime": {
+    "years_one": "Metai",
+    "years_other": "Metai",
+    "months_one": "Mėnesis",
+    "months_other": "Mėnesiai",
+    "weeks_one": "Savaitė",
+    "weeks_other": "Savaitės",
+    "days_one": "Diena",
+    "days_other": "Dienos",
+    "hours_one": "Valanda",
+    "hours_other": "Valandos",
+    "minutes_one": "Minutė",
+    "minutes_other": "Minutės",
+    "seconds_one": "Sekundė",
+    "seconds_other": "Sekundės"
+  }
+}


### PR DESCRIPTION
### What

- add support for `Lithuanian` language

### Why

- improve UX for Lithuanian-speaking users

### How

- following instructions at https://docs.medusajs.com/learn/resources/contribution-guidelines/admin-translations

### Testing

```sh
yarn i18n:validate lt.json
```