### PR TITLE
chore(docs): Update npm command

### DIFF
--- a/www/apps/book/app/learn/deployment/general/page.mdx
+++ b/www/apps/book/app/learn/deployment/general/page.mdx
@@ -305,7 +305,7 @@ The Medusa application's production build, which is created using the `build` co
 If your hosting provider doesn't support setting a current-working directory, set the start command to the following:
 
 ```bash npm2yarn
-cd .medusa/server && npm run install && npm run start
+cd .medusa/server && npm install && npm run start
 ```
 
 ---


### PR DESCRIPTION
`npm run install` in the first place is not a valid command, `yarn run install` will also be fixed by this change as we are using  **npm-to-yarn** package for its conversion (tested).

`yarn run start` is a valid command, i know `yarn start` is a **short-hand** but i cant help here as we have't hardcoded it in the docs its being converted through the same package mentioned above, anyways both are valid so should be fine ig.