### PR TITLE
docs-util: fix hook examples not showing in generated references

### DIFF
--- a/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/workflow-hooks.ts
+++ b/www/utils/packages/typedoc-plugin-markdown-medusa/src/resources/helpers/workflow-hooks.ts
@@ -30,7 +30,7 @@ export default function (theme: MarkdownTheme) {
       hooks.forEach((hook) => {
         const hookReflection =
           hookChildren.find((child) => {
-            if (child.name !== hook.name) {
+            if (child.name !== hook.name || !child.comment) {
               return false
             }
 


### PR DESCRIPTION
Closes DX-1587