### PR TITLE
fix(tax): Make system provider registration backward compatible

### DIFF
--- a/integration-tests/http/__tests__/order-edits/order-edits.spec.ts
+++ b/integration-tests/http/__tests__/order-edits/order-edits.spec.ts
@@ -58,7 +58,7 @@ medusaIntegrationTestRunner({
         await api.post(
           "/admin/tax-regions",
           {
-            provider_id: "tp_system_system",
+            provider_id: "tp_system",
             country_code: "US",
           },
           adminHeaders

--- a/integration-tests/http/__tests__/product/store/product.spec.ts
+++ b/integration-tests/http/__tests__/product/store/product.spec.ts
@@ -2380,7 +2380,7 @@ medusaIntegrationTestRunner({
           `/admin/tax-regions`,
           {
             country_code: "us",
-            provider_id: "tp_system_system",
+            provider_id: "tp_system",
             default_tax_rate: {
               code: "default",
               rate: 5,
@@ -2394,7 +2394,7 @@ medusaIntegrationTestRunner({
           `/admin/tax-regions`,
           {
             country_code: "it",
-            provider_id: "tp_system_system",
+            provider_id: "tp_system",
             default_tax_rate: {
               code: "default",
               rate: 10,
@@ -2408,7 +2408,7 @@ medusaIntegrationTestRunner({
           `/admin/tax-regions`,
           {
             country_code: "dk",
-            provider_id: "tp_system_system",
+            provider_id: "tp_system",
             default_tax_rate: {
               code: "default",
               rate: 20,

--- a/integration-tests/modules/__tests__/fixtures/tax/index.ts
+++ b/integration-tests/modules/__tests__/fixtures/tax/index.ts
@@ -26,12 +26,12 @@ export const setupTaxStructure = async (service: ITaxModuleService) => {
   const [us, dk, de, ca] = await service.createTaxRegions([
     {
       country_code: "US",
-      provider_id: "tp_system_system",
+      provider_id: "tp_system",
       default_tax_rate: { name: "US Default Rate", rate: 2, code: "US_DEF" },
     },
     {
       country_code: "DK",
-      provider_id: "tp_system_system",
+      provider_id: "tp_system",
       default_tax_rate: {
         name: "Denmark Default Rate",
         rate: 25,
@@ -40,7 +40,7 @@ export const setupTaxStructure = async (service: ITaxModuleService) => {
     },
     {
       country_code: "DE",
-      provider_id: "tp_system_system",
+      provider_id: "tp_system",
       default_tax_rate: {
         code: "DE19",
         name: "Germany Default Rate",
@@ -49,7 +49,7 @@ export const setupTaxStructure = async (service: ITaxModuleService) => {
     },
     {
       country_code: "CA",
-      provider_id: "tp_system_system",
+      provider_id: "tp_system",
       default_tax_rate: {
         name: "Canada Default Rate",
         rate: 5,

--- a/integration-tests/modules/__tests__/tax/admin/tax.spec.ts
+++ b/integration-tests/modules/__tests__/tax/admin/tax.spec.ts
@@ -1,7 +1,6 @@
-import { ITaxModuleService } from "@medusajs/types"
-
-import { Modules } from "@medusajs/utils"
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { ITaxModuleService } from "@medusajs/types"
+import { Modules } from "@medusajs/utils"
 import { createAdminUser } from "../../../../helpers/create-admin-user"
 
 jest.setTimeout(50000)
@@ -25,6 +24,20 @@ medusaIntegrationTestRunner({
 
       beforeEach(async () => {
         await createAdminUser(dbConnection, adminHeaders, appContainer)
+      })
+
+      it("should load local provider and custom provider", async () => {
+        const providers = await service.listTaxProviders()
+
+        expect(providers).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: "tp_system", is_enabled: true }),
+            expect.objectContaining({
+              id: "tp_system_system_2",
+              is_enabled: true,
+            }),
+          ])
+        )
       })
 
       it("can retrieve a tax rate", async () => {

--- a/integration-tests/modules/medusa-config.js
+++ b/integration-tests/modules/medusa-config.js
@@ -10,6 +10,13 @@ process.env.LOG_LEVEL = "error"
 
 const enableMedusaV2 = process.env.MEDUSA_FF_MEDUSA_V2 == "true"
 
+const customTaxProviderRegistration = {
+  resolve: {
+    services: [require("@medusajs/tax/dist/providers/system").default],
+  },
+  id: "system_2",
+}
+
 const customPaymentProvider = {
   resolve: {
     services: [require("@medusajs/payment/dist/providers/system").default],
@@ -89,7 +96,12 @@ module.exports = {
     [Modules.WORKFLOW_ENGINE]: true,
     [Modules.API_KEY]: true,
     [Modules.STORE]: true,
-    [Modules.TAX]: true,
+    [Modules.TAX]: {
+      resolve: "@medusajs/tax",
+      options: {
+        providers: [customTaxProviderRegistration],
+      },
+    },
     [Modules.CURRENCY]: true,
     [Modules.ORDER]: true,
     [Modules.PAYMENT]: {

--- a/packages/medusa/src/migration-scripts/migrate-tax-region-provider.ts
+++ b/packages/medusa/src/migration-scripts/migrate-tax-region-provider.ts
@@ -2,8 +2,7 @@ import { updateTaxRegionsStep, useQueryGraphStep } from "@medusajs/core-flows"
 import { MedusaModule } from "@medusajs/framework/modules-sdk"
 import { ExecArgs } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
-import { transform, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
-import { createWorkflow } from "@medusajs/framework/workflows-sdk"
+import { createWorkflow, transform, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
 
 const assignSystemProviderToTaxRegionsWorkflow = createWorkflow(
   "assign-system-provider-to-tax-regions",
@@ -23,7 +22,7 @@ const assignSystemProviderToTaxRegionsWorkflow = createWorkflow(
         )
         .map((taxRegion) => ({
           id: taxRegion.id,
-          provider_id: "tp_system_system",
+          provider_id: "tp_system",
         }))
     })
 

--- a/packages/modules/tax/integration-tests/__tests__/local-providers.spec.ts
+++ b/packages/modules/tax/integration-tests/__tests__/local-providers.spec.ts
@@ -26,25 +26,3 @@ moduleIntegrationTestRunner<ITaxModuleService>({
     })
   },
 })
-
-moduleIntegrationTestRunner<ITaxModuleService>({
-    moduleName: Modules.TAX,
-    testSuite: ({ service }) => {
-      describe("Tax Module Service", () => {
-        describe("providers", () => {
-          it("should have loaded local tax provider successfully", async () => {
-            const providers = await service.listTaxProviders()
-  
-            expect(providers).toEqual(
-              expect.arrayContaining([
-                expect.objectContaining({
-                  id: "tp_system",
-                  is_enabled: true,
-                }),
-              ])
-            )
-          })
-        })
-      })
-    },
-  })

--- a/packages/modules/tax/integration-tests/__tests__/providers.spec.ts
+++ b/packages/modules/tax/integration-tests/__tests__/providers.spec.ts
@@ -1,0 +1,50 @@
+import { ITaxModuleService } from "@medusajs/framework/types"
+
+import { Modules } from "@medusajs/framework/utils"
+import { moduleIntegrationTestRunner } from "@medusajs/test-utils"
+
+jest.setTimeout(30000)
+
+moduleIntegrationTestRunner<ITaxModuleService>({
+  moduleName: Modules.TAX,
+  testSuite: ({ service }) => {
+    describe("Tax Module Service", () => {
+      describe("providers", () => {
+        it("should have loaded local tax provider successfully", async () => {
+          const providers = await service.listTaxProviders()
+
+          expect(providers).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                id: "tp_system",
+                is_enabled: true,
+              }),
+            ])
+          )
+        })
+      })
+    })
+  },
+})
+
+moduleIntegrationTestRunner<ITaxModuleService>({
+    moduleName: Modules.TAX,
+    testSuite: ({ service }) => {
+      describe("Tax Module Service", () => {
+        describe("providers", () => {
+          it("should have loaded local tax provider successfully", async () => {
+            const providers = await service.listTaxProviders()
+  
+            expect(providers).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  id: "tp_system",
+                  is_enabled: true,
+                }),
+              ])
+            )
+          })
+        })
+      })
+    },
+  })

--- a/packages/modules/tax/integration-tests/utils/setup-tax-structure.ts
+++ b/packages/modules/tax/integration-tests/utils/setup-tax-structure.ts
@@ -27,17 +27,17 @@ export const setupTaxStructure = async (service: ITaxModuleService) => {
   const [us, dk, de, ca] = await service.createTaxRegions([
     {
       country_code: "US",
-      provider_id: "tp_system_system",
+      provider_id: "tp_system",
       default_tax_rate: { name: "US Default Rate", rate: 2, code: "US" },
     },
     {
       country_code: "DK",
-      provider_id: "tp_system_system",
+      provider_id: "tp_system",
       default_tax_rate: { name: "Denmark Default Rate", rate: 25, code: "DK" },
     },
     {
       country_code: "DE",
-      provider_id: "tp_system_system",
+      provider_id: "tp_system",
       default_tax_rate: {
         code: "DE19",
         name: "Germany Default Rate",
@@ -46,7 +46,7 @@ export const setupTaxStructure = async (service: ITaxModuleService) => {
     },
     {
       country_code: "CA",
-      provider_id: "tp_system_system",
+      provider_id: "tp_system",
       default_tax_rate: { name: "Canada Default Rate", rate: 5, code: "CA" },
     },
   ])

--- a/packages/modules/tax/src/loaders/providers.ts
+++ b/packages/modules/tax/src/loaders/providers.ts
@@ -1,16 +1,16 @@
 import { moduleProviderLoader } from "@medusajs/framework/modules-sdk"
 
 import {
+  CreateTaxProviderDTO,
   LoaderOptions,
   ModuleProvider,
   ModulesSdkTypes,
-  CreateTaxProviderDTO,
 } from "@medusajs/framework/types"
 import { asFunction, asValue, Lifetime } from "awilix"
 
+import { MedusaError } from "@medusajs/framework/utils"
 import * as providers from "../providers"
 import TaxProviderService from "../services/tax-provider"
-import { MedusaError } from "@medusajs/framework/utils"
 
 const PROVIDER_REGISTRATION_KEY = "tax_providers" as const
 
@@ -46,7 +46,7 @@ export default async ({
 >): Promise<void> => {
   // Local providers
   for (const provider of Object.values(providers)) {
-    await registrationFn(provider, container, { id: "system" })
+    await registrationFn(provider, container, {})
   }
 
   await moduleProviderLoader({


### PR DESCRIPTION
### What
Register the out-of-the-box system tax provider as `tp_system` in the dependency container.

### Why
To avoid the minor breaking change introduced in #12297 in which the registration key was renamed to `tp_system_system`. 