### PR TITLE
fix: fix script migrations order

### DIFF
--- a/.changeset/loud-terms-share.md
+++ b/.changeset/loud-terms-share.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/framework": patch
+---
+
+fix(framework): fix script migrations order

--- a/packages/core/framework/src/migrations/migrator.ts
+++ b/packages/core/framework/src/migrations/migrator.ts
@@ -139,6 +139,7 @@ export abstract class Migrator {
           cwd: basePath,
           ignore: ["**/index.{js,ts}", "**/*.d.ts"],
         })
+        scriptFiles.sort((a, b) => a.localeCompare(b))
 
         if (!scriptFiles?.length) {
           continue


### PR DESCRIPTION
`glob.sync` does not seem to guarantee ascending order. Instead, it seems to depend on the OS. In my Mac e.g., I get sometimes reversed order, which means script migrations got executed in reverse order.