### PR TITLE
feat(dashboard): added ability to position new custom admin route relative to existing route in sidebar

### DIFF
--- a/packages/admin/admin-bundler/package.json
+++ b/packages/admin/admin-bundler/package.json
@@ -4,7 +4,8 @@
   "description": "Bundler for the Medusa admin dashboard.",
   "author": "Kasper Kristensen <kasper@medusajs.com>",
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "watch": "tsup --watch"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/admin/admin-sdk/package.json
+++ b/packages/admin/admin-sdk/package.json
@@ -16,7 +16,8 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "watch": "tsup --watch"
   },
   "devDependencies": {
     "@types/react": "^18.3.2",

--- a/packages/admin/admin-sdk/src/config/types.ts
+++ b/packages/admin/admin-sdk/src/config/types.ts
@@ -30,6 +30,12 @@ export interface RouteConfig {
    * The nested route to display under existing route in the sidebar.
    */
   nested?: NestedRoutePosition
+
+  /**
+   * The position of the nested route in the sidebar.
+   * @default "inside"
+   */
+  nestedPosition?: "after" | "before" | "inside"
 }
 
 export type CustomFormField<

--- a/packages/admin/admin-vite-plugin/package.json
+++ b/packages/admin/admin-vite-plugin/package.json
@@ -6,9 +6,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "repository": {

--- a/packages/admin/admin-vite-plugin/src/routes/__tests__/generate-menu-items.spec.ts
+++ b/packages/admin/admin-vite-plugin/src/routes/__tests__/generate-menu-items.spec.ts
@@ -61,6 +61,22 @@ const mockFileContents = [
 
     export default Page
   `,
+  `
+    import { defineRouteConfig } from "@medusajs/admin-sdk"
+
+    const Page = () => {
+        return <div>Page 4</div>
+    }
+
+    export const config = defineRouteConfig({
+        label: "Page 4",
+        icon: "icon1",
+        nested: "/products",
+        nestedPosition: "after"
+    })
+
+    export default Page
+  `,
 ]
 
 const expectedMenuItems = `
@@ -69,19 +85,29 @@ const expectedMenuItems = `
             label: RouteConfig0.label,
             icon: RouteConfig0.icon,
             path: "/one",
-            nested: undefined
+            nested: undefined,
+            nestedPosition: undefined
           },
           {
             label: RouteConfig1.label,
             icon: undefined,
             path: "/two",
-            nested: undefined
+            nested: undefined,
+            nestedPosition: undefined
           },
           {
             label: RouteConfig2.label,
             icon: RouteConfig2.icon,
             path: "/three",
-            nested: "/products"
+            nested: "/products",
+            nestedPosition: undefined
+          },
+          {
+            label: RouteConfig3.label,
+            icon: RouteConfig3.icon,
+            path: "/four",
+            nested: "/products",
+            nestedPosition: RouteConfig3.nestedPosition
           }
         ]
       `
@@ -92,6 +118,7 @@ describe("generateMenuItems", () => {
       "Users/user/medusa/src/admin/routes/one/page.tsx",
       "Users/user/medusa/src/admin/routes/two/page.tsx",
       "Users/user/medusa/src/admin/routes/three/page.tsx",
+      "Users/user/medusa/src/admin/routes/four/page.tsx",
     ]
     vi.mocked(utils.crawl).mockResolvedValue(mockFiles)
 
@@ -107,6 +134,7 @@ describe("generateMenuItems", () => {
       `import { config as RouteConfig0 } from "Users/user/medusa/src/admin/routes/one/page.tsx"`,
       `import { config as RouteConfig1 } from "Users/user/medusa/src/admin/routes/two/page.tsx"`,
       `import { config as RouteConfig2 } from "Users/user/medusa/src/admin/routes/three/page.tsx"`,
+      `import { config as RouteConfig3 } from "Users/user/medusa/src/admin/routes/four/page.tsx"`,
     ])
     expect(utils.normalizeString(result.code)).toEqual(
       utils.normalizeString(expectedMenuItems)
@@ -119,6 +147,7 @@ describe("generateMenuItems", () => {
       "C:\\medusa\\src\\admin\\routes\\one\\page.tsx",
       "C:\\medusa\\src\\admin\\routes\\two\\page.tsx",
       "C:\\medusa\\src\\admin\\routes\\three\\page.tsx",
+      "C:\\medusa\\src\\admin\\routes\\four\\page.tsx",
     ]
     vi.mocked(utils.crawl).mockResolvedValue(mockFiles)
 
@@ -132,6 +161,7 @@ describe("generateMenuItems", () => {
       `import { config as RouteConfig0 } from "C:/medusa/src/admin/routes/one/page.tsx"`,
       `import { config as RouteConfig1 } from "C:/medusa/src/admin/routes/two/page.tsx"`,
       `import { config as RouteConfig2 } from "C:/medusa/src/admin/routes/three/page.tsx"`,
+      `import { config as RouteConfig3 } from "C:/medusa/src/admin/routes/four/page.tsx"`,
     ])
     expect(utils.normalizeString(result.code)).toEqual(
       utils.normalizeString(expectedMenuItems)

--- a/packages/admin/admin-vite-plugin/src/routes/generate-menu-items.ts
+++ b/packages/admin/admin-vite-plugin/src/routes/generate-menu-items.ts
@@ -28,6 +28,7 @@ type RouteConfig = {
   label: boolean
   icon: boolean
   nested?: string
+  nestedPosition: boolean
 }
 
 type MenuItem = {
@@ -35,6 +36,7 @@ type MenuItem = {
   label: string
   path: string
   nested?: string
+  nestedPosition?: string
 }
 
 type MenuItemResult = {
@@ -64,12 +66,13 @@ function generateCode(results: MenuItemResult[]): string {
 }
 
 function formatMenuItem(route: MenuItem): string {
-  const { label, icon, path, nested } = route
+  const { label, icon, path, nested, nestedPosition } = route
   return `{
     label: ${label},
     icon: ${icon || "undefined"},
     path: "${path}",
-    nested: ${nested ? `"${nested}"` : "undefined"}
+    nested: ${nested ? `"${nested}"` : "undefined"},
+    nestedPosition: ${nestedPosition || "undefined"}
   }`
 }
 
@@ -130,6 +133,9 @@ function generateMenuItem(
     icon: config.icon ? `${configName}.icon` : undefined,
     path: getRoute(file),
     nested: config.nested,
+    nestedPosition: config.nestedPosition
+      ? `${configName}.nestedPosition`
+      : undefined,
   }
 }
 
@@ -216,6 +222,7 @@ function processConfigProperties(
     return null
   }
 
+  const hasNestedPosition = hasProperty("nestedPosition")
   const nested = properties.find(
     (prop) =>
       isObjectProperty(prop) && isIdentifier(prop.key, { name: "nested" })
@@ -244,6 +251,7 @@ function processConfigProperties(
     label: hasLabel,
     icon: hasProperty("icon"),
     nested: nestedValue,
+    nestedPosition: hasNestedPosition,
   }
 }
 

--- a/packages/admin/dashboard/src/components/layout/main-layout/main-layout.tsx
+++ b/packages/admin/dashboard/src/components/layout/main-layout/main-layout.tsx
@@ -290,9 +290,28 @@ const CoreRouteSection = () => {
   menuItems.forEach((item) => {
     if (item.nested) {
       const route = coreRoutes.find((route) => route.to === item.nested)
-      if (route) {
-        route.items?.push(item)
+      if (!route) return
+
+      if (item.nestedPosition === "after") {
+        const routeIndex = coreRoutes.findIndex(
+          (route) => route.to === item.nested
+        )
+        // Push menu item to position after core route
+        coreRoutes.splice(routeIndex + 1, 0, item)
+        return
       }
+
+      if (item.nestedPosition === "before") {
+        const routeIndex = coreRoutes.findIndex(
+          (route) => route.to === item.nested
+        )
+        // Push menu item to position before core route
+        coreRoutes.splice(routeIndex, 0, item)
+        return
+      }
+
+      // Push menu item to position inside core route
+      route.items?.push(item)
     }
   })
 

--- a/packages/admin/dashboard/src/components/layout/nav-item/nav-item.tsx
+++ b/packages/admin/dashboard/src/components/layout/nav-item/nav-item.tsx
@@ -1,3 +1,4 @@
+import { NestedRoutePosition } from "@medusajs/admin-shared"
 import { Kbd, Text, clx } from "@medusajs/ui"
 import { Collapsible as RadixCollapsible } from "radix-ui"
 import {
@@ -26,7 +27,8 @@ export type INavItem = {
   items?: NestedItemProps[]
   type?: ItemType
   from?: string
-  nested?: string
+  nested?: NestedRoutePosition
+  nestedPosition?: "after" | "before" | "inside"
 }
 
 const BASE_NAV_LINK_CLASSES =

--- a/packages/admin/dashboard/src/dashboard-app/dashboard-app.tsx
+++ b/packages/admin/dashboard/src/dashboard-app/dashboard-app.tsx
@@ -174,6 +174,7 @@ export class DashboardApp {
         icon: item.icon ? <item.icon /> : undefined,
         items: [],
         nested: item.nested,
+        nestedPosition: item.nestedPosition,
       }
 
       if (parentPath !== "/" && tempRegistry[parentPath]) {

--- a/packages/admin/dashboard/src/dashboard-app/types.ts
+++ b/packages/admin/dashboard/src/dashboard-app/types.ts
@@ -24,6 +24,7 @@ export type MenuItemExtension = {
   path: string
   icon?: ComponentType
   nested?: NestedRoutePosition
+  nestedPosition?: "after" | "before" | "inside"
 }
 
 export type WidgetExtension = {


### PR DESCRIPTION
This PR add ability to position your custom route of custom modules or plugins relative to core routes.
Currently you can only insert custom routes inside existing core routes.

<img width="939" alt="image" src="https://github.com/user-attachments/assets/bdf69444-685b-4337-bee3-1c926d880fd9" />
<img width="658" alt="image" src="https://github.com/user-attachments/assets/00ed3e79-2fda-4776-9a5f-72da9e23555f" />
