### PR TITLE
fix: Add missing migration for payment statuses

### DIFF
--- a/packages/modules/payment/src/migrations/.snapshot-medusa-payment.json
+++ b/packages/modules/payment/src/migrations/.snapshot-medusa-payment.json
@@ -211,6 +211,7 @@
             "partially_authorized",
             "canceled",
             "failed",
+            "partially_captured",
             "completed"
           ],
           "mappedType": "enum"

--- a/packages/modules/payment/src/migrations/Migration20250625084134.ts
+++ b/packages/modules/payment/src/migrations/Migration20250625084134.ts
@@ -1,0 +1,17 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20250625084134 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "payment_collection" drop constraint if exists "payment_collection_status_check";`);
+
+    this.addSql(`alter table if exists "payment_collection" add constraint "payment_collection_status_check" check("status" in ('not_paid', 'awaiting', 'authorized', 'partially_authorized', 'canceled', 'failed', 'partially_captured', 'completed'));`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "payment_collection" drop constraint if exists "payment_collection_status_check";`);
+
+    this.addSql(`alter table if exists "payment_collection" add constraint "payment_collection_status_check" check("status" in ('not_paid', 'awaiting', 'authorized', 'partially_authorized', 'canceled', 'failed', 'completed'));`);
+  }
+
+}


### PR DESCRIPTION
The status was in the enum but it seems the migration was never created.