### PR TITLE
Vulnerability for axios : upgrade axios to version 1.8.2

### DIFF
--- a/packages/medusa-telemetry/package.json
+++ b/packages/medusa-telemetry/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.22.10",
-    "axios": "^0.21.4",
+    "axios": "^1.8.2",
     "axios-retry": "^3.1.9",
     "boxen": "^5.0.1",
     "ci-info": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7145,7 +7145,7 @@ __metadata:
   resolution: "@medusajs/telemetry@workspace:packages/medusa-telemetry"
   dependencies:
     "@babel/runtime": ^7.22.10
-    axios: ^0.21.4
+    axios: ^1.8.2
     axios-retry: ^3.1.9
     boxen: ^5.0.1
     ci-info: ^3.2.0


### PR DESCRIPTION
I'm using the tool Trivy in my CI/CD and it shows me a vulnerability for the old version of Axios installed in the package medusa-telemetry.
There is no breaking changes for the code used in this package, so I think it can be upgraded easily, to fix the vulnerability.