### PR TITLE
fix(core-flows): skip location check if inventory is not managed

### DIFF
--- a/.changeset/tough-bats-walk.md
+++ b/.changeset/tough-bats-walk.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): skip location check if variant is not managed when preparing inventory confirm

--- a/packages/core/core-flows/src/cart/utils/__tests__/prepare-confirm-inventory-input.spec.ts
+++ b/packages/core/core-flows/src/cart/utils/__tests__/prepare-confirm-inventory-input.spec.ts
@@ -92,25 +92,7 @@ describe("prepareConfirmInventoryInput", () => {
         {
           id: "pv_2",
           manage_inventory: false,
-          inventory_items: [
-            {
-              inventory_item_id: "ii_2",
-              variant_id: "pv_2",
-              required_quantity: 1,
-              inventory: [
-                {
-                  location_levels: {
-                    stock_locations: [
-                      {
-                        id: "sl_1",
-                        sales_channels: [{ id: "sc_1" }],
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          ],
+          inventory_items: [], // not managed variant doesn't have inventory
         },
       ],
       items: [

--- a/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
+++ b/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
@@ -100,7 +100,6 @@ export const prepareConfirmInventoryInput = (data: {
             0
         )
 
-        // TODO: check if this stock location is avaialable in the input.sales_channel_id
         if (!mapLocationAvailability.has(location_levels.location_id)) {
           mapLocationAvailability.set(location_levels.location_id, new Map())
         }

--- a/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
+++ b/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
@@ -100,6 +100,7 @@ export const prepareConfirmInventoryInput = (data: {
             0
         )
 
+        // TODO: check if this stock location is avaialable in the input.sales_channel_id
         if (!mapLocationAvailability.has(location_levels.location_id)) {
           mapLocationAvailability.set(location_levels.location_id, new Map())
         }
@@ -151,6 +152,7 @@ export const prepareConfirmInventoryInput = (data: {
   if (salesChannelId) {
     for (const variant of allVariants.values()) {
       if (
+        variant.manage_inventory &&
         !variantsWithLocationForChannel.has(variant.id) &&
         !variant.allow_backorder
       ) {


### PR DESCRIPTION
**What**
- skip location association check if variant is not managed when preparing inventory confirm