### PR TITLE
Bug fixing related to storefront error regarding "collection_id" on queryParams of Product

### DIFF
--- a/packages/core/types/src/http/product/store/queries.ts
+++ b/packages/core/types/src/http/product/store/queries.ts
@@ -9,6 +9,10 @@ export interface StoreProductOptionParams extends BaseProductOptionParams {}
 export interface StoreProductVariantParams extends BaseProductVariantParams {}
 export interface StoreProductPricingContext {
   /**
+   * The collection ID of customer's managed collections of products. This parameter must be included if you want to fetch a specific collection to display or other purposes.
+   */
+  collection_id?: string
+  /**
    * The ID of the customer's region. This parameter must be included if you want to apply taxes on the product variant's price.
    */
   region_id?: string


### PR DESCRIPTION
Regarding "Object literal may only specify known properties, and 'collection_id' does not exist in type 'FindParams & StoreProductParams'."
<img width="612" alt="queryParam" src="https://github.com/user-attachments/assets/b965aa6c-9a94-4871-8ea3-3f943d73ba0a" />
