### PR TITLE
fix(utils): move payment events to core flows events

### DIFF
--- a/.changeset/famous-kangaroos-dress.md
+++ b/.changeset/famous-kangaroos-dress.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+fix(utils): export payment events in core flows

--- a/packages/core/utils/src/core-flows/events.ts
+++ b/packages/core/utils/src/core-flows/events.ts
@@ -814,3 +814,32 @@ export const FulfillmentWorkflowEvents = {
    */
   DELIVERY_CREATED: "delivery.created",
 }
+
+/**
+ * @category Payment
+ * @customNamespace Payment
+ */
+export const PaymentEvents = {
+  /**
+   * Emitted when a payment is captured.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // the ID of the payment
+   * }
+   * ```
+   */
+  CAPTURED: "payment.captured",
+  /**
+   * Emitted when a payment is refunded.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // the ID of the payment
+   * }
+   * ```
+   */
+  REFUNDED: "payment.refunded",
+}

--- a/packages/core/utils/src/payment/events.ts
+++ b/packages/core/utils/src/payment/events.ts
@@ -1,4 +1,0 @@
-export const PaymentEvents = {
-  CAPTURED: "payment.captured",
-  REFUNDED: "payment.refunded",
-}

--- a/packages/core/utils/src/payment/index.ts
+++ b/packages/core/utils/src/payment/index.ts
@@ -1,5 +1,4 @@
 export * from "./abstract-payment-provider"
-export * from "./events"
 export * from "./payment-collection"
 export * from "./payment-session"
 export * from "./webhook"


### PR DESCRIPTION
Move payment events that are placed in a separate file to be with other core-flow events. This is necessary for the event references in the docs