### PR TITLE
Fix cannot read properties of undefined (reading 'account_holders')

### DIFF
--- a/packages/core/core-flows/src/payment-collection/workflows/create-payment-session.ts
+++ b/packages/core/core-flows/src/payment-collection/workflows/create-payment-session.ts
@@ -117,7 +117,7 @@ export const createPaymentSessionsWorkflow = createWorkflow(
       })
 
       const existingAccountHolder = transform({ customer, input }, (data) => {
-        return data.customer.account_holders.find(
+        return data.customer?.account_holders?.find(
           (ac) => ac.provider_id === data.input.provider_id
         )
       })


### PR DESCRIPTION
I see many error logs in the create payment session workflow containing "Cannot read properties of undefined (reading 'account_holders')".

This PR should resolve it.