### PR TITLE
feat(tax, cart, core-flows, utils, types): Compound TaxRate (Tax on Tax) Feature

### DIFF
--- a/.github/workflows/vennyx-release.yml
+++ b/.github/workflows/vennyx-release.yml
@@ -1,0 +1,166 @@
+name: Vennyx Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: choice
+        default: "latest"
+        description: "Which tag to use for publishing"
+        required: true
+        options:
+          - latest
+          - beta
+          - alpha
+          - next
+  push:
+    branches:
+      - vennyx-2.7.1
+    paths-ignore:
+      - "docs/**"
+      - "www/**"
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  build-and-publish:
+    name: Build and Publish to Vennyx Organization
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@vennyx-org"
+
+      - name: Create GitHub .npmrc
+        run: |
+          cat << EOF > .npmrc
+          @vennyx-org:registry=https://npm.pkg.github.com
+          //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
+          EOF
+
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Build original packages
+        run: |
+          # Build packages with original names first
+          yarn
+          yarn build
+
+      - name: Define common timestamp
+        run: |
+          echo "COMMON_TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
+
+      - name: List and prepare publishable packages
+        run: |
+          echo "Creating directory for publishable packages..."
+          mkdir -p ./publishable-packages
+
+          # Find all non-private packages and prepare them for publishing
+          find packages -name "package.json" -not -path "*/node_modules/*" -type f | while read -r pkg_file; do
+            # Skip private packages
+            if grep -q "\"private\":\s*true" "$pkg_file"; then
+              continue
+            fi
+            
+            PKG_DIR=$(dirname "$pkg_file")
+            PKG_NAME=$(jq -r '.name' "$pkg_file")
+            PKG_VERSION=$(jq -r '.version' "$pkg_file")
+            
+            if [ -z "$PKG_NAME" ] || [ "$PKG_NAME" = "null" ]; then
+              echo "Warning: Invalid package name in $pkg_file, skipping"
+              continue
+            fi
+            
+            echo "Preparing package: $PKG_NAME@$PKG_VERSION"
+            
+            # Create a clean directory for each package
+            TARGET_DIR="./publishable-packages/$(basename "$PKG_DIR")"
+            mkdir -p "$TARGET_DIR"
+            
+            # Copy the built files (lib, dist, etc.)
+            if [ -d "$PKG_DIR/lib" ]; then
+              cp -r "$PKG_DIR/lib" "$TARGET_DIR/"
+            fi
+            if [ -d "$PKG_DIR/dist" ]; then
+              cp -r "$PKG_DIR/dist" "$TARGET_DIR/"
+            fi
+            
+            # Copy essential files
+            cp "$pkg_file" "$TARGET_DIR/package.json"
+            if [ -f "$PKG_DIR/README.md" ]; then
+              cp "$PKG_DIR/README.md" "$TARGET_DIR/"
+            fi
+            if [ -f "$PKG_DIR/LICENSE" ]; then
+              cp "$PKG_DIR/LICENSE" "$TARGET_DIR/"
+            fi
+            
+            # Update package.json with vennyx-org scope
+            if [[ "$PKG_NAME" == @* ]]; then
+              # For scoped packages like @medusajs/utils -> @vennyx-org/utils
+              PACKAGE_NAME_WITHOUT_SCOPE=$(echo "$PKG_NAME" | sed 's/^@[^\/]*\///')
+              NEW_NAME="@vennyx-org/$PACKAGE_NAME_WITHOUT_SCOPE"
+            else
+              # For regular packages
+              NEW_NAME="@vennyx-org/$PKG_NAME"
+            fi
+            
+            # Update package.json
+            jq --arg name "$NEW_NAME" \
+               --arg url "https://github.com/vennyx-org/medusa.git" \
+               --arg dir "$PKG_DIR" \
+               --arg buildnum "$COMMON_TIMESTAMP" \
+               '.name = $name | .version = .version + "-" + $buildnum | .repository = {type: "git", url: $url, directory: $dir} | .publishConfig = {registry: "https://npm.pkg.github.com", access: "restricted"}' \
+               "$TARGET_DIR/package.json" > "$TARGET_DIR/package.json.new" && \
+                mv "$TARGET_DIR/package.json.new" "$TARGET_DIR/package.json"
+            
+            echo "Prepared $NEW_NAME (original: $PKG_NAME) in $TARGET_DIR"
+          done
+
+          echo "Package preparation complete."
+
+      - name: Publish prepared packages
+        run: |
+          echo "Publishing prepared packages..."
+
+          export SUCCESS_COUNT=0
+          export FAIL_COUNT=0
+
+          find ./publishable-packages -type d -maxdepth 1 -mindepth 1 | while read -r pkg_dir; do
+            if [ -f "$pkg_dir/package.json" ]; then
+              PKG_NAME=$(jq -r '.name' "$pkg_dir/package.json")
+              PKG_VERSION=$(jq -r '.version' "$pkg_dir/package.json")
+              
+              echo "Publishing $PKG_NAME@$PKG_VERSION from $pkg_dir"
+              
+              pushd "$pkg_dir" > /dev/null
+              
+              if npm publish --access restricted --tag ${{ github.event.inputs.version || 'latest' }}; then
+                echo "✅ Successfully published $PKG_NAME@$PKG_VERSION"
+                export SUCCESS_COUNT=$((SUCCESS_COUNT+1))
+              else
+                echo "❌ Failed to publish $PKG_NAME"
+                export FAIL_COUNT=$((FAIL_COUNT+1))
+              fi
+              
+              popd > /dev/null
+            fi
+          done
+
+          echo "Publishing complete: $SUCCESS_COUNT packages published successfully, $FAIL_COUNT failed"
+
+          if [ "$FAIL_COUNT" -gt 0 ]; then
+            echo "::warning::$FAIL_COUNT packages failed to publish"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/admin/dashboard/src/i18n/translations/$schema.json
+++ b/packages/admin/dashboard/src/i18n/translations/$schema.json
@@ -6876,6 +6876,30 @@
               "required": ["label", "hint", "true", "false"],
               "additionalProperties": false
             },
