### PR TITLE
Update 6.3. Using TypeScript Aliases - Alias should run after build, not before

### DIFF
--- a/www/apps/book/app/learn/configurations/ts-aliases/page.mdx
+++ b/www/apps/book/app/learn/configurations/ts-aliases/page.mdx
@@ -21,7 +21,7 @@ Then, add a new `resolve:aliases` script to your `package.json` and update the `
   "scripts": {
     // other scripts...
     "resolve:aliases": "tsc --showConfig -p tsconfig.json > tsconfig.resolved.json && tsc-alias -p tsconfig.resolved.json && rimraf tsconfig.resolved.json",
-    "build": "npm run resolve:aliases && medusa build"
+    "build": "medusa build && npm run resolve:aliases"
   }
 }
 ```


### PR DESCRIPTION
https://docs.medusajs.com/learn/configurations/ts-aliases

`npm run resolve:aliases` should run after `medusa build` to change out the aliases in the build output. 

So instead of the current guide
`"build": "npm run resolve:aliases && medusa build"`

I should be 
`"build": "medusa build && npm run resolve:aliases"`
