### PR TITLE
docs: added missing comma in `initiatePayment` method's example

### DIFF
--- a/www/apps/resources/references/payment_provider/classes/payment_provider.AbstractPaymentProvider/page.mdx
+++ b/www/apps/resources/references/payment_provider/classes/payment_provider.AbstractPaymentProvider/page.mdx
@@ -328,7 +328,7 @@ class MyPaymentProviderService extends AbstractPaymentProvider<
     )
 
     return {
-      id: response.id
+      id: response.id,
       data: response,
     }
   }


### PR DESCRIPTION
In the snippet, it's missing comma