+            "isCompound": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "hint": {
+                  "type": "string"
+                },
+                "true": {
+                  "type": "string"
+                },
+                "false": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "hint",
+                "true",
+                "false"
+              ],
+              "additionalProperties": false
+            },
             "defaultTaxRate": {
               "type": "object",
               "properties": {

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -1844,6 +1844,12 @@
         "true": "Combinable",
         "false": "Not combinable"
       },
+      "isCompound": {
+        "label": "Compound",
+        "hint": "Whether this tax rate is compound, which means it will be applied on top of the previous combinable tax rates.",
+        "true": "Compound",
+        "false": "Not compound"
+      },
       "defaultTaxRate": {
         "label": "Default tax rate",
         "tooltip": "The default tax rate for this region. An example is the standard VAT rate for a country or region.",
@@ -2654,7 +2660,10 @@
         "placeholder": "wrong_size",
         "tooltip": "The value should be a unique identifier for the return reason."
       },
-      "label": { "label": "Label", "placeholder": "Wrong size" },
+      "label": {
+        "label": "Label",
+        "placeholder": "Wrong size"
+      },
       "description": {
         "label": "Description",
         "placeholder": "Customer received the wrong size"

--- a/packages/admin/dashboard/src/routes/tax-regions/common/components/tax-override-card/tax-override-card.tsx
+++ b/packages/admin/dashboard/src/routes/tax-regions/common/components/tax-override-card/tax-override-card.tsx
@@ -37,18 +37,15 @@ export const TaxOverrideCard = ({ taxRate }: TaxOverrideCardProps) => {
     return null
   }
 
-  const groupedRules = taxRate.rules.reduce(
-    (acc, rule) => {
-      if (!acc[rule.reference]) {
-        acc[rule.reference] = []
-      }
+  const groupedRules = taxRate.rules.reduce((acc, rule) => {
+    if (!acc[rule.reference]) {
+      acc[rule.reference] = []
+    }
 
-      acc[rule.reference].push(rule.reference_id)
+    acc[rule.reference].push(rule.reference_id)
 
-      return acc
-    },
-    {} as Record<string, string[]>
-  )
+    return acc
+  }, {} as Record<string, string[]>)
 
   const validKeys = Object.values(TaxRateRuleReferenceType)
   const numberOfTargets = Object.keys(groupedRules).map((key) =>
@@ -91,6 +88,11 @@ export const TaxOverrideCard = ({ taxRate }: TaxOverrideCardProps) => {
             {taxRate.is_combinable
               ? t("taxRegions.fields.isCombinable.true")
               : t("taxRegions.fields.isCombinable.false")}
+          </StatusBadge>
+          <StatusBadge color={taxRate.is_compound ? "green" : "grey"}>
+            {taxRate.is_compound
+              ? t("taxRegions.fields.isCompound.true")
+              : t("taxRegions.fields.isCompound.false")}
           </StatusBadge>
           <ActionMenu
             groups={[

--- a/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-create/components/tax-region-override-create-form/tax-region-tax-override-create.tsx
+++ b/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-create/components/tax-region-override-create-form/tax-region-tax-override-create.tsx
@@ -47,6 +47,7 @@ const TaxRegionCreateTaxOverrideSchema = z.object({
     })
     .optional(),
   is_combinable: z.boolean().optional(),
+  is_compound: z.boolean().optional(),
   enabled_rules: z.object({
     product: z.boolean(),
     product_type: z.boolean(),
@@ -81,6 +82,7 @@ export const TaxRegionCreateTaxOverrideForm = ({
       name: "",
       code: "",
       is_combinable: false,
+      is_compound: false,
       rate: {
         value: "",
       },
@@ -149,6 +151,7 @@ export const TaxRegionCreateTaxOverrideForm = ({
         rate: values.rate?.float,
         code: values.code,
         is_combinable: values.is_combinable,
+        is_compound: values.is_compound,
         rules: rules,
         is_default: false,
       },
@@ -429,6 +432,19 @@ export const TaxRegionCreateTaxOverrideForm = ({
                 name="is_combinable"
                 label={t("taxRegions.fields.isCombinable.label")}
                 description={t("taxRegions.fields.isCombinable.hint")}
+                onCheckedChange={(value) => {
+                  if (!value) {
+                    form.setValue("is_compound", false, {
+                      shouldDirty: true,
+                    })
+                  }
+                }}
+              />
+              <SwitchBox
+                control={form.control}
+                name="is_compound"
+                label={t("taxRegions.fields.isCompound.label")}
+                description={t("taxRegions.fields.isCompound.hint")}
               />
               <div className="flex flex-col gap-y-3">
                 <div className="flex items-center justify-between gap-x-4">

--- a/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-edit/components/tax-region-tax-override-edit-form/tax-region-tax-override-edit-form.tsx
+++ b/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-edit/components/tax-region-tax-override-edit-form/tax-region-tax-override-edit-form.tsx
@@ -55,6 +55,7 @@ const TaxRegionTaxRateEditSchema = z.object({
     value: z.string().optional(),
   }),
   is_combinable: z.boolean().optional(),
+  is_compound: z.boolean().optional(),
   enabled_rules: z.object({
     product: z.boolean(),
     product_type: z.boolean(),
@@ -86,6 +87,7 @@ export const TaxRegionTaxOverrideEditForm = ({
         value: taxRate.rate?.toString() || "",
       },
       is_combinable: taxRate.is_combinable,
+      is_compound: taxRate.is_compound,
       enabled_rules: {
         product: initialValues.product.length > 0,
         product_type: initialValues.product_type.length > 0,
@@ -148,9 +150,10 @@ export const TaxRegionTaxOverrideEditForm = ({
     await mutateAsync(
       {
         name: values.name,
-        code: values.code || null,
+        code: values.code || "",
         rate: values.rate?.float,
         is_combinable: values.is_combinable,
+        is_compound: values.is_compound,
         rules,
       },
       {
@@ -339,6 +342,11 @@ export const TaxRegionTaxOverrideEditForm = ({
     (value) => !value
   )
 
+  const watchedIsCombinable = useWatch({
+    control: form.control,
+    name: "is_combinable",
+  })
+
   return (
     <RouteDrawer.Form form={form}>
       <KeyboundForm
@@ -408,8 +416,21 @@ export const TaxRegionTaxOverrideEditForm = ({
               name="is_combinable"
               label={t("taxRegions.fields.isCombinable.label")}
               description={t("taxRegions.fields.isCombinable.hint")}
+              onCheckedChange={(value) => {
+                if (!value) {
+                  form.setValue("is_compound", false, {
+                    shouldDirty: true,
+                  })
+                }
+              }}
             />
           )}
+          <SwitchBox
+            control={form.control}
+            name="is_compound"
+            label={t("taxRegions.fields.isCompound.label")}
+            description={t("taxRegions.fields.isCompound.hint")}
+          />
           <div className="flex flex-col gap-y-3">
             <div className="flex items-center justify-between gap-x-4">
               <div className="flex flex-col">

--- a/packages/core/core-flows/src/cart/steps/set-tax-lines-for-items.ts
+++ b/packages/core/core-flows/src/cart/steps/set-tax-lines-for-items.ts
@@ -116,6 +116,7 @@ export const setTaxLinesForItemsStep = createStep(
           rate: taxLine.rate,
           provider_id: taxLine.provider_id,
           item_id: taxLine.item_id,
+          is_compound: taxLine.is_compound,
         }))
       )
     }
@@ -129,6 +130,7 @@ export const setTaxLinesForItemsStep = createStep(
         rate: taxLine.rate,
         provider_id: taxLine.provider_id,
         shipping_method_id: taxLine.shipping_method_id,
+        is_compound: taxLine.is_compound,
       }))
     )
   }
@@ -142,6 +144,7 @@ function normalizeItemTaxLinesForCart(
     tax_rate_id: taxLine.rate_id,
     code: taxLine.code!,
     rate: taxLine.rate!,
+    is_compound: taxLine.is_compound,
     provider_id: taxLine.provider_id,
     item_id: taxLine.line_item_id,
   }))
@@ -155,6 +158,7 @@ function normalizeShippingTaxLinesForCart(
     tax_rate_id: taxLine.rate_id,
     code: taxLine.code!,
     rate: taxLine.rate!,
+    is_compound: taxLine.is_compound,
     provider_id: taxLine.provider_id,
     shipping_method_id: taxLine.shipping_line_id,
   }))

--- a/packages/core/types/src/cart/common.ts
+++ b/packages/core/types/src/cart/common.ts
@@ -120,6 +120,11 @@ export interface TaxLineDTO {
   rate: number
 
   /**
+   * Whether the tax line is compound.
+   */
+  is_compound?: boolean
+
+  /**
    * The ID of the associated provider.
    */
   provider_id?: string

--- a/packages/core/types/src/cart/mutations.ts
+++ b/packages/core/types/src/cart/mutations.ts
@@ -378,6 +378,11 @@ export interface CreateTaxLineDTO {
   rate: number
 
   /**
+   * Whether the tax line is compound.
+   */
+  is_compound?: boolean
+
+  /**
    * The associated provider's ID.
    */
   provider_id?: string
@@ -415,6 +420,11 @@ export interface UpdateTaxLineDTO {
    * The rate of the tax line.
    */
   rate?: number
+
+  /**
+   * Whether the tax line is compound.
+   */
+  is_compound?: boolean
 
   /**
    * The associated provider's ID.

--- a/packages/core/types/src/http/tax-rate/admin/entities.ts
+++ b/packages/core/types/src/http/tax-rate/admin/entities.ts
@@ -3,14 +3,14 @@ import { AdminTaxRegion } from "../../tax-region"
 export interface AdminTaxRateRule {
   /**
    * The name of the table that the rule references.
-   * 
+   *
    * @example
    * "product_type"
    */
   reference: string
   /**
    * The ID of the record in the table that the rule references.
-   * 
+   *
    * @example
    * "protyp_123"
    */
@@ -50,6 +50,10 @@ export interface AdminTaxRate {
    * Whether the tax rate is the default tax rate in its tax region.
    */
   is_default: boolean
+  /**
+   * Whether the tax rate is a compound tax rate
+   */
+  is_compound: boolean
   /**
    * The date the tax rate was created.
    */

--- a/packages/core/types/src/http/tax-rate/admin/payloads.ts
+++ b/packages/core/types/src/http/tax-rate/admin/payloads.ts
@@ -1,14 +1,14 @@
 interface AdminCreateTaxRateRule {
   /**
    * The name of the table that the rule references.
-   * 
+   *
    * @example
    * "product_type"
    */
   reference: string
   /**
    * The ID of the record in the table that the rule references.
-   * 
+   *
    * @example
    * "protyp_123"
    */
@@ -45,6 +45,10 @@ export interface AdminCreateTaxRate {
    */
   is_combinable?: boolean
   /**
+   * Whether the tax rate is a compound tax rate
+   */
+  is_compound?: boolean
+  /**
    * Custom key-value pairs that can be added to the tax rate.
    */
   metadata?: Record<string, unknown>
@@ -75,6 +79,10 @@ export interface AdminUpdateTaxRate {
    * Whether the tax rate is combinable with other tax rates.
    */
   is_combinable?: boolean
+  /**
+   * Whether the tax rate is a compound tax rate
+   */
+  is_compound?: boolean
   /**
    * Custom key-value pairs that can be added to the tax rate.
    */

--- a/packages/core/types/src/tax/common.ts
+++ b/packages/core/types/src/tax/common.ts
@@ -53,6 +53,11 @@ export interface TaxRateDTO {
   is_default: boolean
 
   /**
+   * Whether the tax rate is compound.
+   */
+  is_compound: boolean
+
+  /**
    * The creation date of the tax rate.
    */
   created_at: string | Date
@@ -514,6 +519,26 @@ interface TaxLineDTO {
    * The ID of the tax provider used to calculate and retrieve the tax line.
    */
   provider_id: string
+
+  /**
+   * Whether the tax line is compound.
+   */
+  is_compound?: boolean
+
+  /**
+   * Holds custom data in key-value pairs.
+   */
+  metadata?: Record<string, unknown> | null
+
+  /**
+   * The creation date of the tax line.
+   */
+  created_at?: Date
+
+  /**
+   * The update date of the tax line.
+   */
+  updated_at?: Date
 }
 
 /**

--- a/packages/core/types/src/tax/mutations.ts
+++ b/packages/core/types/src/tax/mutations.ts
@@ -47,6 +47,13 @@ export interface CreateTaxRateDTO {
    * Holds custom data in key-value pairs.
    */
   metadata?: MetadataType
+
+  /**
+   * Whether the tax is compound. When true, this tax will be calculated on top of the 
+   * price including previous taxes, instead of just the base price.
+   * Used for taxes like VAT that should apply to the price after other taxes (like SCT in Turkey).
+   */
+  is_compound?: boolean
 }
 
 /**
@@ -92,6 +99,13 @@ export interface UpsertTaxRateDTO {
    * Holds custom data in key-value pairs.
    */
   metadata?: MetadataType
+
+  /**
+   * Whether the tax is compound. When true, this tax will be calculated on top of the 
+   * price including previous taxes, instead of just the base price.
+   * Used for taxes like VAT that should apply to the price after other taxes (like SCT in Turkey).
+   */
+  is_compound?: boolean
 }
 
 /**
@@ -132,6 +146,11 @@ export interface UpdateTaxRateDTO {
    * Learn more [here](https://docs.medusajs.com/resources/commerce-modules/tax/tax-rates-and-rules#combinable-tax-rates).
    */
   is_combinable?: boolean
+
+  /**
+   * Whether the tax rate is compound. When true, this tax will be calculated on top of the 
+   */
+  is_compound?: boolean
 
   /**
    * @ignore

--- a/packages/core/utils/src/totals/line-item/index.ts
+++ b/packages/core/utils/src/totals/line-item/index.ts
@@ -1,4 +1,4 @@
-import { AdjustmentLineDTO, BigNumberInput, TaxLineDTO } from "@medusajs/types"
+import { AdjustmentLineDTO, BigNumberInput, ItemTaxLineDTO } from "@medusajs/types"
 import { isDefined, pickValueFromObject } from "../../common"
 import { calculateAdjustmentTotal } from "../adjustment"
 import { BigNumber } from "../big-number"
@@ -15,7 +15,7 @@ export interface GetItemTotalInput {
   unit_price: BigNumber
   quantity: BigNumber
   is_tax_inclusive?: boolean
-  tax_lines?: Pick<TaxLineDTO, "rate">[]
+  tax_lines?: ItemTaxLineDTO[]
   adjustments?: Pick<AdjustmentLineDTO, "amount">[]
   detail?: {
     fulfilled_quantity: BigNumber

--- a/packages/core/utils/src/totals/tax/index.ts
+++ b/packages/core/utils/src/totals/tax/index.ts
@@ -1,4 +1,4 @@
-import { BigNumberInput, TaxLineDTO } from "@medusajs/types"
+import { BigNumberInput, ItemTaxLineDTO } from "@medusajs/types"
 import { BigNumber } from "../big-number"
 import { MathBN } from "../math"
 
@@ -7,7 +7,7 @@ export function calculateTaxTotal({
   taxableAmount,
   setTotalField,
 }: {
-  taxLines: Pick<TaxLineDTO, "rate">[]
+  taxLines: any[]
   taxableAmount: BigNumberInput
   setTotalField?: string
 }) {
@@ -16,10 +16,30 @@ export function calculateTaxTotal({
   }
 
   let taxTotal = MathBN.convert(0)
+  let baseWithTax = MathBN.convert(taxableAmount)
 
-  for (const taxLine of taxLines) {
+  // First process all non-compound taxes (like SCT)
+  const standardTaxLines = taxLines.filter(taxLine => !taxLine.is_compound);
+  const compoundTaxLines = taxLines.filter(taxLine => taxLine.is_compound);
+
+  // Calculate regular taxes
+  for (const taxLine of standardTaxLines) {
     const rate = MathBN.div(taxLine.rate, 100)
     let taxAmount = MathBN.mult(taxableAmount, rate)
+
+    if (setTotalField) {
+      ;(taxLine as any)[setTotalField] = new BigNumber(taxAmount)
+    }
+
+    taxTotal = MathBN.add(taxTotal, taxAmount)
+    baseWithTax = MathBN.add(baseWithTax, taxAmount) // Add tax to base for compound calculation
+  }
+
+  // Calculate compound taxes (like VAT on SCT)
+  for (const taxLine of compoundTaxLines) {
+    const rate = MathBN.div(taxLine.rate, 100)
+    // Apply to price INCLUDING other taxes
+    let taxAmount = MathBN.mult(baseWithTax, rate)
 
     if (setTotalField) {
       ;(taxLine as any)[setTotalField] = new BigNumber(taxAmount)
@@ -36,26 +56,57 @@ export function calculateAmountsWithTax({
   amount,
   includesTax,
 }: {
-  taxLines: Pick<TaxLineDTO, "rate">[]
+  taxLines: ItemTaxLineDTO[]
   amount: number
   includesTax?: boolean
 }) {
-  const sumTaxRate = MathBN.div(
-    MathBN.sum(...((taxLines ?? []).map((taxLine) => taxLine.rate) ?? [])),
+  // Split tax lines into standard and compound
+  const standardTaxLines = taxLines.filter(taxLine => !taxLine.is_compound);
+  const compoundTaxLines = taxLines.filter(taxLine => taxLine.is_compound);
+
+  // Calculate sum of standard tax rates
+  const sumStandardTaxRate = MathBN.div(
+    MathBN.sum(...((standardTaxLines ?? []).map((taxLine) => taxLine.rate) ?? [])),
     100
   )
 
-  const taxableAmount = includesTax
-    ? MathBN.div(amount, MathBN.add(1, sumTaxRate))
-    : amount
-
-  const tax = calculateTaxTotal({
-    taxLines,
-    taxableAmount,
-  })
-
-  return {
-    priceWithTax: includesTax ? amount : MathBN.add(tax, amount).toNumber(),
-    priceWithoutTax: includesTax ? MathBN.sub(amount, tax).toNumber() : amount,
+  // Handle tax-inclusive pricing differently
+  if (includesTax) {
+    // Complex case: need to back-calculate from tax-inclusive amount with compound taxes
+    
+    // Calculate compound tax rates sum
+    let compoundRateSum = MathBN.convert(0);
+    for (const taxLine of compoundTaxLines) {
+      compoundRateSum = MathBN.add(compoundRateSum, MathBN.div(taxLine.rate, 100))
+    }
+    
+    // Formula for extracting base amount from tax-inclusive pricing with compound tax
+    const taxableAmount = MathBN.div(
+      amount, 
+      MathBN.add(1, MathBN.add(sumStandardTaxRate, compoundRateSum))
+    )
+    
+    const tax = calculateTaxTotal({
+      taxLines,
+      taxableAmount,
+    })
+    
+    return {
+      priceWithTax: amount,
+      priceWithoutTax: MathBN.sub(amount, tax).toNumber(),
+    }
+  } else {
+    // Tax exclusive pricing is easier - we just calculate tax normally
+    const taxableAmount = amount
+    
+    const tax = calculateTaxTotal({
+      taxLines,
+      taxableAmount,
+    })
+    
+    return {
+      priceWithTax: MathBN.add(amount, tax).toNumber(),
+      priceWithoutTax: amount,
+    }
   }
 }

--- a/packages/medusa/src/api/admin/tax-rates/query-config.ts
+++ b/packages/medusa/src/api/admin/tax-rates/query-config.ts
@@ -6,6 +6,7 @@ export const defaults = [
   "tax_region_id",
   "is_default",
   "is_combinable",
+  "is_compound",
   "created_by",
   "created_at",
   "updated_at",

--- a/packages/medusa/src/api/admin/tax-rates/validators.ts
+++ b/packages/medusa/src/api/admin/tax-rates/validators.ts
@@ -42,6 +42,7 @@ export const AdminCreateTaxRate = z.object({
   name: z.string(),
   is_default: z.boolean().optional(),
   is_combinable: z.boolean().optional(),
+  is_compound: z.boolean().optional(),
   tax_region_id: z.string(),
   metadata: z.record(z.unknown()).nullish(),
 })
@@ -54,5 +55,6 @@ export const AdminUpdateTaxRate = z.object({
   name: z.string().optional(),
   is_default: z.boolean().optional(),
   is_combinable: z.boolean().optional(),
+  is_compound: z.boolean().optional(),
   metadata: z.record(z.unknown()).nullish(),
 })

--- a/packages/modules/cart/src/migrations/Migration20250411131500.ts
+++ b/packages/modules/cart/src/migrations/Migration20250411131500.ts
@@ -1,0 +1,15 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20250326151602 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "cart_line_item_tax_line" add column if not exists "is_compound" boolean not null default false;`
+    )
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "cart_line_item_tax_line" drop column if exists "is_compound";`
+    )
+  }
+}

--- a/packages/modules/cart/src/models/line-item-tax-line.ts
+++ b/packages/modules/cart/src/models/line-item-tax-line.ts
@@ -12,6 +12,7 @@ const LineItemTaxLine = model
       description: model.text().nullable(),
       code: model.text(),
       rate: model.float(),
+      is_compound: model.boolean().default(false),
       provider_id: model.text().nullable(),
       metadata: model.json().nullable(),
       tax_rate_id: model.text().nullable(),

--- a/packages/modules/cart/src/types/tax-line.ts
+++ b/packages/modules/cart/src/types/tax-line.ts
@@ -5,6 +5,7 @@ export interface UpdateTaxLineDTO {
   code?: string
   rate?: number
   provider_id?: string
+  is_compound?: boolean
 }
 
 export interface CreateTaxLineDTO {
@@ -13,4 +14,5 @@ export interface CreateTaxLineDTO {
   code: string
   rate: number
   provider_id?: string
+  is_compound?: boolean
 }

--- a/packages/modules/tax/README.md
+++ b/packages/modules/tax/README.md
@@ -1,1 +1,95 @@
 # Tax Module
+
+## Enhanced Tax Features
+
+### Compound Tax Calculation
+
+In some tax systems (like Turkey's), taxes are calculated on top of other taxes. For example, VAT (KDV) is calculated on a price that already includes Special Consumption Tax (ÖTV). The `is_compound` flag enables this behavior.
+
+When a tax rate is marked with `is_compound: true`:
+- It will be calculated after non-compound taxes
+- Its calculation will be based on the price plus all non-compound taxes
+- This ensures proper tax-on-tax calculation for systems like Turkey's
+
+#### Setting Up Compound Taxes
+
+```js
+// Create a tax region
+const region = await taxModuleService.createTaxRegions({
+  country_code: "tr",
+});
+
+// Create first non-compound tax (Special Consumption Tax)
+const sctTaxRate = await taxModuleService.createTaxRates({
+  tax_region_id: region.id,
+  code: "SCT",
+  name: "Special Consumption Tax",
+  rate: 10, // 10%
+  is_combinable: true, 
+  is_compound: false, // Apply this tax to the base price
+});
+
+// Create a compound tax (VAT)
+const vatTaxRate = await taxModuleService.createTaxRates({
+  tax_region_id: region.id,
+  code: "VAT",
+  name: "Value Added Tax",
+  rate: 18, // 18%
+  is_combinable: true,
+  is_compound: true, // Apply this tax to (price + SCT)
+});
+```
+
+With this setup:
+- A product costing 1000 TL will have:
+  - 10% SCT = 100 TL (calculated on 1000 TL)
+  - 18% VAT = 198 TL (calculated on 1100 TL)
+  - Total tax = 298 TL
+  - Final price = 1298 TL
+
+#### Countries with Similar Compound Tax Systems
+
+The compound tax feature supports various international tax systems similar to Turkey's model:
+
+- **Brazil** - IPI (Industrial Product Tax) is applied first, then ICMS (state VAT) is calculated on the price including IPI
+- **Philippines** - Excise taxes apply first, then VAT is calculated on the price including excise tax
+- **Russia** - Excise duties apply first, then VAT is calculated on the price including these duties
+- **India** - For luxury goods, additional cess tax applies on top of GST
+- **Mexico** - IEPS (Special Tax) applies first to certain goods, then VAT is calculated on the price including IEPS
+- **South Africa** - Excise duties on items like alcohol are applied first, then VAT is calculated on the price including duties
+
+### Combinable Tax Rates Without Parent-Child Regions
+
+The enhanced tax module now supports applying multiple tax rates within a single region without requiring parent-child region relationships.
+
+#### Setting Up Combinable Tax Rates
+
+```js
+// Create a tax region
+const region = await taxModuleService.createTaxRegions({
+  country_code: "tr",
+});
+
+// Create a higher SCT rate for luxury goods
+const luxurySctTaxRate = await taxModuleService.createTaxRates({
+  tax_region_id: region.id,
+  code: "LUX-SCT",
+  name: "Luxury Special Consumption Tax",
+  rate: 40, // 40% SCT for luxury goods
+  is_combinable: true,
+  is_compound: false,
+});
+
+// Create VAT as compound tax
+const vatTaxRate = await taxModuleService.createTaxRates({
+  tax_region_id: region.id,
+  code: "VAT",
+  name: "Value Added Tax",
+  rate: 18, // 18% VAT
+  is_combinable: true,
+  is_compound: true, // Apply after SCT
+});
+```
+
+With this setup:
+- All works within a single region

--- a/packages/modules/tax/src/migrations/Migration20250411000002.ts
+++ b/packages/modules/tax/src/migrations/Migration20250411000002.ts
@@ -1,0 +1,17 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20240800000002 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "tax_rate" 
+      ADD COLUMN IF NOT EXISTS "is_compound" BOOLEAN NOT NULL DEFAULT FALSE
+    `)
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "tax_rate" 
+      DROP COLUMN IF EXISTS "is_compound"
+    `)
+  }
+} 

--- a/packages/modules/tax/src/models/tax-rate.ts
+++ b/packages/modules/tax/src/models/tax-rate.ts
@@ -10,6 +10,7 @@ const TaxRate = model
     name: model.text().searchable(),
     is_default: model.boolean().default(false),
     is_combinable: model.boolean().default(false),
+    is_compound: model.boolean().default(false),
     tax_region: model.belongsTo(() => TaxRegion, {
       mappedBy: "tax_rates",
     }),

--- a/packages/modules/tax/src/providers/system.ts
+++ b/packages/modules/tax/src/providers/system.ts
@@ -12,30 +12,50 @@ export default class SystemTaxService implements ITaxProvider {
     shippingLines: TaxTypes.ShippingTaxCalculationLine[],
     _: TaxTypes.TaxCalculationContext
   ): Promise<(TaxTypes.ItemTaxLineDTO | TaxTypes.ShippingTaxLineDTO)[]> {
-    let taxLines: (TaxTypes.ItemTaxLineDTO | TaxTypes.ShippingTaxLineDTO)[] =
-      itemLines.flatMap((l) => {
-        return l.rates.map((r) => ({
+    let taxLines: (TaxTypes.ItemTaxLineDTO | TaxTypes.ShippingTaxLineDTO)[] = []
+
+    // Process item lines - ensuring proper order for compound taxes
+    for (const l of itemLines) {
+      // Sort rates: non-compound first, then compound ones
+      // This ensures compound taxes are applied after regular taxes
+      const sortedRates = [...l.rates].sort((a, b) => {
+        if (a.is_compound === b.is_compound) return 0
+        return a.is_compound ? 1 : -1
+      })
+
+      for (const r of sortedRates) {
+        taxLines.push({
           rate_id: r.id,
           rate: r.rate || 0,
           name: r.name,
           code: r.code,
           line_item_id: l.line_item.id,
           provider_id: this.getIdentifier(),
-        }))
+          is_compound: r.is_compound || false,
+        })
+      }
+    }
+
+    // Process shipping lines - also ensuring proper tax order
+    for (const l of shippingLines) {
+      // Sort rates: non-compound first, then compound ones
+      const sortedRates = [...l.rates].sort((a, b) => {
+        if (a.is_compound === b.is_compound) return 0
+        return a.is_compound ? 1 : -1
       })
 
-    taxLines = taxLines.concat(
-      shippingLines.flatMap((l) => {
-        return l.rates.map((r) => ({
+      for (const r of sortedRates) {
+        taxLines.push({
           rate_id: r.id,
           rate: r.rate || 0,
           name: r.name,
           code: r.code,
           shipping_line_id: l.shipping_line.id,
           provider_id: this.getIdentifier(),
-        }))
-      })
-    )
+          is_compound: r.is_compound || false,
+        })
+      }
+    }
 
     return taxLines
   }

--- a/packages/modules/tax/src/services/tax-module-service.ts
+++ b/packages/modules/tax/src/services/tax-module-service.ts
@@ -663,7 +663,6 @@ export default class TaxModuleService
         isProductMatch: false,
         isProductTypeMatch: false,
         isShippingMatch: false,
-        isPriceThresholdMatch: false,
       }
     }
 


### PR DESCRIPTION

# Compound Tax Calculation Feature

## Overview
This PR introduces support for compound taxation, allowing taxes to be calculated on top of other taxes. This feature is essential for accurately modeling tax systems like Turkey's, where VAT (KDV) is calculated on a price that already includes Special Consumption Tax (ÖTV).

## Key Changes
- Added `is_compound` flag to tax rate models
- Implemented compound tax calculation logic in tax and cart totals calculation
- Updated admin UI to support creating and editing compound tax rates
- Added database migrations for the new fields
- Updated documentation to reflect new capabilities

## Technical Implementation
The implementation properly handles tax-inclusive and tax-exclusive pricing scenarios when compound taxes are present. Compound taxes are:
1. Applied after non-compound taxes
2. Calculated based on the price + all non-compound taxes
3. Properly sequenced in the calculation pipeline

## Use Cases
This feature supports various international tax systems that require compound calculations:

- **Turkey**: VAT calculated on price including SCT
- **Brazil**: ICMS (state VAT) calculated on price including IPI (Industrial Product Tax)
- **Philippines**: VAT calculated on price including excise taxes
- **Russia**: VAT calculated on price including excise duties
- **India**: Additional cess tax on top of GST for luxury goods
- **Mexico**: VAT calculated on price including IEPS (Special Tax)

## Example
For a product costing $100 with 10% SCT and 20% VAT (as compound):
- SCT = $10 (calculated on base price)
- VAT = $22 (calculated on price + SCT = $110)
- Total tax = $32
- Final price = $132

Without the compound flag, VAT would incorrectly be $20 (on base price), leading to a total tax of $30 and final price of $130.

## Migration Notes
This PR includes necessary migrations for database schema updates in both tax and cart modules.
