### PR TITLE
feat: allow configuring hmr server port via the HMR_PORT env var

### DIFF
--- a/packages/admin/admin-bundler/src/utils/config.ts
+++ b/packages/admin/admin-bundler/src/utils/config.ts
@@ -13,7 +13,7 @@ export async function getViteConfig(
   const { default: medusa } = await import("@medusajs/admin-vite-plugin")
 
   const getPort = await import("get-port")
-  const hmrPort = await getPort.default()
+  const hmrPort = process.env.HMR_PORT || (await getPort.default())
 
   const root = path.resolve(process.cwd(), ".medusa/client")
 


### PR DESCRIPTION
This PR allows configuring the Vite HMR server port via the `HMR_PORT` environment variable.

Merged changes with https://github.com/medusajs/medusa/pull/12720