### PR TITLE
fix(dashboard, medusa): validate provider for top level tax regions

### DIFF
--- a/.changeset/old-carrots-develop.md
+++ b/.changeset/old-carrots-develop.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/dashboard": patch
+"@medusajs/medusa": patch
+---
+
+fix(dashboard, medusa): validate provider exists when creating a top level tax region

--- a/integration-tests/http/__tests__/tax-region/admin/tax-region.spec.ts
+++ b/integration-tests/http/__tests__/tax-region/admin/tax-region.spec.ts
@@ -24,7 +24,7 @@ medusaIntegrationTestRunner({
             "/admin/tax-regions",
             {
               country_code: "us",
-              provider_id: "tp_system", // TODO: update when Oli's PR is merged
+              provider_id: "tp_system",
             },
             adminHeaders
           )

--- a/integration-tests/http/__tests__/tax-region/admin/tax-region.spec.ts
+++ b/integration-tests/http/__tests__/tax-region/admin/tax-region.spec.ts
@@ -108,7 +108,7 @@ medusaIntegrationTestRunner({
           expect(status).toEqual(400)
           expect(data).toEqual({
             message:
-              "Provider is required when creating a non-province tax region.",
+              "Invalid request: Provider is required when creating a non-province tax region.",
             type: "invalid_data",
           })
         })

--- a/integration-tests/http/__tests__/tax-region/admin/tax-region.spec.ts
+++ b/integration-tests/http/__tests__/tax-region/admin/tax-region.spec.ts
@@ -24,10 +24,11 @@ medusaIntegrationTestRunner({
             "/admin/tax-regions",
             {
               country_code: "us",
-              provider_id: "tp_system_system", // TODO: update when Oli's PR is merged
+              provider_id: "tp_system", // TODO: update when Oli's PR is merged
             },
             adminHeaders
           )
+
           taxRegion = (
             await api.post(
               "/admin/tax-regions",
@@ -88,6 +89,28 @@ medusaIntegrationTestRunner({
               id: expect.any(String),
               province_code: "ca",
               metadata: { test: "updated 2" },
+            })
+          )
+        })
+
+        it("should create a province tax region without a provider", async () => {
+          const response = await api.post(
+            `/admin/tax-regions`,
+            {
+              country_code: "us",
+              parent_id: taxRegion.id,
+              province_code: "ny",
+            },
+            adminHeaders
+          )
+
+          expect(response.status).toEqual(200)
+          expect(response.data.tax_region).toEqual(
+            expect.objectContaining({
+              id: expect.any(String),
+              country_code: "us",
+              province_code: "ny",
+              provider_id: null,
             })
           )
         })

--- a/packages/admin/dashboard/src/i18n/translations/$schema.json
+++ b/packages/admin/dashboard/src/i18n/translations/$schema.json
@@ -6462,14 +6462,14 @@
             "errors": {
               "type": "object",
               "properties": {
-                "rateIsRequired": {
+                "missingProvider": {
                   "type": "string"
                 },
-                "nameIsRequired": {
+                "missingCountry": {
                   "type": "string"
                 }
               },
-              "required": ["rateIsRequired", "nameIsRequired"],
+              "required": ["missingProvider", "missingCountry"],
               "additionalProperties": false
             },
             "successToast": {

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -1718,8 +1718,8 @@
       "header": "Create Tax Region",
       "hint": "Create a new tax region to define tax rates for a specific country.",
       "errors": {
-        "rateIsRequired": "Tax rate is required when creating a default tax rate.",
-        "nameIsRequired": "Name is required when creating a default tax rate."
+        "missingProvider": "Provider is required when creating a tax region.",
+        "missingCountry": "Country is required when creating a tax region."
       },
       "successToast": "The tax region was successfully created."
     },

--- a/packages/admin/dashboard/src/routes/tax-regions/tax-region-create/components/tax-region-create-form/tax-region-create-form.tsx
+++ b/packages/admin/dashboard/src/routes/tax-regions/tax-region-create/components/tax-region-create-form/tax-region-create-form.tsx
@@ -18,21 +18,40 @@ import { useComboboxData } from "../../../../../hooks/use-combobox-data"
 import { Combobox } from "../../../../../components/inputs/combobox"
 import { formatProvider } from "../../../../../lib/format-provider"
 import { sdk } from "../../../../../lib/client"
+import { i18n } from "../../../../../components/utilities/i18n"
 
 type TaxRegionCreateFormProps = {
   parentId?: string
 }
 
-const TaxRegionCreateSchema = z.object({
-  name: z.string().optional(),
-  code: z.string().optional(),
-  rate: z.object({
-    float: z.number().optional(),
-    value: z.string().optional(),
-  }),
-  country_code: z.string().min(1),
-  provider_id: z.string(),
-})
+const TaxRegionCreateSchema = z
+  .object({
+    name: z.string().optional(),
+    code: z.string().optional(),
+    rate: z.object({
+      float: z.number().optional(),
+      value: z.string().optional(),
+    }),
+    country_code: z.string(),
+    provider_id: z.string(),
+  })
+  .superRefine(({ provider_id, country_code }, ctx) => {
+    if (!provider_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: i18n.t("taxRegions.create.errors.missingProvider"),
+        path: ["provider_id"],
+      })
+    }
+
+    if (!country_code) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: i18n.t("taxRegions.create.errors.missingCountry"),
+        path: ["country_code"],
+      })
+    }
+  })
 
 export const TaxRegionCreateForm = ({ parentId }: TaxRegionCreateFormProps) => {
   const { t } = useTranslation()

--- a/packages/medusa/src/api/admin/tax-regions/validators.ts
+++ b/packages/medusa/src/api/admin/tax-regions/validators.ts
@@ -3,6 +3,7 @@ import {
   createFindParams,
   createOperatorMap,
   createSelectParams,
+  WithAdditionalData,
 } from "../../utils/validators"
 import { applyAndAndOrOperators } from "../../utils/common-validators"
 
@@ -39,8 +40,8 @@ export const AdminGetTaxRegionsParams = createFindParams({
   .merge(AdminGetTaxRegionsParamsFields)
   .merge(applyAndAndOrOperators(AdminGetTaxRegionsParamsFields))
 
-export type AdminCreateTaxRegionType = z.infer<typeof AdminCreateTaxRegion>
-export const AdminCreateTaxRegion = z.object({
+export type AdminCreateTaxRegionType = z.infer<typeof CreateTaxRegion>
+export const CreateTaxRegion = z.object({
   country_code: z.string(),
   provider_id: z.string().nullish(),
   province_code: z.string().nullish(),
@@ -56,6 +57,16 @@ export const AdminCreateTaxRegion = z.object({
     .optional(),
   metadata: z.record(z.unknown()).nullish(),
 })
+
+export const AdminCreateTaxRegion = WithAdditionalData(
+  CreateTaxRegion,
+  (schema) => {
+    return schema.refine((data) => data.parent_id || data.provider_id, {
+      path: ["provider_id"],
+      message: "Provider is required when creating a non-province tax region.",
+    })
+  }
+)
 
 export type AdminUpdateTaxRegionType = z.infer<typeof AdminUpdateTaxRegion>
 export const AdminUpdateTaxRegion = z.object({


### PR DESCRIPTION
**What**
- prevent top level tax region creation without a provider on Admin and in HTTP validation layer