### PR TITLE
fix: allow backorder variants to be added to cart even if no locations

### DIFF
--- a/integration-tests/modules/__tests__/index/query-index.spec.ts
+++ b/integration-tests/modules/__tests__/index/query-index.spec.ts
@@ -79,7 +79,7 @@ async function populateData(api: any) {
       console.log(err)
     })
 
-  await setTimeout(2000)
+  await setTimeout(10000)
 }
 
 process.env.ENABLE_INDEX_MODULE = "true"

--- a/integration-tests/modules/__tests__/index/search.spec.ts
+++ b/integration-tests/modules/__tests__/index/search.spec.ts
@@ -144,7 +144,7 @@ medusaIntegrationTestRunner({
           })
 
         // Timeout to allow indexing to finish
-        await setTimeout(4000)
+        await setTimeout(10000)
 
         const { data: results } = await indexEngine.query<"product">({
           fields: [

--- a/integration-tests/modules/__tests__/order/draft-order.spec.ts
+++ b/integration-tests/modules/__tests__/order/draft-order.spec.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../helpers/create-admin-user"
 import { setupTaxStructure } from "../fixtures"
 
-jest.setTimeout(50000)
+jest.setTimeout(100000)
 
 const env = { MEDUSA_FF_MEDUSA_V2: true }
 
@@ -160,6 +160,14 @@ medusaIntegrationTestRunner({
           {
             [Modules.PRODUCT]: {
               variant_id: product.variants[0].id,
+            },
+            [Modules.INVENTORY]: {
+              inventory_item_id: inventoryItem.id,
+            },
+          },
+          {
+            [Modules.PRODUCT]: {
+              variant_id: product_2.variants[0].id,
             },
             [Modules.INVENTORY]: {
               inventory_item_id: inventoryItem.id,

--- a/packages/core/core-flows/src/cart/utils/__tests__/prepare-confirm-inventory-input.spec.ts
+++ b/packages/core/core-flows/src/cart/utils/__tests__/prepare-confirm-inventory-input.spec.ts
@@ -1,0 +1,533 @@
+import { ConfirmVariantInventoryWorkflowInputDTO } from "@medusajs/framework/types"
+import { MedusaError } from "@medusajs/framework/utils"
+import { prepareConfirmInventoryInput } from "../prepare-confirm-inventory-input"
+
+describe("prepareConfirmInventoryInput", () => {
+  it("should use the quantity from the itemsToUpdate", () => {
+    const input: ConfirmVariantInventoryWorkflowInputDTO = {
+      sales_channel_id: "sc_1",
+      variants: [
+        {
+          id: "pv_1",
+          manage_inventory: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_1",
+              variant_id: "pv_1",
+              required_quantity: 3,
+              inventory: [
+                {
+                  location_levels: {
+                    stock_locations: [
+                      {
+                        id: "sl_1",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      items: [
+        {
+          variant_id: "pv_1",
+          quantity: 1,
+          id: "item_1",
+        },
+      ],
+      itemsToUpdate: [
+        {
+          variant_id: "pv_1",
+          quantity: 2,
+        },
+      ],
+    }
+
+    const output = prepareConfirmInventoryInput({ input })
+
+    expect(output).toEqual({
+      items: [
+        {
+          id: "item_1",
+          inventory_item_id: "ii_1",
+          required_quantity: 3,
+          quantity: 2, // overrides the quantity from the items array
+          allow_backorder: false,
+          location_ids: ["sl_1"],
+        },
+      ],
+    })
+  })
+
+  it("should only return variants with manage_inventory set to true", () => {
+    const input: ConfirmVariantInventoryWorkflowInputDTO = {
+      sales_channel_id: "sc_1",
+      variants: [
+        {
+          id: "pv_1",
+          manage_inventory: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_1",
+              variant_id: "pv_1",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stock_locations: [
+                      {
+                        id: "sl_1",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: "pv_2",
+          manage_inventory: false,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_2",
+              variant_id: "pv_2",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stock_locations: [
+                      {
+                        id: "sl_1",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      items: [
+        {
+          variant_id: "pv_1",
+          quantity: 1,
+          id: "item_1",
+        },
+        {
+          variant_id: "pv_2",
+          quantity: 1,
+          id: "item_2",
+        },
+      ],
+    }
+
+    const output = prepareConfirmInventoryInput({ input })
+
+    expect(output).toEqual({
+      items: [
+        {
+          id: "item_1",
+          inventory_item_id: "ii_1",
+          required_quantity: 1,
+          quantity: 1,
+          allow_backorder: false,
+          location_ids: ["sl_1"],
+        },
+      ],
+    })
+  })
+
+  it("should return all inventory items for a variant", () => {
+    const input: ConfirmVariantInventoryWorkflowInputDTO = {
+      sales_channel_id: "sc_1",
+      variants: [
+        {
+          id: "pv_1",
+          manage_inventory: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_1",
+              variant_id: "pv_1",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stock_locations: [
+                      {
+                        id: "sl_1",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {
+              inventory_item_id: "ii_2",
+              variant_id: "pv_1",
+              required_quantity: 2,
+              inventory: [
+                {
+                  location_levels: {
+                    stock_locations: [
+                      {
+                        id: "sl_1",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      items: [
+        {
+          variant_id: "pv_1",
+          quantity: 1,
+          id: "item_1",
+        },
+      ],
+    }
+
+    const output = prepareConfirmInventoryInput({ input })
+
+    expect(output).toEqual({
+      items: [
+        {
+          id: "item_1",
+          inventory_item_id: "ii_1",
+          required_quantity: 1,
+          quantity: 1,
+          allow_backorder: false,
+          location_ids: ["sl_1"],
+        },
+        {
+          id: "item_1",
+          inventory_item_id: "ii_2",
+          required_quantity: 2,
+          quantity: 1,
+          allow_backorder: false,
+          location_ids: ["sl_1"],
+        },
+      ],
+    })
+  })
+
+  it("should throw an error if any variant has no stock locations linked to the sales channel", () => {
+    const input = {
+      sales_channel_id: "sc_1",
+      variants: [
+        {
+          id: "pv_1",
+          manage_inventory: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_1",
+              variant_id: "pv_1",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stock_locations: [
+                      {
+                        id: "sl_1",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: "pv_2",
+          manage_inventory: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_2",
+              variant_id: "pv_2",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stock_locations: [
+                      {
+                        id: "sl_2",
+                        sales_channels: [{ id: "sc_2" }], // Different sales channel
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      items: [
+        {
+          variant_id: "pv_1",
+          quantity: 1,
+          id: "item_1",
+        },
+        {
+          variant_id: "pv_2",
+          quantity: 1,
+          id: "item_2",
+        },
+      ],
+    }
+
+    expect(() => prepareConfirmInventoryInput({ input })).toThrow(MedusaError)
+  })
+
+  it("if allow_backorder is true, it should return normally even if there's no stock location for the sales channel", () => {
+    const input = {
+      sales_channel_id: "sc_1",
+      variants: [
+        {
+          id: "pv_1",
+          manage_inventory: true,
+          allow_backorder: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_1",
+              variant_id: "pv_1",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stock_locations: [
+                      {
+                        id: "sl_2",
+                        sales_channels: [{ id: "sc_2" }], // Different sales channel
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      items: [
+        {
+          variant_id: "pv_1",
+          quantity: 1,
+          id: "item_1",
+        },
+      ],
+    }
+
+    const result = prepareConfirmInventoryInput({ input })
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: "item_1",
+          inventory_item_id: "ii_1",
+          required_quantity: 1,
+          quantity: 1,
+          allow_backorder: true,
+          location_ids: [], // TODO: what should this be?
+        },
+      ],
+    })
+  })
+
+  it("should return only stock locations with availability, if any", () => {
+    const input = {
+      sales_channel_id: "sc_1",
+      variants: [
+        {
+          id: "pv_1",
+          manage_inventory: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_1",
+              variant_id: "pv_1",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stocked_quantity: 10, // 10 - 9 = 1 < 2: no availability
+                    reserved_quantity: 9,
+                    location_id: "sl_1",
+                    stock_locations: [
+                      {
+                        id: "sl_1",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+                {
+                  location_levels: {
+                    stocked_quantity: 7, // 7 - 5 = 2 >= 2: availability
+                    reserved_quantity: 5,
+                    location_id: "sl_2",
+                    stock_locations: [
+                      {
+                        id: "sl_2",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      items: [
+        {
+          variant_id: "pv_1",
+          quantity: 2,
+          id: "item_1",
+        },
+      ],
+    }
+
+    const result = prepareConfirmInventoryInput({ input })
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: "item_1",
+          inventory_item_id: "ii_1",
+          required_quantity: 1,
+          quantity: 2,
+          allow_backorder: false,
+          location_ids: ["sl_2"], // Only includes location with available stock
+        },
+      ],
+    })
+  })
+
+  it("should return all locations if none has availability", () => {
+    const input = {
+      sales_channel_id: "sc_1",
+      variants: [
+        {
+          id: "pv_1",
+          manage_inventory: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_1",
+              variant_id: "pv_1",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stocked_quantity: 1,
+                    reserved_quantity: 1, // 1 - 1 = 0 < 2: no availability
+                    location_id: "sl_1",
+                    stock_locations: [
+                      {
+                        id: "sl_1",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+                {
+                  location_levels: {
+                    stocked_quantity: 4,
+                    reserved_quantity: 3, // 4 - 3 = 1 < 2: no availability
+                    location_id: "sl_2",
+                    stock_locations: [
+                      {
+                        id: "sl_2",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      items: [
+        {
+          variant_id: "pv_1",
+          quantity: 2,
+          id: "item_1",
+        },
+      ],
+    }
+
+    const result = prepareConfirmInventoryInput({ input })
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: "item_1",
+          inventory_item_id: "ii_1",
+          required_quantity: 1,
+          quantity: 2,
+          allow_backorder: false,
+          location_ids: ["sl_1", "sl_2"], // Includes all locations since none has availability
+        },
+      ],
+    })
+  })
+
+  it("should throw an error if any variant has no inventory items", () => {
+    const input = {
+      sales_channel_id: "sc_1",
+      variants: [
+        {
+          id: "pv_1",
+          manage_inventory: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_1",
+              variant_id: "pv_1",
+              required_quantity: 3,
+              inventory: [
+                {
+                  location_levels: {
+                    stock_locations: [
+                      {
+                        id: "sl_1",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: "pv_2",
+          manage_inventory: true,
+          inventory_items: [], // No inventory items
+        },
+      ],
+      items: [
+        {
+          variant_id: "pv_1",
+          quantity: 1,
+          id: "item_1",
+        },
+        {
+          variant_id: "pv_2",
+          quantity: 1,
+          id: "item_2",
+        },
+      ],
+    }
+
+    expect(() => prepareConfirmInventoryInput({ input })).toThrow(MedusaError)
+  })
+})

--- a/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
+++ b/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
@@ -38,6 +38,17 @@ interface ConfirmInventoryItem {
   location_ids: string[]
 }
 
+/**
+ * This function prepares the input for the confirm inventory workflow.
+ * In essesnce, it maps a list of cart items to a list of inventory items,
+ * serving as a bridge between the cart and inventory domains.
+ *
+ * @throws {MedusaError} INVALID_DATA if any cart item is for a variant that has no inventory items.
+ * @throws {MedusaError} INVALID_DATA if any cart item is for a variant with no stock locations in the input.sales_channel_id. An exception is made for variants with allow_backorder set to true.
+ *
+ * @returns {ConfirmInventoryPreparationInput}
+ * A list of inventory items to confirm. Only inventory items for variants with managed inventory are included.
+ */
 export const prepareConfirmInventoryInput = (data: {
   input: ConfirmVariantInventoryWorkflowInputDTO
 }) => {


### PR DESCRIPTION
#10694 
I had agreed with @olivermrbl to refactor `prepareConfirmInventoryInput`, but I'll leave that for another PR cause there's still a couple things I need to figure out. I did add some unit tests for it here to guarantee the coming refactor won't break anything.