### PR TITLE
fix(types): change update signature of IAuthProvider

### DIFF
--- a/.changeset/eighty-moles-occur.md
+++ b/.changeset/eighty-moles-occur.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": patch
+---
+
+fix(types): change update signature of IAuthProvider

--- a/packages/core/types/src/auth/provider.ts
+++ b/packages/core/types/src/auth/provider.ts
@@ -25,12 +25,6 @@ export interface AuthIdentityProviderService {
   getState: (key: string) => Promise<Record<string, unknown> | null>
 }
 
-/**
- * ## Overview
- *
- * Authentication provider interface for the auth module.
- *
- */
 export interface IAuthProvider {
   authenticate(
     data: AuthenticationInput,
@@ -44,8 +38,8 @@ export interface IAuthProvider {
     data: AuthenticationInput,
     authIdentityProviderService: AuthIdentityProviderService
   ): Promise<AuthenticationResponse>
-  update: (
+  update(
     data: Record<string, unknown>,
     authIdentityProviderService: AuthIdentityProviderService
-  ) => Promise<AuthenticationResponse>
+  ): Promise<AuthenticationResponse>
 }


### PR DESCRIPTION
Change the signature of the `update` method in `IAuthProvider` to match other methods. this is necessary as in the generated references `update` was being inferred as a property rather than a method.