### PR TITLE
fix admin watch mode in medusa plugin:develop

### DIFF
--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -40,7 +40,6 @@ export class Compiler {
       "integration-tests",
       "test",
       "unit-tests",
-      "src/admin",
     ]
   }
 


### PR DESCRIPTION
Admin routes not being rebuild during `medusa plugin:develop`

probably caused by https://github.com/medusajs/medusa/pull/10926
possibly fixes https://github.com/medusajs/medusa/issues/12556