### PR TITLE
Deduplicate SubscriberContext

### DIFF
--- a/packages/core/types/src/event-bus/common.ts
+++ b/packages/core/types/src/event-bus/common.ts
@@ -2,7 +2,7 @@ import { Context } from "../shared-context"
 
 export type Subscriber<TData = unknown> = (data: Event<TData>) => Promise<void>
 
-export type SubscriberContext = {
+export type SubscriberContext = Record<string, unknown> & {
   /**
    * The ID of the subscriber. Useful when retrying failed subscribers.
    */

--- a/packages/medusa/src/types/subscribers.ts
+++ b/packages/medusa/src/types/subscribers.ts
@@ -1,12 +1,8 @@
-import { Event, MedusaContainer } from "@medusajs/framework/types"
-
-interface SubscriberContext extends Record<string, unknown> {
-  subscriberId?: string
-}
+import { Event, MedusaContainer, EventBusTypes } from "@medusajs/framework/types"
 
 export type SubscriberConfig = {
   event: string | string[]
-  context?: SubscriberContext
+  context?: EventBusTypes.SubscriberContext
 }
 
 export type SubscriberArgs<T = unknown> = {


### PR DESCRIPTION
I'm implementing my own Event Bus that needs custom options for subscription's context. The definition of `EventTypes` used in `AbstractEventBusModuleService` don't allow for this.

However, I realised a similar type is also declared in `SubscriberConfig`. This PR de-deduplicates this definition and opens the subscription context in the event bus to custom data.