### PR TITLE
Fix for plugin import on Windows

### DIFF
--- a/.changeset/cyan-berries-poke.md
+++ b/.changeset/cyan-berries-poke.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+Fix plugin import on windows

--- a/packages/core/utils/src/common/get-resolved-plugins.ts
+++ b/packages/core/utils/src/common/get-resolved-plugins.ts
@@ -100,7 +100,7 @@ async function resolvePlugin(
         resolve: path.join(
           isAdminLocal ? pluginStaticOptions.srcDir : name,
           "admin"
-        ),
+        ).split(path.sep).join("/"),
       }
     : undefined
 


### PR DESCRIPTION
Normalising all the separators manually to '/' fixes this.