### PR TITLE
fix(dashboard): properly register settings custom routes

### DIFF
--- a/.changeset/green-penguins-kiss.md
+++ b/.changeset/green-penguins-kiss.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): properly register settings custom routes

--- a/packages/admin/dashboard/src/dashboard-app/routes/get-route.map.tsx
+++ b/packages/admin/dashboard/src/dashboard-app/routes/get-route.map.tsx
@@ -1714,7 +1714,7 @@ export function getRouteMap({
                 },
               ],
             },
-            ...settingsRoutes,
+            ...(settingsRoutes?.[0]?.children || []),
           ],
         },
       ],


### PR DESCRIPTION
**What**
- custom setting routes were registered under `/settings/settings/custom-route` instead of `/settings/custom-route`

---

CLOSES SUP-1384