### PR TITLE
feat(index): Only run the synchronisation in worker/shared mode

### DIFF
--- a/.changeset/dirty-trees-smoke.md
+++ b/.changeset/dirty-trees-smoke.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/index": patch
+---
+
+feat(index): Only run the synchronisation in worker/shared mode


### PR DESCRIPTION
RESOLVES FRMW-2967

**What**
Off load the index sync task to worker or shared instances to reduce impact on the main server instances handling other tasks