### PR TITLE
Fix: Incorrect Example File Name in Subscriber Section

### DIFF
--- a/www/apps/book/app/learn/fundamentals/events-and-subscribers/page.mdx
+++ b/www/apps/book/app/learn/fundamentals/events-and-subscribers/page.mdx
@@ -34,7 +34,7 @@ Find a list of all emitted events in [this reference](!resources!/references/eve
 
 You create a subscriber in a TypeScript or JavaScript file under the `src/subscribers` directory. The file exports the function to execute and the subscriber's configuration that indicate what event(s) it listens to.
 
-For example, create the file `src/subscribers/order-placed.ts` with the following content:
+For example, create the file `src/subscribers/product-created.ts` with the following content:
 
 ![Example of subscriber file in the application's directory structure](https://res.cloudinary.com/dza7lstvk/image/upload/v1732866244/Medusa%20Book/subscriber-dir-overview_pusyeu.jpg)
 

--- a/www/apps/book/public/llms-full.txt
+++ b/www/apps/book/public/llms-full.txt
@@ -2589,7 +2589,7 @@ Find a list of all emitted events in [this reference](https://docs.medusajs.com/
 
 You create a subscriber in a TypeScript or JavaScript file under the `src/subscribers` directory. The file exports the function to execute and the subscriber's configuration that indicate what event(s) it listens to.
 
-For example, create the file `src/subscribers/order-placed.ts` with the following content:
+For example, create the file `src/subscribers/product-created.ts` with the following content:
 
 ![Example of subscriber file in the application's directory structure](https://res.cloudinary.com/dza7lstvk/image/upload/v1732866244/Medusa%20Book/subscriber-dir-overview_pusyeu.jpg)
 


### PR DESCRIPTION
Solving issue [#12559](https://github.com/medusajs/medusa/issues/12559) this PR corrects the example file name provided in the Events and Subscribers section of the documentation. Previously, the guide instructed users to create a file at:

_`src/subscribers/order-placed.ts`_
However, the appropriate file name should be:

_`src/subscribers/product-created.ts`_
This fix aligns the documentation with the actual subscriber example, ensuring clarity and preventing confusion for developers following the guide.

<img width="1497" alt="subscriber-wrong-file-name" src="https://github.com/user-attachments/assets/23320e3d-75ee-4df9-9a9c-5b77edfe08ff" />

Changes
Updated the incorrect file name in the Subscriber section example from order-placed.ts to product_created.ts.

Review
@shahednasser – kindly review when you get the chance. Thanks!