### PR TITLE
fix: fix German translation for 'captured'

### DIFF
--- a/packages/admin/dashboard/src/i18n/translations/de.json
+++ b/packages/admin/dashboard/src/i18n/translations/de.json
@@ -964,7 +964,7 @@
         "authorized": "Autorisiert",
         "partiallyAuthorized": "Teilweise autorisiert",
         "awaiting": "Warten",
-        "captured": "Gefangen",
+        "captured": "Erhalten",
         "partiallyRefunded": "Teilweise erstattet",
         "partiallyCaptured": "Teilweise erfasst",
         "refunded": "Erstattet",


### PR DESCRIPTION
While 'gefangen' is a correct German word, using it here is not correct.

'Erhalten' is more like 'received'.