### PR TITLE
fix(js-sdk, types): fixes types and deprecate duplicate methods

### DIFF
--- a/.changeset/gorgeous-wombats-arrive.md
+++ b/.changeset/gorgeous-wombats-arrive.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/js-sdk": patch
+"@medusajs/types": patch
+---
+
+fix(js-sdk, types): fixes types and deprecate duplicate methods

--- a/packages/core/js-sdk/src/admin/return.ts
+++ b/packages/core/js-sdk/src/admin/return.ts
@@ -152,7 +152,7 @@ export class Return {
   async updateReturnShipping(
     id: string,
     actionId: string,
-    body: HttpTypes.AdminAddReturnShipping,
+    body: HttpTypes.AdminUpdateReturnShipping,
     query?: HttpTypes.SelectParams,
     headers?: ClientHeaders
   ) {

--- a/packages/core/js-sdk/src/admin/sales-channel.ts
+++ b/packages/core/js-sdk/src/admin/sales-channel.ts
@@ -86,6 +86,9 @@ export class SalesChannel {
     )
   }
 
+  /**
+   * @deprecated Use {@link batchProducts} instead
+   */
   async updateProducts(
     id: string,
     body: HttpTypes.AdminUpdateSalesChannelProducts,
@@ -103,7 +106,7 @@ export class SalesChannel {
 
   async batchProducts(
     id: string,
-    body: HttpTypes.AdminBatchLink,
+    body: HttpTypes.AdminUpdateSalesChannelProducts,
     headers?: ClientHeaders
   ) {
     return await this.client.fetch<HttpTypes.AdminSalesChannelResponse>(

--- a/packages/core/types/src/http/workflow-execution/admin/entities.ts
+++ b/packages/core/types/src/http/workflow-execution/admin/entities.ts
@@ -26,7 +26,7 @@ export type TransactionStepState =
   | "skipped_failure"
   | "timeout"
 
-interface AdminWorkflowExecutionExecution {
+export interface AdminWorkflowExecutionExecution {
   steps: Record<string, AdminWorkflowExecutionStep>
 }
 


### PR DESCRIPTION
- Fix the input type of `updateReturnShipping`
- Mark `uploadProducts` in `SalesChannel` JS SDK class as deprecated because it's a duplicate of `batchProducts` (I checked the codebase and in the admin we use `batchProducts` and we never use `updateProducts`, but I marked it as deprecated instead of removing it in case it's a breaking change)
- Export `AdminWorkflowExecutionExecution` interface (mainly useful for documentation)