### PR TITLE
fix(dashboard,core-flows): create multiple transactions when multiple refunds occur

### DIFF
--- a/.changeset/early-lions-repeat.md
+++ b/.changeset/early-lions-repeat.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/dashboard": patch
+"@medusajs/core-flows": patch
+---
+
+fix(dashboard,core-flows): create multiple transactions when multiple refunds occur

--- a/integration-tests/http/__tests__/payment/admin/payment.spec.ts
+++ b/integration-tests/http/__tests__/payment/admin/payment.spec.ts
@@ -239,11 +239,19 @@ medusaIntegrationTestRunner({
       it("should issue multiple refunds", async () => {
         const payment = order.payment_collections[0].payments[0]
 
+        expect(order.summary.pending_difference).toEqual(100)
+
         await api.post(
           `/admin/payments/${payment.id}/capture`,
           undefined,
           adminHeaders
         )
+
+        let updatedOrder = (
+          await api.get(`/admin/orders/${order.id}`, adminHeaders)
+        ).data.order
+
+        expect(updatedOrder.summary.pending_difference).toEqual(-100)
 
         const refundReason = (
           await api.post(
@@ -263,6 +271,12 @@ medusaIntegrationTestRunner({
           adminHeaders
         )
 
+        updatedOrder = (
+          await api.get(`/admin/orders/${order.id}`, adminHeaders)
+        ).data.order
+
+        expect(updatedOrder.summary.pending_difference).toEqual(-75)
+
         await api.post(
           `/admin/payments/${payment.id}/refund`,
           {
@@ -272,6 +286,12 @@ medusaIntegrationTestRunner({
           },
           adminHeaders
         )
+
+        updatedOrder = (
+          await api.get(`/admin/orders/${order.id}`, adminHeaders)
+        ).data.order
+
+        expect(updatedOrder.summary.pending_difference).toEqual(-50)
 
         const refundedPayment = (
           await api.get(`/admin/payments/${payment.id}`, adminHeaders)

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Link, useNavigate } from "react-router-dom"
+import { Link } from "react-router-dom"
 
 import {
   ArrowDownRightMini,
@@ -114,7 +114,7 @@ export const OrderSummarySection = ({ order }: OrderSummarySectionProps) => {
     }
 
     return false
-  }, [reservations])
+  }, [reservations, order.items])
 
   const unpaidPaymentCollection = order.payment_collections.find(
     (pc) => pc.status === "not_paid"
@@ -133,8 +133,7 @@ export const OrderSummarySection = ({ order }: OrderSummarySectionProps) => {
 
   const showPayment =
     unpaidPaymentCollection && pendingDifference > 0 && isAmountSignificant
-  const showRefund =
-    unpaidPaymentCollection && pendingDifference < 0 && isAmountSignificant
+  const showRefund = pendingDifference < 0 && isAmountSignificant
 
   const handleMarkAsPaid = async (
     paymentCollection: AdminPaymentCollection

--- a/packages/core/core-flows/src/order/steps/add-order-transaction.ts
+++ b/packages/core/core-flows/src/order/steps/add-order-transaction.ts
@@ -5,12 +5,16 @@ import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
 /**
  * The transaction(s) to add to the order.
  */
-export type AddOrderTransactionStepInput = CreateOrderTransactionDTO | CreateOrderTransactionDTO[]
+export type AddOrderTransactionStepInput =
+  | CreateOrderTransactionDTO
+  | CreateOrderTransactionDTO[]
 
 /**
  * The added order transaction(s).
  */
-export type AddOrderTransactionStepOutput = CreateOrderTransactionDTO | CreateOrderTransactionDTO[]
+export type AddOrderTransactionStepOutput =
+  | CreateOrderTransactionDTO
+  | CreateOrderTransactionDTO[]
 
 export const addOrderTransactionStepId = "add-order-transaction"
 /**
@@ -18,35 +22,17 @@ export const addOrderTransactionStepId = "add-order-transaction"
  */
 export const addOrderTransactionStep = createStep(
   addOrderTransactionStepId,
-  async (
-    data: AddOrderTransactionStepInput,
-    { container }
-  ) => {
+  async (data: AddOrderTransactionStepInput, { container }) => {
     const service = container.resolve(Modules.ORDER)
 
     const trxsData = Array.isArray(data) ? data : [data]
 
-    for (const trx of trxsData) {
-      const existing = await service.listOrderTransactions(
-        {
-          order_id: trx.order_id,
-          reference: trx.reference,
-          reference_id: trx.reference_id,
-        },
-        {
-          select: ["id"],
-        }
-      )
-
-      if (existing.length) {
-        return new StepResponse(null)
-      }
-    }
-
     const created = await service.addOrderTransactions(trxsData)
 
     return new StepResponse(
-      (Array.isArray(data) ? created : created[0]) as AddOrderTransactionStepOutput,
+      (Array.isArray(data)
+        ? created
+        : created[0]) as AddOrderTransactionStepOutput,
       created.map((c) => c.id)
     )
   },


### PR DESCRIPTION
what:

When multiple refunds are currently performed on the same payment, we don't create additional transactions due to a validation that was in place. Removing it continues to add the transactions, but still fails when the refunded value is greater than captured value (which is expected) 

This also fixes an error that does not display the refundable amount when there is a paid payment collection. 