### PR TITLE
docs: fix no lines code block example

### DIFF
--- a/www/apps/ui/src/components/hook-table.tsx
+++ b/www/apps/ui/src/components/hook-table.tsx
@@ -67,6 +67,7 @@ const Row = ({ value, type, description }: HookData) => {
           <Tooltip
             tooltipChildren={<pre>{type.shape}</pre>}
             className="font-mono max-w-[500px]"
+            tooltipClassName="!text-left"
           >
             <div className="flex items-center gap-x-1">
               <span>{type.name}</span>

--- a/www/apps/ui/src/components/props-table.tsx
+++ b/www/apps/ui/src/components/props-table.tsx
@@ -165,6 +165,7 @@ const Row = ({
                 <Tooltip
                   tooltipChildren={<pre>{typeNode.tooltipContent}</pre>}
                   className="font-mono !max-w-none"
+                  tooltipClassName="!text-left"
                 >
                   <div className="flex items-center gap-x-1">
                     <code>{typeNode.text}</code>

--- a/www/apps/ui/src/content/docs/components/code-block.mdx
+++ b/www/apps/ui/src/content/docs/components/code-block.mdx
@@ -83,3 +83,7 @@ You could also choose to omit the header entirely:
 ### No Line Numbers
 
 <ComponentExample name="code-block-no-lines" />
+
+### No Copy Button
+
+<ComponentExample name="code-block-no-copy" />

--- a/www/apps/ui/src/examples/code-block-no-copy.tsx
+++ b/www/apps/ui/src/examples/code-block-no-copy.tsx
@@ -5,11 +5,11 @@ const snippets = [
     label: "Medusa JS SDK",
     language: "jsx",
     code: `// Install the JS SDK in your storefront project: @medusajs/js-sdk\n\nimport Medusa from "@medusajs/js-sdk"\n\nconst medusa = new Medusa({\n  baseUrl: import.meta.env.NEXT_PUBLIC_BACKEND_URL || "/",\n  publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PAK\n})\nconst { product } = await medusa.store.products.retrieve("prod_123")\nconsole.log(product.id)`,
-    hideLineNumbers: true,
+    hideCopy: true,
   },
 ]
 
-export default function CodeBlockNoLines() {
+export default function CodeBlockNoCopy() {
   return (
     <div className="w-full">
       <CodeBlock snippets={snippets}>

--- a/www/apps/ui/src/registries/example-registry.tsx
+++ b/www/apps/ui/src/registries/example-registry.tsx
@@ -735,6 +735,11 @@ export const ExampleRegistry: ExampleRegistryType = {
     ),
     file: "src/examples/code-block-no-header.tsx",
   },
+  "code-block-no-copy": {
+    name: "code-block-no-copy",
+    component: React.lazy(async () => import("@/examples/code-block-no-copy")),
+    file: "src/examples/code-block-no-copy.tsx",
+  },
   "container-layout": {
     name: "container-layout",
     component: React.lazy(async () => import("@/examples/container-layout")),


### PR DESCRIPTION
- Fix the no lines example for code blocks in Medusa UI
- Other: Add a new example for removing the copy button
- Other: Fix tooltip styling for prop types

Closes DX-1568