### PR TITLE
test(workflow-engine): Ensure failed subscriber does not compensate workflows

### DIFF
--- a/integration-tests/modules/__tests__/workflow-engine/workflow-engine.ts
+++ b/integration-tests/modules/__tests__/workflow-engine/workflow-engine.ts
@@ -91,10 +91,10 @@ medusaIntegrationTestRunner({
         })
       })
 
-      describe("Ensure event subscribers", () => {
+      describe("Workflows event", () => {
         const failingEventName = "failing-event"
 
-        it("Should not compensate the workflow if the event subscriber throws an error", async () => {
+        it("should not compensate the workflow if the event subscriber fails", async () => {
           const step1 = createStep(
             {
               name: "my-step",

--- a/integration-tests/modules/__tests__/workflow-engine/workflow-engine.ts
+++ b/integration-tests/modules/__tests__/workflow-engine/workflow-engine.ts
@@ -1,4 +1,4 @@
-import { Modules } from "@medusajs/framework/utils"
+import { Modules, TransactionState } from "@medusajs/framework/utils"
 import {
   createStep,
   createWorkflow,
@@ -11,8 +11,10 @@ import {
   adminHeaders,
   createAdminUser,
 } from "../../../helpers/create-admin-user"
+import { emitEventStep } from "@medusajs/core-flows"
+import { IEventBusModuleService } from "@medusajs/types"
 
-jest.setTimeout(50000)
+jest.setTimeout(300000)
 
 medusaIntegrationTestRunner({
   testSuite: ({ dbConnection, getContainer, api }) => {
@@ -83,6 +85,81 @@ medusaIntegrationTestRunner({
               idempotencyKey: "my-workflow-name:trx-id:my-step:invoke",
               meta: {
                 myStuff: "myStuff",
+              },
+            })
+          )
+        })
+      })
+
+      describe("Ensure event subscribers", () => {
+        const failingEventName = "failing-event"
+
+        it("Should not compensate the workflow if the event subscriber throws an error", async () => {
+          const step1 = createStep(
+            {
+              name: "my-step",
+            },
+            async (_) => {
+              return new StepResponse({ result: "success" })
+            }
+          )
+
+          createWorkflow(
+            {
+              name: "my-workflow-name",
+              retentionTime: 50,
+            },
+            function (input: WorkflowData<{ initial: string }>) {
+              const stepRes = step1()
+
+              emitEventStep({
+                eventName: failingEventName,
+                data: {
+                  input: stepRes,
+                },
+              })
+
+              return new WorkflowResponse(stepRes)
+            }
+          )
+
+          const container = getContainer()
+          const eventBus = container.resolve(
+            Modules.EVENT_BUS
+          ) as IEventBusModuleService
+
+          const eventSpy = jest.fn()
+          eventBus.subscribe(failingEventName, async (event) => {
+            eventSpy(event)
+            throw new Error("Failed to emit event")
+          })
+
+          const engine = container.resolve(Modules.WORKFLOW_ENGINE)
+
+          const transactionId = "trx-id-failing-event"
+          const res = await engine.run("my-workflow-name", {
+            transactionId,
+            input: {
+              initial: "abc",
+            },
+          })
+
+          expect(res.result).toEqual({ result: "success" })
+
+          const executions = await engine.listWorkflowExecutions({
+            transaction_id: transactionId,
+          })
+
+          expect(executions.length).toBe(1)
+          expect(executions[0].state).toBe(TransactionState.DONE)
+
+          expect(eventSpy).toHaveBeenCalledTimes(1)
+          expect(eventSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              data: {
+                input: {
+                  result: "success",
+                },
               },
             })
           )

--- a/integration-tests/modules/package.json
+++ b/integration-tests/modules/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "test:integration": "NODE_OPTIONS=--experimental-vm-modules jest --no-cache --maxWorkers=50% --bail --detectOpenHandles --forceExit --logHeapUsage",
+    "test:integration": "NODE_OPTIONS=--experimental-vm-modules jest --no-cache --maxWorkers=50% --bail --detectOpenHandles --forceExit --logHeapUsage -- __tests__/workflow-engine/workflow-engine.ts",
     "test:integration:chunk": "NODE_OPTIONS=--experimental-vm-modules jest --silent --no-cache --bail --maxWorkers=50% --forceExit",
     "build": "tsc --allowJs --outDir ./dist"
   },

--- a/integration-tests/modules/package.json
+++ b/integration-tests/modules/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "test:integration": "NODE_OPTIONS=--experimental-vm-modules jest --no-cache --maxWorkers=50% --bail --detectOpenHandles --forceExit --logHeapUsage -- __tests__/workflow-engine/workflow-engine.ts",
+    "test:integration": "NODE_OPTIONS=--experimental-vm-modules jest --no-cache --maxWorkers=50% --bail --detectOpenHandles --forceExit --logHeapUsage",
     "test:integration:chunk": "NODE_OPTIONS=--experimental-vm-modules jest --silent --no-cache --bail --maxWorkers=50% --forceExit",
     "build": "tsc --allowJs --outDir ./dist"
   },


### PR DESCRIPTION
**What**
Just add an integration tests to ensure no regression in the following behavior:
- Workflows should not be compensated if an event subscriber failed 