### PR TITLE
fix: only log server errors

### DIFF
--- a/packages/core/framework/src/http/__fixtures__/server/index.ts
+++ b/packages/core/framework/src/http/__fixtures__/server/index.ts
@@ -9,14 +9,14 @@ import express from "express"
 import querystring from "querystring"
 import supertest from "supertest"
 
-import { config } from "../mocks"
 import { MedusaContainer } from "@medusajs/types"
 import { configManager } from "../../../config"
 import { container } from "../../../container"
 import { featureFlagsLoader } from "../../../feature-flags"
 import { logger } from "../../../logger"
-import { MedusaRequest } from "../../types"
 import { ApiLoader } from "../../router"
+import { MedusaRequest } from "../../types"
+import { config } from "../mocks"
 
 function asArray(resolvers) {
   return {
@@ -69,6 +69,7 @@ export const createServer = async (rootDir) => {
   container.register({
     logger: asValue({
       error: () => {},
+      info: () => {},
     }),
     manager: asValue({}),
   })

--- a/packages/core/framework/src/http/middlewares/error-handler.ts
+++ b/packages/core/framework/src/http/middlewares/error-handler.ts
@@ -1,9 +1,9 @@
+import { ErrorRequestHandler, NextFunction, Response } from "express"
 import { fromZodIssue } from "zod-validation-error"
-import { NextFunction, ErrorRequestHandler, Response } from "express"
 
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/utils"
-import { formatException } from "./exception-formatter"
 import { MedusaRequest } from "../types"
+import { formatException } from "./exception-formatter"
 
 const QUERY_RUNNER_RELEASED = "QueryRunnerAlreadyReleasedError"
 const TRANSACTION_STARTED = "TransactionAlreadyStartedError"
@@ -31,7 +31,6 @@ export function errorHandler() {
     }
 
     err = formatException(err)
-    logger.error(err)
 
     const errorType = err.type || err.name
     const errObj = {
@@ -80,6 +79,10 @@ export function errorHandler() {
         errObj.message = "An unknown error occurred."
         errObj.type = "unknown_error"
         break
+    }
+
+    if (statusCode >= 500) {
+      logger.error(err)
     }
 
     if ("issues" in err && Array.isArray(err.issues)) {

--- a/packages/core/framework/src/http/middlewares/error-handler.ts
+++ b/packages/core/framework/src/http/middlewares/error-handler.ts
@@ -83,6 +83,8 @@ export function errorHandler() {
 
     if (statusCode >= 500) {
       logger.error(err)
+    } else {
+      logger.info(err.message)
     }
 
     if ("issues" in err && Array.isArray(err.issues)) {


### PR DESCRIPTION
We're seeing a lot of "expected" client-side 4xx errors in our logs, which just create a lot of noise. A typical case is stale UI: someone performs an action on an entity that doesn't exist anymore, or isn't anymore in the state the UI is showing, resulting in 404 or other errors. I think we should only log 5xx as errors, as they are the server's responsibility. For 4xx we have the request logging which should be enough. 