### PR TITLE
fix(core-flows,utils): move fulfillment workflow events

### DIFF
--- a/.changeset/friendly-hairs-cross.md
+++ b/.changeset/friendly-hairs-cross.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/core-flows": patch
+"@medusajs/utils": patch
+---
+
+fix(core-flows,utils): move fulfillment workflow events

--- a/packages/core/core-flows/src/order/workflows/create-shipment.ts
+++ b/packages/core/core-flows/src/order/workflows/create-shipment.ts
@@ -8,7 +8,7 @@ import {
   OrderWorkflow,
   ProductVariantDTO,
 } from "@medusajs/framework/types"
-import { FulfillmentEvents, MathBN, Modules } from "@medusajs/framework/utils"
+import { FulfillmentWorkflowEvents, MathBN, Modules } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   WorkflowResponse,
@@ -243,7 +243,7 @@ export const createOrderShipmentWorkflow = createWorkflow(
     )
 
     emitEventStep({
-      eventName: FulfillmentEvents.SHIPMENT_CREATED,
+      eventName: FulfillmentWorkflowEvents.SHIPMENT_CREATED,
       data: { id: shipment.id, no_notification: input.no_notification },
     })
 

--- a/packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts
+++ b/packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts
@@ -7,7 +7,7 @@ import {
   ProductVariantDTO,
   RegisterOrderDeliveryDTO,
 } from "@medusajs/framework/types"
-import { FulfillmentEvents, MathBN, Modules } from "@medusajs/framework/utils"
+import { FulfillmentWorkflowEvents, MathBN, Modules } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   WorkflowResponse,
@@ -261,7 +261,7 @@ export const markOrderFulfillmentAsDeliveredWorkflow = createWorkflow(
     )
 
     emitEventStep({
-      eventName: FulfillmentEvents.DELIVERY_CREATED,
+      eventName: FulfillmentWorkflowEvents.DELIVERY_CREATED,
       data: { id: deliveredFulfillment.id },
     })
 

--- a/packages/core/utils/src/core-flows/events.ts
+++ b/packages/core/utils/src/core-flows/events.ts
@@ -107,3 +107,28 @@ export const RegionWorkflowEvents = {
   CREATED: "region.created",
   DELETED: "region.deleted",
 }
+
+/**
+ * @category Fulfillment
+ */
+export const FulfillmentWorkflowEvents = {
+  /**
+   * Emitted when a shipment is created for an order.
+   * 
+   * @eventPayload
+   * {
+   *   id, // the ID of the shipment
+   *   no_notification, // whether to notify the customer
+   * }
+   */
+  SHIPMENT_CREATED: "shipment.created",
+  /**
+   * Emitted when a fulfillment is marked as delivered.
+   * 
+   * @eventPayload
+   * {
+   *   id, // the ID of the fulfillment
+   * }
+   */
+  DELIVERY_CREATED: "delivery.created",
+}

--- a/packages/core/utils/src/fulfillment/events.ts
+++ b/packages/core/utils/src/fulfillment/events.ts
@@ -29,6 +29,4 @@ const eventBaseNames: [
 
 export const FulfillmentEvents = {
   ...buildEventNamesFromEntityName(eventBaseNames, Modules.FULFILLMENT),
-  SHIPMENT_CREATED: "shipment.created",
-  DELIVERY_CREATED: "delivery.created",
 }

--- a/packages/core/utils/src/fulfillment/events.ts
+++ b/packages/core/utils/src/fulfillment/events.ts
@@ -29,4 +29,12 @@ const eventBaseNames: [
 
 export const FulfillmentEvents = {
   ...buildEventNamesFromEntityName(eventBaseNames, Modules.FULFILLMENT),
+  /**
+   * @deprecated use `FulfillmentWorkflowEvents.SHIPMENT_CREATED` instead
+   */
+  SHIPMENT_CREATED: "shipment.created",
+  /**
+   * @deprecated use `FulfillmentWorkflowEvents.DELIVERY_CREATED` instead
+   */
+  DELIVERY_CREATED: "delivery.created",
 }


### PR DESCRIPTION
Move fulfillment workflow events to be with other workflow events.

Could be considered a breaking change for users using the previously `FulfillmentEvents` variable