### PR TITLE
Docs/deploying on aws terraform

### DIFF
--- a/www/apps/resources/app/deployment/medusa-application/aws-terraform/page.mdx
+++ b/www/apps/resources/app/deployment/medusa-application/aws-terraform/page.mdx
@@ -1,0 +1,215 @@
+---
+sidebar_label: "AWS Terraform"
+---
+
+import { Prerequisites } from "docs-ui"
+
+export const metadata = {
+  title: `Deploy the Medusa Backend using the Terraform Module on AWS`,
+}
+
+# {metadata.title}
+
+This guide explains how to use the [**Terraform module for Medusa**](https://registry.terraform.io/modules/u11d-com/medusajs/aws) to deploy a production-ready e-commerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices. It provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized Medusa deployments.
+
+
+## Introduction
+
+### What is Terraform?
+Terraform is an infrastructure-as-code tool that allows you to define and provision cloud resources using code. It simplifies the process of managing cloud infrastructure and ensures consistency across environments. Learn more about Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/infrastructure-as-code).
+
+### Why Use Terraform Module for Medusa?
+[Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) simplifies the deployment of Medusa on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
+
+---
+
+## Prerequisites
+
+Before using Terraform module for Medusa, ensure you have the following tools and accounts set up:
+
+### Tools Required
+- **Terraform CLI**: Install Terraform by following the [official installation guide](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
+- **AWS CLI**: Install the AWS CLI by following the [official installation guide](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
+- **Node.js**: Install Node.js from the [official website](https://nodejs.org/).
+
+### AWS Account Setup
+- **Create an AWS Account**: If you don’t already have an AWS account, follow the [AWS Getting Started Guide](https://docs.aws.amazon.com/accounts/latest/reference/getting-started.html) to create one.
+- **Configure AWS Credentials**: Set up your AWS credentials for Terraform by following the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html).
+
+---
+
+## Architectural Decisions Behind the Terraform Module
+When designing the Terraform module for Medusa, we prioritized scalability, security, and performance while minimizing the operational overhead for development teams. To achieve this, we selected fully managed AWS services, allowing teams to focus on building e-commerce solutions without the complexity of maintaining cloud infrastructure.
+
+Key architectural decisions include:
+- Use of Managed Services: All core components — such as Amazon RDS for PostgreSQL, Amazon ElastiCache for Redis, and the Application Load Balancer (ALB) — are fully managed services. This eliminates the need for teams to handle infrastructure maintenance tasks like patching, backups, and scaling operations.
+- Containerization with AWS Fargate: We run Medusa services as ECS tasks on AWS Fargate, removing the need for Kubernetes cluster management. Teams can focus on defining scaling policies without worrying about the underlying infrastructure.
+- Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate [repository](https://github.com/u11d-com/medusa-starter/tree/v2)). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
+
+By leveraging managed services, this architecture reduces the time, effort, and expertise required to maintain infrastructure. It provides the flexibility to control scalability while ensuring high availability, robust security, and optimal performance — allowing development teams to concentrate on delivering business value through their e-commerce platforms.
+
+## Overview of the Terraform Module
+
+The [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) sets up the following AWS resources to support Medusa:
+
+### Core Infrastructure
+- RDS for PostgreSQL: A managed relational database for storing Medusa data.
+- ElastiCache (Redis): A caching layer to improve performance.
+- AWS Fargate for ECS Backend Tasks: Runs the Medusa backend as containerized tasks.
+- Amazon S3: Cloud object storage that ensures scalability, data availability, security, and performance.
+- Application Load Balancer (ALB): Distributes incoming traffic to backend tasks.
+
+### Optional Infrastructure
+- Elastic Container Registry (ECR): Stores Docker images for the backend and frontend (if enabled).
+- Frontend ECS Tasks: Runs the frontend application (if enabled).
+- CloudFront: A CDN that serves the frontend with low latency (if enabled).
+
+### Mapping Medusa Architectural Modules to AWS Infrastructure
+
+| Medusa Architectural Module | AWS Provisioned Infrastructure | Notes |
+|----------------------------|-------------------------------|--------|
+| Internal Database | Amazon RDS for PostgreSQL | |
+| [Cache Modules](https://docs.medusajs.com/resources/architectural-modules/cache/redis) | Amazon ElastiCache | |
+| [Event Modules](https://docs.medusajs.com/resources/architectural-modules/event/redis) | Amazon ElastiCache | |
+| [File Module Providers](https://docs.medusajs.com/resources/architectural-modules/file/s3) | Amazon S3 | |
+| [Workflow Engine Modules](https://docs.medusajs.com/resources/architectural-modules/workflow-engine/redis) | Amazon ElastiCache | |
+| Notification Module Providers | Amazon SES | *Planned for future implementation* |
+
+---
+
+## Step-by-Step Guide to Using the Terraform Module
+
+### Step 1: Download or Clone the Module
+Clone the Terraform module repository to your local machine:
+```bash
+git clone https://github.com/u11d-com/terraform-aws-medusajs
+cd terraform-u11d-medusajs/examples/minimal
+```
+
+### Step 2: Provide Variables for the Module
+See module inputs documentation for available configuration options.
+[Example configurations](https://registry.terraform.io/modules/u11d-com/medusajs/aws) as a reference.
+
+Example variables:
+```hcl
+backend_container_image = "your-medusa-backend-image:v2.5.1"
+project     = "medusa"
+environment = "prod"
+owner       = "my-team"
+```
+
+### Step 3: Initialize Terraform
+Run the following command to initialize Terraform and download the required providers:
+```bash
+terraform init
+```
+
+### Step 4: Plan the Infrastructure
+Preview the resources that Terraform will create:
+```bash
+terraform plan
+```
+
+### Step 5: Apply the Infrastructure
+Deploy the infrastructure by running:
+```bash
+terraform apply
+```
+Confirm the deployment by typing `yes` when prompted.
+
+### Step 6: Verify the Setup
+1. Check the Terraform outputs for the Medusa backend URL.
+2. Use the URL to verify that the backend is running.
+
+
+## Connecting Medusa to the Deployed Infrastructure
+
+Once the infrastructure is deployed, the Medusa backend URL will be available in the Terraform outputs. Use this URL to connect your Medusa application to the deployed backend.
+
+
+### Configuring Medusa with Provisioned AWS Services
+In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your Medusa application:
+
+1. Configure S3 and Redis Plugins:
+- Set up the appropriate Medusa plugins for S3 and Redis to enable object storage and caching functionalities ([example](https://github.com/u11d-com/medusa-starter/blob/v2/backend/medusa-config.ts))
+  - [Redis Cache Module](https://docs.medusajs.com/resources/architectural-modules/cache/redis)
+  - [File Service - S3 plugin](https://docs.medusajs.com/resources/architectural-modules/file/s3)
+- The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
+
+2. Use Predefined Environment Variables:
+- The Terraform module automatically generates all necessary environment variables, following Medusa’s naming conventions.
+- These variables simplify the configuration process, ensuring seamless compatibility with Medusa.
+
+All internal connections between services are securely configured with proper access controls, reducing the need for additional security configurations.
+By following these steps, you’ll ensure your Medusa application is fully integrated with the cloud infrastructure, optimized for performance, scalability, and security.
+
+## Optional Features
+
+### Enable ECR for Container Images
+To create an ECR repository for storing container images, provide the following variable:
+```hcl
+ecr_backend_create = true
+ecr_storefront_create = true
+```
+
+See [ECR Documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html) to learn how to log in and push images.
+
+### Use an External Image Repository
+If you’re using an external image repository, provide the repository address and image tag as variables, optionally you might need to provide credentials for repository:
+```hcl
+backend_container_image = "your-repo/medusa-backend:v2.5.1"
+backend_container_registry_credentials = {
+    username = "your-registry-username"
+    password = "your-registry-password"
+  }
+storefront_container_image = "your-repo/medusa-backend:v2.5.1"
+storefront_container_registry_credentials = {
+    username = "your-registry-username"
+    password = "your-registry-password"
+  }
+```
+
+## Common Issues and Troubleshooting
+
+### Common Errors
+- AWS Permission Errors: Ensure your AWS credentials are correctly configured.
+- Terraform State Issues: Avoid manually modifying resources created by Terraform.
+
+### Clean Up Resources
+To delete all resources created by Terraform, run:
+```bash
+terraform destroy
+```
+
+---
+
+## Next Steps
+- Learn how to set up Medusa locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter/tree/v2).
+- Explore the Medusa starter templates:
+  - [Backend Starter Template](https://github.com/medusajs/medusa-starter-default).
+  - [Frontend Starter Template](https://github.com/medusajs/nextjs-starter-medusa).
+
+
+### Deploy the Frontend
+Medusa starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the Medusa backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
+
+To deploy the frontend, provide the following variables:
+```hcl
+storefront_create = true
+storefront_container_image  = "your-repo/frontend:v1.20.11"
+```
+
+For a detailed step-by-step guide on building, pushing, and configuring the storefront container image, refer to the [Storefront Deployment Guide](../storefront/deploying-next-on-aws-using-terraform.md). Following this guide ensures that your storefront is correctly built, stored in AWS ECR, and integrated with the Terraform module.
+
+---
+
+## FAQs
+
+### Can I use this for local development?
+No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter/tree/v2) to set up Medusa locally.
+
+### How do I update the infrastructure?
+Modify the Terraform configuration files and run `terraform apply` to apply the changes.
+
+---
+:heart: _Technology made with passion by [u11d](https://u11d.com)_

--- a/www/apps/resources/app/deployment/medusa-application/aws-terraform/page.mdx
+++ b/www/apps/resources/app/deployment/medusa-application/aws-terraform/page.mdx
@@ -92,7 +92,7 @@ See module inputs documentation for available configuration options.
 
 Example variables:
 ```hcl
-backend_container_image = "your-medusa-backend-image:v2.5.1"
+backend_container_image = "your-medusa-backend-image:v2.6.1"
 project     = "medusa"
 environment = "prod"
 owner       = "my-team"
@@ -124,8 +124,7 @@ Confirm the deployment by typing `yes` when prompted.
 
 ## Connecting Medusa to the Deployed Infrastructure
 
-Once the infrastructure is deployed, the Medusa backend URL will be available in the Terraform outputs. Use this URL to connect your Medusa application to the deployed backend.
-
+Once the infrastructure is deployed, the Medusa backend URL will be available in the Terraform outputs. Use this URL to connect your storefront application to the deployed backend.
 
 ### Configuring Medusa with Provisioned AWS Services
 In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your Medusa application:
@@ -157,12 +156,12 @@ See [ECR Documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/r
 ### Use an External Image Repository
 If you’re using an external image repository, provide the repository address and image tag as variables, optionally you might need to provide credentials for repository:
 ```hcl
-backend_container_image = "your-repo/medusa-backend:v2.5.1"
+backend_container_image = "your-repo/medusa-backend:v2.6.1"
 backend_container_registry_credentials = {
     username = "your-registry-username"
     password = "your-registry-password"
   }
-storefront_container_image = "your-repo/medusa-backend:v2.5.1"
+storefront_container_image = "your-repo/medusa-backend:v2.6.1"
 storefront_container_registry_credentials = {
     username = "your-registry-username"
     password = "your-registry-password"
@@ -189,17 +188,16 @@ terraform destroy
   - [Backend Starter Template](https://github.com/medusajs/medusa-starter-default).
   - [Frontend Starter Template](https://github.com/medusajs/nextjs-starter-medusa).
 
-
 ### Deploy the Frontend
 Medusa starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the Medusa backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
 
 To deploy the frontend, provide the following variables:
 ```hcl
 storefront_create = true
-storefront_container_image  = "your-repo/frontend:v1.20.11"
+storefront_container_image  = "your-repo/frontend:v2.6.1"
 ```
 
-For a detailed step-by-step guide on building, pushing, and configuring the storefront container image, refer to the [Storefront Deployment Guide](../storefront/deploying-next-on-aws-using-terraform.md). Following this guide ensures that your storefront is correctly built, stored in AWS ECR, and integrated with the Terraform module.
+For a detailed step-by-step guide on building, pushing, and configuring the storefront container image, refer to the [Storefront Deployment Guide](../../storefront/aws-terraform/page.mdx). Following this guide ensures that your storefront is correctly built, stored in AWS ECR, and integrated with the Terraform module.
 
 ---
 

--- a/www/apps/resources/app/deployment/medusa-application/aws-terraform/page.mdx
+++ b/www/apps/resources/app/deployment/medusa-application/aws-terraform/page.mdx
@@ -12,13 +12,14 @@ export const metadata = {
 
 This guide explains how to use the [**Terraform module for Medusa**](https://registry.terraform.io/modules/u11d-com/medusajs/aws) to deploy a production-ready e-commerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices. It provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized Medusa deployments.
 
-
 ## Introduction
 
 ### What is Terraform?
+
 Terraform is an infrastructure-as-code tool that allows you to define and provision cloud resources using code. It simplifies the process of managing cloud infrastructure and ensures consistency across environments. Learn more about Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/infrastructure-as-code).
 
 ### Why Use Terraform Module for Medusa?
+
 [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) simplifies the deployment of Medusa on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
 
 ---
@@ -28,20 +29,24 @@ Terraform is an infrastructure-as-code tool that allows you to define and provis
 Before using Terraform module for Medusa, ensure you have the following tools and accounts set up:
 
 ### Tools Required
+
 - **Terraform CLI**: Install Terraform by following the [official installation guide](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
 - **AWS CLI**: Install the AWS CLI by following the [official installation guide](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
 - **Node.js**: Install Node.js from the [official website](https://nodejs.org/).
 
 ### AWS Account Setup
+
 - **Create an AWS Account**: If you don’t already have an AWS account, follow the [AWS Getting Started Guide](https://docs.aws.amazon.com/accounts/latest/reference/getting-started.html) to create one.
 - **Configure AWS Credentials**: Set up your AWS credentials for Terraform by following the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html).
 
 ---
 
 ## Architectural Decisions Behind the Terraform Module
+
 When designing the Terraform module for Medusa, we prioritized scalability, security, and performance while minimizing the operational overhead for development teams. To achieve this, we selected fully managed AWS services, allowing teams to focus on building e-commerce solutions without the complexity of maintaining cloud infrastructure.
 
 Key architectural decisions include:
+
 - Use of Managed Services: All core components — such as Amazon RDS for PostgreSQL, Amazon ElastiCache for Redis, and the Application Load Balancer (ALB) — are fully managed services. This eliminates the need for teams to handle infrastructure maintenance tasks like patching, backups, and scaling operations.
 - Containerization with AWS Fargate: We run Medusa services as ECS tasks on AWS Fargate, removing the need for Kubernetes cluster management. Teams can focus on defining scaling policies without worrying about the underlying infrastructure.
 - Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate [repository](https://github.com/u11d-com/medusa-starter/tree/v2)). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
@@ -53,6 +58,7 @@ By leveraging managed services, this architecture reduces the time, effort, and 
 The [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) sets up the following AWS resources to support Medusa:
 
 ### Core Infrastructure
+
 - RDS for PostgreSQL: A managed relational database for storing Medusa data.
 - ElastiCache (Redis): A caching layer to improve performance.
 - AWS Fargate for ECS Backend Tasks: Runs the Medusa backend as containerized tasks.
@@ -60,6 +66,7 @@ The [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com
 - Application Load Balancer (ALB): Distributes incoming traffic to backend tasks.
 
 ### Optional Infrastructure
+
 - Elastic Container Registry (ECR): Stores Docker images for the backend and frontend (if enabled).
 - Frontend ECS Tasks: Runs the frontend application (if enabled).
 - CloudFront: A CDN that serves the frontend with low latency (if enabled).
@@ -80,17 +87,21 @@ The [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com
 ## Step-by-Step Guide to Using the Terraform Module
 
 ### Step 1: Download or Clone the Module
+
 Clone the Terraform module repository to your local machine:
-```bash
+
+```shell
 git clone https://github.com/u11d-com/terraform-aws-medusajs
 cd terraform-u11d-medusajs/examples/minimal
 ```
 
 ### Step 2: Provide Variables for the Module
+
 See module inputs documentation for available configuration options.
 [Example configurations](https://registry.terraform.io/modules/u11d-com/medusajs/aws) as a reference.
 
 Example variables:
+
 ```hcl
 backend_container_image = "your-medusa-backend-image:v2.6.1"
 project     = "medusa"
@@ -99,43 +110,53 @@ owner       = "my-team"
 ```
 
 ### Step 3: Initialize Terraform
+
 Run the following command to initialize Terraform and download the required providers:
-```bash
+
+```shell
 terraform init
 ```
 
 ### Step 4: Plan the Infrastructure
+
 Preview the resources that Terraform will create:
-```bash
+
+```shell
 terraform plan
 ```
 
 ### Step 5: Apply the Infrastructure
+
 Deploy the infrastructure by running:
-```bash
+
+```shell
 terraform apply
 ```
+
 Confirm the deployment by typing `yes` when prompted.
 
 ### Step 6: Verify the Setup
+
 1. Check the Terraform outputs for the Medusa backend URL.
 2. Use the URL to verify that the backend is running.
-
 
 ## Connecting Medusa to the Deployed Infrastructure
 
 Once the infrastructure is deployed, the Medusa backend URL will be available in the Terraform outputs. Use this URL to connect your storefront application to the deployed backend.
 
 ### Configuring Medusa with Provisioned AWS Services
+
 In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your Medusa application:
 
 1. Configure S3 and Redis Plugins:
+
 - Set up the appropriate Medusa plugins for S3 and Redis to enable object storage and caching functionalities ([example](https://github.com/u11d-com/medusa-starter/blob/v2/backend/medusa-config.ts))
   - [Redis Cache Module](https://docs.medusajs.com/resources/architectural-modules/cache/redis)
   - [File Service - S3 plugin](https://docs.medusajs.com/resources/architectural-modules/file/s3)
 - The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
 
 2. Use Predefined Environment Variables:
+
 - The Terraform module automatically generates all necessary environment variables, following Medusa’s naming conventions.
 - These variables simplify the configuration process, ensuring seamless compatibility with Medusa.
 
@@ -145,7 +166,9 @@ By following these steps, you’ll ensure your Medusa application is fully integ
 ## Optional Features
 
 ### Enable ECR for Container Images
+
 To create an ECR repository for storing container images, provide the following variable:
+
 ```hcl
 ecr_backend_create = true
 ecr_storefront_create = true
@@ -154,7 +177,9 @@ ecr_storefront_create = true
 See [ECR Documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html) to learn how to log in and push images.
 
 ### Use an External Image Repository
+
 If you’re using an external image repository, provide the repository address and image tag as variables, optionally you might need to provide credentials for repository:
+
 ```hcl
 backend_container_image = "your-repo/medusa-backend:v2.6.1"
 backend_container_registry_credentials = {
@@ -171,27 +196,33 @@ storefront_container_registry_credentials = {
 ## Common Issues and Troubleshooting
 
 ### Common Errors
+
 - AWS Permission Errors: Ensure your AWS credentials are correctly configured.
 - Terraform State Issues: Avoid manually modifying resources created by Terraform.
 
 ### Clean Up Resources
+
 To delete all resources created by Terraform, run:
-```bash
+
+```shell
 terraform destroy
 ```
 
 ---
 
 ## Next Steps
+
 - Learn how to set up Medusa locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter/tree/v2).
 - Explore the Medusa starter templates:
   - [Backend Starter Template](https://github.com/medusajs/medusa-starter-default).
   - [Frontend Starter Template](https://github.com/medusajs/nextjs-starter-medusa).
 
 ### Deploy the Frontend
+
 Medusa starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the Medusa backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
 
 To deploy the frontend, provide the following variables:
+
 ```hcl
 storefront_create = true
 storefront_container_image  = "your-repo/frontend:v2.6.1"
@@ -204,10 +235,12 @@ For a detailed step-by-step guide on building, pushing, and configuring the stor
 ## FAQs
 
 ### Can I use this for local development?
+
 No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter/tree/v2) to set up Medusa locally.
 
 ### How do I update the infrastructure?
+
 Modify the Terraform configuration files and run `terraform apply` to apply the changes.
 
 ---
-:heart: _Technology made with passion by [u11d](https://u11d.com)_
+:heart: *Technology made with passion by [u11d](https://u11d.com)*

--- a/www/apps/resources/app/deployment/storefront/aws-terraform/page.mdx
+++ b/www/apps/resources/app/deployment/storefront/aws-terraform/page.mdx
@@ -15,6 +15,7 @@ This guide explains how to build the Medusa Storefront using the provided starte
 ## Prerequisites
 
 Before proceeding, ensure you have the following:
+
 - **Docker**: Installed and running on your machine. Download Docker [here](https://docs.docker.com/get-started/get-docker/).
 - **AWS CLI**: Installed and configured with your AWS credentials. Follow the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html) if you haven’t set it up yet.
 - **Git**: Installed on your machine. Download Git [here](https://git-scm.com/).
@@ -25,15 +26,18 @@ Before proceeding, ensure you have the following:
 ## Setting Up the Storefront Repository
 
 1. Clone the [`medusa-starter`](https://github.com/u11d-com/medusa-starter/tree/v2) repository to your local machine:
-  ```bash
+
+  ```shell
   git clone https://github.com/u11d-com/medusa-starter.git
   cd medusa-starter
   ```
 
 2. Navigate to the `storefront` directory and initialize the repository, this sets up the storefront based on the [Medusa Next.js starter template](https://github.com/medusajs/nextjs-starter-medusa)
-  ```bash
+
+  ```shell
   git clone https://github.com/medusajs/nextjs-starter-medusa.git
   ```
+
   Copy and replace files from storefront folder to created directory.
 
   This sets up the Medusa storefront starter template (Medusa v2).
@@ -43,20 +47,22 @@ Before proceeding, ensure you have the following:
 ## Building the Storefront Docker Container Image
 
 1. Aquire `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` from Medusa Admin Dashboard:
-  * Go to https://my.medusa.backend/app
-  * Log in with admin credentials
-  * Go to `Settings`, then `Publishable API Keys` under `Developer`
-  * Copy default token value.
+
+- Go to https://my.medusa.backend/app
+- Log in with admin credentials
+- Go to `Settings`, then `Publishable API Keys` under `Developer`
+- Copy default token value.
 
 2. Build the Docker container image for the storefront:
   When building a Docker image on a macOS machine (which uses Apple Silicon, typically ARM-based chips), you need to specify the --platform=linux/amd64 flag to ensure compatibility with AWS ECS, which commonly runs on x86_64 architecture.
 
-   ```bash
+   ```shell
    docker build --build-arg MEDUSA_BACKEND_URL="https://my.medusa.backend" --build-arg NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY="pk_testvalue123" -t medusa_storefront:2.0.0 .
    ```
-   - Replace `medusa_storefront:2.0.0` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:2.0.0`.
-   - Replace `https://my.medusa.backend` with your existing Medusa backend URL address.
-   - Replace `pk_testvalue123` with your existing publishable key.
+
+- Replace `medusa_storefront:2.0.0` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:2.0.0`.
+- Replace `https://my.medusa.backend` with your existing Medusa backend URL address.
+- Replace `pk_testvalue123` with your existing publishable key.
 
 ---
 
@@ -65,39 +71,51 @@ Before proceeding, ensure you have the following:
 To deploy the storefront, you’ll need to push the Docker container image to an AWS ECR repository. Follow these steps:
 
 ### Step 1: Authenticate Docker to Your ECR Repository
+
 Run the following command to authenticate Docker to your AWS ECR registry:
-```bash
+
+```shell
 aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
 ```
+
 Replace:
+
 - `<region>` with your desired AWS region code (for example, `eu-west-1`). You can find the complete list of region codes in the [AWS Regions documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions). Make sure to use the same region where your Amazon Elastic Container Registry (ECR) is deployed.
 - `<aws_account_id>` with your [AWS account ID](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html#FindAccountId).
   You can check it by running:
-  ```bash
+
+  ```shell
   aws sts get-caller-identity \
       --query Account \
       --output text
   ```
+
 If you created your ECR repository using the [Terraform Module for Medusa on AWS](https://registry.terraform.io/modules/u11d-com/medusajs/aws), you can find the ECR repository URL in the module's output values after deployment.
 
-
 ### Step 2: Tag the Docker Container Image
+
 Tag the Docker container image with your ECR repository URI:
-```bash
+
+```shell
 docker tag medusa_storefront:2.0.0 <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
 ```
+
 Replace:
+
 - `medusa_storefront:2.0.0` with the image tag you created earlier.
 - `<aws_account_id>`, `<region>`, `<repository>`, and `<tag>` with your AWS account ID, region, ECR repository name, and desired image tag, respectively.
 
 ### Step 3: Push the Docker Image
+
 Push the Docker container image to your ECR repository:
-```bash
+
+```shell
 docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
 ```
 
 Example:
-```bash
+
+```shell
 docker push 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-storefront:2.0.0
 ```
 
@@ -108,25 +126,30 @@ For more details, refer to the [AWS ECR documentation](https://docs.aws.amazon.c
 ## Connecting the Storefront to Your Terraform Infrastructure
 
 After pushing the Docker image, connect it to your infrastructure deployed via Terraform:
+
 1. Reference the ECR Image in Terraform:
 Add the ECR repository URI and tag to your Terraform configuration:
+
 ```hcl
 storefront_container_image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>"
 ```
 
 2. Enable storefront deployment:
 Ensure the storefront is enabled in your Terraform module configuration:
+
 ```hcl
 storefront_create = true
 ```
 
 3. Plan and apply Terraform changes:
 Deploy the updated configuration:
-```bash
+
+```shell
 terraform init
 terraform plan
 terraform apply
 ```
+
 Confirm the changes when prompted.
 
 ---
@@ -134,6 +157,7 @@ Confirm the changes when prompted.
 ## Troubleshooting
 
 ### Common Issues
+
 - **Docker Build Fails**:
   - Ensure all dependencies are installed.
   - Verify the `Dockerfile` is correctly configured.
@@ -150,9 +174,10 @@ Confirm the changes when prompted.
   - Check Terraform logs for specific error messages.
 
 ## Additional Resources
+
 - [Medusa Documentation](https://docs.medusajs.com)
 - [Next.js Documentation](https://nextjs.org/)
 - [Terraform Module for Medusa on AWS Provider Documentation](https://registry.terraform.io/modules/u11d-com/medusajs/aws)
 
 ---
-:heart: _Technology made with passion by [u11d](https://u11d.com)_
+:heart: *Technology made with passion by [u11d](https://u11d.com)*

--- a/www/apps/resources/app/deployment/storefront/aws-terraform/page.mdx
+++ b/www/apps/resources/app/deployment/storefront/aws-terraform/page.mdx
@@ -25,19 +25,18 @@ Before proceeding, ensure you have the following:
 ## Setting Up the Storefront Repository
 
 1. Clone the [`medusa-starter`](https://github.com/u11d-com/medusa-starter/tree/v2) repository to your local machine:
-   ```bash
-   git clone https://github.com/u11d-com/medusa-starter.git
-   cd medusa-starter
-   ```
+  ```bash
+  git clone https://github.com/u11d-com/medusa-starter.git
+  cd medusa-starter
+  ```
 
 2. Navigate to the `storefront` directory and initialize the repository, this sets up the storefront based on the [Medusa Next.js starter template](https://github.com/medusajs/nextjs-starter-medusa)
-   ```bash
-   cd storefront
-   git init
-   git remote add origin https://github.com/medusajs/nextjs-starter-medusa.git
-   git checkout main
-   ```
+  ```bash
+  git clone https://github.com/medusajs/nextjs-starter-medusa.git
+  ```
+  Copy and replace files from storefront folder to created directory.
 
+  This sets up the Medusa storefront starter template (Medusa v2).
 
 ---
 
@@ -50,10 +49,12 @@ Before proceeding, ensure you have the following:
   * Copy default token value.
 
 2. Build the Docker container image for the storefront:
+  When building a Docker image on a macOS machine (which uses Apple Silicon, typically ARM-based chips), you need to specify the --platform=linux/amd64 flag to ensure compatibility with AWS ECS, which commonly runs on x86_64 architecture.
+
    ```bash
-   docker build --build-arg MEDUSA_BACKEND_URL="https://my.medusa.backend" --build-arg NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY="pk_testvalue123" -t medusa_storefront:1.0.0 .
+   docker build --build-arg MEDUSA_BACKEND_URL="https://my.medusa.backend" --build-arg NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY="pk_testvalue123" -t medusa_storefront:2.0.0 .
    ```
-   - Replace `medusa_storefront:1.0.0` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:1.0.0`.
+   - Replace `medusa_storefront:2.0.0` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:2.0.0`.
    - Replace `https://my.medusa.backend` with your existing Medusa backend URL address.
    - Replace `pk_testvalue123` with your existing publishable key.
 

--- a/www/apps/resources/app/deployment/storefront/aws-terraform/page.mdx
+++ b/www/apps/resources/app/deployment/storefront/aws-terraform/page.mdx
@@ -1,0 +1,157 @@
+---
+sidebar_label: "AWS Terraform"
+---
+
+import { Prerequisites } from "docs-ui"
+
+export const metadata = {
+  title: `Build and Deploy the Medusa Next.js Storefront on AWS`,
+}
+
+# {metadata.title}
+
+This guide explains how to build the Medusa Storefront using the provided starter template and deploy the resulting Docker container image to an AWS Elastic Container Registry (ECR). This process is essential for deploying the frontend as part of the Medusa e-commerce solution.
+
+## Prerequisites
+
+Before proceeding, ensure you have the following:
+- **Docker**: Installed and running on your machine. Download Docker [here](https://docs.docker.com/get-started/get-docker/).
+- **AWS CLI**: Installed and configured with your AWS credentials. Follow the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html) if you haven’t set it up yet.
+- **Git**: Installed on your machine. Download Git [here](https://git-scm.com/).
+- **Terraform**: (Optional but recommended) Installed for deploying infrastructure. Download Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
+
+---
+
+## Setting Up the Storefront Repository
+
+1. Clone the [`medusa-starter`](https://github.com/u11d-com/medusa-starter/tree/v2) repository to your local machine:
+   ```bash
+   git clone https://github.com/u11d-com/medusa-starter.git
+   cd medusa-starter
+   ```
+
+2. Navigate to the `storefront` directory and initialize the repository, this sets up the storefront based on the [Medusa Next.js starter template](https://github.com/medusajs/nextjs-starter-medusa)
+   ```bash
+   cd storefront
+   git init
+   git remote add origin https://github.com/medusajs/nextjs-starter-medusa.git
+   git checkout main
+   ```
+
+
+---
+
+## Building the Storefront Docker Container Image
+
+1. Aquire `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` from Medusa Admin Dashboard:
+  * Go to https://my.medusa.backend/app
+  * Log in with admin credentials
+  * Go to `Settings`, then `Publishable API Keys` under `Developer`
+  * Copy default token value.
+
+2. Build the Docker container image for the storefront:
+   ```bash
+   docker build --build-arg MEDUSA_BACKEND_URL="https://my.medusa.backend" --build-arg NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY="pk_testvalue123" -t medusa_storefront:1.0.0 .
+   ```
+   - Replace `medusa_storefront:1.0.0` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:1.0.0`.
+   - Replace `https://my.medusa.backend` with your existing Medusa backend URL address.
+   - Replace `pk_testvalue123` with your existing publishable key.
+
+---
+
+## Pushing the Container Image to AWS Elastic Container Registry (ECR)
+
+To deploy the storefront, you’ll need to push the Docker container image to an AWS ECR repository. Follow these steps:
+
+### Step 1: Authenticate Docker to Your ECR Repository
+Run the following command to authenticate Docker to your AWS ECR registry:
+```bash
+aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
+```
+Replace:
+- `<region>` with your desired AWS region code (for example, `eu-west-1`). You can find the complete list of region codes in the [AWS Regions documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions). Make sure to use the same region where your Amazon Elastic Container Registry (ECR) is deployed.
+- `<aws_account_id>` with your [AWS account ID](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html#FindAccountId).
+  You can check it by running:
+  ```bash
+  aws sts get-caller-identity \
+      --query Account \
+      --output text
+  ```
+If you created your ECR repository using the [Terraform Module for Medusa on AWS](https://registry.terraform.io/modules/u11d-com/medusajs/aws), you can find the ECR repository URL in the module's output values after deployment.
+
+
+### Step 2: Tag the Docker Container Image
+Tag the Docker container image with your ECR repository URI:
+```bash
+docker tag medusa_storefront:2.0.0 <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
+```
+Replace:
+- `medusa_storefront:2.0.0` with the image tag you created earlier.
+- `<aws_account_id>`, `<region>`, `<repository>`, and `<tag>` with your AWS account ID, region, ECR repository name, and desired image tag, respectively.
+
+### Step 3: Push the Docker Image
+Push the Docker container image to your ECR repository:
+```bash
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
+```
+
+Example:
+```bash
+docker push 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-storefront:2.0.0
+```
+
+For more details, refer to the [AWS ECR documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
+
+---
+
+## Connecting the Storefront to Your Terraform Infrastructure
+
+After pushing the Docker image, connect it to your infrastructure deployed via Terraform:
+1. Reference the ECR Image in Terraform:
+Add the ECR repository URI and tag to your Terraform configuration:
+```hcl
+storefront_container_image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>"
+```
+
+2. Enable storefront deployment:
+Ensure the storefront is enabled in your Terraform module configuration:
+```hcl
+storefront_create = true
+```
+
+3. Plan and apply Terraform changes:
+Deploy the updated configuration:
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+Confirm the changes when prompted.
+
+---
+
+## Troubleshooting
+
+### Common Issues
+- **Docker Build Fails**:
+  - Ensure all dependencies are installed.
+  - Verify the `Dockerfile` is correctly configured.
+  - Check for syntax errors or missing files.
+- **ECR Authentication Fails**:
+  - Confirm that your AWS credentials are correctly configured with sufficient permissions.
+  - Ensure your AWS CLI session is active (re-authenticate if necessary).
+- **Image Push Fails**:
+  - Ensure the ECR repository exists.
+  - Ensure the repository URI and image tag are correctly specified.
+  - Check for network connectivity issues.
+- **Terraform Apply Fails**:
+  - Confirm that the referenced Docker image exists in the ECR repository.
+  - Check Terraform logs for specific error messages.
+
+## Additional Resources
+- [Medusa Documentation](https://docs.medusajs.com)
+- [Next.js Documentation](https://nextjs.org/)
+- [Terraform Module for Medusa on AWS Provider Documentation](https://registry.terraform.io/modules/u11d-com/medusajs/aws)
+
+---
+:heart: _Technology made with passion by [u11d](https://u11d.com)_


### PR DESCRIPTION
What

This pull request adds documentation for deploying a Medusa backend and an example storefront (from official templates) on AWS using Terraform and Terraform modules. The documentation outlines the deployment process in detail.

Why

We recently created a Terraform module, available at https://registry.terraform.io/modules/u11d-com/medusajs/aws, to simplify Medusa deployments on AWS. This documentation is being added to explain how users can leverage this module to deploy a new Medusa instance efficiently.

How

We developed a publicly accessible Terraform module, published it on the Terraform Registry, and created accompanying documentation that describes how to use it. The documentation provides step-by-step instructions for deploying the Medusa backend and an example storefront using the module.

Testing

The changes can be tested by reviewing the documentation for clarity and completeness. Reviewers can also follow the documented steps to deploy a test instance of Medusa on AWS using the Terraform module and verify that the deployment works as expected. Ensure that all links (e.g., to the Terraform Registry) are functional and that the instructions are easy to follow.