### PR TITLE
fix(orchestration): handle multiple shortcuts with same name

### DIFF
--- a/.changeset/tame-hats-crash.md
+++ b/.changeset/tame-hats-crash.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/orchestration": patch
+---
+
+fix(orchestration): handle multiple field aliases with same name

--- a/packages/core/orchestration/src/joiner/remote-joiner.ts
+++ b/packages/core/orchestration/src/joiner/remote-joiner.ts
@@ -318,32 +318,7 @@ export class RemoteJoiner {
         }
 
         // Multiple "fieldAlias" w/ same name need the entity to handle different paths
-        for (const [alias, fieldAlias] of Object.entries(
-          extend.fieldAlias ?? {}
-        )) {
-          const objAlias = isString(fieldAlias)
-            ? { path: fieldAlias }
-            : fieldAlias
-
-          if (service_.fieldAlias[alias]) {
-            if (!Array.isArray(service_.fieldAlias[alias])) {
-              service_.fieldAlias[alias] = [service_.fieldAlias[alias]]
-            }
-
-            if (
-              service_.fieldAlias[alias].some((f) => f.entity === extend.entity)
-            ) {
-              throw new Error(
-                `Cannot add alias "${alias}" for "${extend.serviceName}". It is already defined for Entity "${extend.entity}".`
-              )
-            }
-          } else {
-            service_.fieldAlias[alias] = {
-              ...objAlias,
-              entity: extend.entity,
-            }
-          }
-        }
+        this.mergeFieldAlias(service_, extend)
       }
     }
 
@@ -388,6 +363,33 @@ export class RemoteJoiner {
     }
 
     return serviceConfigs
+  }
+
+  private mergeFieldAlias(service_, extend) {
+    for (const [alias, fieldAlias] of Object.entries(extend.fieldAlias ?? {})) {
+      const objAlias = isString(fieldAlias)
+        ? { path: fieldAlias }
+        : (fieldAlias as object)
+
+      if (service_.fieldAlias[alias]) {
+        if (!Array.isArray(service_.fieldAlias[alias])) {
+          service_.fieldAlias[alias] = [service_.fieldAlias[alias]]
+        }
+
+        if (
+          service_.fieldAlias[alias].some((f) => f.entity === extend.entity)
+        ) {
+          throw new Error(
+            `Cannot add alias "${alias}" for "${extend.serviceName}". It is already defined for Entity "${extend.entity}".`
+          )
+        }
+      } else {
+        service_.fieldAlias[alias] = {
+          ...objAlias,
+          entity: extend.entity,
+        }
+      }
+    }
   }
 
   private getServiceConfig({

--- a/packages/core/orchestration/src/joiner/remote-joiner.ts
+++ b/packages/core/orchestration/src/joiner/remote-joiner.ts
@@ -317,7 +317,33 @@ export class RemoteJoiner {
           service_.relationships?.set(aliasName, rel)
         }
 
-        Object.assign(service_.fieldAlias ?? {}, extend.fieldAlias)
+        // Multiple "fieldAlias" w/ same name need the entity to handle different paths
+        for (const [alias, fieldAlias] of Object.entries(
+          extend.fieldAlias ?? {}
+        )) {
+          const objAlias = isString(fieldAlias)
+            ? { path: fieldAlias }
+            : fieldAlias
+
+          if (service_.fieldAlias[alias]) {
+            if (!Array.isArray(service_.fieldAlias[alias])) {
+              service_.fieldAlias[alias] = [service_.fieldAlias[alias]]
+            }
+
+            if (
+              service_.fieldAlias[alias].some((f) => f.entity === extend.entity)
+            ) {
+              throw new Error(
+                `Cannot add alias "${alias}" for "${extend.serviceName}". It is already defined for Entity "${extend.entity}".`
+              )
+            }
+          } else {
+            service_.fieldAlias[alias] = {
+              ...objAlias,
+              entity: extend.entity,
+            }
+          }
+        }
       }
     }
 
@@ -1081,7 +1107,23 @@ export class RemoteJoiner {
   }) {
     const serviceConfig = currentServiceConfig
     const fieldAlias = currentServiceConfig.fieldAlias ?? {}
-    const alias = fieldAlias[property] as any
+    let alias = fieldAlias[property] as any
+
+    // Handle multiple shortcuts for the same property
+    if (Array.isArray(alias)) {
+      const currentPathEntity = parsedExpands.get(
+        [BASE_PATH, ...currentPath].join(".")
+      )?.entity
+
+      alias = alias.find((a) => a.entity == currentPathEntity)
+      if (!alias) {
+        throw new Error(
+          `Cannot resolve alias path "${currentPath.join(
+            "."
+          )}" that matches entity ${currentPathEntity}.`
+        )
+      }
+    }
 
     const path = isString(alias) ? alias : alias.path
     const fieldAliasIsList = isString(alias) ? false : !!alias.isList


### PR DESCRIPTION
What:
 * Correctly handle multiple links created with the same shortcut name on different entities of the same module.
E.g: Product -> SalesChannel (alias: sales_channels), and ProductCategory -> SalesChannel (alias: sales_channels)

FIXES: SUP-1308