### PR TITLE
fix(index): merge filterable fields schema

### DIFF
--- a/.changeset/tough-horses-return.md
+++ b/.changeset/tough-horses-return.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/test-utils": patch
+"@medusajs/index": patch
+---
+
+fix(index): merge filterable fields with default fields

--- a/packages/modules/index/src/utils/build-config.ts
+++ b/packages/modules/index/src/utils/build-config.ts
@@ -1206,7 +1206,7 @@ function buildSchemaFromFilterableLinks(
         })
         .join("\n")
 
-      return `type ${entity} ${events} {
+      return `extend type ${entity} ${events} {
 ${fieldDefinitions}
 }`
     })


### PR DESCRIPTION
What:
 * When extending the filtrable fields of modules indexed by default (e.g Product), it should merge the new fields with the default ones.