### PR TITLE
docs(dashboard): add guidance for standalone admin dashboard build and deployment

### DIFF
--- a/www/apps/book/app/learn/build/page.mdx
+++ b/www/apps/book/app/learn/build/page.mdx
@@ -40,6 +40,12 @@ The `build` command accepts a `--admin-only` option that outputs the admin to th
 npx medusa build --admin-only
 ```
 
+<Note>
+
+Detailed guidance on deploying the standalone admin dashboard to Vercel is available in the documentation: [Deploying Standalon Dashboard](https://docs.perseides.org/guides/v2/customize-admin-ui/standalone)
+
+</Note>
+
 ---
 
 ## Start Built Medusa Application


### PR DESCRIPTION
This update enhances the documentation for the Medusa build process by adding a dedicated section on how to build and deploy the admin dashboard independently from the main application. It explains the use of the --admin-only flag with the medusa build command, which outputs the admin dashboard to a separate directory suitable for standalone deployment (e.g., on Vercel).

this is related to this issue #12901 