### PR TITLE
fix(js-sdk): allow passing custom request body parameters in auth.register method

### DIFF
--- a/.changeset/beige-carrots-care.md
+++ b/.changeset/beige-carrots-care.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/js-sdk": patch
+---
+
+fix(js-sdk): allow passing custom request body parameters in auth.register method

--- a/packages/core/js-sdk/src/auth/index.ts
+++ b/packages/core/js-sdk/src/auth/index.ts
@@ -48,7 +48,7 @@ export class Auth {
   register = async (
     actor: string,
     method: string,
-    payload: HttpTypes.AdminSignUpWithEmailPassword
+    payload: HttpTypes.AdminSignUpWithEmailPassword | Record<string, unknown>
   ) => {
     const { token } = await this.client.fetch<{ token: string }>(
       `/auth/${actor}/${method}/register`,


### PR DESCRIPTION
The `auth.login` method of the JS SDK allows passing custom, which is useful for custom authentication providers. For example:

```ts
const response = await sdk.auth.login("customer", "phone-auth", {
      phone
    })
```

However, the `auth.register` method doesn't allow that, so we can't do the following:

```ts
const response = await sdk.auth.register("customer", "phone-auth", {
      phone
    })
```

Instead, we'd have to use the `client.fetch` method.

This PR fixes the input type of the payload passed to the `register` method to be similar to that of `login`,  which would allow using it with custom authentication providers