### PR TITLE
chore(types,utils): fixes to TSDocs for HTTP types and payment provider

### DIFF
--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -170,6 +170,11 @@ export interface BaseProductVariant {
   manage_inventory: boolean | null
   /**
    * The variant's inventory quantity if `manage_inventory` is enabled.
+   * This field is only retrieved in the [Get Product](https://docs.medusajs.com/api/store#products_getproductsid)
+   * and [List Products](https://docs.medusajs.com/api/store#products_getproducts) API routes if you
+   * pass `+variants.inventory_quantity` in the `fields` query parameter.
+   * 
+   * Learn more in the [Retrieve Product Variant's Inventory](https://docs.medusajs.com/resources/storefront-development/products/inventory) storefront guide.
    */
   inventory_quantity?: number
   /**

--- a/packages/core/utils/src/payment/abstract-payment-provider.ts
+++ b/packages/core/utils/src/payment/abstract-payment-provider.ts
@@ -486,6 +486,11 @@ export abstract class AbstractPaymentProvider<TConfig = Record<string, unknown>>
    *   ): Promise<UpdatePaymentOutput> {
    *     const { amount, currency_code, context } = input
    *     const externalId = input.data?.id
+   * 
+   *     // Validate context.customer
+   *     if (!context || !context.customer) {
+   *       throw new Error("Context must include a valid customer.");
+   *     }
    *
    *     // assuming you have a client that updates the payment
    *     const response = await this.client.update(


### PR DESCRIPTION
- Add a note about when `inventory_quantity` is available in a variant
- Fix example for `updatePayment` in payment provider's TSDocs

Closes #11916 and #12080