### PR TITLE
fix: Fix garbled characters in zhCN.json translation file

### DIFF
--- a/packages/admin/dashboard/src/i18n/translations/zhCN.json
+++ b/packages/admin/dashboard/src/i18n/translations/zhCN.json
@@ -603,7 +603,7 @@
       },
       "variants": {
         "label": "产品变体",
-        "hint": "未选中的变体将不会被创建,���排序将影响变体在前端的排序方式。"
+        "hint": "未选中的变体将不会被创建,此排序将影响变体在前端的排序方式。"
       },
       "mid_code": {
         "label": "MID 代码"
@@ -636,7 +636,7 @@
           "inventoryKit": "显示库存项目"
         },
         "inventoryKit": "库存套件",
-        "inventoryKitHint": "此变体是否由���个库存项目组成？",
+        "inventoryKitHint": "此变体是否由多个库存项目组成？",
         "validation": {
           "itemId": "请选择库存项目。",
           "quantity": "数量为必填项。请输入一个正数。"
@@ -708,7 +708,7 @@
     "deleteWarning": "您即将删除系列 {{title}}。此操作无法撤销。",
     "removeSingleProductWarning": "您即将从系列中移除产品 {{title}}。此操作无法撤销。",
     "removeProductsWarning_one": "您即将从系列中移除 {{count}} 个产品。此操作无法撤销。",
-    "removeProductsWarning_other": "您即将从系列中移除 {{count}} 个产品。此��作无法撤销。",
+    "removeProductsWarning_other": "您即将从系列中移除 {{count}} 个产品。此操作无法撤销。",
     "products": {
       "list": {
         "noRecordsMessage": "系列中没有产品。"
@@ -1580,7 +1580,7 @@
           "options": {
             "fixed": {
               "label": "固定",
-              "hint": "配��选项的价格是固定的,不会根据订单内容变化。"
+              "hint": "配送选项的价格是固定的,不会根据订单内容变化。"
             },
             "calculated": {
               "label": "计算",


### PR DESCRIPTION
This PR fixes several garbled characters in the Chinese (Simplified) translation file zhCN.json to ensure proper parsing and display of the file.