### PR TITLE
fix(docs): correct module reference in useQueryGraphStep tip

### DIFF
--- a/www/apps/resources/app/how-to-tutorials/tutorials/product-reviews/page.mdx
+++ b/www/apps/resources/app/how-to-tutorials/tutorials/product-reviews/page.mdx
@@ -539,7 +539,7 @@ In the workflow's constructor function, you:
 
 <Note title="Tip">
 
-`useQueryGraphStep` uses [Query](!docs!/learn/fundamentals/module-links/query), which allows you to retrieve data across modules. For example, in the above snippet you're retrieving the cart's promotions, which are managed in the [Promotion Module](../../../commerce-modules/promotion/page.mdx), by passing `promotions.code` to the `fields` array.
+`useQueryGraphStep` uses [Query](!docs!/learn/fundamentals/module-links/query), which allows you to retrieve data across modules. For example, in the above snippet you're retrieving the product, which is managed in the [Product Module](../../../commerce-modules/product/page.mdx), by passing `id` to the `fields` array.
 
 </Note>
 


### PR DESCRIPTION
Corrected an inaccurate example in the useQueryGraphStep tip within the review workflow documentation.

Updated the entity reference from "cart's promotions" to "product" to align with the actual code context.