### PR TITLE
docs: fix TypeScript errors in marketplace vendor tutorial

### DIFF
--- a/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
+++ b/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
@@ -590,86 +590,68 @@ import {
     WorkflowResponse,
     transform,
   } from "@medusajs/framework/workflows-sdk"
-  import { 
-    setAuthAppMetadataStep,
-    useQueryGraphStep,
-  } from "@medusajs/medusa/core-flows"
-  import createVendorAdminStep from "./steps/create-vendor-admin"
-  import createVendorStep from "./steps/create-vendor"
-  
-  export type CreateVendorWorkflowInput = {
-    name: string
-    handle?: string
-    logo?: string
-    admin: {
-      email: string
-      first_name?: string
-      last_name?: string
+import { 
+setAuthAppMetadataStep,
+useQueryGraphStep,
+} from "@medusajs/medusa/core-flows"
+import createVendorAdminStep from "./steps/create-vendor-admin"
+import createVendorStep from "./steps/create-vendor"
+
+export type CreateVendorWorkflowInput = {
+name: string
+handle?: string
+logo?: string
+admin: {
+    email: string
+    first_name?: string
+    last_name?: string
+}
+authIdentityId: string
+}
+
+const createVendorWorkflow = createWorkflow(
+"create-vendor",
+function (input: CreateVendorWorkflowInput) {
+    const vendor = createVendorStep({
+    name: input.name,
+    handle: input.handle,
+    logo: input.logo,
+    })
+
+    const vendorAdminData = transform({
+    input,
+    vendor,
+    }, (data) => {
+    return {
+        ...data.input.admin,
+        vendor_id: data.vendor.id,
     }
-    authIdentityId: string
-  }
-  
-  type QueryResponse = {
-    data: Array<{
-      id: string
-      name: string
-      handle: string | null
-      logo: string | null
-      admins: Array<{
-        id: string
-        email: string
-        first_name: string | null
-        last_name: string | null
-      }>
-    }>
-  }
-  
-  const createVendorWorkflow = createWorkflow(
-    "create-vendor",
-    function (input: CreateVendorWorkflowInput): WorkflowResponse<{
-      vendor: QueryResponse["data"][0]
-    }> {
-      const vendor = createVendorStep({
-        name: input.name,
-        handle: input.handle,
-        logo: input.logo,
-      })
-  
-      const vendorAdminData = transform({
-        input,
-        vendor,
-      }, (data) => {
-        return {
-          ...data.input.admin,
-          vendor_id: data.vendor.id,
-        }
-      })
-  
-      const vendorAdmin = createVendorAdminStep(
-        vendorAdminData
-      )
-  
-      setAuthAppMetadataStep({
-        authIdentityId: input.authIdentityId,
-        actorType: "vendor",
-        value: vendorAdmin.id,
-      })
-  
-      const response = useQueryGraphStep({
-        entity: "vendor",
-        fields: ["id", "name", "handle", "logo", "admins.*"],
-        filters: {
-          id: vendor.id,
-        },
-      }) as QueryResponse
-  
-      return new WorkflowResponse({
-        vendor: response.data[0],
-      })
-    }
-  )
-  
-  export default createVendorWorkflow
+    })
+
+    const vendorAdmin = createVendorAdminStep(
+    vendorAdminData
+    )
+
+    setAuthAppMetadataStep({
+    authIdentityId: input.authIdentityId,
+    actorType: "vendor",
+    value: vendorAdmin.id,
+    })
+    // @ts-ignore
+    const { data: vendorWithAdmin } = useQueryGraphStep({
+    entity: "vendor",
+    fields: ["id", "name", "handle", "logo", "admins.*"],
+    filters: {
+        id: vendor.id,
+    },
+    })
+
+    return new WorkflowResponse({
+    vendor: vendorWithAdmin[0],
+    })
+})
+
+export default createVendorWorkflow
 ```
 
 You create a workflow with `createWorkflow` from the Workflows SDK. It accepts two parameters:

--- a/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
+++ b/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
@@ -586,72 +586,90 @@ export const vendorWorkflowHighlights = [
 
 ```ts title="src/workflows/marketplace/create-vendor/index.ts" highlights={vendorWorkflowHighlights}
 import { 
-  createWorkflow,
-  WorkflowResponse,
-} from "@medusajs/framework/workflows-sdk"
-import { 
-  setAuthAppMetadataStep,
-  useQueryGraphStep,
-} from "@medusajs/medusa/core-flows"
-import createVendorAdminStep from "./steps/create-vendor-admin"
-import createVendorStep from "./steps/create-vendor"
-
-export type CreateVendorWorkflowInput = {
-  name: string
-  handle?: string
-  logo?: string
-  admin: {
-    email: string
-    first_name?: string
-    last_name?: string
+    createWorkflow,
+    WorkflowResponse,
+    transform,
+  } from "@medusajs/framework/workflows-sdk"
+  import { 
+    setAuthAppMetadataStep,
+    useQueryGraphStep,
+  } from "@medusajs/medusa/core-flows"
+  import createVendorAdminStep from "./steps/create-vendor-admin"
+  import createVendorStep from "./steps/create-vendor"
+  
+  export type CreateVendorWorkflowInput = {
+    name: string
+    handle?: string
+    logo?: string
+    admin: {
+      email: string
+      first_name?: string
+      last_name?: string
+    }
+    authIdentityId: string
   }
-  authIdentityId: string
-}
-
-const createVendorWorkflow = createWorkflow(
-  "create-vendor",
-  function (input: CreateVendorWorkflowInput) {
-    const vendor = createVendorStep({
-      name: input.name,
-      handle: input.handle,
-      logo: input.logo,
-    })
-
-    const vendorAdminData = transform({
-      input,
-      vendor,
-    }, (data) => {
-      return {
-        ...data.input.admin,
-        vendor_id: data.vendor.id,
-      }
-    })
-
-    const vendorAdmin = createVendorAdminStep(
-      vendorAdminData
-    )
-
-    setAuthAppMetadataStep({
-      authIdentityId: input.authIdentityId,
-      actorType: "vendor",
-      value: vendorAdmin.id,
-    })
-
-    const { data: vendorWithAdmin } = useQueryGraphStep({
-      entity: "vendor",
-      fields: ["id", "name", "handle", "logo", "admins.*"],
-      filters: {
-        id: vendor.id,
-      },
-    })
-
-    return new WorkflowResponse({
-      vendor: vendorWithAdmin[0],
-    })
+  
+  type QueryResponse = {
+    data: Array<{
+      id: string
+      name: string
+      handle: string | null
+      logo: string | null
+      admins: Array<{
+        id: string
+        email: string
+        first_name: string | null
+        last_name: string | null
+      }>
+    }>
   }
-)
-
-export default createVendorAdminWorkflow
+  
+  const createVendorWorkflow = createWorkflow(
+    "create-vendor",
+    function (input: CreateVendorWorkflowInput): WorkflowResponse<{
+      vendor: QueryResponse["data"][0]
+    }> {
+      const vendor = createVendorStep({
+        name: input.name,
+        handle: input.handle,
+        logo: input.logo,
+      })
+  
+      const vendorAdminData = transform({
+        input,
+        vendor,
+      }, (data) => {
+        return {
+          ...data.input.admin,
+          vendor_id: data.vendor.id,
+        }
+      })
+  
+      const vendorAdmin = createVendorAdminStep(
+        vendorAdminData
+      )
+  
+      setAuthAppMetadataStep({
+        authIdentityId: input.authIdentityId,
+        actorType: "vendor",
+        value: vendorAdmin.id,
+      })
+  
+      const response = useQueryGraphStep({
+        entity: "vendor",
+        fields: ["id", "name", "handle", "logo", "admins.*"],
+        filters: {
+          id: vendor.id,
+        },
+      }) as QueryResponse
+  
+      return new WorkflowResponse({
+        vendor: response.data[0],
+      })
+    }
+  )
+  
+  export default createVendorWorkflow
 ```
 
 You create a workflow with `createWorkflow` from the Workflows SDK. It accepts two parameters:

--- a/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
+++ b/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
@@ -586,70 +586,71 @@ export const vendorWorkflowHighlights = [
 
 ```ts title="src/workflows/marketplace/create-vendor/index.ts" highlights={vendorWorkflowHighlights}
 import { 
-    createWorkflow,
-    WorkflowResponse,
-    transform,
-  } from "@medusajs/framework/workflows-sdk"
+  createWorkflow,
+  WorkflowResponse,
+  transform,
+} from "@medusajs/framework/workflows-sdk"
 import { 
-setAuthAppMetadataStep,
-useQueryGraphStep,
+  setAuthAppMetadataStep,
+  useQueryGraphStep,
 } from "@medusajs/medusa/core-flows"
 import createVendorAdminStep from "./steps/create-vendor-admin"
 import createVendorStep from "./steps/create-vendor"
 
 export type CreateVendorWorkflowInput = {
-name: string
-handle?: string
-logo?: string
-admin: {
+  name: string
+  handle?: string
+  logo?: string
+  admin: {
     email: string
     first_name?: string
     last_name?: string
-}
-authIdentityId: string
+  }
+  authIdentityId: string
 }
 
 const createVendorWorkflow = createWorkflow(
-"create-vendor",
-function (input: CreateVendorWorkflowInput) {
+  "create-vendor",
+  function (input: CreateVendorWorkflowInput) {
     const vendor = createVendorStep({
-    name: input.name,
-    handle: input.handle,
-    logo: input.logo,
+      name: input.name,
+      handle: input.handle,
+      logo: input.logo,
     })
 
     const vendorAdminData = transform({
-    input,
-    vendor,
+      input,
+      vendor,
     }, (data) => {
-    return {
+      return {
         ...data.input.admin,
         vendor_id: data.vendor.id,
-    }
+      }
     })
 
     const vendorAdmin = createVendorAdminStep(
-    vendorAdminData
+      vendorAdminData
     )
 
     setAuthAppMetadataStep({
-    authIdentityId: input.authIdentityId,
-    actorType: "vendor",
-    value: vendorAdmin.id,
+      authIdentityId: input.authIdentityId,
+      actorType: "vendor",
+      value: vendorAdmin.id,
     })
     // @ts-ignore
     const { data: vendorWithAdmin } = useQueryGraphStep({
-    entity: "vendor",
-    fields: ["id", "name", "handle", "logo", "admins.*"],
-    filters: {
+      entity: "vendor",
+      fields: ["id", "name", "handle", "logo", "admins.*"],
+      filters: {
         id: vendor.id,
-    },
+      },
     })
 
     return new WorkflowResponse({
-    vendor: vendorWithAdmin[0],
+      vendor: vendorWithAdmin[0],
     })
-})
+  }
+)
 
 export default createVendorWorkflow
 ```


### PR DESCRIPTION
The index.ts code example in "Create Workflow" section of the Marketplace Vendor Tutorial contains TypeScript errors that prevent successful compilation:

Missing transform import: The tutorial uses the transform function on line 33, but it's not imported from "@medusajs/framework/workflows-sdk"

TypeScript union type complexity error: When working with the useQueryGraphStep function, TypeScript throws "Expression produces a union type that is too complex to represent" error

Incorrect export name: On line 67, the export is export default createVendorAdminWorkflow but the workflow is defined as createVendorWorkflow (line 24)

These errors make it impossible for developers to follow the tutorial successfully without debugging TypeScript errors.

Closes #12301 