### PR TITLE
fix: module import paths to contain unix slash

### DIFF
--- a/.changeset/plenty-apricots-remain.md
+++ b/.changeset/plenty-apricots-remain.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+fix: module import paths to contain unix slash

--- a/packages/core/utils/src/modules-sdk/modules-to-container-types.ts
+++ b/packages/core/utils/src/modules-sdk/modules-to-container-types.ts
@@ -2,6 +2,7 @@ import { join } from "path"
 import { Modules } from "./definition"
 import type { LoadedModule } from "@medusajs/types"
 import { FileSystem } from "../common/file-system"
+import { toUnixSlash } from "../common/to-unix-slash"
 import { toCamelCase } from "../common/to-camel-case"
 import { upperCaseFirst } from "../common/upper-case-first"
 
@@ -56,7 +57,7 @@ const SERVICES_INTERFACES = {
  */
 function normalizeModuleResolvePath(modulePath: string) {
   return modulePath.startsWith("./") || modulePath.startsWith("../")
-    ? join("../", "../", modulePath)
+    ? toUnixSlash(join("../", "../", modulePath))
     : modulePath
 }
 


### PR DESCRIPTION
Currently when types are generated on Windows, they result in using Windows slash for relative imports. This PR, fixes that to always use Unix imports