### PR TITLE
Docs/deploying on aws terraform review

### DIFF
--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -229,5 +229,4 @@ No, you can use the [medusa-starter repository](https://github.com/u11d-com/medu
 Modify the Terraform configuration files and run `terraform apply` to apply the changes.
 
 ---
-
-:heart: _Technology made with passion by u11d_
+:heart: _Technology made with passion by [u11d](https://u11d.com)_

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -1,6 +1,11 @@
-# **Terraform Module for MedusaJS on AWS**
+---
+description: 'Learn step-by-step.'
+addHowToData: true
+---
 
-This guide explains how to use the **Terraform module for MedusaJS** to deploy a production-ready e-commerce backend on AWS. The module is designed for front-end developers with little to no experience in AWS or Terraform, making it easy to set up and manage infrastructure.
+# Deploy the Medusa Backend using the Terraform Module on AWS
+
+This guide explains how to use the [**Terraform module for MedusaJS**](https://github.com/u11d-com/terraform-aws-medusajs) to deploy a production-ready e-commerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices. It provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized MedusaJS deployments.
 
 ## Table of Contents
 
@@ -11,8 +16,12 @@ This guide explains how to use the **Terraform module for MedusaJS** to deploy a
   - [Tools Required](#tools-required)
   - [AWS Account Setup](#aws-account-setup)
 - [Overview of the Terraform Module](#overview-of-the-terraform-module)
+  - [Core Infrastructure](#core-infrastructure)
+  - [Optional Infrastructure](#optional-infrastructure)
+- [Architectural Decisions Behind the Terraform Module](#architectural-decisions-behind-the-terraform-module)
 - [Step-by-Step Guide to Using the Terraform Module](#step-by-step-guide-to-using-the-terraform-module)
-- [Connecting MedusaJS to the Deployed Infrastructure](#connecting-medusajs-to-the-deployed-infrastructure)
+- [Connecting Medusa to the Deployed Infrastructure](#connecting-medusa-to-the-deployed-infrastructure)
+  - [Configuring Medusa with Provisioned AWS Services](#configuring-medusa-with-provisioned-aws-services)
 - [Optional Features](#optional-features)
   - [Enable ECR for Container Images](#enable-ecr-for-container-images)
   - [Use an External Image Repository](#use-an-external-image-repository)
@@ -27,58 +36,80 @@ This guide explains how to use the **Terraform module for MedusaJS** to deploy a
 
 ---
 
-## **Introduction**
+## Introduction
 
-### **What is Terraform?**
+### What is Terraform?
 Terraform is an infrastructure-as-code tool that allows you to define and provision cloud resources using code. It simplifies the process of managing cloud infrastructure and ensures consistency across environments. Learn more about Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/infrastructure-as-code).
 
-### **Why Use This Terraform Module?**
-This Terraform module simplifies the deployment of MedusaJS on AWS by automating the setup of essential infrastructure components, such as databases, caching, and backend services. It’s designed for front-end developers who want to focus on building their e-commerce store without worrying about cloud infrastructure.
+### Why Use Terraform Module for Medusa?
+[Terraform module for Medusa](https://github.com/u11d-com/terraform-aws-medusajs) simplifies the deployment of MedusaJS on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](https://docs.medusajs.com/resources/architectural-modules) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
 
 ---
 
-## **Prerequisites**
+## Prerequisites
 
-Before using this Terraform module, ensure you have the following tools and accounts set up:
+Before using Terraform module for Medusa, ensure you have the following tools and accounts set up:
 
-### **Tools Required**
+### Tools Required
 - **Terraform CLI**: Install Terraform by following the [official installation guide](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
 - **AWS CLI**: Install the AWS CLI by following the [official installation guide](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
 - **Node.js**: Install Node.js from the [official website](https://nodejs.org/).
 
-### **AWS Account Setup**
+### AWS Account Setup
 - **Create an AWS Account**: If you don’t already have an AWS account, follow the [AWS Getting Started Guide](https://docs.aws.amazon.com/accounts/latest/reference/getting-started.html) to create one.
 - **Configure AWS Credentials**: Set up your AWS credentials for Terraform by following the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html).
 
 ---
 
-## **Overview of the Terraform Module**
+## Architectural Decisions Behind the Terraform Module
+When designing the Terraform module for Medusa, we prioritized scalability, security, and performance while minimizing the operational overhead for development teams. To achieve this, we selected fully managed AWS services, allowing teams to focus on building e-commerce solutions without the complexity of maintaining cloud infrastructure.
 
-This Terraform module sets up the following AWS resources for MedusaJS:
+Key architectural decisions include:
+- Use of Managed Services: All core components — such as Amazon RDS for PostgreSQL, Amazon ElastiCache for Redis, and the Application Load Balancer (ALB) — are fully managed services. This eliminates the need for teams to handle infrastructure maintenance tasks like patching, backups, and scaling operations.
+- Containerization with AWS Fargate: We run Medusa services as ECS tasks on AWS Fargate, removing the need for Kubernetes cluster management. Teams can focus on defining scaling policies without worrying about the underlying infrastructure.
+- Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate repository). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
 
-### **Core Infrastructure**
-- **RDS (PostgreSQL)**: A managed relational database for storing MedusaJS data.
-- **Redis**: A caching layer to improve performance.
-- **ECS (Backend Tasks)**: Runs the MedusaJS backend as containerized tasks.
-- **ALB (Application Load Balancer)**: Distributes incoming traffic to the backend tasks.
+By leveraging managed services, this architecture reduces the time, effort, and expertise required to maintain infrastructure. It provides the flexibility to control scalability while ensuring high availability, robust security, and optimal performance — allowing development teams to concentrate on delivering business value through their e-commerce platforms.
 
-### **Optional Features**
-- **ECR (Elastic Container Registry)**: Stores Docker images for the backend and frontend (if enabled).
-- **Frontend ECS Tasks**: Runs the frontend application (if enabled).
-- **CloudFront**: A CDN to serve the frontend with low latency (if enabled).
+## Overview of the Terraform Module
+
+The `Terraform module for Medusa` sets up the following AWS resources to support Medusa:
+
+### Core Infrastructure
+- RDS for PostgreSQL: A managed relational database for storing Medusa data.
+- ElastiCache: A caching layer to improve performance.
+- AWS Fargate for ECS Backend Tasks: Runs the Medusa backend as containerized tasks.
+- Amazon S3: Cloud object storage that ensures scalability, data availability, security, and performance.
+- Application Load Balancer (ALB): Distributes incoming traffic to backend tasks.
+
+### Optional Infrastructure
+- Elastic Container Registry (ECR): Stores Docker images for the backend and frontend (if enabled).
+- Frontend ECS Tasks: Runs the frontend application (if enabled).
+- CloudFront: A CDN that serves the frontend with low latency (if enabled).
+
+### Mapping Medusa Architectural Modules to AWS Infrastructure
+
+| **Medusa Architectural Module** | **AWS Provisioned Infrastructure**      | **Notes**                             |
+|:---------------------------------|:---------------------------------------|:--------------------------------------|
+| Internal Database               | Amazon RDS for PostgreSQL              |                                        |
+| Cache Modules                   | Amazon ElastiCache                     |                                        |
+| Event Modules                   | Amazon ElastiCache                     |                                        |
+| File Module Providers           | Amazon S3                              |                                        |
+| Workflow Engine Modules         | Amazon ElastiCache                     |                                        |
+| Notification Module Providers   | Amazon SES                             | *Planned for future implementation*   |
 
 ---
 
-## **Step-by-Step Guide to Using the Terraform Module**
+## Step-by-Step Guide to Using the Terraform Module
 
-### **Step 1: Download or Clone the Module**
+### Step 1: Download or Clone the Module
 Clone the Terraform module repository to your local machine:
 ```bash
 git clone https://github.com/u11d-com/terraform-aws-medusajs
 cd terraform-u11d-medusajs/exaples/minimal
 ```
 
-### **Step 2: Provide Variables for the Module**
+### Step 2: Provide Variables for the Module
 See module inputs documentation for available configuration options.
 [Example configurations](https://github.com/u11d-com/terraform-aws-medusajs/tree/main?tab=readme-ov-file#examples) as a reference.
 
@@ -88,69 +119,82 @@ aws_region = "us-east-1"
 backend_container_image = "your-medusa-backend-image:latest"
 ```
 
-### **Step 3: Initialize Terraform**
+### Step 3: Initialize Terraform
 Run the following command to initialize Terraform and download the required providers:
 ```bash
 terraform init
 ```
 
-### **Step 4: Plan the Infrastructure**
+### Step 4: Plan the Infrastructure
 Preview the resources that Terraform will create:
 ```bash
 terraform plan
 ```
 
-### **Step 5: Apply the Infrastructure**
+### Step 5: Apply the Infrastructure
 Deploy the infrastructure by running:
 ```bash
 terraform apply
 ```
 Confirm the deployment by typing `yes` when prompted.
 
-### **Step 6: Verify the Setup**
+### Step 6: Verify the Setup
 1. Check the Terraform outputs for the MedusaJS backend URL.
 2. Use the URL to verify that the backend is running.
 
----
 
-## **Connecting MedusaJS to the Deployed Infrastructure**
+## Connecting Medusa to the Deployed Infrastructure
 
 Once the infrastructure is deployed, the MedusaJS backend URL will be available in the Terraform outputs. Use this URL to connect your MedusaJS application to the deployed backend.
 
----
 
-## **Optional Features**
+### Configuring Medusa with Provisioned AWS Services
+In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your MedusaJS application:
 
-### **Enable ECR for Container Images**
+1. Configure S3 and Redis Plugins:
+- Set up the appropriate MedusaJS plugins for S3 and Redis to enable object storage and caching functionalities.
+- The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
+  - [Redis Cache Module](https://docs.medusajs.com/v1/development/cache/modules/redis)
+  - [File Service - S3 plugin](https://docs.medusajs.com/v1/plugins/file-service/s3)
+
+2. Use Predefined Environment Variables:
+- The Terraform module automatically generates all necessary environment variables, following Medusa’s naming conventions.
+- These variables simplify the configuration process, ensuring seamless compatibility with MedusaJS.
+
+All internal connections between services are securely configured with proper access controls, reducing the need for additional security configurations.
+By following these steps, you’ll ensure your MedusaJS application is fully integrated with the cloud infrastructure, optimized for performance, scalability, and security.
+
+## Optional Features
+
+### Enable ECR for Container Images
 To create an ECR repository for storing container images, provide the following variable:
 ```hcl
 ecr_backend_create = true
 ecr_storefront_create = true
 ```
 
-### **Use an External Image Repository**
+### Use an External Image Repository
 If you’re using an external image repository, provide the repository address and image tag as variables, optionally you might need to provide credentials for repository:
 ```hcl
-backend_container_image = "your-repo/medusa-backend:latest"
+backend_container_image = "your-repo/medusa-backend:v1.20.11"
 backend_container_registry_credentials = {
     username = "your-registry-username"
     password = "your-registry-password"
   }
-storefront_container_image = "your-repo/medusa-backend:latest"
+storefront_container_image = "your-repo/medusa-backend:v1.20.11"
 storefront_container_registry_credentials = { = {
     username = "your-registry-username"
     password = "your-registry-password"
   }
 ```
----
 
-## **Common Issues and Troubleshooting**
+## Common Issues and Troubleshooting
 
-### **Common Errors**
-- **AWS Permission Errors**: Ensure your AWS credentials are correctly configured.
-- **Terraform State Issues**: Avoid manually modifying resources created by Terraform.
+### Common Errors
+- AWS Permission Errors: Ensure your AWS credentials are correctly configured.
+- Terraform State Issues: Avoid manually modifying resources created by Terraform.
 
-### **Clean Up Resources**
+### Clean Up Resources
 To delete all resources created by Terraform, run:
 ```bash
 terraform destroy
@@ -158,29 +202,30 @@ terraform destroy
 
 ---
 
-## **Next Steps**
+## Next Steps
 - Learn how to set up MedusaJS locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter).
 - Explore the MedusaJS starter templates:
   - [Backend Starter Template](https://github.com/medusajs/medusa-starter-default).
   - [Frontend Starter Template](https://github.com/medusajs/nextjs-starter-medusa).
 
-### **Deploy the Frontend**
+
+### Deploy the Frontend
 MedusaJS starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the MedusaJS backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
 
 To deploy the frontend, provide the following variables:
 ```hcl
 storefront_create = true
-storefront_container_image  = "your-repo/frontend:latest"
+storefront_container_image  = "your-repo/frontend:v1.20.11"
 ```
 
 ---
 
-## **FAQs**
+## FAQs
 
-### **Can I use this for local development?**
+### Can I use this for local development?
 No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter) to set up MedusaJS locally.
 
-### **How do I update the infrastructure?**
+### How do I update the infrastructure?
 Modify the Terraform configuration files and run `terraform apply` to apply the changes.
 
 ---

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -5,36 +5,8 @@ addHowToData: true
 
 # Deploy the Medusa Backend using the Terraform Module on AWS
 
-This guide explains how to use the [**Terraform module for MedusaJS**](https://github.com/u11d-com/terraform-aws-medusajs) to deploy a production-ready e-commerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices. It provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized MedusaJS deployments.
+This guide explains how to use the [**Terraform module for Medusa**](https://github.com/u11d-com/terraform-aws-medusajs) to deploy a production-ready e-commerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices. It provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized Medusa deployments.
 
-## Table of Contents
-
-- [Introduction](#Introduction)
-  - [What is Terraform?](#what-is-terraform)
-  - [Why Use This Terraform Module?](#why-use-this-terraform-module)
-- [Prerequisites](#prerequisites)
-  - [Tools Required](#tools-required)
-  - [AWS Account Setup](#aws-account-setup)
-- [Overview of the Terraform Module](#overview-of-the-terraform-module)
-  - [Core Infrastructure](#core-infrastructure)
-  - [Optional Infrastructure](#optional-infrastructure)
-- [Architectural Decisions Behind the Terraform Module](#architectural-decisions-behind-the-terraform-module)
-- [Step-by-Step Guide to Using the Terraform Module](#step-by-step-guide-to-using-the-terraform-module)
-- [Connecting Medusa to the Deployed Infrastructure](#connecting-medusa-to-the-deployed-infrastructure)
-  - [Configuring Medusa with Provisioned AWS Services](#configuring-medusa-with-provisioned-aws-services)
-- [Optional Features](#optional-features)
-  - [Enable ECR for Container Images](#enable-ecr-for-container-images)
-  - [Use an External Image Repository](#use-an-external-image-repository)
-- [Common Issues and Troubleshooting](#common-issues-and-troubleshooting)
-  - [Common Errors](#common-errors)
-  - [Clean Up Resources](#clean-up-resources)
-- [Next Steps](#next-steps)
-  - [Deploy the Frontend](#deploy-the-frontend)
-- [FAQs](#faqs)
-  - [Can I use this for local development?](#can-i-use-this-for-local-development)
-  - [How do I update the infrastructure?](#how-do-i-update-the-infrastructure)
-
----
 
 ## Introduction
 
@@ -42,7 +14,7 @@ This guide explains how to use the [**Terraform module for MedusaJS**](https://g
 Terraform is an infrastructure-as-code tool that allows you to define and provision cloud resources using code. It simplifies the process of managing cloud infrastructure and ensures consistency across environments. Learn more about Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/infrastructure-as-code).
 
 ### Why Use Terraform Module for Medusa?
-[Terraform module for Medusa](https://github.com/u11d-com/terraform-aws-medusajs) simplifies the deployment of MedusaJS on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
+[Terraform module for Medusa](https://github.com/u11d-com/terraform-aws-medusajs) simplifies the deployment of Medusa on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
 
 ---
 
@@ -139,30 +111,30 @@ terraform apply
 Confirm the deployment by typing `yes` when prompted.
 
 ### Step 6: Verify the Setup
-1. Check the Terraform outputs for the MedusaJS backend URL.
+1. Check the Terraform outputs for the Medusa backend URL.
 2. Use the URL to verify that the backend is running.
 
 
 ## Connecting Medusa to the Deployed Infrastructure
 
-Once the infrastructure is deployed, the MedusaJS backend URL will be available in the Terraform outputs. Use this URL to connect your MedusaJS application to the deployed backend.
+Once the infrastructure is deployed, the Medusa backend URL will be available in the Terraform outputs. Use this URL to connect your Medusa application to the deployed backend.
 
 
 ### Configuring Medusa with Provisioned AWS Services
-In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your MedusaJS application:
+In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your Medusa application:
 
 1. Configure S3 and Redis Plugins:
-- Set up the appropriate MedusaJS plugins for S3 and Redis to enable object storage and caching functionalities.
+- Set up the appropriate Medusa plugins for S3 and Redis to enable object storage and caching functionalities.
   - [Redis Cache Module](https://docs.medusajs.com/v1/development/cache/modules/redis)
   - [File Service - S3 plugin](https://docs.medusajs.com/v1/plugins/file-service/s3)
 - The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
 
 2. Use Predefined Environment Variables:
 - The Terraform module automatically generates all necessary environment variables, following Medusa’s naming conventions.
-- These variables simplify the configuration process, ensuring seamless compatibility with MedusaJS.
+- These variables simplify the configuration process, ensuring seamless compatibility with Medusa.
 
 All internal connections between services are securely configured with proper access controls, reducing the need for additional security configurations.
-By following these steps, you’ll ensure your MedusaJS application is fully integrated with the cloud infrastructure, optimized for performance, scalability, and security.
+By following these steps, you’ll ensure your Medusa application is fully integrated with the cloud infrastructure, optimized for performance, scalability, and security.
 
 ## Optional Features
 
@@ -203,14 +175,14 @@ terraform destroy
 ---
 
 ## Next Steps
-- Learn how to set up MedusaJS locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter).
-- Explore the MedusaJS starter templates:
+- Learn how to set up Medusa locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter).
+- Explore the Medusa starter templates:
   - [Backend Starter Template](https://github.com/medusajs/medusa-starter-default).
   - [Frontend Starter Template](https://github.com/medusajs/nextjs-starter-medusa).
 
 
 ### Deploy the Frontend
-MedusaJS starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the MedusaJS backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
+Medusa starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the Medusa backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
 
 To deploy the frontend, provide the following variables:
 ```hcl
@@ -218,12 +190,14 @@ storefront_create = true
 storefront_container_image  = "your-repo/frontend:v1.20.11"
 ```
 
+For a detailed step-by-step guide on building, pushing, and configuring the storefront container image, refer to the [Storefront Deployment Guide](../storefront/deploying-next-on-aws-using-terraform.md). Following this guide ensures that your storefront is correctly built, stored in AWS ECR, and integrated with the Terraform module.
+
 ---
 
 ## FAQs
 
 ### Can I use this for local development?
-No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter) to set up MedusaJS locally.
+No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter) to set up Medusa locally.
 
 ### How do I update the infrastructure?
 Modify the Terraform configuration files and run `terraform apply` to apply the changes.

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -78,7 +78,7 @@ The `Terraform module for Medusa` sets up the following AWS resources to support
 Clone the Terraform module repository to your local machine:
 ```bash
 git clone https://github.com/u11d-com/terraform-aws-medusajs
-cd terraform-u11d-medusajs/examples/minimal
+cd terraform-aws-medusajs/examples/minimal
 ```
 
 ### Step 2: Provide Variables for the Module

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -147,7 +147,7 @@ ecr_backend_create = true
 ecr_storefront_create = true
 ```
 
-See [ECR Documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html) learn how to log in and push images.
+See [ECR Documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html) to learn how to log in and push images.
 
 ### Use an External Image Repository
 If you’re using an external image repository, provide the repository address and image tag as variables, optionally you might need to provide credentials for repository:

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -1,5 +1,5 @@
 ---
-description: 'Learn step-by-step.'
+description: 'Step-by-step deployment instruction'
 addHowToData: true
 ---
 

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -5,7 +5,7 @@ addHowToData: true
 
 # Deploy the Medusa Backend using the Terraform Module on AWS
 
-This guide explains how to use the [**Terraform module for MedusaJS**](https://github.com/u11d-com/terraform-aws-medusajs) to deploy a production-ready e-commerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices. It provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized MedusaJS deployments.
+This guide explains how to use the [**Terraform module for Medusa**](https://registry.terraform.io/modules/u11d-com/medusajs/aws) to deploy a production-ready e-commerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices. It provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized Medusa deployments.
 
 ## Table of Contents
 
@@ -42,7 +42,7 @@ This guide explains how to use the [**Terraform module for MedusaJS**](https://g
 Terraform is an infrastructure-as-code tool that allows you to define and provision cloud resources using code. It simplifies the process of managing cloud infrastructure and ensures consistency across environments. Learn more about Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/infrastructure-as-code).
 
 ### Why Use Terraform Module for Medusa?
-[Terraform module for Medusa](https://github.com/u11d-com/terraform-aws-medusajs) simplifies the deployment of MedusaJS on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
+[Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) simplifies the deployment of Medusa on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
 
 ---
 
@@ -73,7 +73,7 @@ By leveraging managed services, this architecture reduces the time, effort, and 
 
 ## Overview of the Terraform Module
 
-The `Terraform module for Medusa` sets up the following AWS resources to support Medusa:
+The [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) sets up the following AWS resources to support Medusa:
 
 ### Core Infrastructure
 - RDS for PostgreSQL: A managed relational database for storing Medusa data.
@@ -111,12 +111,14 @@ cd terraform-u11d-medusajs/examples/minimal
 
 ### Step 2: Provide Variables for the Module
 See module inputs documentation for available configuration options.
-[Example configurations](https://github.com/u11d-com/terraform-aws-medusajs/tree/main?tab=readme-ov-file#examples) as a reference.
+[Example configurations](https://registry.terraform.io/modules/u11d-com/medusajs/aws) as a reference.
 
 Example variables:
 ```hcl
-aws_region = "us-east-1"
 backend_container_image = "your-medusa-backend-image:v1.20.11"
+project     = "medusa"
+environment = "prod"
+owner       = "my-team"
 ```
 
 ### Step 3: Initialize Terraform
@@ -139,30 +141,30 @@ terraform apply
 Confirm the deployment by typing `yes` when prompted.
 
 ### Step 6: Verify the Setup
-1. Check the Terraform outputs for the MedusaJS backend URL.
+1. Check the Terraform outputs for the Medusa backend URL.
 2. Use the URL to verify that the backend is running.
 
 
 ## Connecting Medusa to the Deployed Infrastructure
 
-Once the infrastructure is deployed, the MedusaJS backend URL will be available in the Terraform outputs. Use this URL to connect your MedusaJS application to the deployed backend.
+Once the infrastructure is deployed, the Medusa backend URL will be available in the Terraform outputs. Use this URL to connect your Medusa application to the deployed backend.
 
 
 ### Configuring Medusa with Provisioned AWS Services
-In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your MedusaJS application:
+In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your Medusa application:
 
 1. Configure S3 and Redis Plugins:
-- Set up the appropriate MedusaJS plugins for S3 and Redis to enable object storage and caching functionalities.
+- Set up the appropriate Medusa plugins for S3 and Redis to enable object storage and caching functionalities.
   - [Redis Cache Module](https://docs.medusajs.com/v1/development/cache/modules/redis)
   - [File Service - S3 plugin](https://docs.medusajs.com/v1/plugins/file-service/s3)
 - The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
 
 2. Use Predefined Environment Variables:
 - The Terraform module automatically generates all necessary environment variables, following Medusa’s naming conventions.
-- These variables simplify the configuration process, ensuring seamless compatibility with MedusaJS.
+- These variables simplify the configuration process, ensuring seamless compatibility with Medusa.
 
 All internal connections between services are securely configured with proper access controls, reducing the need for additional security configurations.
-By following these steps, you’ll ensure your MedusaJS application is fully integrated with the cloud infrastructure, optimized for performance, scalability, and security.
+By following these steps, you’ll ensure your Medusa application is fully integrated with the cloud infrastructure, optimized for performance, scalability, and security.
 
 ## Optional Features
 
@@ -172,6 +174,8 @@ To create an ECR repository for storing container images, provide the following 
 ecr_backend_create = true
 ecr_storefront_create = true
 ```
+
+See [ECR Documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html) learn how to log in and push images.
 
 ### Use an External Image Repository
 If you’re using an external image repository, provide the repository address and image tag as variables, optionally you might need to provide credentials for repository:
@@ -203,14 +207,14 @@ terraform destroy
 ---
 
 ## Next Steps
-- Learn how to set up MedusaJS locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter).
-- Explore the MedusaJS starter templates:
+- Learn how to set up Medusa locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter).
+- Explore the Medusa starter templates:
   - [Backend Starter Template](https://github.com/medusajs/medusa-starter-default).
   - [Frontend Starter Template](https://github.com/medusajs/nextjs-starter-medusa).
 
 
 ### Deploy the Frontend
-MedusaJS starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the MedusaJS backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
+Medusa starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the Medusa backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
 
 To deploy the frontend, provide the following variables:
 ```hcl
@@ -223,7 +227,7 @@ storefront_container_image  = "your-repo/frontend:v1.20.11"
 ## FAQs
 
 ### Can I use this for local development?
-No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter) to set up MedusaJS locally.
+No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter) to set up Medusa locally.
 
 ### How do I update the infrastructure?
 Modify the Terraform configuration files and run `terraform apply` to apply the changes.

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -42,7 +42,7 @@ This guide explains how to use the [**Terraform module for MedusaJS**](https://g
 Terraform is an infrastructure-as-code tool that allows you to define and provision cloud resources using code. It simplifies the process of managing cloud infrastructure and ensures consistency across environments. Learn more about Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/infrastructure-as-code).
 
 ### Why Use Terraform Module for Medusa?
-[Terraform module for Medusa](https://github.com/u11d-com/terraform-aws-medusajs) simplifies the deployment of MedusaJS on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](https://docs.medusajs.com/resources/architectural-modules) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
+[Terraform module for Medusa](https://github.com/u11d-com/terraform-aws-medusajs) simplifies the deployment of MedusaJS on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
 
 ---
 
@@ -67,7 +67,7 @@ When designing the Terraform module for Medusa, we prioritized scalability, secu
 Key architectural decisions include:
 - Use of Managed Services: All core components — such as Amazon RDS for PostgreSQL, Amazon ElastiCache for Redis, and the Application Load Balancer (ALB) — are fully managed services. This eliminates the need for teams to handle infrastructure maintenance tasks like patching, backups, and scaling operations.
 - Containerization with AWS Fargate: We run Medusa services as ECS tasks on AWS Fargate, removing the need for Kubernetes cluster management. Teams can focus on defining scaling policies without worrying about the underlying infrastructure.
-- Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate repository). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
+- Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate [repository](https://github.com/u11d-com/medusa-starter)). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
 
 By leveraging managed services, this architecture reduces the time, effort, and expertise required to maintain infrastructure. It provides the flexibility to control scalability while ensuring high availability, robust security, and optimal performance — allowing development teams to concentrate on delivering business value through their e-commerce platforms.
 
@@ -77,7 +77,7 @@ The `Terraform module for Medusa` sets up the following AWS resources to support
 
 ### Core Infrastructure
 - RDS for PostgreSQL: A managed relational database for storing Medusa data.
-- ElastiCache: A caching layer to improve performance.
+- ElastiCache (Redis): A caching layer to improve performance.
 - AWS Fargate for ECS Backend Tasks: Runs the Medusa backend as containerized tasks.
 - Amazon S3: Cloud object storage that ensures scalability, data availability, security, and performance.
 - Application Load Balancer (ALB): Distributes incoming traffic to backend tasks.
@@ -89,14 +89,14 @@ The `Terraform module for Medusa` sets up the following AWS resources to support
 
 ### Mapping Medusa Architectural Modules to AWS Infrastructure
 
-| **Medusa Architectural Module** | **AWS Provisioned Infrastructure**      | **Notes**                             |
-|:---------------------------------|:---------------------------------------|:--------------------------------------|
-| Internal Database               | Amazon RDS for PostgreSQL              |                                        |
-| Cache Modules                   | Amazon ElastiCache                     |                                        |
-| Event Modules                   | Amazon ElastiCache                     |                                        |
-| File Module Providers           | Amazon S3                              |                                        |
-| Workflow Engine Modules         | Amazon ElastiCache                     |                                        |
-| Notification Module Providers   | Amazon SES                             | *Planned for future implementation*   |
+| Medusa Architectural Module | AWS Provisioned Infrastructure | Notes |
+|----------------------------|-------------------------------|--------|
+| Internal Database | Amazon RDS for PostgreSQL | |
+| [Cache Modules](https://docs.medusajs.com/v1/development/cache/modules/redis) | Amazon ElastiCache | |
+| [Event Modules](https://docs.medusajs.com/v1/development/events/modules/redis) | Amazon ElastiCache | |
+| [File Module Providers](https://docs.medusajs.com/v1/plugins/file-service/s3) | Amazon S3 | |
+| Workflow Engine Modules | Amazon ElastiCache | |
+| Notification Module Providers | Amazon SES | *Planned for future implementation* |
 
 ---
 
@@ -106,7 +106,7 @@ The `Terraform module for Medusa` sets up the following AWS resources to support
 Clone the Terraform module repository to your local machine:
 ```bash
 git clone https://github.com/u11d-com/terraform-aws-medusajs
-cd terraform-u11d-medusajs/exaples/minimal
+cd terraform-u11d-medusajs/examples/minimal
 ```
 
 ### Step 2: Provide Variables for the Module
@@ -116,7 +116,7 @@ See module inputs documentation for available configuration options.
 Example variables:
 ```hcl
 aws_region = "us-east-1"
-backend_container_image = "your-medusa-backend-image:latest"
+backend_container_image = "your-medusa-backend-image:v1.20.11"
 ```
 
 ### Step 3: Initialize Terraform
@@ -153,9 +153,9 @@ In addition to the backend, the Terraform module provisions key AWS resources, i
 
 1. Configure S3 and Redis Plugins:
 - Set up the appropriate MedusaJS plugins for S3 and Redis to enable object storage and caching functionalities.
-- The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
   - [Redis Cache Module](https://docs.medusajs.com/v1/development/cache/modules/redis)
   - [File Service - S3 plugin](https://docs.medusajs.com/v1/plugins/file-service/s3)
+- The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
 
 2. Use Predefined Environment Variables:
 - The Terraform module automatically generates all necessary environment variables, following Medusa’s naming conventions.
@@ -182,7 +182,7 @@ backend_container_registry_credentials = {
     password = "your-registry-password"
   }
 storefront_container_image = "your-repo/medusa-backend:v1.20.11"
-storefront_container_registry_credentials = { = {
+storefront_container_registry_credentials = {
     username = "your-registry-username"
     password = "your-registry-password"
   }

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -1,0 +1,188 @@
+# **Terraform Module for MedusaJS on AWS**
+
+This guide explains how to use the **Terraform module for MedusaJS** to deploy a production-ready e-commerce backend on AWS. The module is designed for front-end developers with little to no experience in AWS or Terraform, making it easy to set up and manage infrastructure.
+
+## Table of Contents
+
+- [Introduction](#Introduction)
+  - [What is Terraform?](#what-is-terraform)
+  - [Why Use This Terraform Module?](#why-use-this-terraform-module)
+- [Prerequisites](#prerequisites)
+  - [Tools Required](#tools-required)
+  - [AWS Account Setup](#aws-account-setup)
+- [Overview of the Terraform Module](#overview-of-the-terraform-module)
+- [Step-by-Step Guide to Using the Terraform Module](#step-by-step-guide-to-using-the-terraform-module)
+- [Connecting MedusaJS to the Deployed Infrastructure](#connecting-medusajs-to-the-deployed-infrastructure)
+- [Optional Features](#optional-features)
+  - [Enable ECR for Container Images](#enable-ecr-for-container-images)
+  - [Use an External Image Repository](#use-an-external-image-repository)
+- [Common Issues and Troubleshooting](#common-issues-and-troubleshooting)
+  - [Common Errors](#common-errors)
+  - [Clean Up Resources](#clean-up-resources)
+- [Next Steps](#next-steps)
+  - [Deploy the Frontend](#deploy-the-frontend)
+- [FAQs](#faqs)
+  - [Can I use this for local development?](#can-i-use-this-for-local-development)
+  - [How do I update the infrastructure?](#how-do-i-update-the-infrastructure)
+
+---
+
+## **Introduction**
+
+### **What is Terraform?**
+Terraform is an infrastructure-as-code tool that allows you to define and provision cloud resources using code. It simplifies the process of managing cloud infrastructure and ensures consistency across environments. Learn more about Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/infrastructure-as-code).
+
+### **Why Use This Terraform Module?**
+This Terraform module simplifies the deployment of MedusaJS on AWS by automating the setup of essential infrastructure components, such as databases, caching, and backend services. It’s designed for front-end developers who want to focus on building their e-commerce store without worrying about cloud infrastructure.
+
+---
+
+## **Prerequisites**
+
+Before using this Terraform module, ensure you have the following tools and accounts set up:
+
+### **Tools Required**
+- **Terraform CLI**: Install Terraform by following the [official installation guide](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
+- **AWS CLI**: Install the AWS CLI by following the [official installation guide](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
+- **Node.js**: Install Node.js from the [official website](https://nodejs.org/).
+
+### **AWS Account Setup**
+- **Create an AWS Account**: If you don’t already have an AWS account, follow the [AWS Getting Started Guide](https://docs.aws.amazon.com/accounts/latest/reference/getting-started.html) to create one.
+- **Configure AWS Credentials**: Set up your AWS credentials for Terraform by following the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html).
+
+---
+
+## **Overview of the Terraform Module**
+
+This Terraform module sets up the following AWS resources for MedusaJS:
+
+### **Core Infrastructure**
+- **RDS (PostgreSQL)**: A managed relational database for storing MedusaJS data.
+- **Redis**: A caching layer to improve performance.
+- **ECS (Backend Tasks)**: Runs the MedusaJS backend as containerized tasks.
+- **ALB (Application Load Balancer)**: Distributes incoming traffic to the backend tasks.
+
+### **Optional Features**
+- **ECR (Elastic Container Registry)**: Stores Docker images for the backend and frontend (if enabled).
+- **Frontend ECS Tasks**: Runs the frontend application (if enabled).
+- **CloudFront**: A CDN to serve the frontend with low latency (if enabled).
+
+---
+
+## **Step-by-Step Guide to Using the Terraform Module**
+
+### **Step 1: Download or Clone the Module**
+Clone the Terraform module repository to your local machine:
+```bash
+git clone https://github.com/u11d-com/terraform-aws-medusajs
+cd terraform-u11d-medusajs/exaples/minimal
+```
+
+### **Step 2: Provide Variables for the Module**
+See module inputs documentation for available configuration options.
+[Example configurations](https://github.com/u11d-com/terraform-aws-medusajs/tree/main?tab=readme-ov-file#examples) as a reference.
+
+Example variables:
+```hcl
+aws_region = "us-east-1"
+backend_container_image = "your-medusa-backend-image:latest"
+```
+
+### **Step 3: Initialize Terraform**
+Run the following command to initialize Terraform and download the required providers:
+```bash
+terraform init
+```
+
+### **Step 4: Plan the Infrastructure**
+Preview the resources that Terraform will create:
+```bash
+terraform plan
+```
+
+### **Step 5: Apply the Infrastructure**
+Deploy the infrastructure by running:
+```bash
+terraform apply
+```
+Confirm the deployment by typing `yes` when prompted.
+
+### **Step 6: Verify the Setup**
+1. Check the Terraform outputs for the MedusaJS backend URL.
+2. Use the URL to verify that the backend is running.
+
+---
+
+## **Connecting MedusaJS to the Deployed Infrastructure**
+
+Once the infrastructure is deployed, the MedusaJS backend URL will be available in the Terraform outputs. Use this URL to connect your MedusaJS application to the deployed backend.
+
+---
+
+## **Optional Features**
+
+### **Enable ECR for Container Images**
+To create an ECR repository for storing container images, provide the following variable:
+```hcl
+ecr_backend_create = true
+ecr_storefront_create = true
+```
+
+### **Use an External Image Repository**
+If you’re using an external image repository, provide the repository address and image tag as variables, optionally you might need to provide credentials for repository:
+```hcl
+backend_container_image = "your-repo/medusa-backend:latest"
+backend_container_registry_credentials = {
+    username = "your-registry-username"
+    password = "your-registry-password"
+  }
+storefront_container_image = "your-repo/medusa-backend:latest"
+storefront_container_registry_credentials = { = {
+    username = "your-registry-username"
+    password = "your-registry-password"
+  }
+```
+---
+
+## **Common Issues and Troubleshooting**
+
+### **Common Errors**
+- **AWS Permission Errors**: Ensure your AWS credentials are correctly configured.
+- **Terraform State Issues**: Avoid manually modifying resources created by Terraform.
+
+### **Clean Up Resources**
+To delete all resources created by Terraform, run:
+```bash
+terraform destroy
+```
+
+---
+
+## **Next Steps**
+- Learn how to set up MedusaJS locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter).
+- Explore the MedusaJS starter templates:
+  - [Backend Starter Template](https://github.com/medusajs/medusa-starter-default).
+  - [Frontend Starter Template](https://github.com/medusajs/nextjs-starter-medusa).
+
+### **Deploy the Frontend**
+MedusaJS starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the MedusaJS backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
+
+To deploy the frontend, provide the following variables:
+```hcl
+storefront_create = true
+storefront_container_image  = "your-repo/frontend:latest"
+```
+
+---
+
+## **FAQs**
+
+### **Can I use this for local development?**
+No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter) to set up MedusaJS locally.
+
+### **How do I update the infrastructure?**
+Modify the Terraform configuration files and run `terraform apply` to apply the changes.
+
+---
+
+:heart: _Technology made with passion by u11d_

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -39,7 +39,7 @@ When designing the Terraform module for Medusa, we prioritized scalability, secu
 Key architectural decisions include:
 - Use of Managed Services: All core components — such as Amazon RDS for PostgreSQL, Amazon ElastiCache for Redis, and the Application Load Balancer (ALB) — are fully managed services. This eliminates the need for teams to handle infrastructure maintenance tasks like patching, backups, and scaling operations.
 - Containerization with AWS Fargate: We run Medusa services as ECS tasks on AWS Fargate, removing the need for Kubernetes cluster management. Teams can focus on defining scaling policies without worrying about the underlying infrastructure.
-- Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate [repository](https://github.com/u11d-com/medusa-starter)). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
+- Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate [repository](https://github.com/u11d-com/medusa-starter/tree/v1)). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
 
 By leveraging managed services, this architecture reduces the time, effort, and expertise required to maintain infrastructure. It provides the flexibility to control scalability while ensuring high availability, robust security, and optimal performance — allowing development teams to concentrate on delivering business value through their e-commerce platforms.
 
@@ -179,7 +179,7 @@ terraform destroy
 ---
 
 ## Next Steps
-- Learn how to set up Medusa locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter).
+- Learn how to set up Medusa locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter/tree/v1).
 - Explore the Medusa starter templates:
   - [Backend Starter Template](https://github.com/medusajs/medusa-starter-default).
   - [Frontend Starter Template](https://github.com/medusajs/nextjs-starter-medusa).
@@ -201,7 +201,7 @@ For a detailed step-by-step guide on building, pushing, and configuring the stor
 ## FAQs
 
 ### Can I use this for local development?
-No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter) to set up Medusa locally.
+No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter/tree/v1) to set up Medusa locally.
 
 ### How do I update the infrastructure?
 Modify the Terraform configuration files and run `terraform apply` to apply the changes.

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -7,13 +7,14 @@ addHowToData: true
 
 This guide explains how to use the [**Terraform module for Medusa**](https://registry.terraform.io/modules/u11d-com/medusajs/aws) to deploy a production-ready e-commerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices. It provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized Medusa deployments.
 
-
 ## Introduction
 
 ### What is Terraform?
+
 Terraform is an infrastructure-as-code tool that allows you to define and provision cloud resources using code. It simplifies the process of managing cloud infrastructure and ensures consistency across environments. Learn more about Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/infrastructure-as-code).
 
 ### Why Use Terraform Module for Medusa?
+
 [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) simplifies the deployment of Medusa on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
 
 ---
@@ -23,20 +24,24 @@ Terraform is an infrastructure-as-code tool that allows you to define and provis
 Before using Terraform module for Medusa, ensure you have the following tools and accounts set up:
 
 ### Tools Required
+
 - **Terraform CLI**: Install Terraform by following the [official installation guide](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
 - **AWS CLI**: Install the AWS CLI by following the [official installation guide](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
 - **Node.js**: Install Node.js from the [official website](https://nodejs.org/).
 
 ### AWS Account Setup
+
 - **Create an AWS Account**: If you don’t already have an AWS account, follow the [AWS Getting Started Guide](https://docs.aws.amazon.com/accounts/latest/reference/getting-started.html) to create one.
 - **Configure AWS Credentials**: Set up your AWS credentials for Terraform by following the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html).
 
 ---
 
 ## Architectural Decisions Behind the Terraform Module
+
 When designing the Terraform module for Medusa, we prioritized scalability, security, and performance while minimizing the operational overhead for development teams. To achieve this, we selected fully managed AWS services, allowing teams to focus on building e-commerce solutions without the complexity of maintaining cloud infrastructure.
 
 Key architectural decisions include:
+
 - Use of Managed Services: All core components — such as Amazon RDS for PostgreSQL, Amazon ElastiCache for Redis, and the Application Load Balancer (ALB) — are fully managed services. This eliminates the need for teams to handle infrastructure maintenance tasks like patching, backups, and scaling operations.
 - Containerization with AWS Fargate: We run Medusa services as ECS tasks on AWS Fargate, removing the need for Kubernetes cluster management. Teams can focus on defining scaling policies without worrying about the underlying infrastructure.
 - Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate [repository](https://github.com/u11d-com/medusa-starter/tree/v1)). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
@@ -48,6 +53,7 @@ By leveraging managed services, this architecture reduces the time, effort, and 
 The [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) sets up the following AWS resources to support Medusa:
 
 ### Core Infrastructure
+
 - RDS for PostgreSQL: A managed relational database for storing Medusa data.
 - ElastiCache (Redis): A caching layer to improve performance.
 - AWS Fargate for ECS Backend Tasks: Runs the Medusa backend as containerized tasks.
@@ -55,6 +61,7 @@ The [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com
 - Application Load Balancer (ALB): Distributes incoming traffic to backend tasks.
 
 ### Optional Infrastructure
+
 - Elastic Container Registry (ECR): Stores Docker images for the backend and frontend (if enabled).
 - Frontend ECS Tasks: Runs the frontend application (if enabled).
 - CloudFront: A CDN that serves the frontend with low latency (if enabled).
@@ -75,17 +82,21 @@ The [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com
 ## Step-by-Step Guide to Using the Terraform Module
 
 ### Step 1: Download or Clone the Module
+
 Clone the Terraform module repository to your local machine:
-```bash
+
+```shell
 git clone https://github.com/u11d-com/terraform-aws-medusajs
 cd terraform-u11d-medusajs/examples/minimal
 ```
 
 ### Step 2: Provide Variables for the Module
+
 See module inputs documentation for available configuration options.
 [Example configurations](https://registry.terraform.io/modules/u11d-com/medusajs/aws) as a reference.
 
 Example variables:
+
 ```hcl
 backend_container_image = "your-medusa-backend-image:v1.20.11"
 project     = "medusa"
@@ -94,44 +105,53 @@ owner       = "my-team"
 ```
 
 ### Step 3: Initialize Terraform
+
 Run the following command to initialize Terraform and download the required providers:
-```bash
+
+```shell
 terraform init
 ```
 
 ### Step 4: Plan the Infrastructure
+
 Preview the resources that Terraform will create:
-```bash
+
+```shell
 terraform plan
 ```
 
 ### Step 5: Apply the Infrastructure
+
 Deploy the infrastructure by running:
-```bash
+
+```shell
 terraform apply
 ```
+
 Confirm the deployment by typing `yes` when prompted.
 
 ### Step 6: Verify the Setup
+
 1. Check the Terraform outputs for the Medusa backend URL.
 2. Use the URL to verify that the backend is running.
-
 
 ## Connecting Medusa to the Deployed Infrastructure
 
 Once the infrastructure is deployed, the Medusa backend URL will be available in the Terraform outputs. Use this URL to connect your Medusa application to the deployed backend.
 
-
 ### Configuring Medusa with Provisioned AWS Services
+
 In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your Medusa application:
 
 1. Configure S3 and Redis Plugins:
+
 - Set up the appropriate Medusa plugins for S3 and Redis to enable object storage and caching functionalities.
   - [Redis Cache Module](https://docs.medusajs.com/v1/development/cache/modules/redis)
   - [File Service - S3 plugin](https://docs.medusajs.com/v1/plugins/file-service/s3)
 - The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
 
 2. Use Predefined Environment Variables:
+
 - The Terraform module automatically generates all necessary environment variables, following Medusa’s naming conventions.
 - These variables simplify the configuration process, ensuring seamless compatibility with Medusa.
 
@@ -141,7 +161,9 @@ By following these steps, you’ll ensure your Medusa application is fully integ
 ## Optional Features
 
 ### Enable ECR for Container Images
+
 To create an ECR repository for storing container images, provide the following variable:
+
 ```hcl
 ecr_backend_create = true
 ecr_storefront_create = true
@@ -150,7 +172,9 @@ ecr_storefront_create = true
 See [ECR Documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html) to learn how to log in and push images.
 
 ### Use an External Image Repository
+
 If you’re using an external image repository, provide the repository address and image tag as variables, optionally you might need to provide credentials for repository:
+
 ```hcl
 backend_container_image = "your-repo/medusa-backend:v1.20.11"
 backend_container_registry_credentials = {
@@ -167,28 +191,33 @@ storefront_container_registry_credentials = {
 ## Common Issues and Troubleshooting
 
 ### Common Errors
+
 - AWS Permission Errors: Ensure your AWS credentials are correctly configured.
 - Terraform State Issues: Avoid manually modifying resources created by Terraform.
 
 ### Clean Up Resources
+
 To delete all resources created by Terraform, run:
-```bash
+
+```shell
 terraform destroy
 ```
 
 ---
 
 ## Next Steps
+
 - Learn how to set up Medusa locally using the [medusa-starter repository](https://github.com/u11d-com/medusa-starter/tree/v1).
 - Explore the Medusa starter templates:
   - [Backend Starter Template](https://github.com/medusajs/medusa-starter-default).
   - [Frontend Starter Template](https://github.com/medusajs/nextjs-starter-medusa).
 
-
 ### Deploy the Frontend
+
 Medusa starter kits typically use the Next.js framework to build the storefront web application. Next.js requires that the Medusa backend is available and responsive during the build process to properly fetch data and create a fully functional storefront. This is important because storefront will be built using the API provided by the backend application.
 
 To deploy the frontend, provide the following variables:
+
 ```hcl
 storefront_create = true
 storefront_container_image  = "your-repo/frontend:v1.20.11"
@@ -201,10 +230,12 @@ For a detailed step-by-step guide on building, pushing, and configuring the stor
 ## FAQs
 
 ### Can I use this for local development?
+
 No, you can use the [medusa-starter repository](https://github.com/u11d-com/medusa-starter/tree/v1) to set up Medusa locally.
 
 ### How do I update the infrastructure?
+
 Modify the Terraform configuration files and run `terraform apply` to apply the changes.
 
 ---
-:heart: _Technology made with passion by [u11d](https://u11d.com)_
+:heart: *Technology made with passion by [u11d](https://u11d.com)*

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -5,7 +5,15 @@ addHowToData: true
 
 # Deploy the Medusa Backend using the Terraform Module on AWS
 
-This guide explains how to use the [**Terraform module for Medusa**](https://registry.terraform.io/modules/u11d-com/medusajs/aws) to deploy a production-ready e-commerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices. It provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized Medusa deployments.
+This guide explains how to use the [**Terraform module for Medusa**](https://registry.terraform.io/modules/u11d-com/medusajs/aws) to deploy a production-ready ecommerce backend on AWS. Designed for development teams building Medusa platforms, this module streamlines infrastructure setup while incorporating security best practices.
+
+This module provides a robust and scalable foundation, enabling teams to quickly deploy a functional backend and then focus on advanced customizations and feature development accelerating development by eliminating the complexities of manual infrastructure provisioning. As a result, teams can rapidly deploy and iterate, significantly minimizing time spent on infrastructure management. This module establishes a reliable groundwork for even the most sophisticated and customized Medusa deployments.
+
+:::note
+
+This guide was submitted through a community contribution.
+
+:::
 
 ## Introduction
 
@@ -38,12 +46,12 @@ Before using Terraform module for Medusa, ensure you have the following tools an
 
 ## Architectural Decisions Behind the Terraform Module
 
-When designing the Terraform module for Medusa, we prioritized scalability, security, and performance while minimizing the operational overhead for development teams. To achieve this, we selected fully managed AWS services, allowing teams to focus on building e-commerce solutions without the complexity of maintaining cloud infrastructure.
+When designing the Terraform module for Medusa, [U11D](https://u11d.com) prioritized scalability, security, and performance while minimizing the operational overhead for development teams. To achieve this, [U11D](https://u11d.com) selected fully managed AWS services, allowing teams to focus on building e-commerce solutions without the complexity of maintaining cloud infrastructure.
 
 Key architectural decisions include:
 
 - Use of Managed Services: All core components — such as Amazon RDS for PostgreSQL, Amazon ElastiCache for Redis, and the Application Load Balancer (ALB) — are fully managed services. This eliminates the need for teams to handle infrastructure maintenance tasks like patching, backups, and scaling operations.
-- Containerization with AWS Fargate: We run Medusa services as ECS tasks on AWS Fargate, removing the need for Kubernetes cluster management. Teams can focus on defining scaling policies without worrying about the underlying infrastructure.
+- Containerization with AWS Fargate: Module run Medusa services as ECS tasks on AWS Fargate, removing the need for Kubernetes cluster management. Teams can focus on defining scaling policies without worrying about the underlying infrastructure.
 - Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate [repository](https://github.com/u11d-com/medusa-starter/tree/v1)). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
 
 By leveraging managed services, this architecture reduces the time, effort, and expertise required to maintain infrastructure. It provides the flexibility to control scalability while ensuring high availability, robust security, and optimal performance — allowing development teams to concentrate on delivering business value through their e-commerce platforms.
@@ -85,7 +93,7 @@ The [Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com
 
 Clone the Terraform module repository to your local machine:
 
-```shell
+```bash
 git clone https://github.com/u11d-com/terraform-aws-medusajs
 cd terraform-u11d-medusajs/examples/minimal
 ```
@@ -108,7 +116,7 @@ owner       = "my-team"
 
 Run the following command to initialize Terraform and download the required providers:
 
-```shell
+```bash
 terraform init
 ```
 
@@ -116,7 +124,7 @@ terraform init
 
 Preview the resources that Terraform will create:
 
-```shell
+```bash
 terraform plan
 ```
 
@@ -124,7 +132,7 @@ terraform plan
 
 Deploy the infrastructure by running:
 
-```shell
+```bash
 terraform apply
 ```
 
@@ -199,7 +207,7 @@ storefront_container_registry_credentials = {
 
 To delete all resources created by Terraform, run:
 
-```shell
+```bash
 terraform destroy
 ```
 
@@ -238,4 +246,3 @@ No, you can use the [medusa-starter repository](https://github.com/u11d-com/medu
 Modify the Terraform configuration files and run `terraform apply` to apply the changes.
 
 ---
-:heart: *Technology made with passion by [u11d](https://u11d.com)*

--- a/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/server/deploying-on-aws-using-terraform.md
@@ -15,15 +15,13 @@ This guide was submitted through a community contribution.
 
 :::
 
-## Introduction
-
-### What is Terraform?
+## What is Terraform?
 
 Terraform is an infrastructure-as-code tool that allows you to define and provision cloud resources using code. It simplifies the process of managing cloud infrastructure and ensures consistency across environments. Learn more about Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/infrastructure-as-code).
 
-### Why Use Terraform Module for Medusa?
+## Why Use Terraform Module for Medusa?
 
-[Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) simplifies the deployment of Medusa on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their e-commerce stores without the overhead of managing cloud infrastructure.
+[Terraform module for Medusa](https://registry.terraform.io/modules/u11d-com/medusajs/aws) simplifies the deployment of Medusa on AWS by automating the setup of essential infrastructure components. It aligns with Medusa’s [architectural modules](#mapping-medusa-architectural-modules-to-aws-infrastructure) for data caching, event distribution, asset and file access, and workflow management. By providing optional infrastructure services, it empowers developers to make informed decisions and optimize the system for production environments. This module is designed for development teams who want to focus on building their ecommerce stores without the overhead of managing cloud infrastructure.
 
 ---
 
@@ -46,7 +44,7 @@ Before using Terraform module for Medusa, ensure you have the following tools an
 
 ## Architectural Decisions Behind the Terraform Module
 
-When designing the Terraform module for Medusa, [U11D](https://u11d.com) prioritized scalability, security, and performance while minimizing the operational overhead for development teams. To achieve this, [U11D](https://u11d.com) selected fully managed AWS services, allowing teams to focus on building e-commerce solutions without the complexity of maintaining cloud infrastructure.
+When designing the Terraform module for Medusa, [U11D](https://u11d.com) prioritized scalability, security, and performance while minimizing the operational overhead for development teams. To achieve this, [U11D](https://u11d.com) selected fully managed AWS services, allowing teams to focus on building ecommerce solutions without the complexity of maintaining cloud infrastructure.
 
 Key architectural decisions include:
 
@@ -54,7 +52,7 @@ Key architectural decisions include:
 - Containerization with AWS Fargate: Module run Medusa services as ECS tasks on AWS Fargate, removing the need for Kubernetes cluster management. Teams can focus on defining scaling policies without worrying about the underlying infrastructure.
 - Optimized Docker Images: The Terraform module is complemented by Docker image definitions (provided as Dockerfiles in a separate [repository](https://github.com/u11d-com/medusa-starter/tree/v1)). These images follow best practices for security, performance, and minimal size, ensuring efficient resource utilization in production environments.
 
-By leveraging managed services, this architecture reduces the time, effort, and expertise required to maintain infrastructure. It provides the flexibility to control scalability while ensuring high availability, robust security, and optimal performance — allowing development teams to concentrate on delivering business value through their e-commerce platforms.
+By leveraging managed services, this architecture reduces the time, effort, and expertise required to maintain infrastructure. It provides the flexibility to control scalability while ensuring high availability, robust security, and optimal performance — allowing development teams to concentrate on delivering business value through their ecommerce platforms.
 
 ## Overview of the Terraform Module
 
@@ -143,6 +141,8 @@ Confirm the deployment by typing `yes` when prompted.
 1. Check the Terraform outputs for the Medusa backend URL.
 2. Use the URL to verify that the backend is running.
 
+---
+
 ## Connecting Medusa to the Deployed Infrastructure
 
 Once the infrastructure is deployed, the Medusa backend URL will be available in the Terraform outputs. Use this URL to connect your Medusa application to the deployed backend.
@@ -152,19 +152,18 @@ Once the infrastructure is deployed, the Medusa backend URL will be available in
 In addition to the backend, the Terraform module provisions key AWS resources, including an Amazon S3 bucket for object storage and an Amazon ElastiCache (Redis) instance. To integrate these services with your Medusa application:
 
 1. Configure S3 and Redis Plugins:
-
-- Set up the appropriate Medusa plugins for S3 and Redis to enable object storage and caching functionalities.
-  - [Redis Cache Module](https://docs.medusajs.com/v1/development/cache/modules/redis)
-  - [File Service - S3 plugin](https://docs.medusajs.com/v1/plugins/file-service/s3)
-- The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
-
+  - Set up the appropriate Medusa plugins for S3 and Redis to enable object storage and caching functionalities.
+    - [Redis Cache Module](https://docs.medusajs.com/v1/development/cache/modules/redis)
+    - [File Service - S3 plugin](https://docs.medusajs.com/v1/plugins/file-service/s3)
+  - The same Redis instance can be utilized for multiple Medusa modules, including cache, event handling, file storage, and the workflow engine.
 2. Use Predefined Environment Variables:
-
-- The Terraform module automatically generates all necessary environment variables, following Medusa’s naming conventions.
-- These variables simplify the configuration process, ensuring seamless compatibility with Medusa.
+  - The Terraform module automatically generates all necessary environment variables, following Medusa’s naming conventions.
+  - These variables simplify the configuration process, ensuring seamless compatibility with Medusa.
 
 All internal connections between services are securely configured with proper access controls, reducing the need for additional security configurations.
 By following these steps, you’ll ensure your Medusa application is fully integrated with the cloud infrastructure, optimized for performance, scalability, and security.
+
+---
 
 ## Optional Features
 
@@ -195,6 +194,8 @@ storefront_container_registry_credentials = {
     password = "your-registry-password"
   }
 ```
+
+---
 
 ## Common Issues and Troubleshooting
 

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -40,9 +40,10 @@ Before proceeding, ensure you have the following:
 
 1. Build the Docker container image for the storefront:
    ```bash
-   docker build -t medusa_storefront:1.0.0 .
+   docker build --build-arg MEDUSA_BACKEND_URL="https://my.medusa.backend" -t medusa_storefront:1.0.0 .
    ```
    - Replace `medusa_storefront:1.0.0` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:1.0.0`.
+   - Replace `https://my.medusa.backend` with your existing Medusa backend URL address.
 
 ---
 
@@ -64,7 +65,7 @@ Replace:
       --query Account \
       --output text
   ```
-If you created your ECR repository using the [Terraform Module for Medusa on AWS](https://github.com/u11d-com/terraform-aws-medusajs), you can find the ECR repository URL in the module's output values after deployment.
+If you created your ECR repository using the [Terraform Module for Medusa on AWS](https://registry.terraform.io/modules/u11d-com/medusajs/aws/latest), you can find the ECR repository URL in the module's output values after deployment.
 
 
 ### Step 2: Tag the Docker Container Image
@@ -138,7 +139,7 @@ Confirm the changes when prompted.
 ## Additional Resources
 - [Medusa Documentation](https://docs.medusajs.com/v1/)
 - [Next.js Documentation](https://nextjs.org/)
-- [Terraform Module for Medusa on AWS Provider Documentation](https://github.com/u11d-com/terraform-aws-medusajs)
+- [Terraform Module for Medusa on AWS Provider Documentation](https://registry.terraform.io/modules/u11d-com/medusajs/aws/latest)
 
 ---
 :heart: _Technology made with passion by [u11d](https://u11d.com)_

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -1,0 +1,115 @@
+Got it! I’ll create a separate document that explains how to build the frontend image using the provided commands and how to push it to an AWS ECR repository. Here’s the draft:
+
+---
+
+# **Building and Deploying the MedusaJS Frontend**
+
+This guide explains how to build the MedusaJS frontend using the provided starter template and deploy the resulting Docker image to an AWS ECR repository. This process is essential for deploying the frontend as part of the MedusaJS e-commerce solution.
+
+- [Prerequisites](#prerequisites)
+- [Setting Up the Frontend Repository](#setting-up-the-frontend-repository)
+- [Building the Frontend Docker Image](#building-the-frontend-docker-image)
+- [Pushing the Image to AWS ECR](#pushing-the-image-to-aws-ecr)
+- [Next Steps](#next-steps)
+- [Troubleshooting](#troubleshooting)
+  - [Common Issues](#common-issues)
+
+---
+
+## **Prerequisites**
+
+Before proceeding, ensure you have the following:
+- **Docker**: Installed and running on your machine. Download Docker [here](https://docs.docker.com/get-started/get-docker/).
+- **AWS CLI**: Installed and configured with your AWS credentials. Follow the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html) if you haven’t set it up yet.
+- **Git**: Installed on your machine. Download Git [here](https://git-scm.com/).
+
+---
+
+## **Setting Up the Frontend Repository**
+
+1. Clone the `medusa-starter` repository to your local machine:
+   ```bash
+   git clone https://github.com/u11d-com/medusa-starter.git
+   cd medusa-starter
+   ```
+
+2. Navigate to the `storefront` directory and initialize the frontend repository:
+   ```bash
+   cd storefront
+   git init
+   git remote add origin https://github.com/medusajs/nextjs-starter-medusa.git
+   git fetch --depth 1 origin 0f5452dfe44838f890b798789d75db1a81303b7a
+   git checkout 0f5452dfe44838f890b798789d75db1a81303b7a
+   ```
+
+---
+
+## **Building the Frontend Docker Image**
+
+1. Build the Docker image for the frontend:
+   ```bash
+   docker build -t medusa_storefront:1.0.0 .
+   ```
+   - Replace `medusa:storefront` with a tag in the format `<image_tag>:<version>`. For example, `my-frontend:1.0.0`.
+
+---
+
+## **Pushing the Image to AWS ECR**
+
+To deploy the frontend, you’ll need to push the Docker image to an AWS ECR repository. Follow these steps:
+
+### **Step 1: Authenticate Docker to Your ECR Repository**
+Run the following command to authenticate Docker to your ECR repository:
+```bash
+aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
+```
+Replace:
+- `<region>` with your AWS region (e.g., `us-east-1`).
+- `<aws_account_id>` with your AWS account ID.
+
+### **Step 2: Tag the Docker Image**
+Tag the Docker image with your ECR repository URI:
+```bash
+docker tag medusa:storefront <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
+```
+Replace:
+- `<aws_account_id>` with your AWS account ID.
+- `<region>` with your AWS region.
+- `<repository>` with the name of your ECR repository.
+- `<tag>` with the desired image tag (e.g., `1.0.0`).
+
+### **Step 3: Push the Docker Image**
+Push the Docker image to your ECR repository:
+```bash
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
+```
+
+Example:
+```bash
+docker push 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-frontend:1.0.0
+```
+
+For more details, refer to the [AWS ECR documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
+
+---
+
+## **Next Steps**
+
+- Use the pushed image in your Terraform configuration by providing the ECR repository URI and tag in module configuration:
+  ```hcl
+  storefront_container_image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>"
+  ```
+- Deploy the frontend by enabling the `storefront_create` option in your Terraform configuration.
+
+---
+
+## **Troubleshooting**
+
+### **Common Issues**
+- **Docker Build Fails**: Ensure all dependencies are installed and the Dockerfile is correctly configured.
+- **ECR Authentication Fails**: Verify that your AWS credentials are correctly configured and have the necessary permissions.
+- **Image Push Fails**: Ensure the ECR repository exists and the image tag matches the repository URI.
+
+---
+
+:heart: _Technology made with passion by u11d_

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -1,35 +1,31 @@
-# **Building and Deploying the MedusaJS Frontend**
-
-This guide explains how to build the MedusaJS frontend using the provided starter template and deploy the resulting Docker image to an AWS ECR repository. This process is essential for deploying the frontend as part of the MedusaJS e-commerce solution.
-
-- [Prerequisites](#prerequisites)
-- [Setting Up the Frontend Repository](#setting-up-the-frontend-repository)
-- [Building the Frontend Docker Image](#building-the-frontend-docker-image)
-- [Pushing the Image to AWS ECR](#pushing-the-image-to-aws-ecr)
-- [Next Steps](#next-steps)
-- [Troubleshooting](#troubleshooting)
-  - [Common Issues](#common-issues)
-
+---
+description: 'Step-by-step deployment instruction'
+addHowToData: true
 ---
 
-## **Prerequisites**
+# Build and Deploy the Medusa Next.js Storefront on AWS
+
+This guide explains how to build the Medusa Storefront using the provided starter template and deploy the resulting Docker container image to an AWS Elastic Container Registry (ECR). This process is essential for deploying the frontend as part of the Medusa e-commerce solution.
+
+## Prerequisites
 
 Before proceeding, ensure you have the following:
 - **Docker**: Installed and running on your machine. Download Docker [here](https://docs.docker.com/get-started/get-docker/).
 - **AWS CLI**: Installed and configured with your AWS credentials. Follow the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html) if you haven’t set it up yet.
 - **Git**: Installed on your machine. Download Git [here](https://git-scm.com/).
+- **Terraform**: (Optional but recommended) Installed for deploying infrastructure. Download Terraform [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
 
 ---
 
-## **Setting Up the Frontend Repository**
+## Setting Up the Storefront Repository
 
-1. Clone the `medusa-starter` repository to your local machine:
+1. Clone the [`medusa-starter`](https://github.com/u11d-com/medusa-starter) repository to your local machine:
    ```bash
    git clone https://github.com/u11d-com/medusa-starter.git
    cd medusa-starter
    ```
 
-2. Navigate to the `storefront` directory and initialize the frontend repository:
+2. Navigate to the `storefront` directory and initialize the repository:
    ```bash
    cd storefront
    git init
@@ -37,75 +33,103 @@ Before proceeding, ensure you have the following:
    git fetch --depth 1 origin 0f5452dfe44838f890b798789d75db1a81303b7a
    git checkout 0f5452dfe44838f890b798789d75db1a81303b7a
    ```
-
+This sets up the storefront based on the Medusa Next.js starter template for version 1.
 ---
 
-## **Building the Frontend Docker Image**
+## Building the Storefront Docker Container Image
 
-1. Build the Docker image for the frontend:
+1. Build the Docker container image for the storefront:
    ```bash
    docker build -t medusa_storefront:1.0.0 .
    ```
-   - Replace `medusa:storefront` with a tag in the format `<image_tag>:<version>`. For example, `my-frontend:1.0.0`.
+   - Replace `medusa_storefront` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:1.0.0`.
 
 ---
 
-## **Pushing the Image to AWS ECR**
+## Pushing the Container Image to AWS Elastic Container Registry (ECR)
 
-To deploy the frontend, you’ll need to push the Docker image to an AWS ECR repository. Follow these steps:
+To deploy the storefront, you’ll need to push the Docker container image to an AWS ECR repository. Follow these steps:
 
-### **Step 1: Authenticate Docker to Your ECR Repository**
-Run the following command to authenticate Docker to your ECR repository:
+### Step 1: Authenticate Docker to Your ECR Repository
+Run the following command to authenticate Docker to your AWS ECR registry:
 ```bash
 aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
 ```
 Replace:
-- `<region>` with your AWS region (e.g., `us-east-1`).
-- `<aws_account_id>` with your AWS account ID.
+- `<aws_account_id>` with your [AWS account ID](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html#FindAccountId).
+- `<region>` with your [AWS region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions) (e.g., `eu-west-1`).
 
-### **Step 2: Tag the Docker Image**
-Tag the Docker image with your ECR repository URI:
+### Step 2: Tag the Docker Container Image
+Tag the Docker container image with your ECR repository URI:
 ```bash
 docker tag medusa:storefront <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
 ```
 Replace:
-- `<aws_account_id>` with your AWS account ID.
-- `<region>` with your AWS region.
-- `<repository>` with the name of your ECR repository.
-- `<tag>` with the desired image tag (e.g., `1.0.0`).
+- `medusa_storefront:1.0.0` with the image tag you created earlier.
+- `<aws_account_id>`, `<region>`, `<repository>`, and `<tag>` with your AWS account ID, region, ECR repository name, and desired image tag, respectively.
 
-### **Step 3: Push the Docker Image**
-Push the Docker image to your ECR repository:
+### Step 3: Push the Docker Image
+Push the Docker container image to your ECR repository:
 ```bash
 docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
 ```
 
 Example:
 ```bash
-docker push 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-frontend:1.0.0
+docker push 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-storefront:1.0.0
 ```
 
 For more details, refer to the [AWS ECR documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
 
 ---
 
-## **Next Steps**
+## Connecting the Storefront to Your Terraform Infrastructure
 
-- Use the pushed image in your Terraform configuration by providing the ECR repository URI and tag in module configuration:
-  ```hcl
-  storefront_container_image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>"
-  ```
-- Deploy the frontend by enabling the `storefront_create` option in your Terraform configuration.
+After pushing the Docker image, connect it to your infrastructure deployed via Terraform:
+1. Reference the ECR Image in Terraform:
+Add the ECR repository URI and tag to your Terraform configuration:
+```hcl
+storefront_container_image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>"
+```
+
+2. Enable Storefront Deployment:
+Ensure the storefront is enabled in your Terraform module configuration:
+```hcl
+storefront_create = true
+```
+
+3. Apply Terraform Changes:
+Deploy the updated configuration:
+```hcl
+terraform init
+terraform apply
+```
+Confirm the changes when prompted.
 
 ---
 
-## **Troubleshooting**
+## Troubleshooting
 
-### **Common Issues**
-- **Docker Build Fails**: Ensure all dependencies are installed and the Dockerfile is correctly configured.
-- **ECR Authentication Fails**: Verify that your AWS credentials are correctly configured and have the necessary permissions.
-- **Image Push Fails**: Ensure the ECR repository exists and the image tag matches the repository URI.
+### Common Issues
+- **Docker Build Fails**:
+  - Ensure all dependencies are installed.
+  - Verify the `Dockerfile` is correctly configured.
+  - Check for syntax errors or missing files.
+- **ECR Authentication Fails**:
+  - Confirm that your AWS credentials are correctly configured with sufficient permissions.
+  - Ensure your AWS CLI session is active (re-authenticate if necessary).
+- **Image Push Fails**:
+  - Ensure the ECR repository exists.
+  - Ensure the repository URI and image tag are correctly specified.
+  - Check for network connectivity issues.
+- **Terraform Apply Fails**:
+  - Confirm that the referenced Docker image exists in the ECR repository.
+  - Check Terraform logs for specific error messages.
+
+## Additional Resources
+- [MedusaJS Documentation](https://docs.medusajs.com/v1/)
+- [Next.js Documentation](https://nextjs.org/)
+- [Terraform Module for Medusa on AWS Provider Documentation](https://github.com/u11d-com/terraform-aws-medusajs)
 
 ---
-
-:heart: _Technology made with passion by u11d_
+:heart: _Technology made with passion by [u11d](https://u11d.com)_

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -25,7 +25,7 @@ Before proceeding, ensure you have the following:
    cd medusa-starter
    ```
 
-2. Navigate to the `storefront` directory and initialize the repository:
+2. Navigate to the `storefront` directory and initialize the repository, this sets up the storefront based on the [Medusa Next.js starter template](https://github.com/medusajs/nextjs-starter-medusa) for version 1:
    ```bash
    cd storefront
    git init
@@ -33,7 +33,7 @@ Before proceeding, ensure you have the following:
    git fetch --depth 1 origin 0f5452dfe44838f890b798789d75db1a81303b7a
    git checkout 0f5452dfe44838f890b798789d75db1a81303b7a
    ```
-This sets up the storefront based on the Medusa Next.js starter template for version 1.
+
 ---
 
 ## Building the Storefront Docker Container Image
@@ -42,7 +42,7 @@ This sets up the storefront based on the Medusa Next.js starter template for ver
    ```bash
    docker build -t medusa_storefront:1.0.0 .
    ```
-   - Replace `medusa_storefront` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:1.0.0`.
+   - Replace `medusa_storefront:1.0.0` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:1.0.0`.
 
 ---
 
@@ -56,13 +56,21 @@ Run the following command to authenticate Docker to your AWS ECR registry:
 aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
 ```
 Replace:
+- `<region>` with your desired AWS region code (for example, `eu-west-1`). You can find the complete list of region codes in the [AWS Regions documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions). Make sure to use the same region where your Amazon Elastic Container Registry (ECR) is deployed.
 - `<aws_account_id>` with your [AWS account ID](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html#FindAccountId).
-- `<region>` with your [AWS region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions) (e.g., `eu-west-1`).
+  You can check it by running:
+  ```bash
+  aws sts get-caller-identity \
+      --query Account \
+      --output text
+  ```
+If you created your ECR repository using the [Terraform Module for Medusa on AWS](https://github.com/u11d-com/terraform-aws-medusajs), you can find the ECR repository URL in the module's output values after deployment.
+
 
 ### Step 2: Tag the Docker Container Image
 Tag the Docker container image with your ECR repository URI:
 ```bash
-docker tag medusa:storefront <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
+docker tag medusa_storefront:1.0.0 <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
 ```
 Replace:
 - `medusa_storefront:1.0.0` with the image tag you created earlier.
@@ -92,16 +100,17 @@ Add the ECR repository URI and tag to your Terraform configuration:
 storefront_container_image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>"
 ```
 
-2. Enable Storefront Deployment:
+2. Enable storefront deployment:
 Ensure the storefront is enabled in your Terraform module configuration:
 ```hcl
 storefront_create = true
 ```
 
-3. Apply Terraform Changes:
+3. Plan and apply Terraform changes:
 Deploy the updated configuration:
-```hcl
+```bash
 terraform init
+terraform plan
 terraform apply
 ```
 Confirm the changes when prompted.

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -127,7 +127,7 @@ Confirm the changes when prompted.
   - Check Terraform logs for specific error messages.
 
 ## Additional Resources
-- [MedusaJS Documentation](https://docs.medusajs.com/v1/)
+- [Medusa Documentation](https://docs.medusajs.com/v1/)
 - [Next.js Documentation](https://nextjs.org/)
 - [Terraform Module for Medusa on AWS Provider Documentation](https://github.com/u11d-com/terraform-aws-medusajs)
 

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -67,7 +67,7 @@ Replace:
       --query Account \
       --output text
   ```
-If you created your ECR repository using the [Terraform Module for Medusa on AWS](https://registry.terraform.io/modules/u11d-com/medusajs/aws/latest), you can find the ECR repository URL in the module's output values after deployment.
+If you created your ECR repository using the [Terraform Module for Medusa on AWS](https://registry.terraform.io/modules/u11d-com/medusajs/aws), you can find the ECR repository URL in the module's output values after deployment.
 
 
 ### Step 2: Tag the Docker Container Image
@@ -141,7 +141,7 @@ Confirm the changes when prompted.
 ## Additional Resources
 - [Medusa Documentation](https://docs.medusajs.com/v1/)
 - [Next.js Documentation](https://nextjs.org/)
-- [Terraform Module for Medusa on AWS Provider Documentation](https://registry.terraform.io/modules/u11d-com/medusajs/aws/latest)
+- [Terraform Module for Medusa on AWS Provider Documentation](https://registry.terraform.io/modules/u11d-com/medusajs/aws)
 
 ---
 :heart: _Technology made with passion by [u11d](https://u11d.com)_

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -1,7 +1,3 @@
-Got it! I’ll create a separate document that explains how to build the frontend image using the provided commands and how to push it to an AWS ECR repository. Here’s the draft:
-
----
-
 # **Building and Deploying the MedusaJS Frontend**
 
 This guide explains how to build the MedusaJS frontend using the provided starter template and deploy the resulting Docker image to an AWS ECR repository. This process is essential for deploying the frontend as part of the MedusaJS e-commerce solution.

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -5,7 +5,7 @@ addHowToData: true
 
 # Build and Deploy the Medusa Next.js Storefront on AWS
 
-This guide explains how to build the Medusa Storefront using the provided starter template and deploy the resulting Docker container image to an AWS Elastic Container Registry (ECR). This process is essential for deploying the frontend as part of the Medusa e-commerce solution.
+This guide explains how to build the Medusa Storefront using the provided starter template and deploy the resulting Docker container image to an AWS Elastic Container Registry (ECR). This process is essential for deploying the frontend as part of the Medusa ecommerce solution.
 
 :::note
 

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -10,6 +10,7 @@ This guide explains how to build the Medusa Storefront using the provided starte
 ## Prerequisites
 
 Before proceeding, ensure you have the following:
+
 - **Docker**: Installed and running on your machine. Download Docker [here](https://docs.docker.com/get-started/get-docker/).
 - **AWS CLI**: Installed and configured with your AWS credentials. Follow the [AWS CLI Quickstart guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html) if you haven’t set it up yet.
 - **Git**: Installed on your machine. Download Git [here](https://git-scm.com/).
@@ -20,14 +21,16 @@ Before proceeding, ensure you have the following:
 ## Setting Up the Storefront Repository
 
 1. Clone the [`medusa-starter`](https://github.com/u11d-com/medusa-starter/tree/v1) repository to your local machine:
-   ```bash
+
+   ```shell
    git clone https://github.com/u11d-com/medusa-starter.git
    cd medusa-starter
    git checkout -b v1 origin/v1
    ```
 
 2. Navigate to the `storefront` directory and initialize the repository, this sets up the storefront based on the [Medusa Next.js starter template](https://github.com/medusajs/nextjs-starter-medusa) for version 1:
-   ```bash
+
+   ```shell
    cd storefront
    git init
    git remote add origin https://github.com/medusajs/nextjs-starter-medusa.git
@@ -35,15 +38,16 @@ Before proceeding, ensure you have the following:
    git checkout 0f5452dfe44838f890b798789d75db1a81303b7a
    ```
 
-
 ---
 
 ## Building the Storefront Docker Container Image
 
 1. Build the Docker container image for the storefront:
-   ```bash
+
+   ```shell
    docker build --build-arg MEDUSA_BACKEND_URL="https://my.medusa.backend" -t medusa_storefront:1.0.0 .
    ```
+
    - Replace `medusa_storefront:1.0.0` with your preferred image tag in the format `<image_tag>:<version>`, e.g., `my-storefront:1.0.0`.
    - Replace `https://my.medusa.backend` with your existing Medusa backend URL address.
 
@@ -54,39 +58,51 @@ Before proceeding, ensure you have the following:
 To deploy the storefront, you’ll need to push the Docker container image to an AWS ECR repository. Follow these steps:
 
 ### Step 1: Authenticate Docker to Your ECR Repository
+
 Run the following command to authenticate Docker to your AWS ECR registry:
-```bash
+
+```shell
 aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
 ```
+
 Replace:
+
 - `<region>` with your desired AWS region code (for example, `eu-west-1`). You can find the complete list of region codes in the [AWS Regions documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions). Make sure to use the same region where your Amazon Elastic Container Registry (ECR) is deployed.
 - `<aws_account_id>` with your [AWS account ID](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html#FindAccountId).
   You can check it by running:
-  ```bash
+
+  ```shell
   aws sts get-caller-identity \
       --query Account \
       --output text
   ```
+
 If you created your ECR repository using the [Terraform Module for Medusa on AWS](https://registry.terraform.io/modules/u11d-com/medusajs/aws), you can find the ECR repository URL in the module's output values after deployment.
 
-
 ### Step 2: Tag the Docker Container Image
+
 Tag the Docker container image with your ECR repository URI:
-```bash
+
+```shell
 docker tag medusa_storefront:1.0.0 <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
 ```
+
 Replace:
+
 - `medusa_storefront:1.0.0` with the image tag you created earlier.
 - `<aws_account_id>`, `<region>`, `<repository>`, and `<tag>` with your AWS account ID, region, ECR repository name, and desired image tag, respectively.
 
 ### Step 3: Push the Docker Image
+
 Push the Docker container image to your ECR repository:
-```bash
+
+```shell
 docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
 ```
 
 Example:
-```bash
+
+```shell
 docker push 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-storefront:1.0.0
 ```
 
@@ -97,25 +113,30 @@ For more details, refer to the [AWS ECR documentation](https://docs.aws.amazon.c
 ## Connecting the Storefront to Your Terraform Infrastructure
 
 After pushing the Docker image, connect it to your infrastructure deployed via Terraform:
+
 1. Reference the ECR Image in Terraform:
 Add the ECR repository URI and tag to your Terraform configuration:
+
 ```hcl
 storefront_container_image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>"
 ```
 
 2. Enable storefront deployment:
 Ensure the storefront is enabled in your Terraform module configuration:
+
 ```hcl
 storefront_create = true
 ```
 
 3. Plan and apply Terraform changes:
 Deploy the updated configuration:
-```bash
+
+```shell
 terraform init
 terraform plan
 terraform apply
 ```
+
 Confirm the changes when prompted.
 
 ---
@@ -123,6 +144,7 @@ Confirm the changes when prompted.
 ## Troubleshooting
 
 ### Common Issues
+
 - **Docker Build Fails**:
   - Ensure all dependencies are installed.
   - Verify the `Dockerfile` is correctly configured.
@@ -139,9 +161,10 @@ Confirm the changes when prompted.
   - Check Terraform logs for specific error messages.
 
 ## Additional Resources
+
 - [Medusa Documentation](https://docs.medusajs.com/v1/)
 - [Next.js Documentation](https://nextjs.org/)
 - [Terraform Module for Medusa on AWS Provider Documentation](https://registry.terraform.io/modules/u11d-com/medusajs/aws)
 
 ---
-:heart: _Technology made with passion by [u11d](https://u11d.com)_
+:heart: *Technology made with passion by [u11d](https://u11d.com)*

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -27,7 +27,6 @@ Before proceeding, ensure you have the following:
    ```
 
 2. Navigate to the `storefront` directory and initialize the repository, this sets up the storefront based on the [Medusa Next.js starter template](https://github.com/medusajs/nextjs-starter-medusa) for version 1:
-2. Navigate to the `storefront` directory and initialize the repository, this sets up the storefront based on the [Medusa Next.js starter template](https://github.com/medusajs/nextjs-starter-medusa) for version 1:
    ```bash
    cd storefront
    git init

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -7,6 +7,12 @@ addHowToData: true
 
 This guide explains how to build the Medusa Storefront using the provided starter template and deploy the resulting Docker container image to an AWS Elastic Container Registry (ECR). This process is essential for deploying the frontend as part of the Medusa e-commerce solution.
 
+:::note
+
+This guide was submitted through a community contribution.
+
+:::
+
 ## Prerequisites
 
 Before proceeding, ensure you have the following:
@@ -22,7 +28,7 @@ Before proceeding, ensure you have the following:
 
 1. Clone the [`medusa-starter`](https://github.com/u11d-com/medusa-starter/tree/v1) repository to your local machine:
 
-   ```shell
+   ```bash
    git clone https://github.com/u11d-com/medusa-starter.git
    cd medusa-starter
    git checkout -b v1 origin/v1
@@ -30,7 +36,7 @@ Before proceeding, ensure you have the following:
 
 2. Navigate to the `storefront` directory and initialize the repository, this sets up the storefront based on the [Medusa Next.js starter template](https://github.com/medusajs/nextjs-starter-medusa) for version 1:
 
-   ```shell
+   ```bash
    cd storefront
    git init
    git remote add origin https://github.com/medusajs/nextjs-starter-medusa.git
@@ -44,7 +50,7 @@ Before proceeding, ensure you have the following:
 
 1. Build the Docker container image for the storefront:
 
-   ```shell
+   ```bash
    docker build --build-arg MEDUSA_BACKEND_URL="https://my.medusa.backend" -t medusa_storefront:1.0.0 .
    ```
 
@@ -61,7 +67,7 @@ To deploy the storefront, you’ll need to push the Docker container image to an
 
 Run the following command to authenticate Docker to your AWS ECR registry:
 
-```shell
+```bash
 aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
 ```
 
@@ -71,7 +77,7 @@ Replace:
 - `<aws_account_id>` with your [AWS account ID](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html#FindAccountId).
   You can check it by running:
 
-  ```shell
+  ```bash
   aws sts get-caller-identity \
       --query Account \
       --output text
@@ -83,7 +89,7 @@ If you created your ECR repository using the [Terraform Module for Medusa on AWS
 
 Tag the Docker container image with your ECR repository URI:
 
-```shell
+```bash
 docker tag medusa_storefront:1.0.0 <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
 ```
 
@@ -96,13 +102,13 @@ Replace:
 
 Push the Docker container image to your ECR repository:
 
-```shell
+```bash
 docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>
 ```
 
 Example:
 
-```shell
+```bash
 docker push 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-storefront:1.0.0
 ```
 
@@ -131,7 +137,7 @@ storefront_create = true
 3. Plan and apply Terraform changes:
 Deploy the updated configuration:
 
-```shell
+```bash
 terraform init
 terraform plan
 terraform apply
@@ -162,9 +168,6 @@ Confirm the changes when prompted.
 
 ## Additional Resources
 
-- [Medusa Documentation](https://docs.medusajs.com/v1/)
-- [Next.js Documentation](https://nextjs.org/)
 - [Terraform Module for Medusa on AWS Provider Documentation](https://registry.terraform.io/modules/u11d-com/medusajs/aws)
 
 ---
-:heart: *Technology made with passion by [u11d](https://u11d.com)*

--- a/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
+++ b/www/apps/docs/content/deployments/storefront/deploying-next-on-aws-using-terraform.md
@@ -19,10 +19,11 @@ Before proceeding, ensure you have the following:
 
 ## Setting Up the Storefront Repository
 
-1. Clone the [`medusa-starter`](https://github.com/u11d-com/medusa-starter) repository to your local machine:
+1. Clone the [`medusa-starter`](https://github.com/u11d-com/medusa-starter/tree/v1) repository to your local machine:
    ```bash
    git clone https://github.com/u11d-com/medusa-starter.git
    cd medusa-starter
+   git checkout -b v1 origin/v1
    ```
 
 2. Navigate to the `storefront` directory and initialize the repository, this sets up the storefront based on the [Medusa Next.js starter template](https://github.com/medusajs/nextjs-starter-medusa) for version 1:

--- a/www/apps/docs/sidebars.js
+++ b/www/apps/docs/sidebars.js
@@ -383,6 +383,16 @@ module.exports = {
             },
             {
               type: "doc",
+              id: "deployments/server/deploying-on-aws-using-terraform",
+              label: "Deploy on AWS using Terraform",
+              customProps: {
+                sidebar_is_title: true,
+                sidebar_icon: "tools",
+                iconName: "tools",
+              },
+            },
+            {
+              type: "doc",
               id: "deployments/server/general-guide",
               label: "General Deployment",
               customProps: {

--- a/www/apps/docs/sidebars.js
+++ b/www/apps/docs/sidebars.js
@@ -463,6 +463,14 @@ module.exports = {
                 iconName: "academic-cap-solid",
               },
             },
+            {
+              type: "doc",
+              id: "deployments/storefront/deploying-next-on-aws-using-terraform",
+              label: "Deploy Next.js Storefront on AWS",
+              customProps: {
+                iconName: "tools",
+              },
+            },
           ],
           customProps: {
             category_id: "deploy_storefront",

--- a/www/apps/docs/sidebars.js
+++ b/www/apps/docs/sidebars.js
@@ -386,8 +386,6 @@ module.exports = {
               id: "deployments/server/deploying-on-aws-using-terraform",
               label: "Deploy on AWS using Terraform",
               customProps: {
-                sidebar_is_title: true,
-                sidebar_icon: "tools",
                 iconName: "tools",
               },
             },


### PR DESCRIPTION
This pull request is a continuation of #12060. Please note that these changes are intended for Medusa v1.

I've implemented the requested changes from the previous PR.
Thank you for reviewing, and apologies for the delay.

What

This pull request adds documentation for deploying a Medusa backend and an example storefront (from official templates) on AWS using Terraform and Terraform modules. The documentation outlines the deployment process in detail.

Why

We recently created a Terraform module, available at https://registry.terraform.io/modules/u11d-com/medusajs/aws/1.0.0, to simplify Medusa deployments on AWS. This documentation is being added to explain how users can leverage this module to deploy a new Medusa instance efficiently.

How

We developed a publicly accessible Terraform module, published it on the Terraform Registry, and created accompanying documentation that describes how to use it. The documentation provides step-by-step instructions for deploying the Medusa backend and an example storefront using the module.

Testing

The changes can be tested by reviewing the documentation for clarity and completeness. Reviewers can also follow the documented steps to deploy a test instance of Medusa on AWS using the Terraform module and verify that the deployment works as expected. Ensure that all links (e.g., to the Terraform Registry) are functional and that the instructions are easy to follow.
