### PR TITLE
fix(dashboard): call route modal onClose only on route change

### DIFF
--- a/.changeset/loud-drinks-juggle.md
+++ b/.changeset/loud-drinks-juggle.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): call route modal onClose only on route change

--- a/packages/admin/dashboard/src/components/modals/route-modal-form/route-modal-form.tsx
+++ b/packages/admin/dashboard/src/components/modals/route-modal-form/route-modal-form.tsx
@@ -35,22 +35,22 @@ export const RouteModalForm = <TFieldValues extends FieldValues = any>({
     const isSearchChanged = currentLocation.search !== nextLocation.search
 
     if (blockSearch) {
-      const ret = isDirty && (isPathChanged || isSearchChanged)
+      const shouldBlock = isDirty && (isPathChanged || isSearchChanged)
 
-      if (!ret) {
+      if (isPathChanged) {
         onClose?.(isSubmitSuccessful)
       }
 
-      return ret
+      return shouldBlock
     }
 
-    const ret = isDirty && isPathChanged
+    const shouldBlock = isDirty && isPathChanged
 
-    if (!ret) {
+    if (isPathChanged) {
       onClose?.(isSubmitSuccessful)
     }
 
-    return ret
+    return shouldBlock
   })
 
   const handleCancel = () => {


### PR DESCRIPTION
**What**
- order edits would be reset when an add item table is searched because onClose of the route modal would be called