### PR TITLE
docs: fix jest.config.js

### DIFF
--- a/www/apps/book/app/learn/debugging-and-testing/testing-tools/page.mdx
+++ b/www/apps/book/app/learn/debugging-and-testing/testing-tools/page.mdx
@@ -41,6 +41,7 @@ module.exports = {
       {
         jsc: {
           parser: { syntax: "typescript", decorators: true },
+          target: "es2021"
         },
       },
     ],


### PR DESCRIPTION
When following the docs to setup testing, you get the following error: 
```
Failed to deserialize buffer as swc::config::Options
    JSON: {"jsc":{"parser":{"syntax":"typescript","decorators":true},"target":"es2023","transform":{"hidden":{"jest":true}}},"sourceMaps":"inline","module":{"type":"commonjs"},"filename":"integration-tests/setup.js"}

    Caused by:
        unknown variant `es2023`, expected one of `es3`, `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020`, `es2021`, `es2022`, `esnext` at line 1 column 246
```

It only happens when `@swc/jest` is manually installed, explicitly setting the target fixes it. In the starter it works since @swc/jest is not installed directly.

Steps to repro:
- npx create-medusa-app
- yarn test:integration:http (works)
- yarn add --dev @swc/jest
- yarn test:integration:http (error)