### PR TITLE
docs: fix missing quotation mark in marketplace vendor tutorial curl request

### DIFF
--- a/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
+++ b/www/apps/resources/app/recipes/marketplace/examples/vendors/page.mdx
@@ -885,7 +885,7 @@ You can now retrieve an authenticated token of the vendor admin. To do that, sen
 curl -X POST 'http://localhost:9000/auth/vendor/emailpass' \
 -H 'Content-Type: application/json' \
 --data-raw '{
-    "email": "vendor@example.com,
+    "email": "vendor@example.com",
     "password": "supersecret"
 }'
 ```


### PR DESCRIPTION
**What:**
Fixed a syntax error in the curl request example in the marketplace vendor tutorial, where a closing quotation mark was missing in the email string.

**Why:**
Without the closing quotation mark, the curl request would fail when copied and pasted directly, leading to confusion for developers following the tutorial.

**How**:
Added the missing quotation mark after the email address in the curl request JSON data.

**Testing:**
Verified that the JSON is now properly formatted and that the curl request will be executed correctly.

Closes #12314 