### PR TITLE
feat: Search by billing_address and shipping_address on Order model

### DIFF
--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -66,6 +66,35 @@ medusaIntegrationTestRunner({
         expect(response.data.orders).toHaveLength(0)
         expect(response.data.orders).toEqual([])
       })
+
+      it("should search orders by shipping address", async () => {
+        let response = await api.get(`/admin/orders?fields=+shipping_address.address_1,+shipping_address.address_2`, adminHeaders)
+
+        expect(response.data.orders).toHaveLength(1)
+        expect(response.data.orders).toEqual([
+          expect.objectContaining({
+            id: order.id,
+          }),
+        ])
+
+        response = await api.get(`/admin/orders?fields=+shipping_address.address_1,+shipping_address.address_2&q=${order.shipping_address.address_1}`, adminHeaders)
+
+        expect(response.data.orders).toHaveLength(1)
+        expect(response.data.orders).toEqual([
+          expect.objectContaining({
+            id: order.id,
+          }),
+        ])
+
+        response = await api.get(`/admin/orders?q=${order.shipping_address.address_2}`, adminHeaders)
+
+        expect(response.data.orders).toHaveLength(1)
+        expect(response.data.orders).toEqual([
+          expect.objectContaining({
+            id: order.id,
+          }),
+        ])
+      })
     })
 
     describe("POST /orders/:id", () => {

--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -94,6 +94,40 @@ medusaIntegrationTestRunner({
             id: order.id,
           }),
         ])
+
+        response = await api.get(`/admin/orders?q=does-not-exist`, adminHeaders)
+
+        expect(response.data.orders).toHaveLength(0)
+        expect(response.data.orders).toEqual([])
+      })
+
+      it("should search orders by billing address", async () => {
+        let response = await api.get(`/admin/orders?fields=+billing_address.address_1,+billing_address.address_2`, adminHeaders)
+
+        expect(response.data.orders).toHaveLength(1)
+        expect(response.data.orders).toEqual([
+          expect.objectContaining({
+            id: order.id, 
+          }),
+        ])
+
+        response = await api.get(`/admin/orders?fields=+billing_address.address_1,+billing_address.address_2&q=${order.billing_address.address_1}`, adminHeaders)
+
+        expect(response.data.orders).toHaveLength(1)
+        expect(response.data.orders).toEqual([
+          expect.objectContaining({
+            id: order.id,
+          }),
+        ])
+
+        response = await api.get(`/admin/orders?q=${order.billing_address.address_2}`, adminHeaders)
+
+        expect(response.data.orders).toHaveLength(1)
+        expect(response.data.orders).toEqual([
+          expect.objectContaining({
+            id: order.id, 
+          }),
+        ])
       })
     })
 

--- a/packages/modules/order/src/models/order.ts
+++ b/packages/modules/order/src/models/order.ts
@@ -27,12 +27,14 @@ const _Order = model
         mappedBy: undefined,
         foreignKey: true,
       })
+      .searchable()
       .nullable(),
     billing_address: model
       .hasOne<any>(() => OrderAddress, {
         mappedBy: undefined,
         foreignKey: true,
       })
+      .searchable()
       .nullable(),
     summary: model.hasMany<any>(() => OrderSummary, {
       mappedBy: "order",


### PR DESCRIPTION
**What**
Added `.searchable()` method to the `shipping_address` and `billing_address` relationships in the `Order` model, enabling search functionality.

**Why**
Previously searching via `shipping_address` and `billing_address` was not supported, limiting the ability to find orders based on shipping or billing address information.

Resolves SUP-1838