### PR TITLE
fix(dashboard): fix subtitle for tax inclusive fields in promotions

### DIFF
--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -2074,7 +2074,7 @@
       },
       "taxInclusive": {
         "title": "Does promotion include taxes?",
-        "description": "Whether the promotion will be applied before or after taxes"
+        "description": "Enable this field to apply the promotion after taxes have been applied. If disabled, the promotion will be applied before taxes."
       },
       "status": {
         "label": "Status",

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -2074,7 +2074,7 @@
       },
       "taxInclusive": {
         "title": "Does promotion include taxes?",
-        "description": "Enable this field to apply the promotion after taxes have been applied. If disabled, the promotion will be applied before taxes."
+        "description": "Enable this field to apply the promotion after taxes. If disabled, the promotion will be applied before taxes."
       },
       "status": {
         "label": "Status",


### PR DESCRIPTION
Clarify meaning of toggling tax inclusive field in promotions form