### PR TITLE
fix(core, medusa-test-utils): Fix medusa test runner plugin modules loading

### DIFF
--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -37,10 +37,10 @@ export class Compiler {
     this.#adminOnlyDistFolder = path.join(this.#projectRoot, ".medusa/admin")
     this.#pluginsDistFolder = path.join(this.#projectRoot, ".medusa/server")
     this.#backendIgnoreFiles = [
-      "integration-tests",
-      "test",
-      "unit-tests",
-      "src/admin",
+      "/integration-tests/",
+      "/test/",
+      "/unit-tests/",
+      "/src/admin/",
     ]
   }
 
@@ -190,7 +190,7 @@ export class Compiler {
   }> {
     const ts = await this.#loadTSCompiler()
     const filesToCompile = tsConfig.fileNames.filter((fileName) => {
-      return !chunksToIgnore.some((chunk) => fileName.includes(`${chunk}/`))
+      return !chunksToIgnore.some((chunk) => fileName.includes(`${chunk}`))
     })
 
     /**

--- a/packages/medusa-test-utils/src/medusa-test-runner.ts
+++ b/packages/medusa-test-utils/src/medusa-test-runner.ts
@@ -3,6 +3,8 @@ import { MedusaContainer } from "@medusajs/framework/types"
 import {
   ContainerRegistrationKeys,
   createMedusaContainer,
+  getResolvedPlugins,
+  mergePluginModules,
 } from "@medusajs/framework/utils"
 import { asValue } from "awilix"
 import { logger } from "@medusajs/framework/logger"
@@ -140,6 +142,13 @@ class MedusaTestRunner {
   private async setupApplication(): Promise<void> {
     const { container, MedusaAppLoader } = await import("@medusajs/framework")
     const appLoader = new MedusaAppLoader()
+
+    // Load plugins modules
+    const configModule = container.resolve(
+      ContainerRegistrationKeys.CONFIG_MODULE
+    )
+    const plugins = await getResolvedPlugins(this.cwd, configModule)
+    mergePluginModules(configModule, plugins)
 
     container.register({
       [ContainerRegistrationKeys.LOGGER]: asValue(logger),


### PR DESCRIPTION
FIXES SUP-1812
**What**
- Prevent plugin compiler to ignore plugin containing chunk name within its package name
- Fix medusa test runner to actually load plugin modules