### PR TITLE
chore: Patch changesets to avoid major bumps

### DIFF
--- a/.yarn/patches/changesets.patch
+++ b/.yarn/patches/changesets.patch
@@ -1,0 +1,47 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index ee5c0f67fabadeb112e9f238d8b144a4d125830f..c475255224dc1ebde360c1bd31e8fdd285dd8336 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -206,6 +206,10 @@ function shouldBumpMajor({
+   preInfo,
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
++  // Disable major bumps for peerDependencies
++  if (depType === "peerDependencies") {
++    return false;
++  }
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+   return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && ( // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+   // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
+diff --git a/src/determine-dependents.ts b/src/determine-dependents.ts
+index 08c08127ccfb5974d81b3ace592fced5b68aeaf7..4f7a86c34bd944aa0e8225190e0f4f5b6207c961 100644
+--- a/src/determine-dependents.ts
++++ b/src/determine-dependents.ts
+@@ -1,13 +1,13 @@
+-import semverSatisfies from "semver/functions/satisfies";
+ import {
++  Config,
+   DependencyType,
+   PackageJSON,
+   VersionType,
+-  Config,
+ } from "@changesets/types";
+ import { Package } from "@manypkg/get-packages";
+-import { InternalRelease, PreInfo } from "./types";
++import semverSatisfies from "semver/functions/satisfies";
+ import { incrementVersion } from "./increment";
++import { InternalRelease, PreInfo } from "./types";
+ 
+ /*
+   WARNING:
+@@ -223,6 +223,10 @@ function shouldBumpMajor({
+   preInfo: PreInfo | undefined;
+   onlyUpdatePeerDependentsWhenOutOfRange: boolean;
+ }) {
++  // Disable major bumps for peerDependencies
++  if (depType === "peerDependencies") {
++    return false;
++  }
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+   return (
+     depType === "peerDependencies" &&

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "resolutions": {
     "@redocly/cli/react": "^17.0.1",
     "@redocly/cli/react-dom": "^17.0.1",
-    "pg": "8.11.3"
+    "pg": "8.11.3",
+    "@changesets/assemble-release-plan@^6.0.0": "patch:@changesets/assemble-release-plan@npm:^6.0.0#.yarn/patches/changesets.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2995,6 +2995,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@changesets/assemble-release-plan@patch:@changesets/assemble-release-plan@npm:^6.0.0#.yarn/patches/changesets.patch::locator=root%40workspace%3A.":
+  version: 6.0.0
+  resolution: "@changesets/assemble-release-plan@patch:@changesets/assemble-release-plan@npm%3A6.0.0#.yarn/patches/changesets.patch::version=6.0.0&hash=d9ce1e&locator=root%40workspace%3A."
+  dependencies:
+    "@babel/runtime": ^7.20.1
+    "@changesets/errors": ^0.2.0
+    "@changesets/get-dependents-graph": ^2.0.0
+    "@changesets/types": ^6.0.0
+    "@manypkg/get-packages": ^1.1.3
+    semver: ^7.5.3
+  checksum: 30adac69c1aaa4e3905e4336560f2dfbe413e8215f56d9b7c2f3802242c228f7b38c911b120f74594b082091e9a483bcfbcff53ecaa8b15cee3809f462de196c
+  languageName: node
+  linkType: hard
+
 "@changesets/changelog-git@npm:^0.2.0":
   version: 0.2.0
   resolution: "@changesets/changelog-git@npm:0.2.0"


### PR DESCRIPTION
**What**

This PR uses the native `yarn patch` command to fix a "bug" in the changesets tool to assemble the release plan. It prevents major bumps when `peerDependencies` are updated.

**Why**

By default, changesets will major bump packages when their `peerDependencies` are minor bumped. Whether this is the correct behavior is debatable, but in our case, it causes more harm than good. If we want to do a bump major, we want to be very intentional about it. With the current behavior, major bumps can very easily slip through. Additionally, it also means our snapshot version are major bumped which is also not very elegant. Unfortunately, we spotted this before it was too late, so there are some 3.* snapshots out there.

Also, see [this long-running issue](https://github.com/changesets/changesets/issues/1011) on the matter.

Some companies even resort to creating [their own version of the package](https://github.com/module-federation/core/pull/3184) (author of webpack).


