### PR TITLE
fix(medusa): Ensure specified sales channel is used for inventory

### DIFF
--- a/integration-tests/http/__tests__/product/store/product.spec.ts
+++ b/integration-tests/http/__tests__/product/store/product.spec.ts
@@ -1761,6 +1761,28 @@ medusaIntegrationTestRunner({
           )
         })
 
+        it("should throw when multiple sales channels are passed as a query param AND there are multiple sales channels associated with the publishable key", async () => {
+          await api.post(
+            `/admin/api-keys/${publishableKey1.id}/sales-channels`,
+            { add: [salesChannel2.id] },
+            adminHeaders
+          )
+
+          let error = await api
+            .get(
+              `/store/products?sales_channel_id[]=${salesChannel1.id}&sales_channel_id[]=${salesChannel2.id}&fields=variants.inventory_quantity`,
+              { headers: { "x-publishable-api-key": publishableKey1.token } }
+            )
+            .catch((e) => e)
+
+          expect(error.response.status).toEqual(400)
+          expect(error.response.data).toEqual({
+            message:
+              "Inventory availability cannot be calculated in the given context. Either provide a sales channel id or configure a single sales channel in the publishable key",
+            type: "invalid_data",
+          })
+        })
+
         it("should return inventory quantity when variant's manage_inventory is true", async () => {
           await api.post(
             `/admin/products/${product.id}/variants/${variant.id}/inventory-items`,

--- a/packages/core/framework/src/http/utils/maybe-apply-link-filter.ts
+++ b/packages/core/framework/src/http/utils/maybe-apply-link-filter.ts
@@ -10,6 +10,9 @@ export function maybeApplyLinkFilter({
   resourceId,
   filterableField,
   filterByField = "id",
+  // In some rare occasions, we don't want to delete the filterable field, as it's used in subsequent middleware or routes
+  // For example, in the case of the product variant inventory quantity middleware, we need to keep the sales channel id in the filterable fields
+  deleteFilterableField = true,
 }) {
   return async function linkFilter(
     req: MedusaRequest,
@@ -28,7 +31,9 @@ export function maybeApplyLinkFilter({
       ? filterFields
       : [filterFields]
 
-    delete filterableFields[filterableField]
+    if (deleteFilterableField) {
+      delete filterableFields[filterableField]
+    }
 
     let existingFilters = filterableFields[filterByField] as
       | string[]

--- a/packages/medusa/src/api/store/products/middlewares.ts
+++ b/packages/medusa/src/api/store/products/middlewares.ts
@@ -50,6 +50,8 @@ export const storeProductRoutesMiddlewares: MiddlewareRoute[] = [
           entryPoint: "product_sales_channel",
           resourceId: "product_id",
           filterableField: "sales_channel_id",
+          filterByField: "id",
+          deleteFilterableField: false,
         })(req, res, next)
       },
       applyDefaultFilters({

--- a/packages/medusa/src/api/store/products/route.ts
+++ b/packages/medusa/src/api/store/products/route.ts
@@ -109,6 +109,16 @@ async function getProducts(
     }
   }
 
+  let salesChannelFromParam: string | string[] | undefined
+
+  if (isPresent(req.filterableFields.sales_channel_id)) {
+    salesChannelFromParam = req.filterableFields.sales_channel_id as
+      | string
+      | string[]
+      | undefined
+    delete req.filterableFields.sales_channel_id
+  }
+
   const queryObject = remoteQueryObjectFromString({
     entryPoint: "product",
     variables: {
@@ -124,7 +134,8 @@ async function getProducts(
   if (withInventoryQuantity) {
     await wrapVariantsWithInventoryQuantityForSalesChannel(
       req,
-      products.map((product) => product.variants).flat(1)
+      products.map((product) => product.variants).flat(1),
+      salesChannelFromParam
     )
   }
 

--- a/packages/medusa/src/api/store/products/route.ts
+++ b/packages/medusa/src/api/store/products/route.ts
@@ -53,11 +53,11 @@ async function getProductsWithIndexEngine(
   }
 
   const filters: Record<string, any> = req.filterableFields
-  if (isPresent(filters.sales_channel_id)) {
-    const salesChannelIds = filters.sales_channel_id
+  const salesChannelIdsFromQuery = filters.sales_channel_id
 
+  if (isPresent(salesChannelIdsFromQuery)) {
     filters["sales_channels"] ??= {}
-    filters["sales_channels"]["id"] = salesChannelIds
+    filters["sales_channels"]["id"] = salesChannelIdsFromQuery
 
     delete filters.sales_channel_id
   }
@@ -73,7 +73,8 @@ async function getProductsWithIndexEngine(
   if (withInventoryQuantity) {
     await wrapVariantsWithInventoryQuantityForSalesChannel(
       req,
-      products.map((product) => product.variants).flat(1)
+      products.map((product) => product.variants).flat(1),
+      salesChannelIdsFromQuery
     )
   }
 


### PR DESCRIPTION
**What**
Solves inventory calculation for products in the case where:
- A publishable API key has multiple sales channels
- A sales channel is passed as a query param

Until now, if a publishable API key was associated with multiple sales channels, the inventory availability wrapper would fail with: 
```
Inventory availability cannot be calculated in the given context. Either provide a sales channel id or configure a single sales channel in the publishable key
```

This happens because:
1. we don't know which sales channel to pick when calculating the inventory
2. the sales channel from the query param was not used