### PR TITLE
Fix. validating account holder attribute from customer object during …

### DIFF
--- a/packages/core/core-flows/src/payment-collection/workflows/create-payment-session.ts
+++ b/packages/core/core-flows/src/payment-collection/workflows/create-payment-session.ts
@@ -118,7 +118,7 @@ export const createPaymentSessionsWorkflow = createWorkflow(
 
       const existingAccountHolder = transform({ customer, input }, (data) => {
         return data.customer.account_holders.find(
-          (ac) => ac.provider_id === data.input.provider_id
+          (ac) => ac && ac.provider_id === data.input.provider_id
         )
       })
 
@@ -148,7 +148,7 @@ export const createPaymentSessionsWorkflow = createWorkflow(
         return (
           !isPresent(
             data.paymentCustomer?.account_holders.find(
-              (ac) => ac.provider_id === data.input.provider_id
+              (ac) => ac && ac.provider_id === data.input.provider_id
             )
           ) && isPresent(data.accountHolder)
         )


### PR DESCRIPTION
I have seen `create-payment-sessions` throws the following error whenever the customer don't have `account_holder`

```
 {
   message: "Cannot read properties of null (reading 'provider_id')",
   name: 'TypeError',
   stack: "TypeError: Cannot read properties of null (reading 'provider_id')\n" +
     '    at /Users/ismaelflores/Documents/Projects/Uplabs/lambda/apps/medusa2/node_modules/@medusajs/core-flows/src/payment-collection/workflows/create-payment-session.ts:158:9\n' +
     '    at Array.find (<anonymous>)\n' +
     '    at /Users/ismaelflores/Documents/Projects/Uplabs/lambda/apps/medusa2/node_modules/@medusajs/core-flows/src/payment-collection/workflows/create-payment-session.ts:158:9\n' +
     '    at Object.handle.invoke (/Users/ismaelflores/Documents/Projects/Uplabs/lambda/apps/medusa2/node_modules/@medusajs/workflows-sdk/src/utils/composer/create-step.ts:307:31)\n' +
     '    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n' +
     '    at async DistributedTransaction.handler (/Users/ismaelflores/Documents/Projects/Uplabs/lambda/apps/medusa2/node_modules/@medusajs/orchestration/src/workflow/workflow-manager.ts:214:16)\n' +
     '    at async stepHandler (/Users/ismaelflores/Documents/Projects/Uplabs/lambda/apps/medusa2/node_modules/@medusajs/orchestration/src/transaction/transaction-orchestrator.ts:988:14)\n' +
     '    at async Promise.allSettled (index 0)\n' +
     '    at async promiseAll (/Users/ismaelflores/Documents/Projects/Uplabs/lambda/apps/medusa2/node_modules/@medusajs/utils/src/common/promise-all.ts:27:18)\n' +
     '    at async TransactionOrchestrator.executeNext (/Users/ismaelflores/Documents/Projects/Uplabs/lambda/apps/medusa2/node_modules/@medusajs/orchestration/src/transaction/transaction-orchestrator.ts:842:7)\n' +
     '⮑ sat /Users/ismaelflores/Documents/Projects/Uplabs/lambda/apps/medusa2/node_modules/@medusajs/core-flows/dist/payment-collection/workflows/create-payment-session.js: [create-payment-sessions -> create-remote-links (invoke)]'
 }
```

This fix will check if `customer.account_holder[ntx]` is present (not undefined or not null).