### PR TITLE
chore: Remove source maps for icons

### DIFF
--- a/packages/design-system/icons/rollup.config.mjs
+++ b/packages/design-system/icons/rollup.config.mjs
@@ -88,7 +88,7 @@ const configs = bundles
                 }.js`,
               }),
           format,
-          sourcemap: true,
+          sourcemap: false,
           preserveModules,
           globals: {
             react: "react",


### PR DESCRIPTION
REFERENCES CLO-851

Source maps for the icons are largely unnecessary, and add quite a bit of bloat to the final package