### PR TITLE
fix: add operators to RemoteQueryFilters

### DIFF
--- a/packages/core/core-flows/src/stock-location/workflows/update-stock-locations.ts
+++ b/packages/core/core-flows/src/stock-location/workflows/update-stock-locations.ts
@@ -1,5 +1,6 @@
 import {
   FilterableStockLocationProps,
+  RemoteQueryFilters,
   StockLocationDTO,
   UpdateStockLocationInput,
   UpsertStockLocationAddressInput,
@@ -32,10 +33,10 @@ export const updateStockLocationsWorkflowId = "update-stock-locations-workflow"
 /**
  * This workflow updates stock locations matching the specified filters. It's used by the
  * [Update Stock Location Admin API Route](https://docs.medusajs.com/api/admin#stock-locations_poststocklocationsid).
- * 
+ *
  * You can use this workflow within your own customizations or custom workflows, allowing you
  * to update stock locations in your custom flows.
- * 
+ *
  * @example
  * const { result } = await updateStockLocationsWorkflow(container)
  * .run({
@@ -48,9 +49,9 @@ export const updateStockLocationsWorkflowId = "update-stock-locations-workflow"
  *     }
  *   }
  * })
- * 
+ *
  * @summary
- * 
+ *
  * Update stock locations.
  */
 export const updateStockLocationsWorkflow = createWorkflow(
@@ -60,7 +61,7 @@ export const updateStockLocationsWorkflow = createWorkflow(
   ): WorkflowResponse<StockLocationDTO[]> => {
     const stockLocationsQuery = useQueryGraphStep({
       entity: "stock_location",
-      filters: input.selector,
+      filters: input.selector as RemoteQueryFilters<"stock_location">,
       fields: ["id", "address.id"],
     }).config({ name: "get-stock-location" })
 

--- a/packages/core/types/src/modules-sdk/to-remote-query.ts
+++ b/packages/core/types/src/modules-sdk/to-remote-query.ts
@@ -46,9 +46,9 @@ type ExtractFiltersOperators<
 }
 
 type RemoteQueryFilterOperators<T> = {
-  $or?: T[]
-  $and?: T[]
-  $not?: T
+  $or?: (T & RemoteQueryFilterOperators<T>)[]
+  $and?: (T & RemoteQueryFilterOperators<T>)[]
+  $not?: T & RemoteQueryFilterOperators<T>
 }
 
 /**

--- a/packages/core/types/src/modules-sdk/to-remote-query.ts
+++ b/packages/core/types/src/modules-sdk/to-remote-query.ts
@@ -45,6 +45,34 @@ type ExtractFiltersOperators<
     : never
 }
 
+type OperatorsOnlyFilters<
+  TEntry extends string,
+  RemoteQueryEntryPointsLevel = RemoteQueryEntryPoints,
+  Exclusion extends string[] = [],
+  Lim extends number = Depth[3]
+> = Lim extends number
+  ? {
+      $or?: RemoteQueryFilters<
+        TEntry,
+        RemoteQueryEntryPointsLevel,
+        Exclusion,
+        Depth[Lim]
+      >[]
+      $and?: RemoteQueryFilters<
+        TEntry,
+        RemoteQueryEntryPointsLevel,
+        Exclusion,
+        Depth[Lim]
+      >[]
+      $not?: RemoteQueryFilters<
+        TEntry,
+        RemoteQueryEntryPointsLevel,
+        Exclusion,
+        Depth[Lim]
+      >
+    }
+  : never
+
 /**
  * Extract all available filters from a remote entry point deeply
  */
@@ -53,7 +81,7 @@ export type RemoteQueryFilters<
   RemoteQueryEntryPointsLevel = RemoteQueryEntryPoints,
   Exclusion extends string[] = [],
   Lim extends number = Depth[3]
-> = Lim extends number
+> = (Lim extends number
   ? TEntry extends keyof RemoteQueryEntryPointsLevel
     ? TypeOnly<RemoteQueryEntryPointsLevel[TEntry]> extends Array<infer V>
       ? Prettify<
@@ -69,4 +97,5 @@ export type RemoteQueryFilters<
           >
         >
     : Record<string, any>
-  : never
+  : never) &
+  OperatorsOnlyFilters<TEntry, RemoteQueryEntryPointsLevel, Exclusion, Lim>

--- a/packages/core/types/src/modules-sdk/to-remote-query.ts
+++ b/packages/core/types/src/modules-sdk/to-remote-query.ts
@@ -50,28 +50,21 @@ type OperatorsOnlyFilters<
   RemoteQueryEntryPointsLevel = RemoteQueryEntryPoints,
   Exclusion extends string[] = [],
   Lim extends number = Depth[3]
-> = Lim extends number
-  ? {
-      $or?: RemoteQueryFilters<
-        TEntry,
-        RemoteQueryEntryPointsLevel,
-        Exclusion,
-        Depth[Lim]
-      >[]
-      $and?: RemoteQueryFilters<
-        TEntry,
-        RemoteQueryEntryPointsLevel,
-        Exclusion,
-        Depth[Lim]
-      >[]
-      $not?: RemoteQueryFilters<
-        TEntry,
-        RemoteQueryEntryPointsLevel,
-        Exclusion,
-        Depth[Lim]
-      >
-    }
-  : never
+> = {
+  $or?: RemoteQueryFilters<
+    TEntry,
+    RemoteQueryEntryPointsLevel,
+    Exclusion,
+    Lim
+  >[]
+  $and?: RemoteQueryFilters<
+    TEntry,
+    RemoteQueryEntryPointsLevel,
+    Exclusion,
+    Lim
+  >[]
+  $not?: RemoteQueryFilters<TEntry, RemoteQueryEntryPointsLevel, Exclusion, Lim>
+}
 
 /**
  * Extract all available filters from a remote entry point deeply

--- a/packages/core/types/src/modules-sdk/to-remote-query.ts
+++ b/packages/core/types/src/modules-sdk/to-remote-query.ts
@@ -45,36 +45,21 @@ type ExtractFiltersOperators<
     : never
 }
 
-type OperatorsOnlyFilters<
-  TEntry extends string,
-  RemoteQueryEntryPointsLevel = RemoteQueryEntryPoints,
-  Exclusion extends string[] = [],
-  Lim extends number = Depth[3]
-> = {
-  $or?: RemoteQueryFilters<
-    TEntry,
-    RemoteQueryEntryPointsLevel,
-    Exclusion,
-    Lim
-  >[]
-  $and?: RemoteQueryFilters<
-    TEntry,
-    RemoteQueryEntryPointsLevel,
-    Exclusion,
-    Lim
-  >[]
-  $not?: RemoteQueryFilters<TEntry, RemoteQueryEntryPointsLevel, Exclusion, Lim>
+type RemoteQueryFilterOperators<T> = {
+  $or?: T[]
+  $and?: T[]
+  $not?: T
 }
 
 /**
  * Extract all available filters from a remote entry point deeply
  */
-export type RemoteQueryFilters<
+export type InternalRemoteQueryFilters<
   TEntry extends string,
   RemoteQueryEntryPointsLevel = RemoteQueryEntryPoints,
   Exclusion extends string[] = [],
   Lim extends number = Depth[3]
-> = (Lim extends number
+> = Lim extends number
   ? TEntry extends keyof RemoteQueryEntryPointsLevel
     ? TypeOnly<RemoteQueryEntryPointsLevel[TEntry]> extends Array<infer V>
       ? Prettify<
@@ -90,5 +75,24 @@ export type RemoteQueryFilters<
           >
         >
     : Record<string, any>
-  : never) &
-  OperatorsOnlyFilters<TEntry, RemoteQueryEntryPointsLevel, Exclusion, Lim>
+  : never
+
+export type RemoteQueryFilters<
+  TEntry extends string,
+  RemoteQueryEntryPointsLevel = RemoteQueryEntryPoints,
+  Exclusion extends string[] = [],
+  Lim extends number = Depth[3]
+> = RemoteQueryFilterOperators<
+  InternalRemoteQueryFilters<
+    TEntry,
+    RemoteQueryEntryPointsLevel,
+    Exclusion,
+    Lim
+  >
+> &
+  InternalRemoteQueryFilters<
+    TEntry,
+    RemoteQueryEntryPointsLevel,
+    Exclusion,
+    Lim
+  >


### PR DESCRIPTION
This `graph.query` call in the platform gives a typing error:

```
filters: {
  $or: [
    { id: input.build_id },
    { external_id: input.external_build_id },
  ],
}
```

since `RemoteQueryFilters` only allows the entity fields as keys. This PR allows `$or`, `$and` and `$not`, which all work fine at runtime.