### PR TITLE
Fixed inability to specify decimals for a % promotion

### DIFF
--- a/packages/admin/dashboard/src/routes/promotions/promotion-create/components/create-promotion-form/create-promotion-form.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/promotion-create/components/create-promotion-form/create-promotion-form.tsx
@@ -710,7 +710,7 @@ export const CreatePromotionForm = () => {
                                     {...field}
                                     min={0}
                                     onValueChange={(value) => {
-                                      onChange(value ? parseInt(value) : "")
+                                      onChange(value ? parseFloat(value) : "")
                                     }}
                                     code={currencyCode || "USD"}
                                     symbol={
@@ -733,7 +733,7 @@ export const CreatePromotionForm = () => {
                                       onChange(
                                         e.target.value === ""
                                           ? null
-                                          : parseInt(e.target.value)
+                                          : parseFloat(e.target.value)
                                       )
                                     }}
                                   />

--- a/packages/admin/dashboard/src/routes/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
@@ -248,7 +248,7 @@ export const EditPromotionDetailsForm = ({
                         <CurrencyInput
                           min={0}
                           onValueChange={(val) =>
-                            onChange(val ? parseInt(val) : null)
+                            onChange(val ? parseFloat(val) : null)
                           }
                           code={currencyCode}
                           symbol={getCurrencySymbol(currencyCode)}
@@ -266,7 +266,7 @@ export const EditPromotionDetailsForm = ({
                             onChange(
                               e.target.value === ""
                                 ? null
-                                : parseInt(e.target.value)
+                                : parseFloat(e.target.value)
                             )
                           }}
                         />


### PR DESCRIPTION
Fixed inability to specify decimals for a promotion ($ of %) when creating or editing a promotion (fixes #11988)