### PR TITLE
fix: rename Macedonia FYROM to North Macedonia

### DIFF
--- a/packages/admin/dashboard/src/lib/data/countries.ts
+++ b/packages/admin/dashboard/src/lib/data/countries.ts
@@ -932,13 +932,6 @@ export const countries: StaticCountry[] = [
     display_name: "Macao",
   },
   {
-    iso_2: "mk",
-    iso_3: "mkd",
-    num_code: "807",
-    name: "MACEDONIA, THE FORMER YUGOSLAV REPUBLIC OF",
-    display_name: "Macedonia, the Former Yugoslav Republic of",
-  },
-  {
     iso_2: "mg",
     iso_3: "mdg",
     num_code: "450",
@@ -1161,6 +1154,13 @@ export const countries: StaticCountry[] = [
     num_code: "574",
     name: "NORFOLK ISLAND",
     display_name: "Norfolk Island",
+  },
+  {
+    iso_2: "mk",
+    iso_3: "mkd",
+    num_code: "807",
+    name: "NORTH MACEDONIA",
+    display_name: "North Macedonia",
   },
   {
     iso_2: "mp",

--- a/packages/core/utils/src/defaults/countries.ts
+++ b/packages/core/utils/src/defaults/countries.ts
@@ -202,12 +202,6 @@ export const defaultCountries: Country[] = [
   { alpha2: "LT", name: "Lithuania", alpha3: "LTU", numeric: "440" },
   { alpha2: "LU", name: "Luxembourg", alpha3: "LUX", numeric: "442" },
   { alpha2: "MO", name: "Macao", alpha3: "MAC", numeric: "446" },
-  {
-    alpha2: "MK",
-    name: "Macedonia, the Former Yugoslav Republic of",
-    alpha3: "MKD",
-    numeric: "807",
-  },
   { alpha2: "MG", name: "Madagascar", alpha3: "MDG", numeric: "450" },
   { alpha2: "MW", name: "Malawi", alpha3: "MWI", numeric: "454" },
   { alpha2: "MY", name: "Malaysia", alpha3: "MYS", numeric: "458" },
@@ -245,6 +239,12 @@ export const defaultCountries: Country[] = [
   { alpha2: "NG", name: "Nigeria", alpha3: "NGA", numeric: "566" },
   { alpha2: "NU", name: "Niue", alpha3: "NIU", numeric: "570" },
   { alpha2: "NF", name: "Norfolk Island", alpha3: "NFK", numeric: "574" },
+  {
+    alpha2: "MK",
+    name: "North Macedonia",
+    alpha3: "MKD",
+    numeric: "807",
+  },
   {
     alpha2: "MP",
     name: "Northern Mariana Islands",


### PR DESCRIPTION
This PR updates the outdated country name “Macedonia, the former Yugoslav Republic of” to its official name “North Macedonia”, reflecting the internationally recognized designation following the Prespa Agreement.

The name change officially came into effect on February 12, 2019, resolving the naming dispute between Greece and North Macedonia.

For more details, see: [Names and etymology – North Macedonia  – Wikipedia](https://en.wikipedia.org/wiki/North_Macedonia#Names_and_etymology)