### PR TITLE
fix(dashboard): enable filtering on new DataTable

### DIFF
--- a/packages/admin/dashboard/src/components/data-table/data-table.tsx
+++ b/packages/admin/dashboard/src/components/data-table/data-table.tsx
@@ -120,7 +120,8 @@ export const DataTable = <TData,>({
       ...(enableSearch ? ["q"] : []),
       ...(enablePagination ? ["offset"] : []),
     ],
-    prefix
+    prefix,
+    true
   )
   const [_, setSearchParams] = useSearchParams()
 
@@ -175,8 +176,7 @@ export const DataTable = <TData,>({
 
       Object.entries(value).forEach(([key, filter]) => {
         if (
-          prefixedFilterIds.includes(getQueryParamKey(key, prefix)) &&
-          filter
+          prefixedFilterIds.includes(getQueryParamKey(key, prefix))
         ) {
           prev.set(getQueryParamKey(key, prefix), JSON.stringify(filter))
         }
@@ -368,7 +368,7 @@ function parseFilterState(
     const filterValue = value[id]
 
     if (filterValue) {
-      filters[id] = JSON.parse(filterValue)
+      filters[id] = filterValue !== "undefined" ? JSON.parse(filterValue) : undefined
     }
   }
 

--- a/packages/admin/dashboard/src/hooks/use-query-params.tsx
+++ b/packages/admin/dashboard/src/hooks/use-query-params.tsx
@@ -6,7 +6,8 @@ type QueryParams<T extends string> = {
 
 export function useQueryParams<T extends string>(
   keys: T[],
-  prefix?: string
+  prefix?: string,
+  keepUndefinedStrings: boolean = false
 ): QueryParams<T> {
   const [params] = useSearchParams()
 
@@ -17,7 +18,8 @@ export function useQueryParams<T extends string>(
     const prefixedKey = prefix ? `${prefix}_${key}` : key
     const value = params.get(prefixedKey) || undefined
 
-    result[key] = value
+    if (value !== "undefined" || keepUndefinedStrings)
+      result[key] = value
   })
 
   return result

--- a/packages/admin/dashboard/src/routes/users/user-list/components/user-list-table/user-list-table.tsx
+++ b/packages/admin/dashboard/src/routes/users/user-list/components/user-list-table/user-list-table.tsx
@@ -15,12 +15,14 @@ import { useQueryParams } from "../../../../../hooks/use-query-params"
 const PAGE_SIZE = 20
 
 export const UserListTable = () => {
-  const { q, order, offset } = useQueryParams(["q", "order", "offset"])
+  const { q, order, offset, created_at, updated_at } = useQueryParams(["q", "order", "offset", "created_at", "updated_at"])
   const { users, count, isPending, isError, error } = useUsers(
     {
       q,
       order,
       offset: offset ? parseInt(offset) : 0,
+      created_at: created_at ? JSON.parse(created_at) : undefined,
+      updated_at: updated_at ? JSON.parse(updated_at) : undefined,
       limit: PAGE_SIZE,
     },
     {


### PR DESCRIPTION
Closes #12068 

**What**

- Enables filtering on the new DataTable component by allowing to add `key=undefined` pairs to the url search params and appropriately filtering them out.
- Add date filters(created/updated) to the query in UserListTable, which were simply missing


**Why**

As far as i can tell adding undefined values to the search params seems to be the intended way the DataTable filter component was designed. The filter create button already tries to adds undefined values and the DataTableFilterBar checks for undefined to open automatically.   
Since undefined is not a valid JSON token, the parsing had to be tweaked.

**How**

The useQueryParams hook now by default converts string literals "undefined" to actual undefined. This makes sense to me as a default behaviour and keeps compatibility with existing queries.  
Optionally you can keep undefined as a string, which is used in DataTable to retrieve new filters. 

It's needed as a string since actual undefined already means "no filter", not "new empty filter". Alternatively I could have used `null` as a 3rd type, but you'd have to either 1. scatter null checks in every query to avoid backend errors or 2. add a flag to useQueryParams anyway to filter it out. Since it's the same I didn't want to mess with the type, as some functions might not check for null properly.

