### PR TITLE
fix(payment): add account holder methods to the manual provider

### DIFF
--- a/.changeset/stale-forks-cover.md
+++ b/.changeset/stale-forks-cover.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/payment": patch
+---
+
+fix(payment): add account holder methods to the manual provider

--- a/packages/modules/payment/src/providers/system.ts
+++ b/packages/modules/payment/src/providers/system.ts
@@ -7,6 +7,10 @@ import {
   CancelPaymentOutput,
   CapturePaymentInput,
   CapturePaymentOutput,
+  CreateAccountHolderInput,
+  CreateAccountHolderOutput,
+  DeleteAccountHolderInput,
+  DeleteAccountHolderOutput,
   DeletePaymentInput,
   DeletePaymentOutput,
   GetPaymentStatusInput,
@@ -74,6 +78,18 @@ export class SystemProviderService extends AbstractPaymentProvider {
   async capturePayment(
     input: CapturePaymentInput
   ): Promise<CapturePaymentOutput> {
+    return { data: {} }
+  }
+
+  async createAccountHolder(
+    input: CreateAccountHolderInput
+  ): Promise<CreateAccountHolderOutput> {
+    return { id: input.context.customer.id }
+  }
+
+  async deleteAccountHolder(
+    input: DeleteAccountHolderInput
+  ): Promise<DeleteAccountHolderOutput> {
     return { data: {} }
   }
 


### PR DESCRIPTION
**What**
- support account holder methods in the system payment provider

**Why**
- we are unable to write a test with an authenticated customer completing a cart with the manual payment provider since the payment module requires the provider to have account holder methods implemented