### PR TITLE
chore(link-modules): backward compatible links

### DIFF
--- a/.changeset/warm-lies-stare.md
+++ b/.changeset/warm-lies-stare.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/link-modules": patch
+---
+
+chore(link-modules): backward compatible links

--- a/packages/modules/link-modules/src/definitions/cart-payment-collection.ts
+++ b/packages/modules/link-modules/src/definitions/cart-payment-collection.ts
@@ -35,6 +35,7 @@ export const CartPaymentCollection: ModuleJoinerConfig = {
       args: {
         methodSuffix: "PaymentCollections",
       },
+      hasMany: true,
     },
   ],
   extends: [

--- a/packages/modules/link-modules/src/definitions/order-cart.ts
+++ b/packages/modules/link-modules/src/definitions/order-cart.ts
@@ -25,6 +25,7 @@ export const OrderCart: ModuleJoinerConfig = {
       args: {
         methodSuffix: "Orders",
       },
+      hasMany: true,
     },
     {
       serviceName: Modules.CART,


### PR DESCRIPTION
What:
 * Add `hasMany` for links that accepted that in the past. That way we don't block marketplaces to link 1 cart to multiple orders and carts with split payment.