### PR TITLE
fix: Expose complete cart hooks

### DIFF
--- a/integration-tests/modules/__tests__/cart/store/cart.completion.ts
+++ b/integration-tests/modules/__tests__/cart/store/cart.completion.ts
@@ -226,6 +226,13 @@ medusaIntegrationTestRunner({
             },
           })
 
+          completeCartWorkflow.hooks.beforePaymentAuthorization((input) => {
+            expect(input.input.id).toBeDefined()
+          })
+          completeCartWorkflow.hooks.orderCreated((input) => {
+            expect(input.order_id).toBeDefined()
+          })
+
           await completeCartWorkflow(appContainer).run({
             input: {
               id: cart.id,


### PR DESCRIPTION
FIXES #12456

One issue is, the hooks get called even if we don't enter in the `when/then` condition, but without data.