### PR TITLE
fix(types): fix type of application_method_type filter

### DIFF
--- a/.changeset/spotty-spies-act.md
+++ b/.changeset/spotty-spies-act.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": patch
+---
+
+fix(types): fix type of application_method_type filter

--- a/packages/core/types/src/http/promotion/admin/queries.ts
+++ b/packages/core/types/src/http/promotion/admin/queries.ts
@@ -1,4 +1,5 @@
 import { BaseFilterable, OperatorMap } from "../../../dal"
+import { ApplicationMethodTypeValues } from "../../../promotion"
 import { FindParams, SelectParams } from "../../common"
 
 export interface AdminGetPromotionParams extends SelectParams {}
@@ -46,7 +47,7 @@ export interface AdminGetPromotionsParams
   /**
    * Filter by the promotion's application method type.
    */
-  application_method_type?: string | string[]
+  application_method_type?: ApplicationMethodTypeValues | ApplicationMethodTypeValues[]
   /**
    * An array of filters to apply on the entity, where each item in the array is joined with an "and" condition.
    */


### PR DESCRIPTION
The `application_method_type` filter has a `string` type in the HTTP types. This PR accurately sets the type. This is useful for the generated OAS to show the possible filter values.