### PR TITLE
fix: fix weight/length/height/width types in updates

### DIFF
--- a/integration-tests/http/__tests__/product/admin/product.spec.ts
+++ b/integration-tests/http/__tests__/product/admin/product.spec.ts
@@ -3043,12 +3043,20 @@ medusaIntegrationTestRunner({
       describe("batch methods", () => {
         it("successfully creates, updates, and deletes products", async () => {
           const createPayload = getProductFixture({
+            weight: 100,
+            length: 200,
+            height: 300,
+            width: 400,
             title: "Test batch create",
             handle: "test-batch-create",
             shipping_profile_id: shippingProfile.id,
           })
 
           const updatePayload = {
+            weight: 101,
+            length: 201,
+            height: 301,
+            width: 401,
             id: publishedProduct.id,
             title: "Test batch update",
           }

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
@@ -33,6 +33,7 @@ import {
 jest.setTimeout(300000)
 
 moduleIntegrationTestRunner<IProductModuleService>({
+  debug: true,
   moduleName: Modules.PRODUCT,
   injectedDependencies: {
     [Modules.EVENT_BUS]: new MockEventBusService(),
@@ -127,6 +128,10 @@ moduleIntegrationTestRunner<IProductModuleService>({
           productOne = service.createProducts({
             title: "product 1",
             status: ProductStatus.PUBLISHED,
+            weight: 100,
+            length: 200,
+            height: 300,
+            width: 400,
             options: [
               {
                 title: "opt-title",
@@ -236,6 +241,11 @@ moduleIntegrationTestRunner<IProductModuleService>({
           productBefore.images = data.images
           productBefore.thumbnail = data.thumbnail
           productBefore.tag_ids = data.tag_ids
+          // Update the weight/length/height/width to ensure we are compensating the type mismatch with the DB
+          productBefore.weight = 101
+          productBefore.length = 201
+          productBefore.height = 301
+          productBefore.width = 401
           const updatedProducts = await service.upsertProducts([productBefore])
           expect(updatedProducts).toHaveLength(1)
 
@@ -270,6 +280,11 @@ moduleIntegrationTestRunner<IProductModuleService>({
               discountable: productBefore.discountable,
               thumbnail: images[0].url,
               status: productBefore.status,
+              // TODO: Notice how the weight/length/height/width are strings, not respecting the ProductDTO typings
+              weight: "101",
+              length: "201",
+              height: "301",
+              width: "401",
               images: expect.arrayContaining([
                 expect.objectContaining({
                   id: expect.any(String),

--- a/packages/modules/product/src/repositories/product.ts
+++ b/packages/modules/product/src/repositories/product.ts
@@ -21,6 +21,8 @@ export class ProductRepository extends DALUtils.mikroOrmBaseRepositoryFactory(
     ) => void,
     context: Context = {}
   ): Promise<InferEntityType<typeof Product>[]> {
+    updates.forEach((update) => this.correctUpdateDTOTypes(update))
+
     const products = await this.find(
       buildQuery({ id: updates.map((p) => p.id) }, { relations: ["*"] }),
       context
@@ -78,6 +80,15 @@ export class ProductRepository extends DALUtils.mikroOrmBaseRepositoryFactory(
     return updates
       .map((update) => productsMap.get(update.id))
       .filter((product) => product !== undefined)
+  }
+
+  // We should probably fix the column types in the database to avoid this
+  // It would also match the types in ProductVariant, which are already numbers
+  protected correctUpdateDTOTypes(update: any) {
+    update.weight = update.weight?.toString()
+    update.length = update.length?.toString()
+    update.height = update.height?.toString()
+    update.width = update.width?.toString()
   }
 
   /**


### PR DESCRIPTION
There's a mismatch in the types of weight/length/height/width between DTOs and entities. This caused troubles when calling `em.assign`. This fix just maps the type in the repository for now, but I think the solution should be to migrate the DB types to be numbers, which is already the case for ProductVariant.
This also causes e.g. that the types returned by `retrieveProduct` are string instead of the declared numbers.