### PR TITLE
chore(test-cli-with-database): Update cli tag from latest to preview

### DIFF
--- a/.github/workflows/test-cli-with-database.yml
+++ b/.github/workflows/test-cli-with-database.yml
@@ -54,7 +54,7 @@ jobs:
           extension: cli-database
 
       - name: Install Medusa cli
-        run: npm i -g @medusajs/cli@latest
+        run: npm i -g @medusajs/cli@preview
 
       - name: Create Medusa project
         working-directory: ..


### PR DESCRIPTION
**What**
Using the preview version instead of the latest should allow us to catch potential issues earlier before releasing