### PR TITLE
chore: add to TSDocs note about removing item from order edit

### DIFF
--- a/packages/core/core-flows/src/order/workflows/order-edit/order-edit-update-item-quantity.ts
+++ b/packages/core/core-flows/src/order/workflows/order-edit/order-edit-update-item-quantity.ts
@@ -79,6 +79,8 @@ export const orderEditUpdateItemQuantityWorkflowId =
  * This workflow updates the quantity of an existing item in an order's edit. It's used by the
  * [Update Order Item Quantity Admin API Route](https://docs.medusajs.com/api/admin#order-edits_postordereditsiditemsitemitem_id).
  * 
+ * You can also use this workflow to remove an item from an order by setting its quantity to `0`.
+ * 
  * You can use this workflow within your customizations or your own custom workflows, allowing you to update the quantity of an existing 
  * item in an order's edit in your custom flow.
  * 
@@ -98,7 +100,7 @@ export const orderEditUpdateItemQuantityWorkflowId =
  * 
  * @summary
  * 
- * Update the quantity of an existing order item in the order's edit.
+ * Update or remove an existing order item's quantity in the order's edit.
  */
 export const orderEditUpdateItemQuantityWorkflow = createWorkflow(
   orderEditUpdateItemQuantityWorkflowId,

--- a/packages/core/js-sdk/src/admin/order-edit.ts
+++ b/packages/core/js-sdk/src/admin/order-edit.ts
@@ -188,6 +188,8 @@ export class OrderEdit {
    * [Update Item Quantity](https://docs.medusajs.com/api/admin#order-edits_postordereditsiditemsitemitem_id)
    * API route.
    * 
+   * You can also use this method to remove an item from an order by setting the `quantity` to `0`.
+   * 
    * @param id - The order edit's ID.
    * @param itemId - The item's ID in the order.
    * @param body - The data to edit in the item.


### PR DESCRIPTION
Update the TSDocs of the workflow and JS SDK that updates an item in an order edit to also mention that the item can be removed by setting quantity to 0