### PR TITLE
docs: add missing export for CreateBundledProduct component

### DIFF
--- a/www/apps/resources/app/recipes/bundled-products/examples/standard/page.mdx
+++ b/www/apps/resources/app/recipes/bundled-products/examples/standard/page.mdx
@@ -1263,7 +1263,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { sdk } from "../lib/sdk"
 import { HttpTypes } from "@medusajs/framework/types"
 
-export const CreateBundledProduct = () => {
+const CreateBundledProduct = () => {
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState("")
   const [items, setItems] = useState<{
@@ -1277,6 +1277,7 @@ export const CreateBundledProduct = () => {
   ])
   // TODO fetch products
 }
+export default CreateBundledProduct;
 ```
 
 You create a `CreateBundledProduct` component that defines the following state variables:

--- a/www/apps/resources/app/recipes/bundled-products/examples/standard/page.mdx
+++ b/www/apps/resources/app/recipes/bundled-products/examples/standard/page.mdx
@@ -1263,7 +1263,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { sdk } from "../lib/sdk"
 import { HttpTypes } from "@medusajs/framework/types"
 
-const CreateBundledProduct = () => {
+export const CreateBundledProduct = () => {
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState("")
   const [items, setItems] = useState<{


### PR DESCRIPTION
This commit adds a missing `export` statement to the `CreateBundledProduct` component in the "Create Form Component" example.

Without the `export`, readers copying the example wouldn't be able to use the component elsewhere in their project, which could be confusing. This ensures the example is complete and ready to use as-is.