### PR TITLE
fix: Allow setting the status of a payment session when updating

### DIFF
--- a/packages/core/core-flows/src/payment-collection/steps/create-payment-session.ts
+++ b/packages/core/core-flows/src/payment-collection/steps/create-payment-session.ts
@@ -38,6 +38,11 @@ export interface CreatePaymentSessionStepInput {
    * Learn more in [this documentation](https://docs.medusajs.com/resources/commerce-modules/payment/payment-session#data-property).
    */
   data?: Record<string, unknown>
+
+  /**
+   * Holds custom data in key-value pairs.
+   */
+  metadata?: Record<string, unknown>
 }
 
 export const createPaymentSessionStepId = "create-payment-session"
@@ -57,6 +62,7 @@ export const createPaymentSessionStep = createStep(
         amount: input.amount,
         data: input.data ?? {},
         context: input.context,
+        metadata: input.metadata ?? {},
       }
     )
 

--- a/packages/core/types/src/payment/common.ts
+++ b/packages/core/types/src/payment/common.ts
@@ -581,6 +581,11 @@ export interface PaymentSessionDTO {
    * @expandable
    */
   payment?: PaymentDTO
+
+  /**
+   * Holds custom data in key-value pairs.
+   */
+  metadata?: Record<string, unknown>
 }
 
 /**

--- a/packages/core/types/src/payment/mutations.ts
+++ b/packages/core/types/src/payment/mutations.ts
@@ -1,5 +1,5 @@
 import { BigNumberInput } from "../totals"
-import { PaymentCollectionStatus } from "./common"
+import { PaymentCollectionStatus, PaymentSessionStatus } from "./common"
 import {
   PaymentAccountHolderDTO,
   PaymentCustomerDTO,
@@ -212,6 +212,11 @@ export interface CreatePaymentSessionDTO {
    * Necessary context data for the associated payment provider.
    */
   context?: PaymentProviderContext
+
+  /**
+   * Holds custom data in key-value pairs.
+   */
+  metadata?: Record<string, unknown>
 }
 
 /**
@@ -239,9 +244,19 @@ export interface UpdatePaymentSessionDTO {
   amount: BigNumberInput
 
   /**
+   * The status of the payment session.
+   */
+  status?: PaymentSessionStatus
+
+  /**
    * Necessary context data for the associated payment provider.
    */
   context?: PaymentProviderContext
+
+  /**
+   * Holds custom data in key-value pairs.
+   */
+  metadata?: Record<string, unknown>
 }
 
 /**

--- a/packages/core/types/src/payment/provider.ts
+++ b/packages/core/types/src/payment/provider.ts
@@ -257,7 +257,12 @@ export interface AuthorizePaymentOutput extends PaymentProviderOutput {
 /**
  * The result of updating a payment.
  */
-export interface UpdatePaymentOutput extends PaymentProviderOutput {}
+export interface UpdatePaymentOutput extends PaymentProviderOutput {
+  /**
+   * The status of the payment, which will be stored in the payment session's `status` field.
+   */
+  status?: PaymentSessionStatus
+}
 
 /**
  * The result of deleting a payment.

--- a/packages/modules/payment/src/services/payment-module.ts
+++ b/packages/modules/payment/src/services/payment-module.ts
@@ -401,6 +401,7 @@ export default class PaymentModuleService
         currency_code: data.currency_code,
         context: data.context,
         data: data.data,
+        metadata: data.metadata,
       },
       sharedContext
     )
@@ -415,7 +416,7 @@ export default class PaymentModuleService
   ): Promise<PaymentSessionDTO> {
     const session = await this.paymentSessionService_.retrieve(
       data.id,
-      { select: ["id", "data", "provider_id"] },
+      { select: ["id", "status", "data", "provider_id"] },
       sharedContext
     )
 
@@ -435,6 +436,9 @@ export default class PaymentModuleService
         amount: data.amount,
         currency_code: data.currency_code,
         data: providerData.data,
+        // Allow the caller to explicitly set the status (eg. due to a webhook), fallback to the update response, and finally to the existing status.
+        status: data.status ?? providerData.status ?? session.status,
+        metadata: data.metadata,
       },
       sharedContext
     )


### PR DESCRIPTION
Currently there is no way to set the payment session status due to eg. a webhook coming in.

This PR allows for the status to be set, both by the caller, as well as based on the results of an update session call.

It also allows for CRUD on the metadata, which wasn't handled previously