### PR TITLE
feat: add `hasMany` flag to enforce in app link uniqueness

### DIFF
--- a/integration-tests/modules/__tests__/link-modules/define-link.spec.ts
+++ b/integration-tests/modules/__tests__/link-modules/define-link.spec.ts
@@ -46,7 +46,8 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              isList: true,
+              isList: false,
+              createMultiple: true,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -60,6 +61,7 @@ medusaIntegrationTestRunner({
               foreignKey: "region_id",
               alias: "region",
               isList: false,
+              createMultiple: false,
               args: {
                 methodSuffix: "Regions",
               },
@@ -90,9 +92,9 @@ medusaIntegrationTestRunner({
               serviceName: "region",
               entity: "Region",
               fieldAlias: {
-                currencies: {
+                currency: {
                   path: "currency_link.currency",
-                  isList: true,
+                  isList: false,
                   forwardArgumentsOnPath: ["currency_link.currency"],
                 },
               },
@@ -102,7 +104,7 @@ medusaIntegrationTestRunner({
                 primaryKey: "region_id",
                 foreignKey: "id",
                 alias: "currency_link",
-                isList: true,
+                isList: false,
               },
             },
           ],
@@ -147,7 +149,8 @@ medusaIntegrationTestRunner({
               entity: "ProductVariant",
               primaryKey: "id",
               foreignKey: "product_variant_id",
-              isList: true,
+              isList: false,
+              createMultiple: true,
               alias: "product_variant",
               args: {
                 methodSuffix: "ProductVariants",
@@ -160,6 +163,7 @@ medusaIntegrationTestRunner({
               primaryKey: "id",
               foreignKey: "region_id",
               isList: false,
+              createMultiple: false,
               alias: "region",
               args: {
                 methodSuffix: "Regions",
@@ -191,9 +195,9 @@ medusaIntegrationTestRunner({
               serviceName: "region",
               entity: "Region",
               fieldAlias: {
-                product_variants: {
+                product_variant: {
                   path: "product_variant_link.product_variant",
-                  isList: true,
+                  isList: false,
                   forwardArgumentsOnPath: [
                     "product_variant_link.product_variant",
                   ],
@@ -205,7 +209,7 @@ medusaIntegrationTestRunner({
                 primaryKey: "region_id",
                 foreignKey: "id",
                 alias: "product_variant_link",
-                isList: true,
+                isList: false,
               },
             },
           ],
@@ -253,7 +257,8 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              isList: true,
+              isList: false,
+              createMultiple: true,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -266,6 +271,7 @@ medusaIntegrationTestRunner({
               primaryKey: "id",
               foreignKey: "region_id",
               isList: false,
+              createMultiple: false,
               alias: "region",
               args: {
                 methodSuffix: "Regions",
@@ -297,9 +303,9 @@ medusaIntegrationTestRunner({
               serviceName: "region",
               entity: "Region",
               fieldAlias: {
-                currencies: {
+                currency: {
                   path: "currency_link.currency",
-                  isList: true,
+                  isList: false,
                   forwardArgumentsOnPath: ["currency_link.currency"],
                 },
               },
@@ -309,7 +315,7 @@ medusaIntegrationTestRunner({
                 primaryKey: "region_id",
                 foreignKey: "id",
                 alias: "currency_link",
-                isList: true,
+                isList: false,
               },
             },
           ],
@@ -353,7 +359,8 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              isList: true,
+              isList: false,
+              createMultiple: true,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -366,6 +373,115 @@ medusaIntegrationTestRunner({
               primaryKey: "id",
               foreignKey: "region_id",
               isList: true,
+              createMultiple: true,
+              alias: "region",
+              args: {
+                methodSuffix: "Regions",
+              },
+              deleteCascade: false,
+            },
+          ],
+          extends: [
+            {
+              serviceName: "currency",
+              entity: "Currency",
+              fieldAlias: {
+                regions: {
+                  path: "region_link.region",
+                  isList: true,
+                  forwardArgumentsOnPath: ["region_link.region"],
+                },
+              },
+              relationship: {
+                serviceName: "CurrencyCurrencyRegionRegionLink",
+                entity: "LinkCurrencyCurrencyRegionRegion",
+                primaryKey: "currency_code",
+                foreignKey: "code",
+                alias: "region_link",
+                isList: true,
+              },
+            },
+            {
+              serviceName: "region",
+              entity: "Region",
+              fieldAlias: {
+                currency: {
+                  path: "currency_link.currency",
+                  isList: false,
+                  forwardArgumentsOnPath: ["currency_link.currency"],
+                },
+              },
+              relationship: {
+                serviceName: "CurrencyCurrencyRegionRegionLink",
+                entity: "LinkCurrencyCurrencyRegionRegion",
+                primaryKey: "region_id",
+                foreignKey: "id",
+                alias: "currency_link",
+                isList: false,
+              },
+            },
+          ],
+        })
+      })
+
+      it("should generate a proper link with both sides using explicit isList=true", async () => {
+        const currencyLinks = CurrencyModule.linkable
+        const regionLinks = RegionModule.linkable
+
+        const link = defineLink(
+          {
+            linkable: currencyLinks.currency,
+            isList: true,
+          },
+          {
+            linkable: regionLinks.region,
+            isList: true,
+          }
+        )
+
+        const linkDefinition = MedusaModule.getCustomLinks()
+          .map((linkDefinition: any) => {
+            const definition = linkDefinition(
+              MedusaModule.getAllJoinerConfigs()
+            )
+            return definition.serviceName === link.serviceName && definition
+          })
+          .filter(Boolean)[0]
+
+        expect(link.serviceName).toEqual("CurrencyCurrencyRegionRegionLink")
+        expect(linkDefinition).toEqual({
+          serviceName: "CurrencyCurrencyRegionRegionLink",
+          isLink: true,
+          alias: [
+            {
+              name: ["currency_region"],
+              args: {
+                entity: "LinkCurrencyCurrencyRegionRegion",
+              },
+            },
+          ],
+          primaryKeys: ["id", "currency_code", "region_id"],
+          relationships: [
+            {
+              serviceName: "currency",
+              entity: "Currency",
+              primaryKey: "code",
+              foreignKey: "currency_code",
+              isList: true,
+              createMultiple: true,
+              alias: "currency",
+              args: {
+                methodSuffix: "Currencies",
+              },
+              deleteCascade: false,
+            },
+            {
+              serviceName: "region",
+              entity: "Region",
+              primaryKey: "id",
+              foreignKey: "region_id",
+              isList: true,
+              createMultiple: true,
               alias: "region",
               args: {
                 methodSuffix: "Regions",
@@ -410,6 +526,114 @@ medusaIntegrationTestRunner({
                 foreignKey: "id",
                 alias: "currency_link",
                 isList: true,
+              },
+            },
+          ],
+        })
+      })
+
+      it("should generate a proper link with both sides using explicit isList=false", async () => {
+        const currencyLinks = CurrencyModule.linkable
+        const regionLinks = RegionModule.linkable
+
+        const link = defineLink(
+          {
+            linkable: currencyLinks.currency,
+            isList: false,
+          },
+          {
+            linkable: regionLinks.region,
+            isList: false,
+          }
+        )
+
+        const linkDefinition = MedusaModule.getCustomLinks()
+          .map((linkDefinition: any) => {
+            const definition = linkDefinition(
+              MedusaModule.getAllJoinerConfigs()
+            )
+            return definition.serviceName === link.serviceName && definition
+          })
+          .filter(Boolean)[0]
+
+        expect(link.serviceName).toEqual("CurrencyCurrencyRegionRegionLink")
+        expect(linkDefinition).toEqual({
+          serviceName: "CurrencyCurrencyRegionRegionLink",
+          isLink: true,
+          alias: [
+            {
+              name: ["currency_region"],
+              args: {
+                entity: "LinkCurrencyCurrencyRegionRegion",
+              },
+            },
+          ],
+          primaryKeys: ["id", "currency_code", "region_id"],
+          relationships: [
+            {
+              serviceName: "currency",
+              entity: "Currency",
+              primaryKey: "code",
+              foreignKey: "currency_code",
+              isList: false,
+              createMultiple: false,
+              alias: "currency",
+              args: {
+                methodSuffix: "Currencies",
+              },
+              deleteCascade: false,
+            },
+            {
+              serviceName: "region",
+              entity: "Region",
+              primaryKey: "id",
+              foreignKey: "region_id",
+              isList: false,
+              createMultiple: false,
+              alias: "region",
+              args: {
+                methodSuffix: "Regions",
+              },
+              deleteCascade: false,
+            },
+          ],
+          extends: [
+            {
+              serviceName: "currency",
+              entity: "Currency",
+              fieldAlias: {
+                region: {
+                  path: "region_link.region",
+                  isList: false,
+                  forwardArgumentsOnPath: ["region_link.region"],
+                },
+              },
+              relationship: {
+                serviceName: "CurrencyCurrencyRegionRegionLink",
+                entity: "LinkCurrencyCurrencyRegionRegion",
+                primaryKey: "currency_code",
+                foreignKey: "code",
+                alias: "region_link",
+                isList: false,
+              },
+            },
+            {
+              serviceName: "region",
+              entity: "Region",
+              fieldAlias: {
+                currency: {
+                  path: "currency_link.currency",
+                  isList: false,
+                  forwardArgumentsOnPath: ["currency_link.currency"],
+                },
+              },
+              relationship: {
+                serviceName: "CurrencyCurrencyRegionRegionLink",
+                entity: "LinkCurrencyCurrencyRegionRegion",
+                primaryKey: "region_id",
+                foreignKey: "id",
+                alias: "currency_link",
+                isList: false,
               },
             },
           ],

--- a/integration-tests/modules/__tests__/link-modules/define-link.spec.ts
+++ b/integration-tests/modules/__tests__/link-modules/define-link.spec.ts
@@ -46,7 +46,7 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              hasMany: true,
+              hasMany: false,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -147,7 +147,7 @@ medusaIntegrationTestRunner({
               entity: "ProductVariant",
               primaryKey: "id",
               foreignKey: "product_variant_id",
-              hasMany: true,
+              hasMany: false,
               alias: "product_variant",
               args: {
                 methodSuffix: "ProductVariants",
@@ -253,7 +253,7 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              hasMany: true,
+              hasMany: false,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -353,7 +353,7 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              hasMany: true,
+              hasMany: false,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",

--- a/integration-tests/modules/__tests__/link-modules/define-link.spec.ts
+++ b/integration-tests/modules/__tests__/link-modules/define-link.spec.ts
@@ -46,8 +46,7 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              isList: false,
-              createMultiple: true,
+              hasMany: true,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -60,8 +59,7 @@ medusaIntegrationTestRunner({
               primaryKey: "id",
               foreignKey: "region_id",
               alias: "region",
-              isList: false,
-              createMultiple: false,
+              hasMany: false,
               args: {
                 methodSuffix: "Regions",
               },
@@ -149,8 +147,7 @@ medusaIntegrationTestRunner({
               entity: "ProductVariant",
               primaryKey: "id",
               foreignKey: "product_variant_id",
-              isList: false,
-              createMultiple: true,
+              hasMany: true,
               alias: "product_variant",
               args: {
                 methodSuffix: "ProductVariants",
@@ -162,8 +159,7 @@ medusaIntegrationTestRunner({
               entity: "Region",
               primaryKey: "id",
               foreignKey: "region_id",
-              isList: false,
-              createMultiple: false,
+              hasMany: false,
               alias: "region",
               args: {
                 methodSuffix: "Regions",
@@ -257,8 +253,7 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              isList: false,
-              createMultiple: true,
+              hasMany: true,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -270,8 +265,7 @@ medusaIntegrationTestRunner({
               entity: "Region",
               primaryKey: "id",
               foreignKey: "region_id",
-              isList: false,
-              createMultiple: false,
+              hasMany: false,
               alias: "region",
               args: {
                 methodSuffix: "Regions",
@@ -359,8 +353,7 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              isList: false,
-              createMultiple: true,
+              hasMany: true,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -372,8 +365,7 @@ medusaIntegrationTestRunner({
               entity: "Region",
               primaryKey: "id",
               foreignKey: "region_id",
-              isList: true,
-              createMultiple: true,
+              hasMany: true,
               alias: "region",
               args: {
                 methodSuffix: "Regions",
@@ -467,8 +459,7 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              isList: true,
-              createMultiple: true,
+              hasMany: true,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -480,8 +471,7 @@ medusaIntegrationTestRunner({
               entity: "Region",
               primaryKey: "id",
               foreignKey: "region_id",
-              isList: true,
-              createMultiple: true,
+              hasMany: true,
               alias: "region",
               args: {
                 methodSuffix: "Regions",
@@ -575,8 +565,7 @@ medusaIntegrationTestRunner({
               entity: "Currency",
               primaryKey: "code",
               foreignKey: "currency_code",
-              isList: false,
-              createMultiple: false,
+              hasMany: false,
               alias: "currency",
               args: {
                 methodSuffix: "Currencies",
@@ -588,8 +577,7 @@ medusaIntegrationTestRunner({
               entity: "Region",
               primaryKey: "id",
               foreignKey: "region_id",
-              isList: false,
-              createMultiple: false,
+              hasMany: false,
               alias: "region",
               args: {
                 methodSuffix: "Regions",

--- a/packages/core/modules-sdk/src/__mocks__/inventory-module.ts
+++ b/packages/core/modules-sdk/src/__mocks__/inventory-module.ts
@@ -21,5 +21,6 @@ export const InventoryModule = {
     },
   },
 
+  list: jest.fn(async () => []),
   softDelete: jest.fn(() => {}),
 }

--- a/packages/core/modules-sdk/src/__mocks__/inventory-stock-location-link.ts
+++ b/packages/core/modules-sdk/src/__mocks__/inventory-stock-location-link.ts
@@ -65,5 +65,6 @@ export const InventoryStockLocationLink = {
       foreignKeyData?: string
     ) => {}
   ),
+  list: jest.fn(async () => []),
   softDelete: jest.fn(() => {}),
 }

--- a/packages/core/modules-sdk/src/__mocks__/product-inventory-link.ts
+++ b/packages/core/modules-sdk/src/__mocks__/product-inventory-link.ts
@@ -71,5 +71,6 @@ export const ProductInventoryLinkModule = {
       foreignKeyData?: string
     ) => {}
   ),
+  list: jest.fn(async () => []),
   softDelete: jest.fn(() => {}),
 }

--- a/packages/core/modules-sdk/src/__mocks__/product-module.ts
+++ b/packages/core/modules-sdk/src/__mocks__/product-module.ts
@@ -18,5 +18,6 @@ export const ProductModule = {
     alias: [],
   },
 
+  list: jest.fn(async () => []),
   softDelete: jest.fn(() => {}),
 }

--- a/packages/core/modules-sdk/src/__mocks__/stock-location-module.ts
+++ b/packages/core/modules-sdk/src/__mocks__/stock-location-module.ts
@@ -18,5 +18,6 @@ export const StockLocationModule = {
     alias: [],
   },
 
+  list: jest.fn(async () => []),
   softDelete: jest.fn(() => {}),
 }

--- a/packages/core/modules-sdk/src/link.ts
+++ b/packages/core/modules-sdk/src/link.ts
@@ -412,7 +412,7 @@ export class Link {
 
           /**
            * An array of objects to validate for uniqueness before persisting
-           * data to the pivot table. When a link uses "isList: false", we
+           * data to the pivot table. When a link uses "createMultiple: false", we
            * have to limit a relationship with this entity to be a one-to-one
            * or one-to-many
            */
@@ -431,20 +431,20 @@ export class Link {
         linksToValidateForUniqueness.services.push(relationship.serviceName)
 
         /**
-         * When isList is set on false on the relationship, then it means
+         * When createMultiple is set on false on the relationship, then it means
          * we have a one-to-one or many-to-one relationship with the
          * other side and we have limit duplicate entries from other
          * entity. For example:
          *
          * - A brand has a many to one relationship with a product.
-         * - A product can have only one brand. Aka (brand.isList = false)
-         * - A brand can have multiple products. Aka (products.isList = true)
+         * - A product can have only one brand. Aka (brand.createMultiple = false)
+         * - A brand can have multiple products. Aka (products.createMultiple = true)
          *
          * A result of this, we have to ensure that a product_id can only appear
          * once in the pivot table that is used for tracking "brand<>products"
          * relationship.
          */
-        if (relationship.isList === false) {
+        if (relationship.createMultiple === false) {
           const otherSide = relationships.find(
             (other) => other.foreignKey !== relationship.foreignKey
           )

--- a/packages/core/types/src/joiner/index.ts
+++ b/packages/core/types/src/joiner/index.ts
@@ -9,11 +9,6 @@ export type JoinerRelationship = {
    */
   inverse?: boolean
   /**
-   * Allow multiple relationships to exist for this
-   * entity
-   */
-  createMultiple?: boolean
-  /**
    * Force the relationship to return a list
    */
   isList?: boolean

--- a/packages/core/types/src/joiner/index.ts
+++ b/packages/core/types/src/joiner/index.ts
@@ -9,6 +9,11 @@ export type JoinerRelationship = {
    */
   inverse?: boolean
   /**
+   * Allow multiple relationships to exist for this
+   * entity
+   */
+  createMultiple?: boolean
+  /**
    * Force the relationship to return a list
    */
   isList?: boolean

--- a/packages/core/types/src/modules-sdk/index.ts
+++ b/packages/core/types/src/modules-sdk/index.ts
@@ -209,7 +209,7 @@ export type ModuleJoinerConfig = Omit<
           isList?: boolean
         }
     > // alias for deeper nested relationships (e.g. { 'price': 'prices.calculated_price_set.amount' })
-    relationship: ModuleJoinerRelationship
+    relationship: Omit<ModuleJoinerRelationship, "hasMany">
   }[]
   serviceName?: string
   primaryKeys?: string[]
@@ -248,6 +248,11 @@ export declare type ModuleJoinerRelationship = JoinerRelationship & {
    * If true, the link joiner will cascade deleting the relationship
    */
   deleteCascade?: boolean
+  /**
+   * Allow multiple relationships to exist for this
+   * entity
+   */
+  hasMany?: boolean
 }
 
 export type ModuleExports<T = Constructor<any>> = {

--- a/packages/core/utils/src/modules-sdk/define-link.ts
+++ b/packages/core/utils/src/modules-sdk/define-link.ts
@@ -85,6 +85,7 @@ type ModuleLinkableKeyConfig = {
   deleteCascade?: boolean
   primaryKey: string
   alias: string
+  hasMany?: boolean
   shortcut?: Shortcut | Shortcut[]
 }
 
@@ -125,16 +126,12 @@ function buildFieldAlias(fieldAliases?: Shortcut | Shortcut[]) {
 }
 
 function prepareServiceConfig(
-  input: DefineLinkInputSource | DefineReadOnlyLinkInputSource,
-  defaultOptions?: { hasMany?: boolean }
+  input: DefineLinkInputSource | DefineReadOnlyLinkInputSource
 ) {
-  let serviceConfig = {} as ModuleLinkableKeyConfig & {
-    hasMany: boolean
-  }
+  let serviceConfig = {} as ModuleLinkableKeyConfig
 
   if (isInputSource(input)) {
     const source = isToJSON(input) ? input.toJSON() : input
-    const hasMany = defaultOptions?.hasMany ?? false
 
     serviceConfig = {
       key: source.linkable,
@@ -142,7 +139,7 @@ function prepareServiceConfig(
       field: input.field ?? source.field,
       primaryKey: source.primaryKey,
       isList: false,
-      hasMany,
+      hasMany: false,
       deleteCascade: false,
       module: source.serviceName,
       entity: source.entity,
@@ -152,7 +149,7 @@ function prepareServiceConfig(
       ? input.linkable.toJSON()
       : input.linkable
 
-    const hasMany = input.isList ?? defaultOptions?.hasMany ?? false
+    const hasMany = !!input.isList
 
     serviceConfig = {
       key: source.linkable,
@@ -191,12 +188,8 @@ export function defineLink(
   rightService: DefineLinkInputSource | DefineReadOnlyLinkInputSource,
   linkServiceOptions?: ExtraOptions | ReadOnlyExtraOptions
 ): DefineLinkExport {
-  const serviceAObj = prepareServiceConfig(leftService, {
-    hasMany: true,
-  })
-  const serviceBObj = prepareServiceConfig(rightService, {
-    hasMany: false,
-  })
+  const serviceAObj = prepareServiceConfig(leftService)
+  const serviceBObj = prepareServiceConfig(rightService)
 
   if (linkServiceOptions?.readOnly) {
     return defineReadOnlyLink(

--- a/packages/core/utils/src/modules-sdk/define-link.ts
+++ b/packages/core/utils/src/modules-sdk/define-link.ts
@@ -126,15 +126,15 @@ function buildFieldAlias(fieldAliases?: Shortcut | Shortcut[]) {
 
 function prepareServiceConfig(
   input: DefineLinkInputSource | DefineReadOnlyLinkInputSource,
-  defaultOptions?: { createMultiple?: boolean }
+  defaultOptions?: { hasMany?: boolean }
 ) {
   let serviceConfig = {} as ModuleLinkableKeyConfig & {
-    createMultiple: boolean
+    hasMany: boolean
   }
 
   if (isInputSource(input)) {
     const source = isToJSON(input) ? input.toJSON() : input
-    const createMultiple = defaultOptions?.createMultiple ?? false
+    const hasMany = defaultOptions?.hasMany ?? false
 
     serviceConfig = {
       key: source.linkable,
@@ -142,7 +142,7 @@ function prepareServiceConfig(
       field: input.field ?? source.field,
       primaryKey: source.primaryKey,
       isList: false,
-      createMultiple,
+      hasMany,
       deleteCascade: false,
       module: source.serviceName,
       entity: source.entity,
@@ -152,8 +152,7 @@ function prepareServiceConfig(
       ? input.linkable.toJSON()
       : input.linkable
 
-    const createMultiple =
-      input.isList ?? defaultOptions?.createMultiple ?? false
+    const hasMany = input.isList ?? defaultOptions?.hasMany ?? false
 
     serviceConfig = {
       key: source.linkable,
@@ -161,7 +160,7 @@ function prepareServiceConfig(
       field: input.field ?? source.field,
       primaryKey: source.primaryKey,
       isList: input.isList ?? false,
-      createMultiple,
+      hasMany,
       deleteCascade: input.deleteCascade ?? false,
       module: source.serviceName,
       entity: source.entity,
@@ -193,10 +192,10 @@ export function defineLink(
   linkServiceOptions?: ExtraOptions | ReadOnlyExtraOptions
 ): DefineLinkExport {
   const serviceAObj = prepareServiceConfig(leftService, {
-    createMultiple: true,
+    hasMany: true,
   })
   const serviceBObj = prepareServiceConfig(rightService, {
-    createMultiple: false,
+    hasMany: false,
   })
 
   if (linkServiceOptions?.readOnly) {
@@ -386,8 +385,7 @@ ${serviceBObj.module}: {
             methodSuffix: serviceAMethodSuffix,
           },
           deleteCascade: serviceAObj.deleteCascade,
-          isList: serviceAObj.isList,
-          createMultiple: serviceAObj.createMultiple,
+          hasMany: serviceAObj.hasMany,
         },
         {
           serviceName: serviceBObj.module,
@@ -399,8 +397,7 @@ ${serviceBObj.module}: {
             methodSuffix: serviceBMethodSuffix,
           },
           deleteCascade: serviceBObj.deleteCascade,
-          isList: serviceBObj.isList,
-          createMultiple: serviceBObj.createMultiple,
+          hasMany: serviceBObj.hasMany,
         },
       ],
       extends: [

--- a/packages/modules/link-modules/src/definitions/cart-promotion.ts
+++ b/packages/modules/link-modules/src/definitions/cart-promotion.ts
@@ -35,6 +35,7 @@ export const CartPromotion: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Promotions",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/cart-promotion.ts
+++ b/packages/modules/link-modules/src/definitions/cart-promotion.ts
@@ -25,6 +25,7 @@ export const CartPromotion: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Carts",
       },
+      hasMany: true,
     },
     {
       serviceName: Modules.PROMOTION,

--- a/packages/modules/link-modules/src/definitions/customer-account-holder.ts
+++ b/packages/modules/link-modules/src/definitions/customer-account-holder.ts
@@ -35,6 +35,7 @@ export const CustomerAccountHolder: ModuleJoinerConfig = {
       args: {
         methodSuffix: "AccountHolders",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/fulfillment-provider-location.ts
+++ b/packages/modules/link-modules/src/definitions/fulfillment-provider-location.ts
@@ -23,6 +23,7 @@ export const LocationFulfillmentProvider: ModuleJoinerConfig = {
       foreignKey: "stock_location_id",
       alias: "location",
       args: { methodSuffix: "StockLocations" },
+      hasMany: true,
     },
     {
       serviceName: Modules.FULFILLMENT,
@@ -31,6 +32,7 @@ export const LocationFulfillmentProvider: ModuleJoinerConfig = {
       foreignKey: "fulfillment_provider_id",
       alias: "fulfillment_provider",
       args: { methodSuffix: "FulfillmentProviders" },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/fulfillment-set-location.ts
+++ b/packages/modules/link-modules/src/definitions/fulfillment-set-location.ts
@@ -36,6 +36,7 @@ export const LocationFulfillmentSet: ModuleJoinerConfig = {
         methodSuffix: "FulfillmentSets",
       },
       deleteCascade: true,
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/order-claim-payment-collection.ts
+++ b/packages/modules/link-modules/src/definitions/order-claim-payment-collection.ts
@@ -38,6 +38,7 @@ export const OrderClaimPaymentCollection: ModuleJoinerConfig = {
       args: {
         methodSuffix: "PaymentCollections",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/order-exchange-payment-collection.ts
+++ b/packages/modules/link-modules/src/definitions/order-exchange-payment-collection.ts
@@ -38,6 +38,7 @@ export const OrderExchangePaymentCollection: ModuleJoinerConfig = {
       args: {
         methodSuffix: "PaymentCollections",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/order-fulfillment.ts
+++ b/packages/modules/link-modules/src/definitions/order-fulfillment.ts
@@ -35,6 +35,7 @@ export const OrderFulfillment: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Fulfillments",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/order-payment-collection.ts
+++ b/packages/modules/link-modules/src/definitions/order-payment-collection.ts
@@ -36,6 +36,7 @@ export const OrderPaymentCollection: ModuleJoinerConfig = {
         methodSuffix: "PaymentCollections",
       },
       deleteCascade: true,
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/order-promotion.ts
+++ b/packages/modules/link-modules/src/definitions/order-promotion.ts
@@ -35,6 +35,7 @@ export const OrderPromotion: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Promotions",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/order-promotion.ts
+++ b/packages/modules/link-modules/src/definitions/order-promotion.ts
@@ -25,6 +25,7 @@ export const OrderPromotion: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Orders",
       },
+      hasMany: true,
     },
     {
       serviceName: Modules.PROMOTION,

--- a/packages/modules/link-modules/src/definitions/order-return-fulfillment.ts
+++ b/packages/modules/link-modules/src/definitions/order-return-fulfillment.ts
@@ -35,6 +35,7 @@ export const ReturnFulfillment: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Fulfillments",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/product-sales-channel.ts
+++ b/packages/modules/link-modules/src/definitions/product-sales-channel.ts
@@ -27,6 +27,7 @@ export const ProductSalesChannel: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Products",
       },
+      hasMany: true,
     },
     {
       serviceName: Modules.SALES_CHANNEL,

--- a/packages/modules/link-modules/src/definitions/product-sales-channel.ts
+++ b/packages/modules/link-modules/src/definitions/product-sales-channel.ts
@@ -37,6 +37,7 @@ export const ProductSalesChannel: ModuleJoinerConfig = {
       args: {
         methodSuffix: "SalesChannels",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/product-shipping-profile.ts
+++ b/packages/modules/link-modules/src/definitions/product-shipping-profile.ts
@@ -27,6 +27,7 @@ export const ProductShippingProfile: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Products",
       },
+      hasMany: true,
     },
     {
       serviceName: Modules.FULFILLMENT,

--- a/packages/modules/link-modules/src/definitions/product-variant-inventory-item.ts
+++ b/packages/modules/link-modules/src/definitions/product-variant-inventory-item.ts
@@ -34,6 +34,7 @@ export const ProductVariantInventoryItem: ModuleJoinerConfig = {
       args: {
         methodSuffix: "ProductVariants",
       },
+      hasMany: true,
     },
     {
       serviceName: Modules.INVENTORY,
@@ -44,6 +45,7 @@ export const ProductVariantInventoryItem: ModuleJoinerConfig = {
       args: {
         methodSuffix: "InventoryItems",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/publishable-api-key-sales-channel.ts
+++ b/packages/modules/link-modules/src/definitions/publishable-api-key-sales-channel.ts
@@ -27,6 +27,7 @@ export const PublishableApiKeySalesChannel: ModuleJoinerConfig = {
       args: {
         methodSuffix: "ApiKeys",
       },
+      hasMany: true,
     },
     {
       serviceName: Modules.SALES_CHANNEL,
@@ -37,6 +38,7 @@ export const PublishableApiKeySalesChannel: ModuleJoinerConfig = {
       args: {
         methodSuffix: "SalesChannels",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/region-payment-provider.ts
+++ b/packages/modules/link-modules/src/definitions/region-payment-provider.ts
@@ -25,6 +25,7 @@ export const RegionPaymentProvider: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Regions",
       },
+      hasMany: true,
     },
     {
       serviceName: Modules.PAYMENT,
@@ -33,6 +34,7 @@ export const RegionPaymentProvider: ModuleJoinerConfig = {
       foreignKey: "payment_provider_id",
       alias: "payment_provider",
       args: { methodSuffix: "PaymentProviders" },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/sales-channel-location.ts
+++ b/packages/modules/link-modules/src/definitions/sales-channel-location.ts
@@ -25,6 +25,7 @@ export const SalesChannelLocation: ModuleJoinerConfig = {
       args: {
         methodSuffix: "SalesChannels",
       },
+      hasMany: true,
     },
     {
       serviceName: Modules.STOCK_LOCATION,
@@ -35,6 +36,7 @@ export const SalesChannelLocation: ModuleJoinerConfig = {
       args: {
         methodSuffix: "StockLocations",
       },
+      hasMany: true,
     },
   ],
   extends: [


### PR DESCRIPTION
Earlier we used the `isList` flag to enforce uniqueness constraint on a link. However, that leads to a breaking change with the remote query when the `isList` is not explicitly provided. For example:

When `isList` is not provided, we want the `isList` to be `false` (as earlier). However, we want to allow creating multiple links from the primary service. This lead us to changing the default from `isList=false` to `isList=true`, but that had a breaking change in the remote query types and naming scheme.

In this PR, we separate both the concepts and have an internal flag called `createMultiple`. This flag has different defaults from the `isList` flag but infers its value from the `isList` flag when defined explicitly. 