### PR TITLE
docs: sort API reference sidebar items and sections

### DIFF
--- a/www/apps/api-reference/providers/base-specs.tsx
+++ b/www/apps/api-reference/providers/base-specs.tsx
@@ -2,10 +2,9 @@
 
 import { OpenAPI } from "types"
 import { ReactNode, createContext, useContext, useEffect, useMemo } from "react"
-import { Sidebar } from "types"
 import getTagChildSidebarItems from "../utils/get-tag-child-sidebar-items"
 import { useRouter } from "next/navigation"
-import { UpdateActionType, UpdateSidebarItemTypes, useSidebar } from "docs-ui"
+import { UpdateActionType, useSidebar } from "docs-ui"
 import { getSectionId } from "docs-utils"
 
 type BaseSpecsContextType = {

--- a/www/apps/api-reference/types/global.d.ts
+++ b/www/apps/api-reference/types/global.d.ts
@@ -1,6 +1,12 @@
+import { Sidebar } from "types"
+
 declare global {
   interface Window {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     analytics?: any
   }
+}
+
+export type SidebarItem = Sidebar.SidebarItem & {
+  http_method?: string
 }

--- a/www/apps/api-reference/utils/get-tag-child-sidebar-items.tsx
+++ b/www/apps/api-reference/utils/get-tag-child-sidebar-items.tsx
@@ -1,9 +1,9 @@
-import type { OpenAPI } from "types"
+import type { OpenAPI, Sidebar } from "types"
 import dynamic from "next/dynamic"
 import type { MethodLabelProps } from "@/components/MethodLabel"
-import { Sidebar } from "types"
 import { getSectionId } from "docs-utils"
-
+import { SidebarItem } from "../types/global"
+import { compareOperations } from "./sort-operations-utils"
 const MethodLabel = dynamic<MethodLabelProps>(
   async () => import("../components/MethodLabel")
 ) as React.FC<MethodLabelProps>
@@ -11,7 +11,7 @@ const MethodLabel = dynamic<MethodLabelProps>(
 export default function getTagChildSidebarItems(
   paths: OpenAPI.PathsObject
 ): Sidebar.SidebarItem[] {
-  const items: Sidebar.SidebarItem[] = []
+  const items: SidebarItem[] = []
   Object.entries(paths).forEach(([, operations]) => {
     Object.entries(operations).map(([method, operation]) => {
       const definedOperation = operation as OpenAPI.Operation
@@ -30,9 +30,19 @@ export default function getTagChildSidebarItems(
           <MethodLabel method={definedMethod} className="h-fit" />
         ),
         loaded: true,
+        http_method: definedMethod,
       })
     })
   })
 
   return items
+    .sort((a, b) => {
+      return compareOperations({
+        httpMethodA: a.http_method || "",
+        httpMethodB: b.http_method || "",
+        summaryA: (a as Sidebar.SidebarItemLink).title,
+        summaryB: (b as Sidebar.SidebarItemLink).title,
+      })
+    })
+    .map(({ http_method, ...rest }) => rest)
 }

--- a/www/apps/api-reference/utils/sort-operations-utils.ts
+++ b/www/apps/api-reference/utils/sort-operations-utils.ts
@@ -1,0 +1,33 @@
+export const getMethodOrder = (method: string) => {
+  switch (method) {
+    case "get":
+      return 1
+    case "post":
+      return 2
+    case "delete":
+      return 3
+    default:
+      return 4
+  }
+}
+
+export const compareOperations = ({
+  httpMethodA,
+  httpMethodB,
+  summaryA,
+  summaryB,
+}: {
+  httpMethodA: string
+  httpMethodB: string
+  summaryA: string
+  summaryB: string
+}) => {
+  const aOrder = getMethodOrder(httpMethodA)
+  const bOrder = getMethodOrder(httpMethodB)
+
+  if (aOrder !== bOrder) {
+    return aOrder - bOrder
+  }
+
+  return summaryA.localeCompare(summaryB)
+}


### PR DESCRIPTION
Sort the API reference operations within the sections and sidebar in the order:

1. GET -> POST -> DELETE
2. In each of these methods, alphabetically

Closes DX-1522