### PR TITLE
fix: Return and set the correct status when a session is created with…

### DIFF
--- a/packages/core/types/src/payment/provider.ts
+++ b/packages/core/types/src/payment/provider.ts
@@ -190,7 +190,8 @@ export interface UpdateAccountHolderInput extends PaymentProviderInput {
 /**
  * The data to delete an account holder.
  */
-export interface DeleteAccountHolderInput extends Omit<PaymentProviderInput, "context"> {
+export interface DeleteAccountHolderInput
+  extends Omit<PaymentProviderInput, "context"> {
   /**
    * The context of deleting the account holder.
    */
@@ -237,6 +238,10 @@ export interface InitiatePaymentOutput extends PaymentProviderOutput {
    * The ID of the payment session in the payment provider.
    */
   id: string
+  /**
+   * The status of the payment session, which will be stored in the payment session's `status` field.
+   */
+  status?: PaymentSessionStatus
 }
 
 /**
@@ -305,12 +310,15 @@ export interface DeleteAccountHolderOutput extends PaymentProviderOutput {}
 /**
  * The result of listing payment methods for an account holder in the third-party payment provider.
  */
-export interface ListPaymentMethodsOutput extends Array<PaymentProviderOutput & {
-  /**
-   * The ID of the payment method in the payment provider.
-   */
-  id: string
-}> {}
+export interface ListPaymentMethodsOutput
+  extends Array<
+    PaymentProviderOutput & {
+      /**
+       * The ID of the payment method in the payment provider.
+       */
+      id: string
+    }
+  > {}
 
 /**
  * The result of saving a payment method.

--- a/packages/modules/payment/src/services/payment-module.ts
+++ b/packages/modules/payment/src/services/payment-module.ts
@@ -363,6 +363,7 @@ export default class PaymentModuleService
         {
           id: paymentSession!.id,
           data: { ...input.data, ...providerPaymentSession.data },
+          status: providerPaymentSession.status ?? PaymentSessionStatus.PENDING,
         },
         sharedContext
       )


### PR DESCRIPTION
When initiating a payment, it might be that the payment requires further action or is completed from the get go. Until now we didn't capture this, and this PR fixes that.