### PR TITLE
docs-util: throw when schema parsing fails

### DIFF
--- a/www/utils/generated/oas-output/schemas/AdminShippingOptionRule.ts
+++ b/www/utils/generated/oas-output/schemas/AdminShippingOptionRule.ts
@@ -35,8 +35,18 @@
  *       - gte
  *       - nin
  *   value:
- *     type: string
- *     title: value
+ *     oneOf:
+ *       - type: string
+ *         title: value
+ *         description: The shipping option rule's value.
+ *         example: "true"
+ *       - type: array
+ *         description: The shipping option rule's values.
+ *         items:
+ *           type: string
+ *           title: value
+ *           description: A value of the shipping option rule.
+ *           example: "true"
  *   shipping_option_id:
  *     type: string
  *     title: shipping_option_id
@@ -56,5 +66,6 @@
  *     format: date-time
  *     title: deleted_at
  *     description: The date the shipping option rule was deleted.
- *
- */
+ * 
+*/
+

--- a/www/utils/generated/oas-output/schemas/AdminWorkflowExecutionExecution.ts
+++ b/www/utils/generated/oas-output/schemas/AdminWorkflowExecutionExecution.ts
@@ -147,5 +147,6 @@
  *           type: number
  *           title: startedAt
  *           description: The timestamp the step started executing.
- *
- */
+ * 
+*/
+

--- a/www/utils/packages/docs-generator/src/classes/helpers/oas-schema.ts
+++ b/www/utils/packages/docs-generator/src/classes/helpers/oas-schema.ts
@@ -9,6 +9,7 @@ import { parse } from "yaml"
 import formatOas from "../../utils/format-oas.js"
 import pluralize from "pluralize"
 import { capitalize, wordsToPascal } from "utils"
+import chalk from "chalk"
 import { OasArea } from "../kinds/oas.js"
 import {
   isLevelExceeded,
@@ -307,7 +308,7 @@ class OasSchemaHelper {
       return
     }
 
-    return this.parseSchema(schemaFileContent)
+    return this.parseSchema(schemaFileContent, true)
   }
 
   /**
@@ -316,7 +317,10 @@ class OasSchemaHelper {
    * @param content - The schema comment string
    * @returns If the schema is valid and parsed successfully, the schema and its prefix are retrieved.
    */
-  parseSchema(content: string): ParsedSchema | undefined {
+  parseSchema(
+    content: string,
+    failOnParseError = false
+  ): ParsedSchema | undefined {
     const schemaFileContent = content
       .replace(`/**\n`, "")
       .replaceAll(DOCBLOCK_LINE_ASTRIX, "")
@@ -334,8 +338,11 @@ class OasSchemaHelper {
     try {
       schema = parse(splitContent.slice(1).join("\n"))
     } catch (e) {
-      // couldn't parse the OAS, so consider it
-      // not existent
+      if (failOnParseError) {
+        throw e
+      }
+
+      console.error(chalk.red(e))
     }
 
     return schema


### PR DESCRIPTION
Throw error when a schema can't be parsed due to an error in the schema