### PR TITLE
docs(algolia): rename instructed filename to fit code-block and preserve naming conflict instructions

### DIFF
--- a/www/apps/resources/app/integrations/guides/algolia/page.mdx
+++ b/www/apps/resources/app/integrations/guides/algolia/page.mdx
@@ -588,7 +588,7 @@ Learn more about subscribers in the [Events and Subscribers documentation](!docs
 
 </Note>
 
-You create a subscriber in a TypeScript or JavaScript file under the `src/subscribers` directory. So, to create the subscriber that listens to the `algolia.sync` event, create the file `src/subscribers/products-sync.ts` with the following content:
+You create a subscriber in a TypeScript or JavaScript file under the `src/subscribers` directory. So, to create the subscriber that listens to the `algolia.sync` event, create the file `src/subscribers/algolia-sync.ts` with the following content:
 
 ```ts title="src/subscribers/algolia-sync.ts"
 import {


### PR DESCRIPTION
This PR adjusts the filename instruction in the [documentation about integrating Algolia](https://docs.medusajs.com/resources/integrations/guides/algolia#create-products-sync-subscriber) to align with the actual file used in the code-block below (`algolia-sync.ts`). Previously, the instructions could cause confusion due to inconsistent file naming. After this change, there are no remaining uncertainties regarding naming, and the subsequent instruction to create `product-sync.ts` now makes logical sense and doesn't instruct to create a naming conflict.

This update ensures smoother onboarding for developers following the documentation.

---

## Changes

| File             | Description                                                   |
|------------------|---------------------------------------------------------------|
| `resources/integrations/guides/algolia/page.mdx`    | Updated filename reference to `algolia-sync.ts` to match the codebase and avoid confusion. |

---

## Notes

- This change only affects documentation.
- Resolves #12299 .

---

Let me know if anything should be further adjusted or discussed. Thanks!
