### PR TITLE
fix: Use logger in the test runner and migration commands

### DIFF
--- a/packages/core/utils/src/modules-sdk/migration-scripts/migration-down.ts
+++ b/packages/core/utils/src/modules-sdk/migration-scripts/migration-down.ts
@@ -28,8 +28,8 @@ export function buildRevertMigrationScript({ moduleName, pathToMigrations }) {
   > = {}) {
     logger ??= console as unknown as Logger
 
-    console.log(new Array(TERMINAL_SIZE).join("-"))
-    console.log("")
+    logger.info(new Array(TERMINAL_SIZE).join("-"))
+    logger.info("")
     logger.info(`MODULE: ${moduleName}`)
 
     const dbData = loadDatabaseConfig(moduleName, options)!

--- a/packages/core/utils/src/modules-sdk/migration-scripts/migration-generate.ts
+++ b/packages/core/utils/src/modules-sdk/migration-scripts/migration-generate.ts
@@ -35,8 +35,8 @@ export function buildGenerateMigrationScript({
   > = {}) {
     logger ??= console as unknown as Logger
 
-    console.log(new Array(TERMINAL_SIZE).join("-"))
-    console.log("")
+    logger.info(new Array(TERMINAL_SIZE).join("-"))
+    logger.info("")
     logger.info(`MODULE: ${moduleName}`)
 
     const dbData = loadDatabaseConfig(moduleName, options)!

--- a/packages/core/utils/src/modules-sdk/migration-scripts/migration-up.ts
+++ b/packages/core/utils/src/modules-sdk/migration-scripts/migration-up.ts
@@ -28,8 +28,8 @@ export function buildMigrationScript({ moduleName, pathToMigrations }) {
   > = {}) {
     logger ??= console as unknown as Logger
 
-    console.log(new Array(TERMINAL_SIZE).join("-"))
-    console.log("")
+    logger.info(new Array(TERMINAL_SIZE).join("-"))
+    logger.info("")
     logger.info(`MODULE: ${moduleName}`)
 
     const dbData = loadDatabaseConfig(moduleName, options)!

--- a/packages/medusa-test-utils/src/medusa-test-runner-utils/use-db.ts
+++ b/packages/medusa-test-utils/src/medusa-test-runner-utils/use-db.ts
@@ -1,5 +1,5 @@
 import type { MedusaAppLoader } from "@medusajs/framework"
-import { MedusaContainer } from "@medusajs/framework/types"
+import { Logger, MedusaContainer } from "@medusajs/framework/types"
 import {
   ContainerRegistrationKeys,
   getResolvedPlugins,
@@ -38,7 +38,8 @@ export async function migrateDatabase(appLoader: MedusaAppLoader) {
 export async function syncLinks(
   appLoader: MedusaAppLoader,
   directory: string,
-  container: MedusaContainer
+  container: MedusaContainer,
+  logger: Logger
 ) {
   try {
     await loadCustomLinks(directory, container)
@@ -46,11 +47,11 @@ export async function syncLinks(
     const planner = await appLoader.getLinksExecutionPlanner()
     const actionPlan = await planner.createPlan()
     actionPlan.forEach((action) => {
-      console.log(`Sync links: "${action.action}" ${action.tableName}`)
+      logger.info(`Sync links: "${action.action}" ${action.tableName}`)
     })
     await planner.executePlan(actionPlan)
   } catch (err) {
-    console.error("Something went wrong while syncing links")
+    logger.error("Something went wrong while syncing links")
     throw err
   }
 }

--- a/packages/medusa-test-utils/src/medusa-test-runner.ts
+++ b/packages/medusa-test-utils/src/medusa-test-runner.ts
@@ -114,17 +114,17 @@ export function medusaIntegrationTestRunner({
     })
 
     try {
-      console.log(`Creating database ${dbName}`)
+      logger.info(`Creating database ${dbName}`)
       await dbUtils.create(dbName)
       dbUtils.pgConnection_ = await initDb()
     } catch (error) {
-      console.error("Error initializing database", error?.message)
+      logger.error(`Error initializing database: ${error?.message}`)
       throw error
     }
 
-    console.log(`Migrating database with core migrations and links ${dbName}`)
+    logger.info(`Migrating database with core migrations and links ${dbName}`)
     await migrateDatabase(appLoader)
-    await syncLinks(appLoader, cwd, container)
+    await syncLinks(appLoader, cwd, container, logger)
     await clearInstances()
 
     let containerRes: MedusaContainer = container
@@ -147,7 +147,7 @@ export function medusaIntegrationTestRunner({
       serverShutdownRes = shutdown
       portRes = port
     } catch (error) {
-      console.error("Error starting the app", error?.message)
+      logger.error(`Error starting the app:  error?.message`)
       throw error
     }
 
@@ -156,9 +156,9 @@ export function medusaIntegrationTestRunner({
      * an application
      */
     if (inApp) {
-      console.log(`Migrating database with core migrations and links ${dbName}`)
+      logger.info(`Migrating database with core migrations and links ${dbName}`)
       await migrateDatabase(appLoader)
-      await syncLinks(appLoader, cwd, containerRes)
+      await syncLinks(appLoader, cwd, containerRes, logger)
     }
 
     const { default: axios } = (await import("axios")) as any


### PR DESCRIPTION
Tests can get very noisy due to migrations running over and over again, and there is no way to disable the logs.

The PR changes the logging to always use the logger, so the LOG_LEVEL envvar can be used to control the logs