### PR TITLE
docs: add link to manage metadata section in OAS and API reference

### DIFF
--- a/www/apps/api-reference/specs/admin/components/schemas/AdminAddDraftOrderItems.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminAddDraftOrderItems.yaml
@@ -42,3 +42,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminAddDraftOrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminAddDraftOrderShippingMethod.yaml
@@ -25,3 +25,6 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminBatchUpdateProduct.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminBatchUpdateProduct.yaml
@@ -147,6 +147,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   external_id:
     type: string
     title: external_id

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminBatchUpdateProductVariant.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminBatchUpdateProductVariant.yaml
@@ -71,6 +71,9 @@ properties:
   metadata:
     type: object
     description: The product variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   prices:
     type: array
     description: The product variant's prices.

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminClaim.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminClaim.yaml
@@ -68,6 +68,9 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCollection.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCollection.yaml
@@ -45,3 +45,6 @@ properties:
   metadata:
     type: object
     description: The collection's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateCustomerGroup.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateCustomerGroup.yaml
@@ -11,3 +11,6 @@ properties:
   metadata:
     type: object
     description: The customer group's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateFulfillment.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateFulfillment.yaml
@@ -70,6 +70,9 @@ properties:
       metadata:
         type: object
         description: The delivery address's metadata, used to store custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   items:
     type: array
     description: The items to fulfill.
@@ -167,3 +170,6 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateFulfillmentSetServiceZones.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateFulfillmentSetServiceZones.yaml
@@ -22,6 +22,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -42,6 +45,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -71,6 +77,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -105,6 +114,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateGiftCardParams.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateGiftCardParams.yaml
@@ -49,3 +49,6 @@ properties:
   metadata:
     type: object
     description: The gift card's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateInventoryItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateInventoryItem.yaml
@@ -57,3 +57,6 @@ properties:
   metadata:
     type: object
     description: The inventory item's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateOrderCreditLines.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateOrderCreditLines.yaml
@@ -24,3 +24,6 @@ properties:
   metadata:
     type: object
     description: The credit line's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProduct.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProduct.yaml
@@ -146,6 +146,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   external_id:
     type: string
     title: external_id

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProductCategory.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProductCategory.yaml
@@ -35,3 +35,6 @@ properties:
   metadata:
     type: object
     description: The product category's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProductTag.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProductTag.yaml
@@ -11,3 +11,6 @@ properties:
   metadata:
     type: object
     description: The product tag's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProductType.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProductType.yaml
@@ -7,6 +7,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   value:
     type: string
     title: value

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProductVariant.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateProductVariant.yaml
@@ -74,6 +74,9 @@ properties:
   metadata:
     type: object
     description: The variant's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   prices:
     type: array
     description: The variant's prices.

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateRegion.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateRegion.yaml
@@ -41,3 +41,6 @@ properties:
   metadata:
     type: object
     description: The region's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateReservation.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateReservation.yaml
@@ -29,3 +29,6 @@ properties:
   metadata:
     type: object
     description: The reservation's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateReturnReason.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateReturnReason.yaml
@@ -24,3 +24,6 @@ properties:
   metadata:
     type: object
     description: The return reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateSalesChannel.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateSalesChannel.yaml
@@ -19,3 +19,6 @@ properties:
   metadata:
     type: object
     description: The sales channel's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateShippingProfile.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateShippingProfile.yaml
@@ -16,3 +16,6 @@ properties:
   metadata:
     type: object
     description: The shipping profile's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateStockLocation.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateStockLocation.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The stock location's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateStoreCreditAccount.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateStoreCreditAccount.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The store credit account's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateTaxRate.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateTaxRate.yaml
@@ -43,3 +43,6 @@ properties:
   metadata:
     type: object
     description: The tax rate's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCreateTaxRegion.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCreateTaxRegion.yaml
@@ -51,9 +51,15 @@ properties:
       metadata:
         type: object
         description: The default tax rate's metadata, used to store custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   metadata:
     type: object
     description: The tax region's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   provider_id:
     type: string
     title: provider_id

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCustomer.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCustomer.yaml
@@ -62,6 +62,9 @@ properties:
   metadata:
     type: object
     description: The customer's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_by:
     type: string
     title: created_by

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCustomerAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCustomerAddress.yaml
@@ -89,6 +89,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminCustomerGroup.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminCustomerGroup.yaml
@@ -25,6 +25,9 @@ properties:
   metadata:
     type: object
     description: The customer group's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminDraftOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminDraftOrder.yaml
@@ -144,6 +144,9 @@ properties:
   metadata:
     type: object
     description: The draft order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminDraftOrderPreview.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminDraftOrderPreview.yaml
@@ -215,6 +215,9 @@ properties:
             metadata:
               type: object
               description: The item's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             original_total:
               type: number
               title: original_total
@@ -352,6 +355,9 @@ properties:
             metadata:
               type: object
               description: The shipping method's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             tax_lines:
               type: array
               description: The shipping method's tax lines.
@@ -541,6 +547,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminExchange.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminExchange.yaml
@@ -66,6 +66,9 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminFulfillment.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminFulfillment.yaml
@@ -77,6 +77,9 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminFulfillmentAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminFulfillmentAddress.yaml
@@ -74,6 +74,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminInventoryLevel.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminInventoryLevel.yaml
@@ -56,6 +56,9 @@ properties:
   metadata:
     type: object
     description: The location level's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   inventory_item:
     type: object
   available_quantity:

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminInvite.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminInvite.yaml
@@ -35,6 +35,9 @@ properties:
   metadata:
     type: object
     description: The invite's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminOrder.yaml
@@ -139,6 +139,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminOrderAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminOrderAddress.yaml
@@ -65,6 +65,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminOrderChange.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminOrderChange.yaml
@@ -112,6 +112,9 @@ properties:
   metadata:
     type: object
     description: The order change's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   declined_at:
     type: string
     title: declined_at

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminOrderFulfillment.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminOrderFulfillment.yaml
@@ -63,6 +63,9 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminOrderLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminOrderLineItem.yaml
@@ -160,6 +160,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   original_total:
     type: number
     title: original_total

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminOrderPreview.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminOrderPreview.yaml
@@ -217,6 +217,9 @@ properties:
             metadata:
               type: object
               description: The item's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             original_total:
               type: number
               title: original_total
@@ -354,6 +357,9 @@ properties:
             metadata:
               type: object
               description: The shipping method's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             tax_lines:
               type: array
               description: The shipping method's tax lines.
@@ -543,6 +549,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminOrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminOrderShippingMethod.yaml
@@ -60,6 +60,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPaymentCollection.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPaymentCollection.yaml
@@ -50,6 +50,9 @@ properties:
   metadata:
     type: object
     description: The payment collection's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   status:
     type: string
     description: The payment collection's status.

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostClaimsAddItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostClaimsAddItemsReqSchema.yaml
@@ -31,3 +31,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostClaimsShippingActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostClaimsShippingActionReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostClaimsShippingReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostClaimsShippingReqSchema.yaml
@@ -23,3 +23,6 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesAddItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesAddItemsReqSchema.yaml
@@ -35,3 +35,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesRequestItemsReturnActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesRequestItemsReturnActionReqSchema.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesReturnRequestItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesReturnRequestItemsReqSchema.yaml
@@ -35,3 +35,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesShippingActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesShippingActionReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesShippingReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostExchangesShippingReqSchema.yaml
@@ -23,3 +23,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderClaimsReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderClaimsReqSchema.yaml
@@ -30,3 +30,6 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderEditsAddItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderEditsAddItemsReqSchema.yaml
@@ -37,6 +37,9 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         compare_at_unit_price:
           type: number
           title: compare_at_unit_price

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderEditsReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderEditsReqSchema.yaml
@@ -19,3 +19,6 @@ properties:
   metadata:
     type: object
     description: The order edit's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderEditsShippingActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderEditsShippingActionReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The order edit's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderEditsShippingReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderEditsShippingReqSchema.yaml
@@ -23,3 +23,6 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderExchangesReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostOrderExchangesReqSchema.yaml
@@ -19,3 +19,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostReceiveReturnsReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostReceiveReturnsReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsReqSchema.yaml
@@ -27,3 +27,6 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsRequestItemsActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsRequestItemsActionReqSchema.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsRequestItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsRequestItemsReqSchema.yaml
@@ -35,3 +35,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsReturnReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsReturnReqSchema.yaml
@@ -15,3 +15,6 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsShippingActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsShippingActionReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsShippingReqSchema.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminPostReturnsShippingReqSchema.yaml
@@ -23,3 +23,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminProduct.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminProduct.yaml
@@ -86,6 +86,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminProductCategory.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminProductCategory.yaml
@@ -43,6 +43,9 @@ properties:
   metadata:
     type: object
     description: The category's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminProductImage.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminProductImage.yaml
@@ -28,6 +28,9 @@ properties:
   metadata:
     type: object
     description: The image's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   rank:
     type: number
     title: rank

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminProductOption.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminProductOption.yaml
@@ -27,6 +27,9 @@ properties:
   metadata:
     type: object
     description: The product option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminProductOptionValue.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminProductOptionValue.yaml
@@ -22,6 +22,9 @@ properties:
   metadata:
     type: object
     description: The value's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminProductTag.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminProductTag.yaml
@@ -33,3 +33,6 @@ properties:
   metadata:
     type: object
     description: The tag's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminProductType.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminProductType.yaml
@@ -33,3 +33,6 @@ properties:
   metadata:
     type: object
     description: The type's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminProductVariant.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminProductVariant.yaml
@@ -136,6 +136,9 @@ properties:
   metadata:
     type: object
     description: The variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   inventory_items:
     type: array
     description: The variant's inventory items.

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminRefundReason.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminRefundReason.yaml
@@ -23,6 +23,9 @@ properties:
   metadata:
     type: object
     description: The refund reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminRegion.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminRegion.yaml
@@ -36,6 +36,9 @@ properties:
   metadata:
     type: object
     description: The region's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminReservation.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminReservation.yaml
@@ -43,6 +43,9 @@ properties:
   metadata:
     type: object
     description: The reservation's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_by:
     type: string
     title: created_by

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminReturnItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminReturnItem.yaml
@@ -48,3 +48,6 @@ properties:
   metadata:
     type: object
     description: The return item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminReturnReason.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminReturnReason.yaml
@@ -27,6 +27,9 @@ properties:
   metadata:
     type: object
     description: The return reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminSalesChannel.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminSalesChannel.yaml
@@ -30,6 +30,9 @@ properties:
   metadata:
     type: object
     description: The sales channel's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminShippingOption.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminShippingOption.yaml
@@ -88,6 +88,9 @@ properties:
   metadata:
     type: object
     description: The shipping option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminShippingProfile.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminShippingProfile.yaml
@@ -17,6 +17,9 @@ properties:
   metadata:
     type: object
     description: The shipping profile's metadata, holds custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminStore.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminStore.yaml
@@ -40,6 +40,9 @@ properties:
   metadata:
     type: object
     description: The store's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminStoreCreditAccount.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminStoreCreditAccount.yaml
@@ -49,6 +49,9 @@ properties:
   metadata:
     type: object
     description: The store credit account's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminTaxRate.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminTaxRate.yaml
@@ -37,6 +37,9 @@ properties:
   metadata:
     type: object
     description: The tax rate's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   tax_region_id:
     type: string
     title: tax_region_id

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminTaxRegion.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminTaxRegion.yaml
@@ -35,6 +35,9 @@ properties:
   metadata:
     type: object
     description: The tax region's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   parent_id:
     type: string
     title: parent_id

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminTransaction.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminTransaction.yaml
@@ -51,6 +51,9 @@ properties:
   metadata:
     type: object
     description: The transaction's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminTransactionGroup.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminTransactionGroup.yaml
@@ -35,3 +35,6 @@ properties:
   metadata:
     type: object
     description: The transaction group's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateCustomerGroup.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateCustomerGroup.yaml
@@ -9,3 +9,6 @@ properties:
   metadata:
     type: object
     description: The customer group's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateDraftOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateDraftOrder.yaml
@@ -59,6 +59,9 @@ properties:
       metadata:
         type: object
         description: The shipping address's metadata, can hold custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   billing_address:
     type: object
     description: The draft order's billing address.
@@ -111,9 +114,15 @@ properties:
       metadata:
         type: object
         description: The billing address's metadata, can hold custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   metadata:
     type: object
     description: The draft order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   customer_id:
     type: string
     title: customer_id

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateDraftOrderActionShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateDraftOrderActionShippingMethod.yaml
@@ -25,3 +25,6 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateFulfillmentSetServiceZones.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateFulfillmentSetServiceZones.yaml
@@ -25,6 +25,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -49,6 +52,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -82,6 +88,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             city:
               type: string
               title: city
@@ -120,6 +129,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             city:
               type: string
               title: city

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateGiftCardParams.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateGiftCardParams.yaml
@@ -32,3 +32,6 @@ properties:
   metadata:
     type: object
     description: The gift card's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateInventoryItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateInventoryItem.yaml
@@ -58,4 +58,7 @@ properties:
   metadata:
     type: object
     description: The inventory item's metadata. Can be custom data in key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateInventoryItem

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateOrder.yaml
@@ -59,6 +59,9 @@ properties:
       metadata:
         type: object
         description: The address's metadata, can hold custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   billing_address:
     type: object
     description: The order's billing address.
@@ -111,6 +114,12 @@ properties:
       metadata:
         type: object
         description: The address's metadata, can hold custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProduct.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProduct.yaml
@@ -147,6 +147,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   external_id:
     type: string
     title: external_id

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProductCategory.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProductCategory.yaml
@@ -30,6 +30,9 @@ properties:
   metadata:
     type: object
     description: The product category's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   rank:
     type: number
     title: rank

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProductTag.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProductTag.yaml
@@ -8,4 +8,7 @@ properties:
   metadata:
     type: object
     description: The product tag's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateProductTag

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProductType.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProductType.yaml
@@ -8,4 +8,7 @@ properties:
   metadata:
     type: object
     description: The product type's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateProductType

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProductVariant.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateProductVariant.yaml
@@ -71,6 +71,9 @@ properties:
   metadata:
     type: object
     description: The product variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   prices:
     type: array
     description: The product variant's prices.

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateRegion.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateRegion.yaml
@@ -30,6 +30,9 @@ properties:
   metadata:
     type: object
     description: The region's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   is_tax_inclusive:
     type: boolean
     title: is_tax_inclusive

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateReservation.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateReservation.yaml
@@ -16,4 +16,7 @@ properties:
   metadata:
     type: object
     description: The reservation's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateReservation

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateReturnReason.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateReturnReason.yaml
@@ -17,6 +17,9 @@ properties:
   metadata:
     type: object
     description: The return reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 required:
   - value
   - label

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateSalesChannel.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateSalesChannel.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The sales channel's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateShippingProfile.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateShippingProfile.yaml
@@ -12,4 +12,7 @@ properties:
   metadata:
     type: object
     description: The shipping profile's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateShippingProfile

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateStockLocation.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateStockLocation.yaml
@@ -61,3 +61,6 @@ properties:
   metadata:
     type: object
     description: The stock location's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateStore.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateStore.yaml
@@ -43,3 +43,6 @@ properties:
   metadata:
     type: object
     description: The store's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateTaxRate.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateTaxRate.yaml
@@ -48,3 +48,6 @@ properties:
   metadata:
     type: object
     description: The tax rate's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateTaxRegion.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateTaxRegion.yaml
@@ -13,6 +13,9 @@ properties:
   metadata:
     type: object
     description: The tax region's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   provider_id:
     type: string
     title: provider_id

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateUser.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUpdateUser.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The user's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/AdminUser.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/AdminUser.yaml
@@ -36,6 +36,9 @@ properties:
   metadata:
     type: object
     description: The user's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseCart.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseCart.yaml
@@ -73,6 +73,9 @@ properties:
   metadata:
     type: object
     description: The cart's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseCartLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseCartLineItem.yaml
@@ -133,6 +133,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseCartShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseCartShippingMethod.yaml
@@ -57,6 +57,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseClaimItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseClaimItem.yaml
@@ -55,6 +55,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseCollection.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseCollection.yaml
@@ -45,3 +45,6 @@ properties:
   metadata:
     type: object
     description: The collection's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseExchangeItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseExchangeItem.yaml
@@ -33,6 +33,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseOrder.yaml
@@ -134,6 +134,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseOrderAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseOrderAddress.yaml
@@ -63,6 +63,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseOrderFulfillment.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseOrderFulfillment.yaml
@@ -63,6 +63,9 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseOrderLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseOrderLineItem.yaml
@@ -160,6 +160,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   original_total:
     type: number
     title: original_total

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseOrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseOrderShippingMethod.yaml
@@ -60,6 +60,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseOrderTransaction.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseOrderTransaction.yaml
@@ -46,6 +46,9 @@ properties:
   metadata:
     type: object
     description: The transaction's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BasePaymentCollection.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BasePaymentCollection.yaml
@@ -50,6 +50,9 @@ properties:
   metadata:
     type: object
     description: The payment collection's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   status:
     type: string
     description: The payment collection's status.

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseProduct.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseProduct.yaml
@@ -80,6 +80,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseProductCategory.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseProductCategory.yaml
@@ -43,6 +43,9 @@ properties:
   metadata:
     type: object
     description: The category's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseProductImage.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseProductImage.yaml
@@ -28,6 +28,9 @@ properties:
   metadata:
     type: object
     description: The image's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   rank:
     type: number
     title: rank

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseProductOption.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseProductOption.yaml
@@ -27,6 +27,9 @@ properties:
   metadata:
     type: object
     description: The product option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseProductOptionValue.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseProductOptionValue.yaml
@@ -22,6 +22,9 @@ properties:
   metadata:
     type: object
     description: The value's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseProductTag.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseProductTag.yaml
@@ -33,3 +33,6 @@ properties:
   metadata:
     type: object
     description: The tag's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseProductType.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseProductType.yaml
@@ -33,3 +33,6 @@ properties:
   metadata:
     type: object
     description: The type's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseProductVariant.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseProductVariant.yaml
@@ -130,3 +130,6 @@ properties:
   metadata:
     type: object
     description: The variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseRegion.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseRegion.yaml
@@ -35,6 +35,9 @@ properties:
   metadata:
     type: object
     description: The region's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/CreateAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/CreateAddress.yaml
@@ -54,3 +54,6 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/InventoryLevel.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/InventoryLevel.yaml
@@ -41,3 +41,6 @@ properties:
   metadata:
     type: object
     description: The inventory level's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/Order.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/Order.yaml
@@ -177,6 +177,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   canceled_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderAddress.yaml
@@ -62,6 +62,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderChange.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderChange.yaml
@@ -112,6 +112,9 @@ properties:
   metadata:
     type: object
     description: The order change's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   declined_at:
     type: string
     title: declined_at

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderClaim.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderClaim.yaml
@@ -64,6 +64,9 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderCreditLine.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderCreditLine.yaml
@@ -35,6 +35,9 @@ properties:
   metadata:
     type: object
     description: The credit line's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderExchange.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderExchange.yaml
@@ -59,6 +59,9 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderItem.yaml
@@ -62,6 +62,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderLineItem.yaml
@@ -141,6 +141,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   original_total:
     type: number
     title: original_total

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderReturnItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderReturnItem.yaml
@@ -37,6 +37,9 @@ properties:
   metadata:
     type: object
     description: The return item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   order_id:
     type: string
     title: order_id

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderShippingMethod.yaml
@@ -57,6 +57,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/admin/components/schemas/OrderTransaction.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/OrderTransaction.yaml
@@ -48,6 +48,9 @@ properties:
   metadata:
     type: object
     description: The transaction's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/RefundReason.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/RefundReason.yaml
@@ -23,6 +23,9 @@ properties:
   metadata:
     type: object
     description: The refund reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/Return.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/Return.yaml
@@ -47,6 +47,9 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreAddCartLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreAddCartLineItem.yaml
@@ -16,3 +16,6 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCart.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCart.yaml
@@ -78,6 +78,9 @@ properties:
   metadata:
     type: object
     description: The cart's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCartAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCartAddress.yaml
@@ -62,6 +62,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     title: created_at

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCartLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCartLineItem.yaml
@@ -277,6 +277,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     title: created_at

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCartShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCartShippingMethod.yaml
@@ -57,6 +57,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCollection.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCollection.yaml
@@ -45,3 +45,6 @@ properties:
   metadata:
     type: object
     description: The collection's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCreateCart.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCreateCart.yaml
@@ -39,3 +39,6 @@ properties:
   metadata:
     type: object
     description: The cart's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCreateCustomer.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCreateCustomer.yaml
@@ -28,3 +28,6 @@ properties:
   metadata:
     type: object
     description: The customer's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCustomer.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCustomer.yaml
@@ -52,6 +52,9 @@ properties:
   metadata:
     type: object
     description: The customer's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCustomerAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCustomerAddress.yaml
@@ -89,6 +89,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreOrder.yaml
@@ -125,6 +125,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreOrderAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreOrderAddress.yaml
@@ -65,6 +65,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreOrderFulfillment.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreOrderFulfillment.yaml
@@ -63,6 +63,9 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreOrderLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreOrderLineItem.yaml
@@ -349,6 +349,9 @@ properties:
                     metadata:
                       type: object
                       description: The variant's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                 variant_id:
                   type: string
                   title: variant_id
@@ -530,6 +533,9 @@ properties:
                     metadata:
                       type: object
                       description: The product's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                 product_id:
                   type: string
                   title: product_id
@@ -794,6 +800,9 @@ properties:
                     metadata:
                       type: object
                       description: The detail's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -817,6 +826,9 @@ properties:
                 metadata:
                   type: object
                   description: The item's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 original_total:
                   type: number
                   title: original_total
@@ -1016,6 +1028,9 @@ properties:
                     metadata:
                       type: object
                       description: The variant's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -1201,6 +1216,9 @@ properties:
                     metadata:
                       type: object
                       description: The product's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -1494,6 +1512,10 @@ properties:
                         metadata:
                           type: object
                           description: The detail's metadata.
+                          externalDocs:
+                            url: >-
+                              https://docs.medusajs.com/api/store#manage-metadata
+                            description: Learn how to manage metadata
                         created_at:
                           type: string
                           format: date-time
@@ -1524,6 +1546,9 @@ properties:
                 metadata:
                   type: object
                   description: The item's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 created_at:
                   type: string
                   format: date-time
@@ -1878,6 +1903,9 @@ properties:
                     metadata:
                       type: object
                       description: The variant's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                 variant_id:
                   type: string
                   title: variant_id
@@ -2059,6 +2087,9 @@ properties:
                     metadata:
                       type: object
                       description: The product's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                 product_id:
                   type: string
                   title: product_id
@@ -2323,6 +2354,9 @@ properties:
                     metadata:
                       type: object
                       description: The detail's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -2346,6 +2380,9 @@ properties:
                 metadata:
                   type: object
                   description: The item's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 original_total:
                   type: number
                   title: original_total
@@ -2541,6 +2578,9 @@ properties:
                     metadata:
                       type: object
                       description: The variant's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -2726,6 +2766,9 @@ properties:
                     metadata:
                       type: object
                       description: The product's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -3019,6 +3062,10 @@ properties:
                         metadata:
                           type: object
                           description: The detail's metadata.
+                          externalDocs:
+                            url: >-
+                              https://docs.medusajs.com/api/store#manage-metadata
+                            description: Learn how to manage metadata
                         created_at:
                           type: string
                           format: date-time
@@ -3049,6 +3096,9 @@ properties:
                 metadata:
                   type: object
                   description: The item's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 created_at:
                   type: string
                   format: date-time
@@ -3295,6 +3345,9 @@ properties:
                   metadata:
                     type: object
                     description: The variant's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/store#manage-metadata
+                      description: Learn how to manage metadata
                   created_at:
                     type: string
                     format: date-time
@@ -3480,6 +3533,9 @@ properties:
                   metadata:
                     type: object
                     description: The product's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/store#manage-metadata
+                      description: Learn how to manage metadata
                   created_at:
                     type: string
                     format: date-time
@@ -3773,6 +3829,9 @@ properties:
                       metadata:
                         type: object
                         description: The detail's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       created_at:
                         type: string
                         format: date-time
@@ -3803,6 +3862,9 @@ properties:
               metadata:
                 type: object
                 description: The item's metadata.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/store#manage-metadata
+                  description: Learn how to manage metadata
               created_at:
                 type: string
                 format: date-time
@@ -3958,6 +4020,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   original_total:
     type: number
     title: original_total

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreOrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreOrderShippingMethod.yaml
@@ -60,6 +60,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.
@@ -137,6 +140,9 @@ properties:
                 metadata:
                   type: object
                   description: The shipping method's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 tax_lines:
                   type: array
                   description: The shipping method's tax lines.
@@ -668,6 +674,9 @@ properties:
                 metadata:
                   type: object
                   description: The shipping method's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 original_total:
                   type: number
                   title: original_total
@@ -786,6 +795,9 @@ properties:
                 metadata:
                   type: object
                   description: The shipping method's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 tax_lines:
                   type: array
                   description: The shipping method's tax lines.
@@ -1313,6 +1325,9 @@ properties:
                 metadata:
                   type: object
                   description: The shipping method's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 original_total:
                   type: number
                   title: original_total
@@ -1669,6 +1684,9 @@ properties:
               metadata:
                 type: object
                 description: The shipping method's metadata.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/store#manage-metadata
+                  description: Learn how to manage metadata
               original_total:
                 type: number
                 title: original_total

--- a/www/apps/api-reference/specs/admin/components/schemas/StorePaymentCollection.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StorePaymentCollection.yaml
@@ -50,6 +50,9 @@ properties:
   metadata:
     type: object
     description: The payment collection's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   status:
     type: string
     description: The payment collection's status.

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProduct.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProduct.yaml
@@ -68,6 +68,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProductCategory.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProductCategory.yaml
@@ -48,6 +48,9 @@ properties:
   metadata:
     type: object
     description: The category's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProductImage.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProductImage.yaml
@@ -32,6 +32,9 @@ properties:
   metadata:
     type: object
     description: The image's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   rank:
     type: number
     title: rank

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProductOption.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProductOption.yaml
@@ -24,6 +24,9 @@ properties:
   metadata:
     type: object
     description: The option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProductOptionValue.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProductOptionValue.yaml
@@ -22,6 +22,9 @@ properties:
   metadata:
     type: object
     description: The value's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProductTag.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProductTag.yaml
@@ -28,6 +28,9 @@ properties:
   metadata:
     type: object
     description: The tag's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
 required:
   - id
   - value

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProductType.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProductType.yaml
@@ -14,6 +14,9 @@ properties:
   metadata:
     type: object
     description: The product type's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProductVariant.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProductVariant.yaml
@@ -20,6 +20,9 @@ properties:
   metadata:
     type: object
     description: The variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   id:
     type: string
     title: id

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreRegion.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreRegion.yaml
@@ -38,6 +38,9 @@ properties:
   metadata:
     type: object
     description: The region's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreReturnItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreReturnItem.yaml
@@ -44,3 +44,6 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreReturnReason.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreReturnReason.yaml
@@ -27,6 +27,9 @@ properties:
   metadata:
     type: object
     description: The return reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreShippingOption.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreShippingOption.yaml
@@ -70,3 +70,6 @@ properties:
   metadata:
     type: object
     description: The shipping option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreStoreCreditAccount.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreStoreCreditAccount.yaml
@@ -49,6 +49,9 @@ properties:
   metadata:
     type: object
     description: The store credit account's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreTransactionGroup.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreTransactionGroup.yaml
@@ -34,4 +34,7 @@ properties:
   metadata:
     type: object
     description: The transaction group's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: StoreTransactionGroup

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreUpdateCartLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreUpdateCartLineItem.yaml
@@ -11,3 +11,6 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreUpdateCustomer.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreUpdateCustomer.yaml
@@ -21,3 +21,6 @@ properties:
   metadata:
     type: object
     description: The customer's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/UpdateAddress.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/UpdateAddress.yaml
@@ -60,3 +60,6 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/components/schemas/UpdateCartData.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/UpdateCartData.yaml
@@ -47,3 +47,6 @@ properties:
   metadata:
     type: object
     description: The cart's metadata, ca hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -54200,6 +54200,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminAddDraftOrderPromotions:
       type: object
       description: The details of the promotions to add to a draft order.
@@ -54240,6 +54243,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminApiKey:
       type: object
       description: The API key's details.
@@ -54830,6 +54836,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         external_id:
           type: string
           title: external_id
@@ -54916,6 +54925,9 @@ components:
         metadata:
           type: object
           description: The product variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         prices:
           type: array
           description: The product variant's prices.
@@ -55103,6 +55115,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -55301,6 +55316,9 @@ components:
         metadata:
           type: object
           description: The collection's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCollectionDeleteResponse:
       type: object
       description: The details of the deleted collection.
@@ -55396,6 +55414,9 @@ components:
         metadata:
           type: object
           description: The customer group's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateFulfillment:
       type: object
       description: The filfillment's details.
@@ -55469,6 +55490,9 @@ components:
             metadata:
               type: object
               description: The delivery address's metadata, used to store custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         items:
           type: array
           description: The items to fulfill.
@@ -55565,6 +55589,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateFulfillmentSetServiceZones:
       type: object
       description: The service zone's details.
@@ -55590,6 +55617,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -55610,6 +55640,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -55639,6 +55672,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -55673,6 +55709,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -55750,6 +55789,9 @@ components:
         metadata:
           type: object
           description: The gift card's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateInventoryItem:
       type: object
       description: The inventory item's details.
@@ -55810,6 +55852,9 @@ components:
         metadata:
           type: object
           description: The inventory item's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateInventoryLocationLevel:
       type: object
       description: The inventory level's details.
@@ -55856,6 +55901,9 @@ components:
         metadata:
           type: object
           description: The credit line's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreatePaymentCapture:
       type: object
       description: The payment's details.
@@ -56145,6 +56193,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         external_id:
           type: string
           title: external_id
@@ -56191,6 +56242,9 @@ components:
         metadata:
           type: object
           description: The product category's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateProductOption:
       type: object
       description: The product option's details.
@@ -56224,6 +56278,9 @@ components:
         metadata:
           type: object
           description: The product tag's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateProductType:
       type: object
       description: The details of the product type to create.
@@ -56234,6 +56291,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         value:
           type: string
           title: value
@@ -56313,6 +56373,9 @@ components:
         metadata:
           type: object
           description: The variant's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         prices:
           type: array
           description: The variant's prices.
@@ -56480,6 +56543,9 @@ components:
         metadata:
           type: object
           description: The region's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateReservation:
       type: object
       description: The reservation's details.
@@ -56512,6 +56578,9 @@ components:
         metadata:
           type: object
           description: The reservation's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateReturnReason:
       type: object
       description: The details of the return reason to create.
@@ -56539,6 +56608,9 @@ components:
         metadata:
           type: object
           description: The return reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateSalesChannel:
       type: object
       description: The sales channel's details.
@@ -56561,6 +56633,9 @@ components:
         metadata:
           type: object
           description: The sales channel's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateShipment:
       type: object
       description: The shipment's details.
@@ -56753,6 +56828,9 @@ components:
         metadata:
           type: object
           description: The shipping profile's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateStockLocation:
       type: object
       description: The stock location's details.
@@ -56773,6 +56851,9 @@ components:
         metadata:
           type: object
           description: The stock location's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateStockLocationFulfillmentSet:
       type: object
       description: The fulfillment set to create.
@@ -56809,6 +56890,9 @@ components:
         metadata:
           type: object
           description: The store credit account's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateTaxRate:
       type: object
       description: The tax rate's details.
@@ -56854,6 +56938,9 @@ components:
         metadata:
           type: object
           description: The tax rate's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateTaxRateRule:
       type: object
       description: The tax rate rule's details.
@@ -56925,9 +57012,15 @@ components:
             metadata:
               type: object
               description: The default tax rate's metadata, used to store custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         metadata:
           type: object
           description: The tax region's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         provider_id:
           type: string
           title: provider_id
@@ -57148,6 +57241,9 @@ components:
         metadata:
           type: object
           description: The customer's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_by:
           type: string
           title: created_by
@@ -57259,6 +57355,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -57306,6 +57405,9 @@ components:
         metadata:
           type: object
           description: The customer group's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -58057,6 +58159,9 @@ components:
         metadata:
           type: object
           description: The draft order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -58413,6 +58518,9 @@ components:
                   metadata:
                     type: object
                     description: The item's metadata, can hold custom key-value pairs.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   original_total:
                     type: number
                     title: original_total
@@ -58539,6 +58647,9 @@ components:
                   metadata:
                     type: object
                     description: The shipping method's metadata, can hold custom key-value pairs.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   tax_lines:
                     type: array
                     description: The shipping method's tax lines.
@@ -58716,6 +58827,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -58916,6 +59030,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -59157,6 +59274,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -59249,6 +59369,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -59954,6 +60077,9 @@ components:
         metadata:
           type: object
           description: The location level's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         inventory_item:
           type: object
         available_quantity:
@@ -59998,6 +60124,9 @@ components:
         metadata:
           type: object
           description: The invite's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -60308,6 +60437,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -60489,6 +60621,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -60612,6 +60747,9 @@ components:
         metadata:
           type: object
           description: The order change's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         declined_at:
           type: string
           title: declined_at
@@ -60830,6 +60968,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -61053,6 +61194,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         original_total:
           type: number
           title: original_total
@@ -61324,6 +61468,9 @@ components:
                   metadata:
                     type: object
                     description: The item's metadata, can hold custom key-value pairs.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   original_total:
                     type: number
                     title: original_total
@@ -61450,6 +61597,9 @@ components:
                   metadata:
                     type: object
                     description: The shipping method's metadata, can hold custom key-value pairs.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   tax_lines:
                     type: array
                     description: The shipping method's tax lines.
@@ -61627,6 +61777,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -61834,6 +61987,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -62018,6 +62174,9 @@ components:
         metadata:
           type: object
           description: The payment collection's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         status:
           type: string
           description: The payment collection's status.
@@ -62258,6 +62417,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminPostClaimsItemsActionReqSchema:
       type: object
       description: The details to update in the item.
@@ -62291,6 +62453,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostClaimsShippingReqSchema:
       type: object
       description: The details of the shipping method used to ship outbound items.
@@ -62317,6 +62482,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostExchangesAddItemsReqSchema:
       type: object
       description: The details of outbound items.
@@ -62355,6 +62523,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminPostExchangesItemsActionReqSchema:
       type: object
       description: The details to update in an outbound item.
@@ -62388,6 +62559,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostExchangesReturnRequestItemsReqSchema:
       type: object
       description: The details of the inbound (return) items.
@@ -62426,6 +62600,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminPostExchangesShippingActionReqSchema:
       type: object
       description: The details of the shipping method to update.
@@ -62442,6 +62619,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostExchangesShippingReqSchema:
       type: object
       description: The outbound shipping method's details.
@@ -62468,6 +62648,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderClaimsReqSchema:
       type: object
       description: The claim's details.
@@ -62501,6 +62684,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderEditsAddItemsReqSchema:
       type: object
       description: The details of items to be edited.
@@ -62539,6 +62725,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
               compare_at_unit_price:
                 type: number
                 title: compare_at_unit_price
@@ -62586,6 +62775,9 @@ components:
         metadata:
           type: object
           description: The order edit's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderEditsShippingActionReqSchema:
       type: object
       description: The shipping method's details.
@@ -62602,6 +62794,9 @@ components:
         metadata:
           type: object
           description: The order edit's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderEditsShippingReqSchema:
       type: object
       description: The shipping method's details.
@@ -62628,6 +62823,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderEditsUpdateItemQuantityReqSchema:
       type: object
       description: The order item's details to update.
@@ -62673,6 +62871,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReceiveReturnsReqSchema:
       type: object
       description: The return receival details.
@@ -62689,6 +62890,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsConfirmRequestReqSchema:
       type: object
       description: The confirmation's details.
@@ -62785,6 +62989,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsRequestItemsActionReqSchema:
       type: object
       description: The details to update in the item.
@@ -62805,6 +63012,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsRequestItemsReqSchema:
       type: object
       description: The items' details.
@@ -62843,6 +63053,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminPostReturnsReturnReqSchema:
       type: object
       description: The return's details.
@@ -62859,6 +63072,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsShippingActionReqSchema:
       type: object
       description: The shipping method's details.
@@ -62875,6 +63091,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsShippingReqSchema:
       type: object
       description: The shipping method's details.
@@ -62901,6 +63120,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPrice:
       type: object
       description: The price's details.
@@ -63415,6 +63637,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -63543,6 +63768,9 @@ components:
         metadata:
           type: object
           description: The category's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -63694,6 +63922,9 @@ components:
         metadata:
           type: object
           description: The image's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         rank:
           type: number
           title: rank
@@ -63732,6 +63963,9 @@ components:
         metadata:
           type: object
           description: The product option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -63805,6 +64039,9 @@ components:
         metadata:
           type: object
           description: The value's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -63865,6 +64102,9 @@ components:
         metadata:
           type: object
           description: The tag's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminProductTagDeleteResponse:
       type: object
       description: The details of the product tag deletion.
@@ -63964,6 +64204,9 @@ components:
         metadata:
           type: object
           description: The type's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminProductTypeDeleteResponse:
       type: object
       description: The details of the product type deletion.
@@ -64162,6 +64405,9 @@ components:
         metadata:
           type: object
           description: The variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         inventory_items:
           type: array
           description: The variant's inventory items.
@@ -64576,6 +64822,9 @@ components:
         metadata:
           type: object
           description: The refund reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -64625,6 +64874,9 @@ components:
         metadata:
           type: object
           description: The region's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -64738,6 +64990,9 @@ components:
         metadata:
           type: object
           description: The reservation's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_by:
           type: string
           title: created_by
@@ -64890,6 +65145,9 @@ components:
         metadata:
           type: object
           description: The return item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminReturnPreviewResponse:
       type: object
       description: The details of a return and a preview of the order once the return is applied.
@@ -64932,6 +65190,9 @@ components:
         metadata:
           type: object
           description: The return reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -65104,6 +65365,9 @@ components:
         metadata:
           type: object
           description: The sales channel's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -65317,6 +65581,9 @@ components:
         metadata:
           type: object
           description: The shipping option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -65641,6 +65908,9 @@ components:
         metadata:
           type: object
           description: The shipping profile's metadata, holds custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -65895,6 +66165,9 @@ components:
         metadata:
           type: object
           description: The store's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -65957,6 +66230,9 @@ components:
         metadata:
           type: object
           description: The store credit account's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -66154,6 +66430,9 @@ components:
         metadata:
           type: object
           description: The tax rate's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         tax_region_id:
           type: string
           title: tax_region_id
@@ -66281,6 +66560,9 @@ components:
         metadata:
           type: object
           description: The tax region's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         parent_id:
           type: string
           title: parent_id
@@ -66401,6 +66683,9 @@ components:
         metadata:
           type: object
           description: The transaction's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -66449,6 +66734,9 @@ components:
         metadata:
           type: object
           description: The transaction group's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminTransactionGroupsResponse:
       type: object
       description: The paginated list of transaction groups.
@@ -66555,6 +66843,9 @@ components:
         metadata:
           type: object
           description: The customer group's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateDraftOrder:
       type: object
       description: The data to update in the draft order.
@@ -66617,6 +66908,9 @@ components:
             metadata:
               type: object
               description: The shipping address's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         billing_address:
           type: object
           description: The draft order's billing address.
@@ -66669,9 +66963,15 @@ components:
             metadata:
               type: object
               description: The billing address's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         metadata:
           type: object
           description: The draft order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         customer_id:
           type: string
           title: customer_id
@@ -66706,6 +67006,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateDraftOrderItem:
       type: object
       description: The updates to make on a draft order's item.
@@ -66774,6 +67077,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -66798,6 +67104,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -66831,6 +67140,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   city:
                     type: string
                     title: city
@@ -66869,6 +67181,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   city:
                     type: string
                     title: city
@@ -66928,6 +67243,9 @@ components:
         metadata:
           type: object
           description: The gift card's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateInventoryItem:
       type: object
       description: The properties to update in the inventory item.
@@ -66987,6 +67305,9 @@ components:
         metadata:
           type: object
           description: The inventory item's metadata. Can be custom data in key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateInventoryItem
     AdminUpdateInventoryLocationLevel:
       type: object
@@ -67063,6 +67384,9 @@ components:
             metadata:
               type: object
               description: The address's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         billing_address:
           type: object
           description: The order's billing address.
@@ -67115,9 +67439,15 @@ components:
             metadata:
               type: object
               description: The address's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdatePaymentRefundReason:
       type: object
       description: The properties to update in the refund reason.
@@ -67337,6 +67667,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         external_id:
           type: string
           title: external_id
@@ -67372,6 +67705,9 @@ components:
         metadata:
           type: object
           description: The product category's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         rank:
           type: number
           title: rank
@@ -67404,6 +67740,9 @@ components:
         metadata:
           type: object
           description: The product tag's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateProductTag
     AdminUpdateProductType:
       type: object
@@ -67416,6 +67755,9 @@ components:
         metadata:
           type: object
           description: The product type's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateProductType
     AdminUpdateProductVariant:
       type: object
@@ -67489,6 +67831,9 @@ components:
         metadata:
           type: object
           description: The product variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         prices:
           type: array
           description: The product variant's prices.
@@ -67575,6 +67920,9 @@ components:
         metadata:
           type: object
           description: The region's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         is_tax_inclusive:
           type: boolean
           title: is_tax_inclusive
@@ -67599,6 +67947,9 @@ components:
         metadata:
           type: object
           description: The reservation's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateReservation
     AdminUpdateReturnReason:
       type: object
@@ -67620,6 +67971,9 @@ components:
         metadata:
           type: object
           description: The return reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       required:
         - value
         - label
@@ -67643,6 +67997,9 @@ components:
         metadata:
           type: object
           description: The sales channel's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateShippingOption:
       type: object
       description: The properties to update in the shipping option.
@@ -67870,6 +68227,9 @@ components:
         metadata:
           type: object
           description: The shipping profile's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateShippingProfile
     AdminUpdateStockLocation:
       type: object
@@ -67931,6 +68291,9 @@ components:
         metadata:
           type: object
           description: The stock location's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateStore:
       type: object
       description: The properties to update in a store.
@@ -67977,6 +68340,9 @@ components:
         metadata:
           type: object
           description: The store's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateTaxRate:
       type: object
       description: The properties to update in the tax rate.
@@ -68027,6 +68393,9 @@ components:
         metadata:
           type: object
           description: The tax rate's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateTaxRegion:
       type: object
       description: The details to update in a tax region.
@@ -68043,6 +68412,9 @@ components:
         metadata:
           type: object
           description: The tax region's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         provider_id:
           type: string
           title: provider_id
@@ -68067,6 +68439,9 @@ components:
         metadata:
           type: object
           description: The user's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateVariantInventoryItem:
       type: object
       description: The properties to update of the variant's inventory item association.
@@ -68228,6 +68603,9 @@ components:
         metadata:
           type: object
           description: The user's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -68796,6 +69174,9 @@ components:
         metadata:
           type: object
           description: The cart's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -69034,6 +69415,9 @@ components:
         metadata:
           type: object
           description: The item's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -69150,6 +69534,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -69260,6 +69647,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -69318,6 +69708,9 @@ components:
         metadata:
           type: object
           description: The collection's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     BaseExchangeItem:
       type: object
       description: The item's details.
@@ -69354,6 +69747,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -69637,6 +70033,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -69809,6 +70208,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -69882,6 +70284,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -70135,6 +70540,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         original_total:
           type: number
           title: original_total
@@ -70414,6 +70822,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -70675,6 +71086,9 @@ components:
         metadata:
           type: object
           description: The transaction's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -70815,6 +71229,9 @@ components:
         metadata:
           type: object
           description: The payment collection's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         status:
           type: string
           description: The payment collection's status.
@@ -70994,6 +71411,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -71120,6 +71540,9 @@ components:
         metadata:
           type: object
           description: The category's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -71186,6 +71609,9 @@ components:
         metadata:
           type: object
           description: The image's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         rank:
           type: number
           title: rank
@@ -71224,6 +71650,9 @@ components:
         metadata:
           type: object
           description: The product option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -71264,6 +71693,9 @@ components:
         metadata:
           type: object
           description: The value's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -71315,6 +71747,9 @@ components:
         metadata:
           type: object
           description: The tag's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     BaseProductType:
       type: object
       description: The product type's details.
@@ -71351,6 +71786,9 @@ components:
         metadata:
           type: object
           description: The type's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     BaseProductVariant:
       type: object
       description: The product variant's details.
@@ -71480,6 +71918,9 @@ components:
         metadata:
           type: object
           description: The variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     BasePromotionRuleValue:
       type: object
       description: The rule value's details.
@@ -71572,6 +72013,9 @@ components:
         metadata:
           type: object
           description: The region's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -71890,6 +72334,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     CustomerGroupInCustomerFilters:
       type: object
       description: Filter by customer groups to get their associated customers.
@@ -72346,6 +72793,9 @@ components:
         metadata:
           type: object
           description: The inventory level's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     Order:
       type: object
       description: The order change's order.
@@ -72524,6 +72974,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         canceled_at:
           type: string
           format: date-time
@@ -72718,6 +73171,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -72841,6 +73297,9 @@ components:
         metadata:
           type: object
           description: The order change's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         declined_at:
           type: string
           title: declined_at
@@ -73032,6 +73491,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -73118,6 +73580,9 @@ components:
         metadata:
           type: object
           description: The credit line's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -73190,6 +73655,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -73303,6 +73771,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -73457,6 +73928,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         original_total:
           type: number
           title: original_total
@@ -73675,6 +74149,9 @@ components:
         metadata:
           type: object
           description: The return item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         order_id:
           type: string
           title: order_id
@@ -73750,6 +74227,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -73970,6 +74450,9 @@ components:
         metadata:
           type: object
           description: The transaction's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -74012,6 +74495,9 @@ components:
         metadata:
           type: object
           description: The refund reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -74081,6 +74567,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -74185,6 +74674,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreAddCartShippingMethods:
       type: object
       description: The shipping method's details.
@@ -74426,6 +74918,9 @@ components:
         metadata:
           type: object
           description: The cart's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -74608,6 +75103,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           title: created_at
@@ -74898,6 +75396,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           title: created_at
@@ -75078,6 +75579,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -75421,6 +75925,9 @@ components:
         metadata:
           type: object
           description: The collection's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreCollectionResponse:
       type: object
       description: The collection's details.
@@ -75465,6 +75972,9 @@ components:
         metadata:
           type: object
           description: The cart's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreCreateCustomer:
       type: object
       description: The details of the customer to create.
@@ -75496,6 +76006,9 @@ components:
         metadata:
           type: object
           description: The customer's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreCreateCustomerAddress:
       type: object
       description: The address's details.
@@ -75793,6 +76306,9 @@ components:
         metadata:
           type: object
           description: The customer's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -75900,6 +76416,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -76204,6 +76723,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -76385,6 +76907,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -76458,6 +76983,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -76824,6 +77352,9 @@ components:
                           metadata:
                             type: object
                             description: The variant's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                       variant_id:
                         type: string
                         title: variant_id
@@ -77005,6 +77536,9 @@ components:
                           metadata:
                             type: object
                             description: The product's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                       product_id:
                         type: string
                         title: product_id
@@ -77269,6 +77803,9 @@ components:
                           metadata:
                             type: object
                             description: The detail's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -77292,6 +77829,9 @@ components:
                       metadata:
                         type: object
                         description: The item's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       original_total:
                         type: number
                         title: original_total
@@ -77491,6 +78031,9 @@ components:
                           metadata:
                             type: object
                             description: The variant's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -77676,6 +78219,9 @@ components:
                           metadata:
                             type: object
                             description: The product's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -77969,6 +78515,9 @@ components:
                               metadata:
                                 type: object
                                 description: The detail's metadata.
+                                externalDocs:
+                                  url: https://docs.medusajs.com/api/store#manage-metadata
+                                  description: Learn how to manage metadata
                               created_at:
                                 type: string
                                 format: date-time
@@ -77999,6 +78548,9 @@ components:
                       metadata:
                         type: object
                         description: The item's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       created_at:
                         type: string
                         format: date-time
@@ -78353,6 +78905,9 @@ components:
                           metadata:
                             type: object
                             description: The variant's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                       variant_id:
                         type: string
                         title: variant_id
@@ -78534,6 +79089,9 @@ components:
                           metadata:
                             type: object
                             description: The product's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                       product_id:
                         type: string
                         title: product_id
@@ -78798,6 +79356,9 @@ components:
                           metadata:
                             type: object
                             description: The detail's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -78821,6 +79382,9 @@ components:
                       metadata:
                         type: object
                         description: The item's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       original_total:
                         type: number
                         title: original_total
@@ -79016,6 +79580,9 @@ components:
                           metadata:
                             type: object
                             description: The variant's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -79201,6 +79768,9 @@ components:
                           metadata:
                             type: object
                             description: The product's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -79494,6 +80064,9 @@ components:
                               metadata:
                                 type: object
                                 description: The detail's metadata.
+                                externalDocs:
+                                  url: https://docs.medusajs.com/api/store#manage-metadata
+                                  description: Learn how to manage metadata
                               created_at:
                                 type: string
                                 format: date-time
@@ -79524,6 +80097,9 @@ components:
                       metadata:
                         type: object
                         description: The item's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       created_at:
                         type: string
                         format: date-time
@@ -79770,6 +80346,9 @@ components:
                         metadata:
                           type: object
                           description: The variant's metadata.
+                          externalDocs:
+                            url: https://docs.medusajs.com/api/store#manage-metadata
+                            description: Learn how to manage metadata
                         created_at:
                           type: string
                           format: date-time
@@ -79955,6 +80534,9 @@ components:
                         metadata:
                           type: object
                           description: The product's metadata.
+                          externalDocs:
+                            url: https://docs.medusajs.com/api/store#manage-metadata
+                            description: Learn how to manage metadata
                         created_at:
                           type: string
                           format: date-time
@@ -80248,6 +80830,9 @@ components:
                             metadata:
                               type: object
                               description: The detail's metadata.
+                              externalDocs:
+                                url: https://docs.medusajs.com/api/store#manage-metadata
+                                description: Learn how to manage metadata
                             created_at:
                               type: string
                               format: date-time
@@ -80278,6 +80863,9 @@ components:
                     metadata:
                       type: object
                       description: The item's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -80433,6 +81021,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         original_total:
           type: number
           title: original_total
@@ -80558,6 +81149,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -80635,6 +81229,9 @@ components:
                       metadata:
                         type: object
                         description: The shipping method's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       tax_lines:
                         type: array
                         description: The shipping method's tax lines.
@@ -81166,6 +81763,9 @@ components:
                       metadata:
                         type: object
                         description: The shipping method's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       original_total:
                         type: number
                         title: original_total
@@ -81284,6 +81884,9 @@ components:
                       metadata:
                         type: object
                         description: The shipping method's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       tax_lines:
                         type: array
                         description: The shipping method's tax lines.
@@ -81811,6 +82414,9 @@ components:
                       metadata:
                         type: object
                         description: The shipping method's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       original_total:
                         type: number
                         title: original_total
@@ -82167,6 +82773,9 @@ components:
                     metadata:
                       type: object
                       description: The shipping method's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     original_total:
                       type: number
                       title: original_total
@@ -82263,6 +82872,9 @@ components:
         metadata:
           type: object
           description: The payment collection's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         status:
           type: string
           description: The payment collection's status.
@@ -82505,6 +83117,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -82648,6 +83263,9 @@ components:
         metadata:
           type: object
           description: The category's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -82744,6 +83362,9 @@ components:
         metadata:
           type: object
           description: The image's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         rank:
           type: number
           title: rank
@@ -82775,6 +83396,9 @@ components:
         metadata:
           type: object
           description: The option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -82818,6 +83442,9 @@ components:
         metadata:
           type: object
           description: The value's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -82873,6 +83500,9 @@ components:
         metadata:
           type: object
           description: The tag's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
       required:
         - id
         - value
@@ -82936,6 +83566,9 @@ components:
         metadata:
           type: object
           description: The product type's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -83019,6 +83652,9 @@ components:
         metadata:
           type: object
           description: The variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         id:
           type: string
           title: id
@@ -83170,6 +83806,9 @@ components:
         metadata:
           type: object
           description: The region's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -83349,6 +83988,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreReturnReason:
       type: object
       description: The return reason's details.
@@ -83379,6 +84021,9 @@ components:
         metadata:
           type: object
           description: The return reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -83476,6 +84121,9 @@ components:
         metadata:
           type: object
           description: The shipping option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreShippingOptionListResponse:
       type: object
       description: The shipping option's details.
@@ -83598,6 +84246,9 @@ components:
         metadata:
           type: object
           description: The store credit account's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -83686,6 +84337,9 @@ components:
         metadata:
           type: object
           description: The transaction group's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: StoreTransactionGroup
     StoreUpdateCartLineItem:
       type: object
@@ -83701,6 +84355,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreUpdateCustomer:
       type: object
       description: The details to update in the customer.
@@ -83725,6 +84382,9 @@ components:
         metadata:
           type: object
           description: The customer's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreUpdateCustomerAddress:
       type: object
       description: The properties to update in the address.
@@ -83852,6 +84512,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     UpdateCartData:
       type: object
       description: The details to update in a cart.
@@ -83898,6 +84561,9 @@ components:
         metadata:
           type: object
           description: The cart's metadata, ca hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     WorkflowExecutionContext:
       type: object
       description: The workflow execution's context.

--- a/www/apps/api-reference/specs/store/components/schemas/AdminAddDraftOrderItems.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminAddDraftOrderItems.yaml
@@ -42,3 +42,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminAddDraftOrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminAddDraftOrderShippingMethod.yaml
@@ -25,3 +25,6 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminBatchUpdateProduct.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminBatchUpdateProduct.yaml
@@ -147,6 +147,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   external_id:
     type: string
     title: external_id

--- a/www/apps/api-reference/specs/store/components/schemas/AdminBatchUpdateProductVariant.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminBatchUpdateProductVariant.yaml
@@ -71,6 +71,9 @@ properties:
   metadata:
     type: object
     description: The product variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   prices:
     type: array
     description: The product variant's prices.

--- a/www/apps/api-reference/specs/store/components/schemas/AdminClaim.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminClaim.yaml
@@ -68,6 +68,9 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCollection.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCollection.yaml
@@ -45,3 +45,6 @@ properties:
   metadata:
     type: object
     description: The collection's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateCustomerGroup.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateCustomerGroup.yaml
@@ -11,3 +11,6 @@ properties:
   metadata:
     type: object
     description: The customer group's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateFulfillment.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateFulfillment.yaml
@@ -70,6 +70,9 @@ properties:
       metadata:
         type: object
         description: The delivery address's metadata, used to store custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   items:
     type: array
     description: The items to fulfill.
@@ -167,3 +170,6 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateFulfillmentSetServiceZones.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateFulfillmentSetServiceZones.yaml
@@ -22,6 +22,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -42,6 +45,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -71,6 +77,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -105,6 +114,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateGiftCardParams.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateGiftCardParams.yaml
@@ -49,3 +49,6 @@ properties:
   metadata:
     type: object
     description: The gift card's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateInventoryItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateInventoryItem.yaml
@@ -57,3 +57,6 @@ properties:
   metadata:
     type: object
     description: The inventory item's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateOrderCreditLines.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateOrderCreditLines.yaml
@@ -24,3 +24,6 @@ properties:
   metadata:
     type: object
     description: The credit line's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateProduct.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateProduct.yaml
@@ -146,6 +146,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   external_id:
     type: string
     title: external_id

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateProductCategory.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateProductCategory.yaml
@@ -35,3 +35,6 @@ properties:
   metadata:
     type: object
     description: The product category's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateProductTag.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateProductTag.yaml
@@ -11,3 +11,6 @@ properties:
   metadata:
     type: object
     description: The product tag's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateProductType.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateProductType.yaml
@@ -7,6 +7,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   value:
     type: string
     title: value

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateProductVariant.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateProductVariant.yaml
@@ -74,6 +74,9 @@ properties:
   metadata:
     type: object
     description: The variant's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   prices:
     type: array
     description: The variant's prices.

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateRegion.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateRegion.yaml
@@ -41,3 +41,6 @@ properties:
   metadata:
     type: object
     description: The region's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateReservation.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateReservation.yaml
@@ -29,3 +29,6 @@ properties:
   metadata:
     type: object
     description: The reservation's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateReturnReason.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateReturnReason.yaml
@@ -24,3 +24,6 @@ properties:
   metadata:
     type: object
     description: The return reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateSalesChannel.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateSalesChannel.yaml
@@ -19,3 +19,6 @@ properties:
   metadata:
     type: object
     description: The sales channel's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateShippingProfile.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateShippingProfile.yaml
@@ -16,3 +16,6 @@ properties:
   metadata:
     type: object
     description: The shipping profile's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateStockLocation.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateStockLocation.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The stock location's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateStoreCreditAccount.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateStoreCreditAccount.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The store credit account's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateTaxRate.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateTaxRate.yaml
@@ -43,3 +43,6 @@ properties:
   metadata:
     type: object
     description: The tax rate's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCreateTaxRegion.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCreateTaxRegion.yaml
@@ -51,9 +51,15 @@ properties:
       metadata:
         type: object
         description: The default tax rate's metadata, used to store custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   metadata:
     type: object
     description: The tax region's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   provider_id:
     type: string
     title: provider_id

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCustomer.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCustomer.yaml
@@ -62,6 +62,9 @@ properties:
   metadata:
     type: object
     description: The customer's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_by:
     type: string
     title: created_by

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCustomerAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCustomerAddress.yaml
@@ -89,6 +89,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminCustomerGroup.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminCustomerGroup.yaml
@@ -25,6 +25,9 @@ properties:
   metadata:
     type: object
     description: The customer group's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminDraftOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminDraftOrder.yaml
@@ -144,6 +144,9 @@ properties:
   metadata:
     type: object
     description: The draft order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminDraftOrderPreview.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminDraftOrderPreview.yaml
@@ -215,6 +215,9 @@ properties:
             metadata:
               type: object
               description: The item's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             original_total:
               type: number
               title: original_total
@@ -352,6 +355,9 @@ properties:
             metadata:
               type: object
               description: The shipping method's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             tax_lines:
               type: array
               description: The shipping method's tax lines.
@@ -541,6 +547,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminExchange.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminExchange.yaml
@@ -66,6 +66,9 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminFulfillment.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminFulfillment.yaml
@@ -77,6 +77,9 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminFulfillmentAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminFulfillmentAddress.yaml
@@ -74,6 +74,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminInventoryLevel.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminInventoryLevel.yaml
@@ -56,6 +56,9 @@ properties:
   metadata:
     type: object
     description: The location level's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   inventory_item:
     type: object
   available_quantity:

--- a/www/apps/api-reference/specs/store/components/schemas/AdminInvite.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminInvite.yaml
@@ -35,6 +35,9 @@ properties:
   metadata:
     type: object
     description: The invite's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminOrder.yaml
@@ -139,6 +139,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminOrderAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminOrderAddress.yaml
@@ -65,6 +65,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminOrderChange.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminOrderChange.yaml
@@ -112,6 +112,9 @@ properties:
   metadata:
     type: object
     description: The order change's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   declined_at:
     type: string
     title: declined_at

--- a/www/apps/api-reference/specs/store/components/schemas/AdminOrderFulfillment.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminOrderFulfillment.yaml
@@ -63,6 +63,9 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminOrderLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminOrderLineItem.yaml
@@ -160,6 +160,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   original_total:
     type: number
     title: original_total

--- a/www/apps/api-reference/specs/store/components/schemas/AdminOrderPreview.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminOrderPreview.yaml
@@ -217,6 +217,9 @@ properties:
             metadata:
               type: object
               description: The item's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             original_total:
               type: number
               title: original_total
@@ -354,6 +357,9 @@ properties:
             metadata:
               type: object
               description: The shipping method's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             tax_lines:
               type: array
               description: The shipping method's tax lines.
@@ -543,6 +549,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminOrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminOrderShippingMethod.yaml
@@ -60,6 +60,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPaymentCollection.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPaymentCollection.yaml
@@ -50,6 +50,9 @@ properties:
   metadata:
     type: object
     description: The payment collection's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   status:
     type: string
     description: The payment collection's status.

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostClaimsAddItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostClaimsAddItemsReqSchema.yaml
@@ -31,3 +31,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostClaimsShippingActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostClaimsShippingActionReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostClaimsShippingReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostClaimsShippingReqSchema.yaml
@@ -23,3 +23,6 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesAddItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesAddItemsReqSchema.yaml
@@ -35,3 +35,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesRequestItemsReturnActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesRequestItemsReturnActionReqSchema.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesReturnRequestItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesReturnRequestItemsReqSchema.yaml
@@ -35,3 +35,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesShippingActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesShippingActionReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesShippingReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostExchangesShippingReqSchema.yaml
@@ -23,3 +23,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderClaimsReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderClaimsReqSchema.yaml
@@ -30,3 +30,6 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderEditsAddItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderEditsAddItemsReqSchema.yaml
@@ -37,6 +37,9 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         compare_at_unit_price:
           type: number
           title: compare_at_unit_price

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderEditsReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderEditsReqSchema.yaml
@@ -19,3 +19,6 @@ properties:
   metadata:
     type: object
     description: The order edit's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderEditsShippingActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderEditsShippingActionReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The order edit's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderEditsShippingReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderEditsShippingReqSchema.yaml
@@ -23,3 +23,6 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderExchangesReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostOrderExchangesReqSchema.yaml
@@ -19,3 +19,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostReceiveReturnsReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostReceiveReturnsReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsReqSchema.yaml
@@ -27,3 +27,6 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsRequestItemsActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsRequestItemsActionReqSchema.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsRequestItemsReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsRequestItemsReqSchema.yaml
@@ -35,3 +35,6 @@ properties:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsReturnReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsReturnReqSchema.yaml
@@ -15,3 +15,6 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsShippingActionReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsShippingActionReqSchema.yaml
@@ -13,3 +13,6 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsShippingReqSchema.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminPostReturnsShippingReqSchema.yaml
@@ -23,3 +23,6 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminProduct.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminProduct.yaml
@@ -86,6 +86,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminProductCategory.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminProductCategory.yaml
@@ -43,6 +43,9 @@ properties:
   metadata:
     type: object
     description: The category's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminProductImage.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminProductImage.yaml
@@ -28,6 +28,9 @@ properties:
   metadata:
     type: object
     description: The image's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   rank:
     type: number
     title: rank

--- a/www/apps/api-reference/specs/store/components/schemas/AdminProductOption.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminProductOption.yaml
@@ -27,6 +27,9 @@ properties:
   metadata:
     type: object
     description: The product option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminProductOptionValue.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminProductOptionValue.yaml
@@ -22,6 +22,9 @@ properties:
   metadata:
     type: object
     description: The value's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminProductTag.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminProductTag.yaml
@@ -33,3 +33,6 @@ properties:
   metadata:
     type: object
     description: The tag's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminProductType.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminProductType.yaml
@@ -33,3 +33,6 @@ properties:
   metadata:
     type: object
     description: The type's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminProductVariant.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminProductVariant.yaml
@@ -136,6 +136,9 @@ properties:
   metadata:
     type: object
     description: The variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   inventory_items:
     type: array
     description: The variant's inventory items.

--- a/www/apps/api-reference/specs/store/components/schemas/AdminRefundReason.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminRefundReason.yaml
@@ -23,6 +23,9 @@ properties:
   metadata:
     type: object
     description: The refund reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminRegion.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminRegion.yaml
@@ -36,6 +36,9 @@ properties:
   metadata:
     type: object
     description: The region's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminReservation.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminReservation.yaml
@@ -43,6 +43,9 @@ properties:
   metadata:
     type: object
     description: The reservation's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_by:
     type: string
     title: created_by

--- a/www/apps/api-reference/specs/store/components/schemas/AdminReturnItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminReturnItem.yaml
@@ -48,3 +48,6 @@ properties:
   metadata:
     type: object
     description: The return item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminReturnReason.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminReturnReason.yaml
@@ -27,6 +27,9 @@ properties:
   metadata:
     type: object
     description: The return reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminSalesChannel.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminSalesChannel.yaml
@@ -30,6 +30,9 @@ properties:
   metadata:
     type: object
     description: The sales channel's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminShippingOption.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminShippingOption.yaml
@@ -88,6 +88,9 @@ properties:
   metadata:
     type: object
     description: The shipping option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminShippingProfile.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminShippingProfile.yaml
@@ -17,6 +17,9 @@ properties:
   metadata:
     type: object
     description: The shipping profile's metadata, holds custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminStore.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminStore.yaml
@@ -40,6 +40,9 @@ properties:
   metadata:
     type: object
     description: The store's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminStoreCreditAccount.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminStoreCreditAccount.yaml
@@ -49,6 +49,9 @@ properties:
   metadata:
     type: object
     description: The store credit account's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminTaxRate.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminTaxRate.yaml
@@ -37,6 +37,9 @@ properties:
   metadata:
     type: object
     description: The tax rate's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   tax_region_id:
     type: string
     title: tax_region_id

--- a/www/apps/api-reference/specs/store/components/schemas/AdminTaxRegion.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminTaxRegion.yaml
@@ -35,6 +35,9 @@ properties:
   metadata:
     type: object
     description: The tax region's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   parent_id:
     type: string
     title: parent_id

--- a/www/apps/api-reference/specs/store/components/schemas/AdminTransaction.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminTransaction.yaml
@@ -51,6 +51,9 @@ properties:
   metadata:
     type: object
     description: The transaction's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/AdminTransactionGroup.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminTransactionGroup.yaml
@@ -35,3 +35,6 @@ properties:
   metadata:
     type: object
     description: The transaction group's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateCustomerGroup.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateCustomerGroup.yaml
@@ -9,3 +9,6 @@ properties:
   metadata:
     type: object
     description: The customer group's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateDraftOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateDraftOrder.yaml
@@ -59,6 +59,9 @@ properties:
       metadata:
         type: object
         description: The shipping address's metadata, can hold custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   billing_address:
     type: object
     description: The draft order's billing address.
@@ -111,9 +114,15 @@ properties:
       metadata:
         type: object
         description: The billing address's metadata, can hold custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   metadata:
     type: object
     description: The draft order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   customer_id:
     type: string
     title: customer_id

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateDraftOrderActionShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateDraftOrderActionShippingMethod.yaml
@@ -25,3 +25,6 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateFulfillmentSetServiceZones.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateFulfillmentSetServiceZones.yaml
@@ -25,6 +25,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -49,6 +52,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             country_code:
               type: string
               title: country_code
@@ -82,6 +88,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             city:
               type: string
               title: city
@@ -120,6 +129,9 @@ properties:
             metadata:
               type: object
               description: The geo zone's metadata.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
             city:
               type: string
               title: city

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateGiftCardParams.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateGiftCardParams.yaml
@@ -32,3 +32,6 @@ properties:
   metadata:
     type: object
     description: The gift card's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateInventoryItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateInventoryItem.yaml
@@ -58,4 +58,7 @@ properties:
   metadata:
     type: object
     description: The inventory item's metadata. Can be custom data in key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateInventoryItem

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateOrder.yaml
@@ -59,6 +59,9 @@ properties:
       metadata:
         type: object
         description: The address's metadata, can hold custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   billing_address:
     type: object
     description: The order's billing address.
@@ -111,6 +114,12 @@ properties:
       metadata:
         type: object
         description: The address's metadata, can hold custom key-value pairs.
+        externalDocs:
+          url: https://docs.medusajs.com/api/admin#manage-metadata
+          description: Learn how to manage metadata
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProduct.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProduct.yaml
@@ -147,6 +147,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   external_id:
     type: string
     title: external_id

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProductCategory.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProductCategory.yaml
@@ -30,6 +30,9 @@ properties:
   metadata:
     type: object
     description: The product category's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   rank:
     type: number
     title: rank

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProductTag.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProductTag.yaml
@@ -8,4 +8,7 @@ properties:
   metadata:
     type: object
     description: The product tag's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateProductTag

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProductType.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProductType.yaml
@@ -8,4 +8,7 @@ properties:
   metadata:
     type: object
     description: The product type's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateProductType

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProductVariant.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateProductVariant.yaml
@@ -71,6 +71,9 @@ properties:
   metadata:
     type: object
     description: The product variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   prices:
     type: array
     description: The product variant's prices.

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateRegion.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateRegion.yaml
@@ -30,6 +30,9 @@ properties:
   metadata:
     type: object
     description: The region's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   is_tax_inclusive:
     type: boolean
     title: is_tax_inclusive

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateReservation.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateReservation.yaml
@@ -16,4 +16,7 @@ properties:
   metadata:
     type: object
     description: The reservation's metadata. Can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateReservation

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateReturnReason.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateReturnReason.yaml
@@ -17,6 +17,9 @@ properties:
   metadata:
     type: object
     description: The return reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 required:
   - value
   - label

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateSalesChannel.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateSalesChannel.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The sales channel's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateShippingProfile.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateShippingProfile.yaml
@@ -12,4 +12,7 @@ properties:
   metadata:
     type: object
     description: The shipping profile's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: AdminUpdateShippingProfile

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateStockLocation.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateStockLocation.yaml
@@ -61,3 +61,6 @@ properties:
   metadata:
     type: object
     description: The stock location's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateStore.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateStore.yaml
@@ -43,3 +43,6 @@ properties:
   metadata:
     type: object
     description: The store's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateTaxRate.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateTaxRate.yaml
@@ -48,3 +48,6 @@ properties:
   metadata:
     type: object
     description: The tax rate's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateTaxRegion.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateTaxRegion.yaml
@@ -13,6 +13,9 @@ properties:
   metadata:
     type: object
     description: The tax region's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   provider_id:
     type: string
     title: provider_id

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUpdateUser.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUpdateUser.yaml
@@ -17,3 +17,6 @@ properties:
   metadata:
     type: object
     description: The user's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/AdminUser.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/AdminUser.yaml
@@ -36,6 +36,9 @@ properties:
   metadata:
     type: object
     description: The user's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/admin#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseCart.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseCart.yaml
@@ -73,6 +73,9 @@ properties:
   metadata:
     type: object
     description: The cart's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseCartLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseCartLineItem.yaml
@@ -133,6 +133,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseCartShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseCartShippingMethod.yaml
@@ -57,6 +57,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/store/components/schemas/BaseClaimItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseClaimItem.yaml
@@ -55,6 +55,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseCollection.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseCollection.yaml
@@ -45,3 +45,6 @@ properties:
   metadata:
     type: object
     description: The collection's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/BaseExchangeItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseExchangeItem.yaml
@@ -33,6 +33,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseOrder.yaml
@@ -134,6 +134,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseOrderAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseOrderAddress.yaml
@@ -63,6 +63,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseOrderFulfillment.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseOrderFulfillment.yaml
@@ -63,6 +63,9 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseOrderLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseOrderLineItem.yaml
@@ -160,6 +160,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   original_total:
     type: number
     title: original_total

--- a/www/apps/api-reference/specs/store/components/schemas/BaseOrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseOrderShippingMethod.yaml
@@ -60,6 +60,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/store/components/schemas/BaseOrderTransaction.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseOrderTransaction.yaml
@@ -46,6 +46,9 @@ properties:
   metadata:
     type: object
     description: The transaction's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BasePaymentCollection.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BasePaymentCollection.yaml
@@ -50,6 +50,9 @@ properties:
   metadata:
     type: object
     description: The payment collection's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   status:
     type: string
     description: The payment collection's status.

--- a/www/apps/api-reference/specs/store/components/schemas/BaseProduct.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseProduct.yaml
@@ -80,6 +80,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseProductCategory.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseProductCategory.yaml
@@ -43,6 +43,9 @@ properties:
   metadata:
     type: object
     description: The category's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseProductImage.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseProductImage.yaml
@@ -28,6 +28,9 @@ properties:
   metadata:
     type: object
     description: The image's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   rank:
     type: number
     title: rank

--- a/www/apps/api-reference/specs/store/components/schemas/BaseProductOption.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseProductOption.yaml
@@ -27,6 +27,9 @@ properties:
   metadata:
     type: object
     description: The product option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseProductOptionValue.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseProductOptionValue.yaml
@@ -22,6 +22,9 @@ properties:
   metadata:
     type: object
     description: The value's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/BaseProductTag.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseProductTag.yaml
@@ -33,3 +33,6 @@ properties:
   metadata:
     type: object
     description: The tag's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/BaseProductType.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseProductType.yaml
@@ -33,3 +33,6 @@ properties:
   metadata:
     type: object
     description: The type's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/BaseProductVariant.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseProductVariant.yaml
@@ -130,3 +130,6 @@ properties:
   metadata:
     type: object
     description: The variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/BaseRegion.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseRegion.yaml
@@ -35,6 +35,9 @@ properties:
   metadata:
     type: object
     description: The region's metadata.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/CreateAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/CreateAddress.yaml
@@ -54,3 +54,6 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/InventoryLevel.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/InventoryLevel.yaml
@@ -41,3 +41,6 @@ properties:
   metadata:
     type: object
     description: The inventory level's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/Order.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/Order.yaml
@@ -177,6 +177,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   canceled_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/OrderAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderAddress.yaml
@@ -62,6 +62,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/OrderChange.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderChange.yaml
@@ -112,6 +112,9 @@ properties:
   metadata:
     type: object
     description: The order change's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   declined_at:
     type: string
     title: declined_at

--- a/www/apps/api-reference/specs/store/components/schemas/OrderClaim.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderClaim.yaml
@@ -64,6 +64,9 @@ properties:
   metadata:
     type: object
     description: The claim's metadata, used to store custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/OrderCreditLine.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderCreditLine.yaml
@@ -35,6 +35,9 @@ properties:
   metadata:
     type: object
     description: The credit line's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/OrderExchange.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderExchange.yaml
@@ -59,6 +59,9 @@ properties:
   metadata:
     type: object
     description: The exchange's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/OrderItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderItem.yaml
@@ -62,6 +62,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/OrderLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderLineItem.yaml
@@ -141,6 +141,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   original_total:
     type: number
     title: original_total

--- a/www/apps/api-reference/specs/store/components/schemas/OrderReturnItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderReturnItem.yaml
@@ -37,6 +37,9 @@ properties:
   metadata:
     type: object
     description: The return item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   order_id:
     type: string
     title: order_id

--- a/www/apps/api-reference/specs/store/components/schemas/OrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderShippingMethod.yaml
@@ -57,6 +57,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/store/components/schemas/OrderTransaction.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/OrderTransaction.yaml
@@ -48,6 +48,9 @@ properties:
   metadata:
     type: object
     description: The transaction's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/RefundReason.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/RefundReason.yaml
@@ -23,6 +23,9 @@ properties:
   metadata:
     type: object
     description: The refund reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/Return.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/Return.yaml
@@ -47,6 +47,9 @@ properties:
   metadata:
     type: object
     description: The return's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreAddCartLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreAddCartLineItem.yaml
@@ -16,3 +16,6 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCart.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCart.yaml
@@ -78,6 +78,9 @@ properties:
   metadata:
     type: object
     description: The cart's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCartAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCartAddress.yaml
@@ -62,6 +62,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     title: created_at

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCartLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCartLineItem.yaml
@@ -277,6 +277,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     title: created_at

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCartShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCartShippingMethod.yaml
@@ -57,6 +57,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCollection.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCollection.yaml
@@ -45,3 +45,6 @@ properties:
   metadata:
     type: object
     description: The collection's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCreateCart.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCreateCart.yaml
@@ -39,3 +39,6 @@ properties:
   metadata:
     type: object
     description: The cart's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCreateCustomer.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCreateCustomer.yaml
@@ -28,3 +28,6 @@ properties:
   metadata:
     type: object
     description: The customer's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCustomer.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCustomer.yaml
@@ -52,6 +52,9 @@ properties:
   metadata:
     type: object
     description: The customer's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCustomerAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCustomerAddress.yaml
@@ -89,6 +89,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreOrder.yaml
@@ -125,6 +125,9 @@ properties:
   metadata:
     type: object
     description: The order's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreOrderAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreOrderAddress.yaml
@@ -65,6 +65,9 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreOrderFulfillment.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreOrderFulfillment.yaml
@@ -63,6 +63,9 @@ properties:
   metadata:
     type: object
     description: The fulfillment's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreOrderLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreOrderLineItem.yaml
@@ -349,6 +349,9 @@ properties:
                     metadata:
                       type: object
                       description: The variant's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                 variant_id:
                   type: string
                   title: variant_id
@@ -530,6 +533,9 @@ properties:
                     metadata:
                       type: object
                       description: The product's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                 product_id:
                   type: string
                   title: product_id
@@ -794,6 +800,9 @@ properties:
                     metadata:
                       type: object
                       description: The detail's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -817,6 +826,9 @@ properties:
                 metadata:
                   type: object
                   description: The item's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 original_total:
                   type: number
                   title: original_total
@@ -1016,6 +1028,9 @@ properties:
                     metadata:
                       type: object
                       description: The variant's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -1201,6 +1216,9 @@ properties:
                     metadata:
                       type: object
                       description: The product's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -1494,6 +1512,10 @@ properties:
                         metadata:
                           type: object
                           description: The detail's metadata.
+                          externalDocs:
+                            url: >-
+                              https://docs.medusajs.com/api/store#manage-metadata
+                            description: Learn how to manage metadata
                         created_at:
                           type: string
                           format: date-time
@@ -1524,6 +1546,9 @@ properties:
                 metadata:
                   type: object
                   description: The item's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 created_at:
                   type: string
                   format: date-time
@@ -1878,6 +1903,9 @@ properties:
                     metadata:
                       type: object
                       description: The variant's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                 variant_id:
                   type: string
                   title: variant_id
@@ -2059,6 +2087,9 @@ properties:
                     metadata:
                       type: object
                       description: The product's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                 product_id:
                   type: string
                   title: product_id
@@ -2323,6 +2354,9 @@ properties:
                     metadata:
                       type: object
                       description: The detail's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -2346,6 +2380,9 @@ properties:
                 metadata:
                   type: object
                   description: The item's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 original_total:
                   type: number
                   title: original_total
@@ -2541,6 +2578,9 @@ properties:
                     metadata:
                       type: object
                       description: The variant's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -2726,6 +2766,9 @@ properties:
                     metadata:
                       type: object
                       description: The product's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -3019,6 +3062,10 @@ properties:
                         metadata:
                           type: object
                           description: The detail's metadata.
+                          externalDocs:
+                            url: >-
+                              https://docs.medusajs.com/api/store#manage-metadata
+                            description: Learn how to manage metadata
                         created_at:
                           type: string
                           format: date-time
@@ -3049,6 +3096,9 @@ properties:
                 metadata:
                   type: object
                   description: The item's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 created_at:
                   type: string
                   format: date-time
@@ -3295,6 +3345,9 @@ properties:
                   metadata:
                     type: object
                     description: The variant's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/store#manage-metadata
+                      description: Learn how to manage metadata
                   created_at:
                     type: string
                     format: date-time
@@ -3480,6 +3533,9 @@ properties:
                   metadata:
                     type: object
                     description: The product's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/store#manage-metadata
+                      description: Learn how to manage metadata
                   created_at:
                     type: string
                     format: date-time
@@ -3773,6 +3829,9 @@ properties:
                       metadata:
                         type: object
                         description: The detail's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       created_at:
                         type: string
                         format: date-time
@@ -3803,6 +3862,9 @@ properties:
               metadata:
                 type: object
                 description: The item's metadata.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/store#manage-metadata
+                  description: Learn how to manage metadata
               created_at:
                 type: string
                 format: date-time
@@ -3958,6 +4020,9 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   original_total:
     type: number
     title: original_total

--- a/www/apps/api-reference/specs/store/components/schemas/StoreOrderShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreOrderShippingMethod.yaml
@@ -60,6 +60,9 @@ properties:
   metadata:
     type: object
     description: The shipping method's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   tax_lines:
     type: array
     description: The shipping method's tax lines.
@@ -137,6 +140,9 @@ properties:
                 metadata:
                   type: object
                   description: The shipping method's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 tax_lines:
                   type: array
                   description: The shipping method's tax lines.
@@ -668,6 +674,9 @@ properties:
                 metadata:
                   type: object
                   description: The shipping method's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 original_total:
                   type: number
                   title: original_total
@@ -786,6 +795,9 @@ properties:
                 metadata:
                   type: object
                   description: The shipping method's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 tax_lines:
                   type: array
                   description: The shipping method's tax lines.
@@ -1313,6 +1325,9 @@ properties:
                 metadata:
                   type: object
                   description: The shipping method's metadata.
+                  externalDocs:
+                    url: https://docs.medusajs.com/api/store#manage-metadata
+                    description: Learn how to manage metadata
                 original_total:
                   type: number
                   title: original_total
@@ -1669,6 +1684,9 @@ properties:
               metadata:
                 type: object
                 description: The shipping method's metadata.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/store#manage-metadata
+                  description: Learn how to manage metadata
               original_total:
                 type: number
                 title: original_total

--- a/www/apps/api-reference/specs/store/components/schemas/StorePaymentCollection.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StorePaymentCollection.yaml
@@ -50,6 +50,9 @@ properties:
   metadata:
     type: object
     description: The payment collection's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   status:
     type: string
     description: The payment collection's status.

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProduct.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProduct.yaml
@@ -68,6 +68,9 @@ properties:
   metadata:
     type: object
     description: The product's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProductCategory.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProductCategory.yaml
@@ -48,6 +48,9 @@ properties:
   metadata:
     type: object
     description: The category's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProductImage.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProductImage.yaml
@@ -32,6 +32,9 @@ properties:
   metadata:
     type: object
     description: The image's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   rank:
     type: number
     title: rank

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProductOption.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProductOption.yaml
@@ -24,6 +24,9 @@ properties:
   metadata:
     type: object
     description: The option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProductOptionValue.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProductOptionValue.yaml
@@ -22,6 +22,9 @@ properties:
   metadata:
     type: object
     description: The value's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProductTag.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProductTag.yaml
@@ -28,6 +28,9 @@ properties:
   metadata:
     type: object
     description: The tag's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
 required:
   - id
   - value

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProductType.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProductType.yaml
@@ -14,6 +14,9 @@ properties:
   metadata:
     type: object
     description: The product type's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProductVariant.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProductVariant.yaml
@@ -20,6 +20,9 @@ properties:
   metadata:
     type: object
     description: The variant's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   id:
     type: string
     title: id

--- a/www/apps/api-reference/specs/store/components/schemas/StoreRegion.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreRegion.yaml
@@ -38,6 +38,9 @@ properties:
   metadata:
     type: object
     description: The region's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreReturnItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreReturnItem.yaml
@@ -44,3 +44,6 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/StoreReturnReason.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreReturnReason.yaml
@@ -27,6 +27,9 @@ properties:
   metadata:
     type: object
     description: The return reason's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreShippingOption.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreShippingOption.yaml
@@ -70,3 +70,6 @@ properties:
   metadata:
     type: object
     description: The shipping option's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/StoreStoreCreditAccount.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreStoreCreditAccount.yaml
@@ -49,6 +49,9 @@ properties:
   metadata:
     type: object
     description: The store credit account's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
   created_at:
     type: string
     format: date-time

--- a/www/apps/api-reference/specs/store/components/schemas/StoreTransactionGroup.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreTransactionGroup.yaml
@@ -34,4 +34,7 @@ properties:
   metadata:
     type: object
     description: The transaction group's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata
 x-schemaName: StoreTransactionGroup

--- a/www/apps/api-reference/specs/store/components/schemas/StoreUpdateCartLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreUpdateCartLineItem.yaml
@@ -11,3 +11,6 @@ properties:
   metadata:
     type: object
     description: The item's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/StoreUpdateCustomer.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreUpdateCustomer.yaml
@@ -21,3 +21,6 @@ properties:
   metadata:
     type: object
     description: The customer's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/UpdateAddress.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/UpdateAddress.yaml
@@ -60,3 +60,6 @@ properties:
   metadata:
     type: object
     description: The address's metadata, can hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/components/schemas/UpdateCartData.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/UpdateCartData.yaml
@@ -47,3 +47,6 @@ properties:
   metadata:
     type: object
     description: The cart's metadata, ca hold custom key-value pairs.
+    externalDocs:
+      url: https://docs.medusajs.com/api/store#manage-metadata
+      description: Learn how to manage metadata

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -9576,6 +9576,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminAddDraftOrderPromotions:
       type: object
       description: The details of the promotions to add to a draft order.
@@ -9616,6 +9619,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminApiKey:
       type: object
       description: The API key's details.
@@ -10206,6 +10212,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         external_id:
           type: string
           title: external_id
@@ -10292,6 +10301,9 @@ components:
         metadata:
           type: object
           description: The product variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         prices:
           type: array
           description: The product variant's prices.
@@ -10479,6 +10491,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -10677,6 +10692,9 @@ components:
         metadata:
           type: object
           description: The collection's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCollectionDeleteResponse:
       type: object
       description: The details of the deleted collection.
@@ -10772,6 +10790,9 @@ components:
         metadata:
           type: object
           description: The customer group's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateFulfillment:
       type: object
       description: The filfillment's details.
@@ -10845,6 +10866,9 @@ components:
             metadata:
               type: object
               description: The delivery address's metadata, used to store custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         items:
           type: array
           description: The items to fulfill.
@@ -10941,6 +10965,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateFulfillmentSetServiceZones:
       type: object
       description: The service zone's details.
@@ -10966,6 +10993,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -10986,6 +11016,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -11015,6 +11048,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -11049,6 +11085,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -11126,6 +11165,9 @@ components:
         metadata:
           type: object
           description: The gift card's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateInventoryItem:
       type: object
       description: The inventory item's details.
@@ -11186,6 +11228,9 @@ components:
         metadata:
           type: object
           description: The inventory item's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateInventoryLocationLevel:
       type: object
       description: The inventory level's details.
@@ -11232,6 +11277,9 @@ components:
         metadata:
           type: object
           description: The credit line's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreatePaymentCapture:
       type: object
       description: The payment's details.
@@ -11521,6 +11569,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         external_id:
           type: string
           title: external_id
@@ -11567,6 +11618,9 @@ components:
         metadata:
           type: object
           description: The product category's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateProductOption:
       type: object
       description: The product option's details.
@@ -11600,6 +11654,9 @@ components:
         metadata:
           type: object
           description: The product tag's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateProductType:
       type: object
       description: The details of the product type to create.
@@ -11610,6 +11667,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         value:
           type: string
           title: value
@@ -11689,6 +11749,9 @@ components:
         metadata:
           type: object
           description: The variant's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         prices:
           type: array
           description: The variant's prices.
@@ -11856,6 +11919,9 @@ components:
         metadata:
           type: object
           description: The region's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateReservation:
       type: object
       description: The reservation's details.
@@ -11888,6 +11954,9 @@ components:
         metadata:
           type: object
           description: The reservation's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateReturnReason:
       type: object
       description: The details of the return reason to create.
@@ -11915,6 +11984,9 @@ components:
         metadata:
           type: object
           description: The return reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateSalesChannel:
       type: object
       description: The sales channel's details.
@@ -11937,6 +12009,9 @@ components:
         metadata:
           type: object
           description: The sales channel's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateShipment:
       type: object
       description: The shipment's details.
@@ -12129,6 +12204,9 @@ components:
         metadata:
           type: object
           description: The shipping profile's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateStockLocation:
       type: object
       description: The stock location's details.
@@ -12149,6 +12227,9 @@ components:
         metadata:
           type: object
           description: The stock location's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateStockLocationFulfillmentSet:
       type: object
       description: The fulfillment set to create.
@@ -12185,6 +12266,9 @@ components:
         metadata:
           type: object
           description: The store credit account's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateTaxRate:
       type: object
       description: The tax rate's details.
@@ -12230,6 +12314,9 @@ components:
         metadata:
           type: object
           description: The tax rate's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminCreateTaxRateRule:
       type: object
       description: The tax rate rule's details.
@@ -12301,9 +12388,15 @@ components:
             metadata:
               type: object
               description: The default tax rate's metadata, used to store custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         metadata:
           type: object
           description: The tax region's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         provider_id:
           type: string
           title: provider_id
@@ -12524,6 +12617,9 @@ components:
         metadata:
           type: object
           description: The customer's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_by:
           type: string
           title: created_by
@@ -12635,6 +12731,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -12682,6 +12781,9 @@ components:
         metadata:
           type: object
           description: The customer group's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -13433,6 +13535,9 @@ components:
         metadata:
           type: object
           description: The draft order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -13789,6 +13894,9 @@ components:
                   metadata:
                     type: object
                     description: The item's metadata, can hold custom key-value pairs.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   original_total:
                     type: number
                     title: original_total
@@ -13915,6 +14023,9 @@ components:
                   metadata:
                     type: object
                     description: The shipping method's metadata, can hold custom key-value pairs.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   tax_lines:
                     type: array
                     description: The shipping method's tax lines.
@@ -14092,6 +14203,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -14292,6 +14406,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -14533,6 +14650,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -14625,6 +14745,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -15330,6 +15453,9 @@ components:
         metadata:
           type: object
           description: The location level's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         inventory_item:
           type: object
         available_quantity:
@@ -15374,6 +15500,9 @@ components:
         metadata:
           type: object
           description: The invite's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -15684,6 +15813,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -15865,6 +15997,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -15988,6 +16123,9 @@ components:
         metadata:
           type: object
           description: The order change's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         declined_at:
           type: string
           title: declined_at
@@ -16206,6 +16344,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -16429,6 +16570,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         original_total:
           type: number
           title: original_total
@@ -16700,6 +16844,9 @@ components:
                   metadata:
                     type: object
                     description: The item's metadata, can hold custom key-value pairs.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   original_total:
                     type: number
                     title: original_total
@@ -16826,6 +16973,9 @@ components:
                   metadata:
                     type: object
                     description: The shipping method's metadata, can hold custom key-value pairs.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   tax_lines:
                     type: array
                     description: The shipping method's tax lines.
@@ -17003,6 +17153,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -17210,6 +17363,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -17394,6 +17550,9 @@ components:
         metadata:
           type: object
           description: The payment collection's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         status:
           type: string
           description: The payment collection's status.
@@ -17634,6 +17793,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminPostClaimsItemsActionReqSchema:
       type: object
       description: The details to update in the item.
@@ -17667,6 +17829,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostClaimsShippingReqSchema:
       type: object
       description: The details of the shipping method used to ship outbound items.
@@ -17693,6 +17858,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostExchangesAddItemsReqSchema:
       type: object
       description: The details of outbound items.
@@ -17731,6 +17899,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminPostExchangesItemsActionReqSchema:
       type: object
       description: The details to update in an outbound item.
@@ -17764,6 +17935,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostExchangesReturnRequestItemsReqSchema:
       type: object
       description: The details of the inbound (return) items.
@@ -17802,6 +17976,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminPostExchangesShippingActionReqSchema:
       type: object
       description: The details of the shipping method to update.
@@ -17818,6 +17995,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostExchangesShippingReqSchema:
       type: object
       description: The outbound shipping method's details.
@@ -17844,6 +18024,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderClaimsReqSchema:
       type: object
       description: The claim's details.
@@ -17877,6 +18060,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderEditsAddItemsReqSchema:
       type: object
       description: The details of items to be edited.
@@ -17915,6 +18101,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
               compare_at_unit_price:
                 type: number
                 title: compare_at_unit_price
@@ -17962,6 +18151,9 @@ components:
         metadata:
           type: object
           description: The order edit's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderEditsShippingActionReqSchema:
       type: object
       description: The shipping method's details.
@@ -17978,6 +18170,9 @@ components:
         metadata:
           type: object
           description: The order edit's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderEditsShippingReqSchema:
       type: object
       description: The shipping method's details.
@@ -18004,6 +18199,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostOrderEditsUpdateItemQuantityReqSchema:
       type: object
       description: The order item's details to update.
@@ -18049,6 +18247,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReceiveReturnsReqSchema:
       type: object
       description: The return receival details.
@@ -18065,6 +18266,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsConfirmRequestReqSchema:
       type: object
       description: The confirmation's details.
@@ -18161,6 +18365,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsRequestItemsActionReqSchema:
       type: object
       description: The details to update in the item.
@@ -18181,6 +18388,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsRequestItemsReqSchema:
       type: object
       description: The items' details.
@@ -18219,6 +18429,9 @@ components:
               metadata:
                 type: object
                 description: The item's metadata, can hold custom key-value pairs.
+                externalDocs:
+                  url: https://docs.medusajs.com/api/admin#manage-metadata
+                  description: Learn how to manage metadata
     AdminPostReturnsReturnReqSchema:
       type: object
       description: The return's details.
@@ -18235,6 +18448,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsShippingActionReqSchema:
       type: object
       description: The shipping method's details.
@@ -18251,6 +18467,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPostReturnsShippingReqSchema:
       type: object
       description: The shipping method's details.
@@ -18277,6 +18496,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminPrice:
       type: object
       description: The price's details.
@@ -18791,6 +19013,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -18919,6 +19144,9 @@ components:
         metadata:
           type: object
           description: The category's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -19070,6 +19298,9 @@ components:
         metadata:
           type: object
           description: The image's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         rank:
           type: number
           title: rank
@@ -19108,6 +19339,9 @@ components:
         metadata:
           type: object
           description: The product option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -19181,6 +19415,9 @@ components:
         metadata:
           type: object
           description: The value's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -19241,6 +19478,9 @@ components:
         metadata:
           type: object
           description: The tag's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminProductTagDeleteResponse:
       type: object
       description: The details of the product tag deletion.
@@ -19340,6 +19580,9 @@ components:
         metadata:
           type: object
           description: The type's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminProductTypeDeleteResponse:
       type: object
       description: The details of the product type deletion.
@@ -19538,6 +19781,9 @@ components:
         metadata:
           type: object
           description: The variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         inventory_items:
           type: array
           description: The variant's inventory items.
@@ -19952,6 +20198,9 @@ components:
         metadata:
           type: object
           description: The refund reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -20001,6 +20250,9 @@ components:
         metadata:
           type: object
           description: The region's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -20114,6 +20366,9 @@ components:
         metadata:
           type: object
           description: The reservation's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_by:
           type: string
           title: created_by
@@ -20266,6 +20521,9 @@ components:
         metadata:
           type: object
           description: The return item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminReturnPreviewResponse:
       type: object
       description: The details of a return and a preview of the order once the return is applied.
@@ -20308,6 +20566,9 @@ components:
         metadata:
           type: object
           description: The return reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -20480,6 +20741,9 @@ components:
         metadata:
           type: object
           description: The sales channel's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -20693,6 +20957,9 @@ components:
         metadata:
           type: object
           description: The shipping option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -21017,6 +21284,9 @@ components:
         metadata:
           type: object
           description: The shipping profile's metadata, holds custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -21271,6 +21541,9 @@ components:
         metadata:
           type: object
           description: The store's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -21333,6 +21606,9 @@ components:
         metadata:
           type: object
           description: The store credit account's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -21530,6 +21806,9 @@ components:
         metadata:
           type: object
           description: The tax rate's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         tax_region_id:
           type: string
           title: tax_region_id
@@ -21657,6 +21936,9 @@ components:
         metadata:
           type: object
           description: The tax region's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         parent_id:
           type: string
           title: parent_id
@@ -21777,6 +22059,9 @@ components:
         metadata:
           type: object
           description: The transaction's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -21825,6 +22110,9 @@ components:
         metadata:
           type: object
           description: The transaction group's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminTransactionGroupsResponse:
       type: object
       description: The paginated list of transaction groups.
@@ -21931,6 +22219,9 @@ components:
         metadata:
           type: object
           description: The customer group's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateDraftOrder:
       type: object
       description: The data to update in the draft order.
@@ -21993,6 +22284,9 @@ components:
             metadata:
               type: object
               description: The shipping address's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         billing_address:
           type: object
           description: The draft order's billing address.
@@ -22045,9 +22339,15 @@ components:
             metadata:
               type: object
               description: The billing address's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         metadata:
           type: object
           description: The draft order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         customer_id:
           type: string
           title: customer_id
@@ -22082,6 +22382,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateDraftOrderItem:
       type: object
       description: The updates to make on a draft order's item.
@@ -22150,6 +22453,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -22174,6 +22480,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   country_code:
                     type: string
                     title: country_code
@@ -22207,6 +22516,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   city:
                     type: string
                     title: city
@@ -22245,6 +22557,9 @@ components:
                   metadata:
                     type: object
                     description: The geo zone's metadata.
+                    externalDocs:
+                      url: https://docs.medusajs.com/api/admin#manage-metadata
+                      description: Learn how to manage metadata
                   city:
                     type: string
                     title: city
@@ -22304,6 +22619,9 @@ components:
         metadata:
           type: object
           description: The gift card's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateInventoryItem:
       type: object
       description: The properties to update in the inventory item.
@@ -22363,6 +22681,9 @@ components:
         metadata:
           type: object
           description: The inventory item's metadata. Can be custom data in key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateInventoryItem
     AdminUpdateInventoryLocationLevel:
       type: object
@@ -22439,6 +22760,9 @@ components:
             metadata:
               type: object
               description: The address's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         billing_address:
           type: object
           description: The order's billing address.
@@ -22491,9 +22815,15 @@ components:
             metadata:
               type: object
               description: The address's metadata, can hold custom key-value pairs.
+              externalDocs:
+                url: https://docs.medusajs.com/api/admin#manage-metadata
+                description: Learn how to manage metadata
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdatePaymentRefundReason:
       type: object
       description: The properties to update in the refund reason.
@@ -22713,6 +23043,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         external_id:
           type: string
           title: external_id
@@ -22748,6 +23081,9 @@ components:
         metadata:
           type: object
           description: The product category's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         rank:
           type: number
           title: rank
@@ -22780,6 +23116,9 @@ components:
         metadata:
           type: object
           description: The product tag's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateProductTag
     AdminUpdateProductType:
       type: object
@@ -22792,6 +23131,9 @@ components:
         metadata:
           type: object
           description: The product type's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateProductType
     AdminUpdateProductVariant:
       type: object
@@ -22865,6 +23207,9 @@ components:
         metadata:
           type: object
           description: The product variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         prices:
           type: array
           description: The product variant's prices.
@@ -22951,6 +23296,9 @@ components:
         metadata:
           type: object
           description: The region's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         is_tax_inclusive:
           type: boolean
           title: is_tax_inclusive
@@ -22975,6 +23323,9 @@ components:
         metadata:
           type: object
           description: The reservation's metadata. Can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateReservation
     AdminUpdateReturnReason:
       type: object
@@ -22996,6 +23347,9 @@ components:
         metadata:
           type: object
           description: The return reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       required:
         - value
         - label
@@ -23019,6 +23373,9 @@ components:
         metadata:
           type: object
           description: The sales channel's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateShippingOption:
       type: object
       description: The properties to update in the shipping option.
@@ -23246,6 +23603,9 @@ components:
         metadata:
           type: object
           description: The shipping profile's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: AdminUpdateShippingProfile
     AdminUpdateStockLocation:
       type: object
@@ -23307,6 +23667,9 @@ components:
         metadata:
           type: object
           description: The stock location's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateStore:
       type: object
       description: The properties to update in a store.
@@ -23353,6 +23716,9 @@ components:
         metadata:
           type: object
           description: The store's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateTaxRate:
       type: object
       description: The properties to update in the tax rate.
@@ -23403,6 +23769,9 @@ components:
         metadata:
           type: object
           description: The tax rate's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateTaxRegion:
       type: object
       description: The details to update in a tax region.
@@ -23419,6 +23788,9 @@ components:
         metadata:
           type: object
           description: The tax region's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         provider_id:
           type: string
           title: provider_id
@@ -23443,6 +23815,9 @@ components:
         metadata:
           type: object
           description: The user's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
     AdminUpdateVariantInventoryItem:
       type: object
       description: The properties to update of the variant's inventory item association.
@@ -23604,6 +23979,9 @@ components:
         metadata:
           type: object
           description: The user's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/admin#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -24172,6 +24550,9 @@ components:
         metadata:
           type: object
           description: The cart's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -24410,6 +24791,9 @@ components:
         metadata:
           type: object
           description: The item's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -24526,6 +24910,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -24636,6 +25023,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -24694,6 +25084,9 @@ components:
         metadata:
           type: object
           description: The collection's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     BaseExchangeItem:
       type: object
       description: The item's details.
@@ -24730,6 +25123,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -25013,6 +25409,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -25185,6 +25584,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -25258,6 +25660,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -25511,6 +25916,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         original_total:
           type: number
           title: original_total
@@ -25790,6 +26198,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -26051,6 +26462,9 @@ components:
         metadata:
           type: object
           description: The transaction's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -26191,6 +26605,9 @@ components:
         metadata:
           type: object
           description: The payment collection's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         status:
           type: string
           description: The payment collection's status.
@@ -26370,6 +26787,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -26496,6 +26916,9 @@ components:
         metadata:
           type: object
           description: The category's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -26562,6 +26985,9 @@ components:
         metadata:
           type: object
           description: The image's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         rank:
           type: number
           title: rank
@@ -26600,6 +27026,9 @@ components:
         metadata:
           type: object
           description: The product option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -26640,6 +27069,9 @@ components:
         metadata:
           type: object
           description: The value's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -26691,6 +27123,9 @@ components:
         metadata:
           type: object
           description: The tag's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     BaseProductType:
       type: object
       description: The product type's details.
@@ -26727,6 +27162,9 @@ components:
         metadata:
           type: object
           description: The type's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     BaseProductVariant:
       type: object
       description: The product variant's details.
@@ -26856,6 +27294,9 @@ components:
         metadata:
           type: object
           description: The variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     BasePromotionRuleValue:
       type: object
       description: The rule value's details.
@@ -26948,6 +27389,9 @@ components:
         metadata:
           type: object
           description: The region's metadata.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -27266,6 +27710,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     CustomerGroupInCustomerFilters:
       type: object
       description: Filter by customer groups to get their associated customers.
@@ -27722,6 +28169,9 @@ components:
         metadata:
           type: object
           description: The inventory level's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     Order:
       type: object
       description: The order change's order.
@@ -27900,6 +28350,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         canceled_at:
           type: string
           format: date-time
@@ -28094,6 +28547,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -28217,6 +28673,9 @@ components:
         metadata:
           type: object
           description: The order change's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         declined_at:
           type: string
           title: declined_at
@@ -28408,6 +28867,9 @@ components:
         metadata:
           type: object
           description: The claim's metadata, used to store custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -28494,6 +28956,9 @@ components:
         metadata:
           type: object
           description: The credit line's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -28566,6 +29031,9 @@ components:
         metadata:
           type: object
           description: The exchange's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -28679,6 +29147,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -28833,6 +29304,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         original_total:
           type: number
           title: original_total
@@ -29051,6 +29525,9 @@ components:
         metadata:
           type: object
           description: The return item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         order_id:
           type: string
           title: order_id
@@ -29126,6 +29603,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -29346,6 +29826,9 @@ components:
         metadata:
           type: object
           description: The transaction's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -29388,6 +29871,9 @@ components:
         metadata:
           type: object
           description: The refund reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -29457,6 +29943,9 @@ components:
         metadata:
           type: object
           description: The return's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -29561,6 +30050,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreAddCartShippingMethods:
       type: object
       description: The shipping method's details.
@@ -29802,6 +30294,9 @@ components:
         metadata:
           type: object
           description: The cart's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -29984,6 +30479,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           title: created_at
@@ -30274,6 +30772,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           title: created_at
@@ -30454,6 +30955,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -30797,6 +31301,9 @@ components:
         metadata:
           type: object
           description: The collection's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreCollectionResponse:
       type: object
       description: The collection's details.
@@ -30841,6 +31348,9 @@ components:
         metadata:
           type: object
           description: The cart's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreCreateCustomer:
       type: object
       description: The details of the customer to create.
@@ -30872,6 +31382,9 @@ components:
         metadata:
           type: object
           description: The customer's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreCreateCustomerAddress:
       type: object
       description: The address's details.
@@ -31169,6 +31682,9 @@ components:
         metadata:
           type: object
           description: The customer's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -31276,6 +31792,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -31580,6 +32099,9 @@ components:
         metadata:
           type: object
           description: The order's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -31761,6 +32283,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -31834,6 +32359,9 @@ components:
         metadata:
           type: object
           description: The fulfillment's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -32200,6 +32728,9 @@ components:
                           metadata:
                             type: object
                             description: The variant's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                       variant_id:
                         type: string
                         title: variant_id
@@ -32381,6 +32912,9 @@ components:
                           metadata:
                             type: object
                             description: The product's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                       product_id:
                         type: string
                         title: product_id
@@ -32645,6 +33179,9 @@ components:
                           metadata:
                             type: object
                             description: The detail's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -32668,6 +33205,9 @@ components:
                       metadata:
                         type: object
                         description: The item's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       original_total:
                         type: number
                         title: original_total
@@ -32867,6 +33407,9 @@ components:
                           metadata:
                             type: object
                             description: The variant's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -33052,6 +33595,9 @@ components:
                           metadata:
                             type: object
                             description: The product's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -33345,6 +33891,9 @@ components:
                               metadata:
                                 type: object
                                 description: The detail's metadata.
+                                externalDocs:
+                                  url: https://docs.medusajs.com/api/store#manage-metadata
+                                  description: Learn how to manage metadata
                               created_at:
                                 type: string
                                 format: date-time
@@ -33375,6 +33924,9 @@ components:
                       metadata:
                         type: object
                         description: The item's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       created_at:
                         type: string
                         format: date-time
@@ -33729,6 +34281,9 @@ components:
                           metadata:
                             type: object
                             description: The variant's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                       variant_id:
                         type: string
                         title: variant_id
@@ -33910,6 +34465,9 @@ components:
                           metadata:
                             type: object
                             description: The product's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                       product_id:
                         type: string
                         title: product_id
@@ -34174,6 +34732,9 @@ components:
                           metadata:
                             type: object
                             description: The detail's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -34197,6 +34758,9 @@ components:
                       metadata:
                         type: object
                         description: The item's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       original_total:
                         type: number
                         title: original_total
@@ -34392,6 +34956,9 @@ components:
                           metadata:
                             type: object
                             description: The variant's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -34577,6 +35144,9 @@ components:
                           metadata:
                             type: object
                             description: The product's metadata.
+                            externalDocs:
+                              url: https://docs.medusajs.com/api/store#manage-metadata
+                              description: Learn how to manage metadata
                           created_at:
                             type: string
                             format: date-time
@@ -34870,6 +35440,9 @@ components:
                               metadata:
                                 type: object
                                 description: The detail's metadata.
+                                externalDocs:
+                                  url: https://docs.medusajs.com/api/store#manage-metadata
+                                  description: Learn how to manage metadata
                               created_at:
                                 type: string
                                 format: date-time
@@ -34900,6 +35473,9 @@ components:
                       metadata:
                         type: object
                         description: The item's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       created_at:
                         type: string
                         format: date-time
@@ -35146,6 +35722,9 @@ components:
                         metadata:
                           type: object
                           description: The variant's metadata.
+                          externalDocs:
+                            url: https://docs.medusajs.com/api/store#manage-metadata
+                            description: Learn how to manage metadata
                         created_at:
                           type: string
                           format: date-time
@@ -35331,6 +35910,9 @@ components:
                         metadata:
                           type: object
                           description: The product's metadata.
+                          externalDocs:
+                            url: https://docs.medusajs.com/api/store#manage-metadata
+                            description: Learn how to manage metadata
                         created_at:
                           type: string
                           format: date-time
@@ -35624,6 +36206,9 @@ components:
                             metadata:
                               type: object
                               description: The detail's metadata.
+                              externalDocs:
+                                url: https://docs.medusajs.com/api/store#manage-metadata
+                                description: Learn how to manage metadata
                             created_at:
                               type: string
                               format: date-time
@@ -35654,6 +36239,9 @@ components:
                     metadata:
                       type: object
                       description: The item's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     created_at:
                       type: string
                       format: date-time
@@ -35809,6 +36397,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         original_total:
           type: number
           title: original_total
@@ -35934,6 +36525,9 @@ components:
         metadata:
           type: object
           description: The shipping method's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         tax_lines:
           type: array
           description: The shipping method's tax lines.
@@ -36011,6 +36605,9 @@ components:
                       metadata:
                         type: object
                         description: The shipping method's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       tax_lines:
                         type: array
                         description: The shipping method's tax lines.
@@ -36542,6 +37139,9 @@ components:
                       metadata:
                         type: object
                         description: The shipping method's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       original_total:
                         type: number
                         title: original_total
@@ -36660,6 +37260,9 @@ components:
                       metadata:
                         type: object
                         description: The shipping method's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       tax_lines:
                         type: array
                         description: The shipping method's tax lines.
@@ -37187,6 +37790,9 @@ components:
                       metadata:
                         type: object
                         description: The shipping method's metadata.
+                        externalDocs:
+                          url: https://docs.medusajs.com/api/store#manage-metadata
+                          description: Learn how to manage metadata
                       original_total:
                         type: number
                         title: original_total
@@ -37543,6 +38149,9 @@ components:
                     metadata:
                       type: object
                       description: The shipping method's metadata.
+                      externalDocs:
+                        url: https://docs.medusajs.com/api/store#manage-metadata
+                        description: Learn how to manage metadata
                     original_total:
                       type: number
                       title: original_total
@@ -37639,6 +38248,9 @@ components:
         metadata:
           type: object
           description: The payment collection's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         status:
           type: string
           description: The payment collection's status.
@@ -37881,6 +38493,9 @@ components:
         metadata:
           type: object
           description: The product's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -38024,6 +38639,9 @@ components:
         metadata:
           type: object
           description: The category's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -38120,6 +38738,9 @@ components:
         metadata:
           type: object
           description: The image's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         rank:
           type: number
           title: rank
@@ -38151,6 +38772,9 @@ components:
         metadata:
           type: object
           description: The option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -38194,6 +38818,9 @@ components:
         metadata:
           type: object
           description: The value's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -38249,6 +38876,9 @@ components:
         metadata:
           type: object
           description: The tag's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
       required:
         - id
         - value
@@ -38312,6 +38942,9 @@ components:
         metadata:
           type: object
           description: The product type's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -38395,6 +39028,9 @@ components:
         metadata:
           type: object
           description: The variant's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         id:
           type: string
           title: id
@@ -38546,6 +39182,9 @@ components:
         metadata:
           type: object
           description: The region's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -38725,6 +39364,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreReturnReason:
       type: object
       description: The return reason's details.
@@ -38755,6 +39397,9 @@ components:
         metadata:
           type: object
           description: The return reason's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -38852,6 +39497,9 @@ components:
         metadata:
           type: object
           description: The shipping option's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreShippingOptionListResponse:
       type: object
       description: The shipping option's details.
@@ -38974,6 +39622,9 @@ components:
         metadata:
           type: object
           description: The store credit account's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
         created_at:
           type: string
           format: date-time
@@ -39062,6 +39713,9 @@ components:
         metadata:
           type: object
           description: The transaction group's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
       x-schemaName: StoreTransactionGroup
     StoreUpdateCartLineItem:
       type: object
@@ -39077,6 +39731,9 @@ components:
         metadata:
           type: object
           description: The item's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreUpdateCustomer:
       type: object
       description: The details to update in the customer.
@@ -39101,6 +39758,9 @@ components:
         metadata:
           type: object
           description: The customer's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     StoreUpdateCustomerAddress:
       type: object
       description: The properties to update in the address.
@@ -39228,6 +39888,9 @@ components:
         metadata:
           type: object
           description: The address's metadata, can hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     UpdateCartData:
       type: object
       description: The details to update in a cart.
@@ -39274,6 +39937,9 @@ components:
         metadata:
           type: object
           description: The cart's metadata, ca hold custom key-value pairs.
+          externalDocs:
+            url: https://docs.medusajs.com/api/store#manage-metadata
+            description: Learn how to manage metadata
     WorkflowExecutionContext:
       type: object
       description: The workflow execution's context.

--- a/www/apps/book/app/learn/fundamentals/data-models/json-properties/page.mdx
+++ b/www/apps/book/app/learn/fundamentals/data-models/json-properties/page.mdx
@@ -72,7 +72,7 @@ For example, if you want to re-use brands across different products, it's better
 
 ### How Medusa Updates JSON Properties
 
-Consider a Brand Module with a `Brand` data model as shown [in the previous section](#what-are-json-properties). The [module's service](../../modules/page.mdx#2-create-service) will extend `MedusaService`, which generates methods like [updateBrands](!resources!/service-factory-reference/methods/update) to update a brand.
+Consider a Brand Module with a `Brand` data model as shown [in the previous section](#what-is-a-json-property). The [module's service](../../modules/page.mdx#2-create-service) will extend `MedusaService`, which generates methods like [updateBrands](!resources!/service-factory-reference/methods/update) to update a brand.
 
 When you pass a JSON property in the `updateBrands` method, Medusa will merge the provided JSON object with the existing one in the database. So, only the properties you pass will be updated, and the rest will remain unchanged.
 
@@ -235,3 +235,9 @@ The brand record will now have the `metadata` property updated to remove the `is
   }
 }
 ```
+
+### Manage JSON Properties in API Routes
+
+The instructions above also apply when managing JSON properties in API routes, since they typically use a service's `update` method under the hood.
+
+Refer to the [API reference](!api!/store#manage-metadata) to learn more about managing JSON properties, such as `metadata`, in API routes.

--- a/www/apps/book/generated/edit-dates.mjs
+++ b/www/apps/book/generated/edit-dates.mjs
@@ -127,5 +127,5 @@ export const generatedEditDates = {
   "app/learn/fundamentals/generated-types/page.mdx": "2025-07-25T13:17:35.319Z",
   "app/learn/introduction/from-v1-to-v2/page.mdx": "2025-07-30T08:13:48.592Z",
   "app/learn/debugging-and-testing/debug-workflows/page.mdx": "2025-07-30T13:45:14.117Z",
-  "app/learn/fundamentals/data-models/json-properties/page.mdx": "2025-07-31T08:38:55.014Z"
+  "app/learn/fundamentals/data-models/json-properties/page.mdx": "2025-07-31T10:47:27.882Z"
 }

--- a/www/apps/book/public/llms-full.txt
+++ b/www/apps/book/public/llms-full.txt
@@ -9674,7 +9674,7 @@ For example, if you want to re-use brands across different products, it's better
 
 ### How Medusa Updates JSON Properties
 
-Consider a Brand Module with a `Brand` data model as shown [in the previous section](#what-are-json-properties). The [module's service](https://docs.medusajs.com/learn/fundamentals/modules#2-create-service/index.html.md) will extend `MedusaService`, which generates methods like [updateBrands](https://docs.medusajs.com/resources/service-factory-reference/methods/update/index.html.md) to update a brand.
+Consider a Brand Module with a `Brand` data model as shown [in the previous section](#what-is-a-json-property). The [module's service](https://docs.medusajs.com/learn/fundamentals/modules#2-create-service/index.html.md) will extend `MedusaService`, which generates methods like [updateBrands](https://docs.medusajs.com/resources/service-factory-reference/methods/update/index.html.md) to update a brand.
 
 When you pass a JSON property in the `updateBrands` method, Medusa will merge the provided JSON object with the existing one in the database. So, only the properties you pass will be updated, and the rest will remain unchanged.
 
@@ -9833,6 +9833,12 @@ The brand record will now have the `metadata` property updated to remove the `is
   }
 }
 ```
+
+### Manage JSON Properties in API Routes
+
+The instructions above also apply when managing JSON properties in API routes, since they typically use a service's `update` method under the hood.
+
+Refer to the [API reference](https://docs.medusajs.com/api/store#manage-metadata) to learn more about managing JSON properties, such as `metadata`, in API routes.
 
 
 # Manage Relationships

--- a/www/apps/book/public/llms.txt
+++ b/www/apps/book/public/llms.txt
@@ -1,6 +1,6 @@
 # Medusa
 
-> Medusa is a digital commerce platform with a built-in framework for customization. When you install Medusa, you get a fully fledged commerce platform with all the features you need to get off the ground. However, unlike other platforms, Medusa is built with customization in mind. You don't need to build hacky workarounds that are difficult to maintain and scale. Your efforts go into building features that bring your business's vision to life.
+> Medusa is a digital commerce platform with a built-in Framework for customization. When you install Medusa, you get a fully fledged commerce platform with all the features you need to get off the ground. However, unlike other platforms, Medusa is built with customization in mind. You don't need to build hacky workarounds that are difficult to maintain and scale. Your efforts go into building features that bring your business's vision to life.
 
 Medusa ships with three main tools:
 

--- a/www/utils/generated/oas-output/schemas/AdminAddDraftOrderItems.ts
+++ b/www/utils/generated/oas-output/schemas/AdminAddDraftOrderItems.ts
@@ -44,6 +44,9 @@
  *         metadata:
  *           type: object
  *           description: The item's metadata, can hold custom key-value pairs.
+ *           externalDocs:
+ *             url: https://docs.medusajs.com/api/admin#manage-metadata
+ *             description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminAddDraftOrderShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/AdminAddDraftOrderShippingMethod.ts
@@ -25,6 +25,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping method's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminBatchUpdateProduct.ts
+++ b/www/utils/generated/oas-output/schemas/AdminBatchUpdateProduct.ts
@@ -147,6 +147,9 @@
  *   metadata:
  *     type: object
  *     description: The product's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   external_id:
  *     type: string
  *     title: external_id

--- a/www/utils/generated/oas-output/schemas/AdminBatchUpdateProductVariant.ts
+++ b/www/utils/generated/oas-output/schemas/AdminBatchUpdateProductVariant.ts
@@ -71,6 +71,9 @@
  *   metadata:
  *     type: object
  *     description: The product variant's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   prices:
  *     type: array
  *     description: The product variant's prices.

--- a/www/utils/generated/oas-output/schemas/AdminClaim.ts
+++ b/www/utils/generated/oas-output/schemas/AdminClaim.ts
@@ -69,6 +69,9 @@
  *   metadata:
  *     type: object
  *     description: The claim's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminCollection.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCollection.ts
@@ -47,6 +47,9 @@
  *   metadata:
  *     type: object
  *     description: The collection's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateCustomerGroup.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateCustomerGroup.ts
@@ -13,6 +13,9 @@
  *   metadata:
  *     type: object
  *     description: The customer group's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateFulfillment.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateFulfillment.ts
@@ -72,6 +72,9 @@
  *       metadata:
  *         type: object
  *         description: The delivery address's metadata, used to store custom key-value pairs.
+ *         externalDocs:
+ *           url: https://docs.medusajs.com/api/admin#manage-metadata
+ *           description: Learn how to manage metadata
  *   items:
  *     type: array
  *     description: The items to fulfill.
@@ -168,6 +171,9 @@
  *   metadata:
  *     type: object
  *     description: The fulfillment's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateFulfillmentSetServiceZones.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateFulfillmentSetServiceZones.ts
@@ -24,6 +24,9 @@
  *             metadata:
  *               type: object
  *               description: The geo zone's metadata.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             country_code:
  *               type: string
  *               title: country_code
@@ -44,6 +47,9 @@
  *             metadata:
  *               type: object
  *               description: The geo zone's metadata.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             country_code:
  *               type: string
  *               title: country_code
@@ -73,6 +79,9 @@
  *             metadata:
  *               type: object
  *               description: The geo zone's metadata.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             country_code:
  *               type: string
  *               title: country_code
@@ -107,6 +116,9 @@
  *             metadata:
  *               type: object
  *               description: The geo zone's metadata.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             country_code:
  *               type: string
  *               title: country_code

--- a/www/utils/generated/oas-output/schemas/AdminCreateGiftCardParams.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateGiftCardParams.ts
@@ -51,6 +51,9 @@
  *   metadata:
  *     type: object
  *     description: The gift card's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateInventoryItem.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateInventoryItem.ts
@@ -59,6 +59,9 @@
  *   metadata:
  *     type: object
  *     description: The inventory item's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateOrderCreditLines.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateOrderCreditLines.ts
@@ -26,6 +26,9 @@
  *   metadata:
  *     type: object
  *     description: The credit line's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateProduct.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateProduct.ts
@@ -148,6 +148,9 @@
  *   metadata:
  *     type: object
  *     description: The product's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   external_id:
  *     type: string
  *     title: external_id

--- a/www/utils/generated/oas-output/schemas/AdminCreateProductCategory.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateProductCategory.ts
@@ -37,6 +37,9 @@
  *   metadata:
  *     type: object
  *     description: The product category's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateProductTag.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateProductTag.ts
@@ -13,6 +13,9 @@
  *   metadata:
  *     type: object
  *     description: The product tag's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateProductType.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateProductType.ts
@@ -9,6 +9,9 @@
  *   metadata:
  *     type: object
  *     description: The product's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   value:
  *     type: string
  *     title: value

--- a/www/utils/generated/oas-output/schemas/AdminCreateProductVariant.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateProductVariant.ts
@@ -74,6 +74,9 @@
  *   metadata:
  *     type: object
  *     description: The variant's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   prices:
  *     type: array
  *     description: The variant's prices.

--- a/www/utils/generated/oas-output/schemas/AdminCreateRegion.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateRegion.ts
@@ -43,6 +43,9 @@
  *   metadata:
  *     type: object
  *     description: The region's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateReservation.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateReservation.ts
@@ -31,6 +31,9 @@
  *   metadata:
  *     type: object
  *     description: The reservation's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateReturnReason.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateReturnReason.ts
@@ -26,6 +26,9 @@
  *   metadata:
  *     type: object
  *     description: The return reason's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateSalesChannel.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateSalesChannel.ts
@@ -21,6 +21,9 @@
  *   metadata:
  *     type: object
  *     description: The sales channel's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateShippingProfile.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateShippingProfile.ts
@@ -18,6 +18,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping profile's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateStockLocation.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateStockLocation.ts
@@ -19,6 +19,9 @@
  *   metadata:
  *     type: object
  *     description: The stock location's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateStoreCreditAccount.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateStoreCreditAccount.ts
@@ -19,6 +19,9 @@
  *   metadata:
  *     type: object
  *     description: The store credit account's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateTaxRate.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateTaxRate.ts
@@ -44,6 +44,9 @@
  *   metadata:
  *     type: object
  *     description: The tax rate's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminCreateTaxRegion.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCreateTaxRegion.ts
@@ -52,9 +52,15 @@
  *       metadata:
  *         type: object
  *         description: The default tax rate's metadata, used to store custom key-value pairs.
+ *         externalDocs:
+ *           url: https://docs.medusajs.com/api/admin#manage-metadata
+ *           description: Learn how to manage metadata
  *   metadata:
  *     type: object
  *     description: The tax region's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   provider_id:
  *     type: string
  *     title: provider_id

--- a/www/utils/generated/oas-output/schemas/AdminCustomer.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCustomer.ts
@@ -64,6 +64,9 @@
  *   metadata:
  *     type: object
  *     description: The customer's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_by:
  *     type: string
  *     title: created_by

--- a/www/utils/generated/oas-output/schemas/AdminCustomerAddress.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCustomerAddress.ts
@@ -91,6 +91,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminCustomerGroup.ts
+++ b/www/utils/generated/oas-output/schemas/AdminCustomerGroup.ts
@@ -27,6 +27,9 @@
  *   metadata:
  *     type: object
  *     description: The customer group's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminDraftOrder.ts
+++ b/www/utils/generated/oas-output/schemas/AdminDraftOrder.ts
@@ -146,6 +146,9 @@
  *   metadata:
  *     type: object
  *     description: The draft order's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminDraftOrderPreview.ts
+++ b/www/utils/generated/oas-output/schemas/AdminDraftOrderPreview.ts
@@ -214,6 +214,9 @@
  *             metadata:
  *               type: object
  *               description: The item's metadata, can hold custom key-value pairs.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             original_total:
  *               type: number
  *               title: original_total
@@ -340,6 +343,9 @@
  *             metadata:
  *               type: object
  *               description: The shipping method's metadata, can hold custom key-value pairs.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             tax_lines:
  *               type: array
  *               description: The shipping method's tax lines.
@@ -517,6 +523,9 @@
  *   metadata:
  *     type: object
  *     description: The order's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminExchange.ts
+++ b/www/utils/generated/oas-output/schemas/AdminExchange.ts
@@ -64,6 +64,9 @@
  *   metadata:
  *     type: object
  *     description: The exchange's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminFulfillment.ts
+++ b/www/utils/generated/oas-output/schemas/AdminFulfillment.ts
@@ -76,6 +76,9 @@
  *   metadata:
  *     type: object
  *     description: The fulfillment's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminFulfillmentAddress.ts
+++ b/www/utils/generated/oas-output/schemas/AdminFulfillmentAddress.ts
@@ -76,6 +76,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminInventoryLevel.ts
+++ b/www/utils/generated/oas-output/schemas/AdminInventoryLevel.ts
@@ -58,6 +58,9 @@
  *   metadata:
  *     type: object
  *     description: The location level's metadata.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   inventory_item:
  *     $ref: "#/components/schemas/AdminInventoryItem"
  *   available_quantity:

--- a/www/utils/generated/oas-output/schemas/AdminInvite.ts
+++ b/www/utils/generated/oas-output/schemas/AdminInvite.ts
@@ -37,6 +37,9 @@
  *   metadata:
  *     type: object
  *     description: The invite's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminOrder.ts
+++ b/www/utils/generated/oas-output/schemas/AdminOrder.ts
@@ -141,6 +141,9 @@
  *   metadata:
  *     type: object
  *     description: The order's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminOrderAddress.ts
+++ b/www/utils/generated/oas-output/schemas/AdminOrderAddress.ts
@@ -67,6 +67,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminOrderChange.ts
+++ b/www/utils/generated/oas-output/schemas/AdminOrderChange.ts
@@ -112,6 +112,9 @@
  *   metadata:
  *     type: object
  *     description: The order change's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   declined_at:
  *     type: string
  *     title: declined_at

--- a/www/utils/generated/oas-output/schemas/AdminOrderFulfillment.ts
+++ b/www/utils/generated/oas-output/schemas/AdminOrderFulfillment.ts
@@ -62,6 +62,9 @@
  *   metadata:
  *     type: object
  *     description: The fulfillment's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminOrderLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/AdminOrderLineItem.ts
@@ -162,6 +162,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   original_total:
  *     type: number
  *     title: original_total

--- a/www/utils/generated/oas-output/schemas/AdminOrderPreview.ts
+++ b/www/utils/generated/oas-output/schemas/AdminOrderPreview.ts
@@ -214,6 +214,9 @@
  *             metadata:
  *               type: object
  *               description: The item's metadata, can hold custom key-value pairs.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             original_total:
  *               type: number
  *               title: original_total
@@ -340,6 +343,9 @@
  *             metadata:
  *               type: object
  *               description: The shipping method's metadata, can hold custom key-value pairs.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             tax_lines:
  *               type: array
  *               description: The shipping method's tax lines.
@@ -517,6 +523,9 @@
  *   metadata:
  *     type: object
  *     description: The order's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminOrderShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/AdminOrderShippingMethod.ts
@@ -59,6 +59,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping method's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   tax_lines:
  *     type: array
  *     description: The shipping method's tax lines.

--- a/www/utils/generated/oas-output/schemas/AdminPaymentCollection.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPaymentCollection.ts
@@ -52,6 +52,9 @@
  *   metadata:
  *     type: object
  *     description: The payment collection's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   status:
  *     type: string
  *     description: The payment collection's status.

--- a/www/utils/generated/oas-output/schemas/AdminPostClaimsAddItemsReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostClaimsAddItemsReqSchema.ts
@@ -33,6 +33,9 @@
  *         metadata:
  *           type: object
  *           description: The item's metadata, can hold custom key-value pairs.
+ *           externalDocs:
+ *             url: https://docs.medusajs.com/api/admin#manage-metadata
+ *             description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostClaimsShippingActionReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostClaimsShippingActionReqSchema.ts
@@ -15,6 +15,9 @@
  *   metadata:
  *     type: object
  *     description: The claim's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostClaimsShippingReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostClaimsShippingReqSchema.ts
@@ -25,6 +25,9 @@
  *   metadata:
  *     type: object
  *     description: The claim's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostExchangesAddItemsReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostExchangesAddItemsReqSchema.ts
@@ -37,6 +37,9 @@
  *         metadata:
  *           type: object
  *           description: The item's metadata, can hold custom key-value pairs.
+ *           externalDocs:
+ *             url: https://docs.medusajs.com/api/admin#manage-metadata
+ *             description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostExchangesRequestItemsReturnActionReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostExchangesRequestItemsReturnActionReqSchema.ts
@@ -19,6 +19,9 @@
  *   metadata:
  *     type: object
  *     description: The exchange's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostExchangesReturnRequestItemsReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostExchangesReturnRequestItemsReqSchema.ts
@@ -37,6 +37,9 @@
  *         metadata:
  *           type: object
  *           description: The item's metadata, can hold custom key-value pairs.
+ *           externalDocs:
+ *             url: https://docs.medusajs.com/api/admin#manage-metadata
+ *             description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostExchangesShippingActionReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostExchangesShippingActionReqSchema.ts
@@ -15,6 +15,9 @@
  *   metadata:
  *     type: object
  *     description: The exchange's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostExchangesShippingReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostExchangesShippingReqSchema.ts
@@ -25,6 +25,9 @@
  *   metadata:
  *     type: object
  *     description: The exchange's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostOrderClaimsReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostOrderClaimsReqSchema.ts
@@ -32,6 +32,9 @@
  *   metadata:
  *     type: object
  *     description: The claim's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostOrderEditsAddItemsReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostOrderEditsAddItemsReqSchema.ts
@@ -37,6 +37,9 @@
  *         metadata:
  *           type: object
  *           description: The item's metadata, can hold custom key-value pairs.
+ *           externalDocs:
+ *             url: https://docs.medusajs.com/api/admin#manage-metadata
+ *             description: Learn how to manage metadata
  *         compare_at_unit_price:
  *           type: number
  *           title: compare_at_unit_price

--- a/www/utils/generated/oas-output/schemas/AdminPostOrderEditsReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostOrderEditsReqSchema.ts
@@ -21,6 +21,9 @@
  *   metadata:
  *     type: object
  *     description: The order edit's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostOrderEditsShippingActionReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostOrderEditsShippingActionReqSchema.ts
@@ -15,6 +15,9 @@
  *   metadata:
  *     type: object
  *     description: The order edit's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostOrderEditsShippingReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostOrderEditsShippingReqSchema.ts
@@ -25,6 +25,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping method's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostOrderExchangesReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostOrderExchangesReqSchema.ts
@@ -21,6 +21,9 @@
  *   metadata:
  *     type: object
  *     description: The exchange's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostReceiveReturnsReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostReceiveReturnsReqSchema.ts
@@ -15,6 +15,9 @@
  *   metadata:
  *     type: object
  *     description: The return's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostReturnsReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostReturnsReqSchema.ts
@@ -29,6 +29,9 @@
  *   metadata:
  *     type: object
  *     description: The return's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostReturnsRequestItemsActionReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostReturnsRequestItemsActionReqSchema.ts
@@ -19,6 +19,9 @@
  *   metadata:
  *     type: object
  *     description: The claim's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostReturnsRequestItemsReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostReturnsRequestItemsReqSchema.ts
@@ -37,6 +37,9 @@
  *         metadata:
  *           type: object
  *           description: The item's metadata, can hold custom key-value pairs.
+ *           externalDocs:
+ *             url: https://docs.medusajs.com/api/admin#manage-metadata
+ *             description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostReturnsReturnReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostReturnsReturnReqSchema.ts
@@ -15,6 +15,9 @@
  *   metadata:
  *     type: object
  *     description: The return's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostReturnsShippingActionReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostReturnsShippingActionReqSchema.ts
@@ -15,6 +15,9 @@
  *   metadata:
  *     type: object
  *     description: The return's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminPostReturnsShippingReqSchema.ts
+++ b/www/utils/generated/oas-output/schemas/AdminPostReturnsShippingReqSchema.ts
@@ -25,6 +25,9 @@
  *   metadata:
  *     type: object
  *     description: The exchange's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminProduct.ts
+++ b/www/utils/generated/oas-output/schemas/AdminProduct.ts
@@ -88,6 +88,9 @@
  *   metadata:
  *     type: object
  *     description: The product's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminProductCategory.ts
+++ b/www/utils/generated/oas-output/schemas/AdminProductCategory.ts
@@ -45,6 +45,9 @@
  *   metadata:
  *     type: object
  *     description: The category's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminProductImage.ts
+++ b/www/utils/generated/oas-output/schemas/AdminProductImage.ts
@@ -30,6 +30,9 @@
  *   metadata:
  *     type: object
  *     description: The image's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   rank:
  *     type: number
  *     title: rank

--- a/www/utils/generated/oas-output/schemas/AdminProductOption.ts
+++ b/www/utils/generated/oas-output/schemas/AdminProductOption.ts
@@ -29,6 +29,9 @@
  *   metadata:
  *     type: object
  *     description: The product option's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminProductOptionValue.ts
+++ b/www/utils/generated/oas-output/schemas/AdminProductOptionValue.ts
@@ -24,6 +24,9 @@
  *   metadata:
  *     type: object
  *     description: The value's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminProductTag.ts
+++ b/www/utils/generated/oas-output/schemas/AdminProductTag.ts
@@ -35,6 +35,9 @@
  *   metadata:
  *     type: object
  *     description: The tag's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminProductType.ts
+++ b/www/utils/generated/oas-output/schemas/AdminProductType.ts
@@ -35,6 +35,9 @@
  *   metadata:
  *     type: object
  *     description: The type's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminProductVariant.ts
+++ b/www/utils/generated/oas-output/schemas/AdminProductVariant.ts
@@ -134,6 +134,9 @@
  *   metadata:
  *     type: object
  *     description: The variant's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   inventory_items:
  *     type: array
  *     description: The variant's inventory items.

--- a/www/utils/generated/oas-output/schemas/AdminRefundReason.ts
+++ b/www/utils/generated/oas-output/schemas/AdminRefundReason.ts
@@ -25,6 +25,9 @@
  *   metadata:
  *     type: object
  *     description: The refund reason's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminRegion.ts
+++ b/www/utils/generated/oas-output/schemas/AdminRegion.ts
@@ -38,6 +38,9 @@
  *   metadata:
  *     type: object
  *     description: The region's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminReservation.ts
+++ b/www/utils/generated/oas-output/schemas/AdminReservation.ts
@@ -45,6 +45,9 @@
  *   metadata:
  *     type: object
  *     description: The reservation's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_by:
  *     type: string
  *     title: created_by

--- a/www/utils/generated/oas-output/schemas/AdminReturnItem.ts
+++ b/www/utils/generated/oas-output/schemas/AdminReturnItem.ts
@@ -46,6 +46,9 @@
  *   metadata:
  *     type: object
  *     description: The return item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminReturnReason.ts
+++ b/www/utils/generated/oas-output/schemas/AdminReturnReason.ts
@@ -29,6 +29,9 @@
  *   metadata:
  *     type: object
  *     description: The return reason's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminSalesChannel.ts
+++ b/www/utils/generated/oas-output/schemas/AdminSalesChannel.ts
@@ -32,6 +32,9 @@
  *   metadata:
  *     type: object
  *     description: The sales channel's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminShippingOption.ts
+++ b/www/utils/generated/oas-output/schemas/AdminShippingOption.ts
@@ -80,6 +80,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping option's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminShippingProfile.ts
+++ b/www/utils/generated/oas-output/schemas/AdminShippingProfile.ts
@@ -19,6 +19,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping profile's metadata, holds custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminStore.ts
+++ b/www/utils/generated/oas-output/schemas/AdminStore.ts
@@ -42,6 +42,9 @@
  *   metadata:
  *     type: object
  *     description: The store's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminStoreCreditAccount.ts
+++ b/www/utils/generated/oas-output/schemas/AdminStoreCreditAccount.ts
@@ -51,6 +51,9 @@
  *   metadata:
  *     type: object
  *     description: The store credit account's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminTaxRate.ts
+++ b/www/utils/generated/oas-output/schemas/AdminTaxRate.ts
@@ -39,6 +39,9 @@
  *   metadata:
  *     type: object
  *     description: The tax rate's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   tax_region_id:
  *     type: string
  *     title: tax_region_id

--- a/www/utils/generated/oas-output/schemas/AdminTaxRegion.ts
+++ b/www/utils/generated/oas-output/schemas/AdminTaxRegion.ts
@@ -37,6 +37,9 @@
  *   metadata:
  *     type: object
  *     description: The tax region's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   parent_id:
  *     type: string
  *     title: parent_id

--- a/www/utils/generated/oas-output/schemas/AdminTransaction.ts
+++ b/www/utils/generated/oas-output/schemas/AdminTransaction.ts
@@ -53,6 +53,9 @@
  *   metadata:
  *     type: object
  *     description: The transaction's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/AdminTransactionGroup.ts
+++ b/www/utils/generated/oas-output/schemas/AdminTransactionGroup.ts
@@ -37,6 +37,9 @@
  *   metadata:
  *     type: object
  *     description: The transaction group's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUpdateCustomerGroup.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateCustomerGroup.ts
@@ -11,6 +11,9 @@
  *   metadata:
  *     type: object
  *     description: The customer group's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUpdateDraftOrder.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateDraftOrder.ts
@@ -61,6 +61,9 @@
  *       metadata:
  *         type: object
  *         description: The shipping address's metadata, can hold custom key-value pairs.
+ *         externalDocs:
+ *           url: https://docs.medusajs.com/api/admin#manage-metadata
+ *           description: Learn how to manage metadata
  *   billing_address:
  *     type: object
  *     description: The draft order's billing address.
@@ -113,9 +116,15 @@
  *       metadata:
  *         type: object
  *         description: The billing address's metadata, can hold custom key-value pairs.
+ *         externalDocs:
+ *           url: https://docs.medusajs.com/api/admin#manage-metadata
+ *           description: Learn how to manage metadata
  *   metadata:
  *     type: object
  *     description: The draft order's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   customer_id:
  *     type: string
  *     title: customer_id

--- a/www/utils/generated/oas-output/schemas/AdminUpdateDraftOrderActionShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateDraftOrderActionShippingMethod.ts
@@ -25,6 +25,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping method's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUpdateFulfillmentSetServiceZones.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateFulfillmentSetServiceZones.ts
@@ -27,6 +27,9 @@
  *             metadata:
  *               type: object
  *               description: The geo zone's metadata.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             country_code:
  *               type: string
  *               title: country_code
@@ -51,6 +54,9 @@
  *             metadata:
  *               type: object
  *               description: The geo zone's metadata.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             country_code:
  *               type: string
  *               title: country_code
@@ -84,6 +90,9 @@
  *             metadata:
  *               type: object
  *               description: The geo zone's metadata.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             city:
  *               type: string
  *               title: city
@@ -122,6 +131,9 @@
  *             metadata:
  *               type: object
  *               description: The geo zone's metadata.
+ *               externalDocs:
+ *                 url: https://docs.medusajs.com/api/admin#manage-metadata
+ *                 description: Learn how to manage metadata
  *             city:
  *               type: string
  *               title: city

--- a/www/utils/generated/oas-output/schemas/AdminUpdateGiftCardParams.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateGiftCardParams.ts
@@ -34,6 +34,9 @@
  *   metadata:
  *     type: object
  *     description: The gift card's metadata.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUpdateInventoryItem.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateInventoryItem.ts
@@ -58,6 +58,9 @@
  *   metadata:
  *     type: object
  *     description: The inventory item's metadata. Can be custom data in key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * x-schemaName: AdminUpdateInventoryItem
  * 
 */

--- a/www/utils/generated/oas-output/schemas/AdminUpdateOrder.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateOrder.ts
@@ -61,6 +61,9 @@
  *       metadata:
  *         type: object
  *         description: The address's metadata, can hold custom key-value pairs.
+ *         externalDocs:
+ *           url: https://docs.medusajs.com/api/admin#manage-metadata
+ *           description: Learn how to manage metadata
  *   billing_address:
  *     type: object
  *     description: The order's billing address.
@@ -113,9 +116,15 @@
  *       metadata:
  *         type: object
  *         description: The address's metadata, can hold custom key-value pairs.
+ *         externalDocs:
+ *           url: https://docs.medusajs.com/api/admin#manage-metadata
+ *           description: Learn how to manage metadata
  *   metadata:
  *     type: object
  *     description: The order's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUpdateProduct.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateProduct.ts
@@ -147,6 +147,9 @@
  *   metadata:
  *     type: object
  *     description: The product's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   external_id:
  *     type: string
  *     title: external_id

--- a/www/utils/generated/oas-output/schemas/AdminUpdateProductCategory.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateProductCategory.ts
@@ -30,6 +30,9 @@
  *   metadata:
  *     type: object
  *     description: The product category's metadata. Can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   rank:
  *     type: number
  *     title: rank

--- a/www/utils/generated/oas-output/schemas/AdminUpdateProductTag.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateProductTag.ts
@@ -10,6 +10,9 @@
  *   metadata:
  *     type: object
  *     description: The product tag's metadata. Can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * x-schemaName: AdminUpdateProductTag
  * 
 */

--- a/www/utils/generated/oas-output/schemas/AdminUpdateProductType.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateProductType.ts
@@ -10,6 +10,9 @@
  *   metadata:
  *     type: object
  *     description: The product type's metadata. Can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * x-schemaName: AdminUpdateProductType
  * 
 */

--- a/www/utils/generated/oas-output/schemas/AdminUpdateProductVariant.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateProductVariant.ts
@@ -71,6 +71,9 @@
  *   metadata:
  *     type: object
  *     description: The product variant's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   prices:
  *     type: array
  *     description: The product variant's prices.

--- a/www/utils/generated/oas-output/schemas/AdminUpdateRegion.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateRegion.ts
@@ -32,6 +32,9 @@
  *   metadata:
  *     type: object
  *     description: The region's metadata. Can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   is_tax_inclusive:
  *     type: boolean
  *     title: is_tax_inclusive

--- a/www/utils/generated/oas-output/schemas/AdminUpdateReservation.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateReservation.ts
@@ -18,6 +18,9 @@
  *   metadata:
  *     type: object
  *     description: The reservation's metadata. Can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * x-schemaName: AdminUpdateReservation
  * 
 */

--- a/www/utils/generated/oas-output/schemas/AdminUpdateReturnReason.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateReturnReason.ts
@@ -19,6 +19,9 @@
  *   metadata:
  *     type: object
  *     description: The return reason's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * required:
  *   - value
  *   - label

--- a/www/utils/generated/oas-output/schemas/AdminUpdateSalesChannel.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateSalesChannel.ts
@@ -19,6 +19,9 @@
  *   metadata:
  *     type: object
  *     description: The sales channel's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUpdateShippingProfile.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateShippingProfile.ts
@@ -14,6 +14,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping profile's metadata.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * x-schemaName: AdminUpdateShippingProfile
  * 
 */

--- a/www/utils/generated/oas-output/schemas/AdminUpdateStockLocation.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateStockLocation.ts
@@ -59,6 +59,9 @@
  *   metadata:
  *     type: object
  *     description: The stock location's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUpdateStore.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateStore.ts
@@ -45,6 +45,9 @@
  *   metadata:
  *     type: object
  *     description: The store's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUpdateTaxRate.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateTaxRate.ts
@@ -49,6 +49,9 @@
  *   metadata:
  *     type: object
  *     description: The tax rate's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUpdateTaxRegion.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateTaxRegion.ts
@@ -15,6 +15,9 @@
  *   metadata:
  *     type: object
  *     description: The tax region's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   provider_id:
  *     type: string
  *     title: provider_id

--- a/www/utils/generated/oas-output/schemas/AdminUpdateUser.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUpdateUser.ts
@@ -19,6 +19,9 @@
  *   metadata:
  *     type: object
  *     description: The user's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/AdminUser.ts
+++ b/www/utils/generated/oas-output/schemas/AdminUser.ts
@@ -38,6 +38,9 @@
  *   metadata:
  *     type: object
  *     description: The user's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/admin#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseCart.ts
+++ b/www/utils/generated/oas-output/schemas/BaseCart.ts
@@ -75,6 +75,9 @@
  *   metadata:
  *     type: object
  *     description: The cart's metadata.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseCartLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/BaseCartLineItem.ts
@@ -135,6 +135,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseCartShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/BaseCartShippingMethod.ts
@@ -56,6 +56,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping method's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   tax_lines:
  *     type: array
  *     description: The shipping method's tax lines.

--- a/www/utils/generated/oas-output/schemas/BaseClaimItem.ts
+++ b/www/utils/generated/oas-output/schemas/BaseClaimItem.ts
@@ -57,6 +57,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseCollection.ts
+++ b/www/utils/generated/oas-output/schemas/BaseCollection.ts
@@ -47,6 +47,9 @@
  *   metadata:
  *     type: object
  *     description: The collection's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/BaseExchangeItem.ts
+++ b/www/utils/generated/oas-output/schemas/BaseExchangeItem.ts
@@ -35,6 +35,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseOrder.ts
+++ b/www/utils/generated/oas-output/schemas/BaseOrder.ts
@@ -136,6 +136,9 @@
  *   metadata:
  *     type: object
  *     description: The order's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseOrderAddress.ts
+++ b/www/utils/generated/oas-output/schemas/BaseOrderAddress.ts
@@ -65,6 +65,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseOrderFulfillment.ts
+++ b/www/utils/generated/oas-output/schemas/BaseOrderFulfillment.ts
@@ -62,6 +62,9 @@
  *   metadata:
  *     type: object
  *     description: The fulfillment's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseOrderLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/BaseOrderLineItem.ts
@@ -162,6 +162,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   original_total:
  *     type: number
  *     title: original_total

--- a/www/utils/generated/oas-output/schemas/BaseOrderShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/BaseOrderShippingMethod.ts
@@ -59,6 +59,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping method's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   tax_lines:
  *     type: array
  *     description: The shipping method's tax lines.

--- a/www/utils/generated/oas-output/schemas/BaseOrderTransaction.ts
+++ b/www/utils/generated/oas-output/schemas/BaseOrderTransaction.ts
@@ -45,6 +45,9 @@
  *   metadata:
  *     type: object
  *     description: The transaction's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BasePaymentCollection.ts
+++ b/www/utils/generated/oas-output/schemas/BasePaymentCollection.ts
@@ -52,6 +52,9 @@
  *   metadata:
  *     type: object
  *     description: The payment collection's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   status:
  *     type: string
  *     description: The payment collection's status.

--- a/www/utils/generated/oas-output/schemas/BaseProduct.ts
+++ b/www/utils/generated/oas-output/schemas/BaseProduct.ts
@@ -82,6 +82,9 @@
  *   metadata:
  *     type: object
  *     description: The product's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseProductCategory.ts
+++ b/www/utils/generated/oas-output/schemas/BaseProductCategory.ts
@@ -45,6 +45,9 @@
  *   metadata:
  *     type: object
  *     description: The category's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseProductImage.ts
+++ b/www/utils/generated/oas-output/schemas/BaseProductImage.ts
@@ -30,6 +30,9 @@
  *   metadata:
  *     type: object
  *     description: The image's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   rank:
  *     type: number
  *     title: rank

--- a/www/utils/generated/oas-output/schemas/BaseProductOption.ts
+++ b/www/utils/generated/oas-output/schemas/BaseProductOption.ts
@@ -29,6 +29,9 @@
  *   metadata:
  *     type: object
  *     description: The product option's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseProductOptionValue.ts
+++ b/www/utils/generated/oas-output/schemas/BaseProductOptionValue.ts
@@ -24,6 +24,9 @@
  *   metadata:
  *     type: object
  *     description: The value's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/BaseProductTag.ts
+++ b/www/utils/generated/oas-output/schemas/BaseProductTag.ts
@@ -35,6 +35,9 @@
  *   metadata:
  *     type: object
  *     description: The tag's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/BaseProductType.ts
+++ b/www/utils/generated/oas-output/schemas/BaseProductType.ts
@@ -35,6 +35,9 @@
  *   metadata:
  *     type: object
  *     description: The type's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/BaseProductVariant.ts
+++ b/www/utils/generated/oas-output/schemas/BaseProductVariant.ts
@@ -128,6 +128,9 @@
  *   metadata:
  *     type: object
  *     description: The variant's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/BaseRegion.ts
+++ b/www/utils/generated/oas-output/schemas/BaseRegion.ts
@@ -37,6 +37,9 @@
  *   metadata:
  *     type: object
  *     description: The region's metadata.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/CreateAddress.ts
+++ b/www/utils/generated/oas-output/schemas/CreateAddress.ts
@@ -56,6 +56,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/InventoryLevel.ts
+++ b/www/utils/generated/oas-output/schemas/InventoryLevel.ts
@@ -43,6 +43,9 @@
  *   metadata:
  *     type: object
  *     description: The inventory level's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/Order.ts
+++ b/www/utils/generated/oas-output/schemas/Order.ts
@@ -177,6 +177,9 @@
  *   metadata:
  *     type: object
  *     description: The order's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   canceled_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/OrderAddress.ts
+++ b/www/utils/generated/oas-output/schemas/OrderAddress.ts
@@ -64,6 +64,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/OrderChange.ts
+++ b/www/utils/generated/oas-output/schemas/OrderChange.ts
@@ -112,6 +112,9 @@
  *   metadata:
  *     type: object
  *     description: The order change's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   declined_at:
  *     type: string
  *     title: declined_at

--- a/www/utils/generated/oas-output/schemas/OrderClaim.ts
+++ b/www/utils/generated/oas-output/schemas/OrderClaim.ts
@@ -65,6 +65,9 @@
  *   metadata:
  *     type: object
  *     description: The claim's metadata, used to store custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/OrderCreditLine.ts
+++ b/www/utils/generated/oas-output/schemas/OrderCreditLine.ts
@@ -35,6 +35,9 @@
  *   metadata:
  *     type: object
  *     description: The credit line's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/OrderExchange.ts
+++ b/www/utils/generated/oas-output/schemas/OrderExchange.ts
@@ -57,6 +57,9 @@
  *   metadata:
  *     type: object
  *     description: The exchange's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/OrderItem.ts
+++ b/www/utils/generated/oas-output/schemas/OrderItem.ts
@@ -64,6 +64,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/OrderLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/OrderLineItem.ts
@@ -143,6 +143,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   original_total:
  *     type: number
  *     title: original_total

--- a/www/utils/generated/oas-output/schemas/OrderReturnItem.ts
+++ b/www/utils/generated/oas-output/schemas/OrderReturnItem.ts
@@ -37,6 +37,9 @@
  *   metadata:
  *     type: object
  *     description: The return item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   order_id:
  *     type: string
  *     title: order_id

--- a/www/utils/generated/oas-output/schemas/OrderShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/OrderShippingMethod.ts
@@ -56,6 +56,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping method's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   tax_lines:
  *     type: array
  *     description: The shipping method's tax lines.

--- a/www/utils/generated/oas-output/schemas/OrderTransaction.ts
+++ b/www/utils/generated/oas-output/schemas/OrderTransaction.ts
@@ -47,6 +47,9 @@
  *   metadata:
  *     type: object
  *     description: The transaction's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/RefundReason.ts
+++ b/www/utils/generated/oas-output/schemas/RefundReason.ts
@@ -25,6 +25,9 @@
  *   metadata:
  *     type: object
  *     description: The refund reason's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/Return.ts
+++ b/www/utils/generated/oas-output/schemas/Return.ts
@@ -49,6 +49,9 @@
  *   metadata:
  *     type: object
  *     description: The return's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreAddCartLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/StoreAddCartLineItem.ts
@@ -18,6 +18,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/StoreCart.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCart.ts
@@ -77,6 +77,9 @@
  *   metadata:
  *     type: object
  *     description: The cart's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreCartAddress.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCartAddress.ts
@@ -64,6 +64,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     title: created_at

--- a/www/utils/generated/oas-output/schemas/StoreCartLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCartLineItem.ts
@@ -279,6 +279,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     title: created_at

--- a/www/utils/generated/oas-output/schemas/StoreCartShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCartShippingMethod.ts
@@ -56,6 +56,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping method's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   tax_lines:
  *     type: array
  *     description: The shipping method's tax lines.

--- a/www/utils/generated/oas-output/schemas/StoreCollection.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCollection.ts
@@ -47,6 +47,9 @@
  *   metadata:
  *     type: object
  *     description: The collection's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/StoreCreateCart.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCreateCart.ts
@@ -34,6 +34,9 @@
  *   metadata:
  *     type: object
  *     description: The cart's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/StoreCreateCustomer.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCreateCustomer.ts
@@ -30,6 +30,9 @@
  *   metadata:
  *     type: object
  *     description: The customer's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/StoreCustomer.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCustomer.ts
@@ -54,6 +54,9 @@
  *   metadata:
  *     type: object
  *     description: The customer's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreCustomerAddress.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCustomerAddress.ts
@@ -91,6 +91,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreOrder.ts
+++ b/www/utils/generated/oas-output/schemas/StoreOrder.ts
@@ -127,6 +127,9 @@
  *   metadata:
  *     type: object
  *     description: The order's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreOrderAddress.ts
+++ b/www/utils/generated/oas-output/schemas/StoreOrderAddress.ts
@@ -67,6 +67,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreOrderFulfillment.ts
+++ b/www/utils/generated/oas-output/schemas/StoreOrderFulfillment.ts
@@ -62,6 +62,9 @@
  *   metadata:
  *     type: object
  *     description: The fulfillment's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreOrderLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/StoreOrderLineItem.ts
@@ -351,6 +351,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The variant's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                 variant_id:
  *                   type: string
  *                   title: variant_id
@@ -532,6 +535,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The product's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                 product_id:
  *                   type: string
  *                   title: product_id
@@ -796,6 +802,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The detail's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                     created_at:
  *                       type: string
  *                       format: date-time
@@ -819,6 +828,9 @@
  *                 metadata:
  *                   type: object
  *                   description: The item's metadata.
+ *                   externalDocs:
+ *                     url: https://docs.medusajs.com/api/store#manage-metadata
+ *                     description: Learn how to manage metadata
  *                 original_total:
  *                   type: number
  *                   title: original_total
@@ -1018,6 +1030,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The variant's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                     created_at:
  *                       type: string
  *                       format: date-time
@@ -1203,6 +1218,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The product's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                     created_at:
  *                       type: string
  *                       format: date-time
@@ -1496,6 +1514,9 @@
  *                         metadata:
  *                           type: object
  *                           description: The detail's metadata.
+ *                           externalDocs:
+ *                             url: https://docs.medusajs.com/api/store#manage-metadata
+ *                             description: Learn how to manage metadata
  *                         created_at:
  *                           type: string
  *                           format: date-time
@@ -1526,6 +1547,9 @@
  *                 metadata:
  *                   type: object
  *                   description: The item's metadata.
+ *                   externalDocs:
+ *                     url: https://docs.medusajs.com/api/store#manage-metadata
+ *                     description: Learn how to manage metadata
  *                 created_at:
  *                   type: string
  *                   format: date-time
@@ -1880,6 +1904,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The variant's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                 variant_id:
  *                   type: string
  *                   title: variant_id
@@ -2061,6 +2088,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The product's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                 product_id:
  *                   type: string
  *                   title: product_id
@@ -2325,6 +2355,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The detail's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                     created_at:
  *                       type: string
  *                       format: date-time
@@ -2348,6 +2381,9 @@
  *                 metadata:
  *                   type: object
  *                   description: The item's metadata.
+ *                   externalDocs:
+ *                     url: https://docs.medusajs.com/api/store#manage-metadata
+ *                     description: Learn how to manage metadata
  *                 original_total:
  *                   type: number
  *                   title: original_total
@@ -2543,6 +2579,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The variant's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                     created_at:
  *                       type: string
  *                       format: date-time
@@ -2728,6 +2767,9 @@
  *                     metadata:
  *                       type: object
  *                       description: The product's metadata.
+ *                       externalDocs:
+ *                         url: https://docs.medusajs.com/api/store#manage-metadata
+ *                         description: Learn how to manage metadata
  *                     created_at:
  *                       type: string
  *                       format: date-time
@@ -3021,6 +3063,9 @@
  *                         metadata:
  *                           type: object
  *                           description: The detail's metadata.
+ *                           externalDocs:
+ *                             url: https://docs.medusajs.com/api/store#manage-metadata
+ *                             description: Learn how to manage metadata
  *                         created_at:
  *                           type: string
  *                           format: date-time
@@ -3051,6 +3096,9 @@
  *                 metadata:
  *                   type: object
  *                   description: The item's metadata.
+ *                   externalDocs:
+ *                     url: https://docs.medusajs.com/api/store#manage-metadata
+ *                     description: Learn how to manage metadata
  *                 created_at:
  *                   type: string
  *                   format: date-time
@@ -3297,6 +3345,9 @@
  *                   metadata:
  *                     type: object
  *                     description: The variant's metadata.
+ *                     externalDocs:
+ *                       url: https://docs.medusajs.com/api/store#manage-metadata
+ *                       description: Learn how to manage metadata
  *                   created_at:
  *                     type: string
  *                     format: date-time
@@ -3482,6 +3533,9 @@
  *                   metadata:
  *                     type: object
  *                     description: The product's metadata.
+ *                     externalDocs:
+ *                       url: https://docs.medusajs.com/api/store#manage-metadata
+ *                       description: Learn how to manage metadata
  *                   created_at:
  *                     type: string
  *                     format: date-time
@@ -3775,6 +3829,9 @@
  *                       metadata:
  *                         type: object
  *                         description: The detail's metadata.
+ *                         externalDocs:
+ *                           url: https://docs.medusajs.com/api/store#manage-metadata
+ *                           description: Learn how to manage metadata
  *                       created_at:
  *                         type: string
  *                         format: date-time
@@ -3805,6 +3862,9 @@
  *               metadata:
  *                 type: object
  *                 description: The item's metadata.
+ *                 externalDocs:
+ *                   url: https://docs.medusajs.com/api/store#manage-metadata
+ *                   description: Learn how to manage metadata
  *               created_at:
  *                 type: string
  *                 format: date-time
@@ -3960,6 +4020,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   original_total:
  *     type: number
  *     title: original_total

--- a/www/utils/generated/oas-output/schemas/StoreOrderShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/StoreOrderShippingMethod.ts
@@ -59,6 +59,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping method's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   tax_lines:
  *     type: array
  *     description: The shipping method's tax lines.
@@ -136,6 +139,9 @@
  *                 metadata:
  *                   type: object
  *                   description: The shipping method's metadata.
+ *                   externalDocs:
+ *                     url: https://docs.medusajs.com/api/store#manage-metadata
+ *                     description: Learn how to manage metadata
  *                 tax_lines:
  *                   type: array
  *                   description: The shipping method's tax lines.
@@ -667,6 +673,9 @@
  *                 metadata:
  *                   type: object
  *                   description: The shipping method's metadata.
+ *                   externalDocs:
+ *                     url: https://docs.medusajs.com/api/store#manage-metadata
+ *                     description: Learn how to manage metadata
  *                 original_total:
  *                   type: number
  *                   title: original_total
@@ -785,6 +794,9 @@
  *                 metadata:
  *                   type: object
  *                   description: The shipping method's metadata.
+ *                   externalDocs:
+ *                     url: https://docs.medusajs.com/api/store#manage-metadata
+ *                     description: Learn how to manage metadata
  *                 tax_lines:
  *                   type: array
  *                   description: The shipping method's tax lines.
@@ -1312,6 +1324,9 @@
  *                 metadata:
  *                   type: object
  *                   description: The shipping method's metadata.
+ *                   externalDocs:
+ *                     url: https://docs.medusajs.com/api/store#manage-metadata
+ *                     description: Learn how to manage metadata
  *                 original_total:
  *                   type: number
  *                   title: original_total
@@ -1668,6 +1683,9 @@
  *               metadata:
  *                 type: object
  *                 description: The shipping method's metadata.
+ *                 externalDocs:
+ *                   url: https://docs.medusajs.com/api/store#manage-metadata
+ *                   description: Learn how to manage metadata
  *               original_total:
  *                 type: number
  *                 title: original_total

--- a/www/utils/generated/oas-output/schemas/StorePaymentCollection.ts
+++ b/www/utils/generated/oas-output/schemas/StorePaymentCollection.ts
@@ -52,6 +52,9 @@
  *   metadata:
  *     type: object
  *     description: The payment collection's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   status:
  *     type: string
  *     description: The payment collection's status.

--- a/www/utils/generated/oas-output/schemas/StoreProduct.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProduct.ts
@@ -70,6 +70,9 @@
  *   metadata:
  *     type: object
  *     description: The product's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreProductCategory.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProductCategory.ts
@@ -50,6 +50,9 @@
  *   metadata:
  *     type: object
  *     description: The category's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreProductImage.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProductImage.ts
@@ -34,6 +34,9 @@
  *   metadata:
  *     type: object
  *     description: The image's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   rank:
  *     type: number
  *     title: rank

--- a/www/utils/generated/oas-output/schemas/StoreProductOption.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProductOption.ts
@@ -26,6 +26,9 @@
  *   metadata:
  *     type: object
  *     description: The option's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreProductOptionValue.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProductOptionValue.ts
@@ -24,6 +24,9 @@
  *   metadata:
  *     type: object
  *     description: The value's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreProductTag.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProductTag.ts
@@ -30,6 +30,9 @@
  *   metadata:
  *     type: object
  *     description: The tag's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * required:
  *   - id
  *   - value

--- a/www/utils/generated/oas-output/schemas/StoreProductType.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProductType.ts
@@ -16,6 +16,9 @@
  *   metadata:
  *     type: object
  *     description: The product type's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreProductVariant.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProductVariant.ts
@@ -22,6 +22,9 @@
  *   metadata:
  *     type: object
  *     description: The variant's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   id:
  *     type: string
  *     title: id

--- a/www/utils/generated/oas-output/schemas/StoreRegion.ts
+++ b/www/utils/generated/oas-output/schemas/StoreRegion.ts
@@ -38,6 +38,9 @@
  *   metadata:
  *     type: object
  *     description: The region's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreReturnItem.ts
+++ b/www/utils/generated/oas-output/schemas/StoreReturnItem.ts
@@ -46,6 +46,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/StoreReturnReason.ts
+++ b/www/utils/generated/oas-output/schemas/StoreReturnReason.ts
@@ -29,6 +29,9 @@
  *   metadata:
  *     type: object
  *     description: The return reason's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreShippingOption.ts
+++ b/www/utils/generated/oas-output/schemas/StoreShippingOption.ts
@@ -69,6 +69,9 @@
  *   metadata:
  *     type: object
  *     description: The shipping option's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/StoreStoreCreditAccount.ts
+++ b/www/utils/generated/oas-output/schemas/StoreStoreCreditAccount.ts
@@ -51,6 +51,9 @@
  *   metadata:
  *     type: object
  *     description: The store credit account's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  *   created_at:
  *     type: string
  *     format: date-time

--- a/www/utils/generated/oas-output/schemas/StoreTransactionGroup.ts
+++ b/www/utils/generated/oas-output/schemas/StoreTransactionGroup.ts
@@ -36,6 +36,9 @@
  *   metadata:
  *     type: object
  *     description: The transaction group's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * x-schemaName: StoreTransactionGroup
  * 
 */

--- a/www/utils/generated/oas-output/schemas/StoreUpdateCartLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/StoreUpdateCartLineItem.ts
@@ -13,6 +13,9 @@
  *   metadata:
  *     type: object
  *     description: The item's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/StoreUpdateCustomer.ts
+++ b/www/utils/generated/oas-output/schemas/StoreUpdateCustomer.ts
@@ -23,6 +23,9 @@
  *   metadata:
  *     type: object
  *     description: The customer's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/UpdateAddress.ts
+++ b/www/utils/generated/oas-output/schemas/UpdateAddress.ts
@@ -62,6 +62,9 @@
  *   metadata:
  *     type: object
  *     description: The address's metadata, can hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/UpdateCartData.ts
+++ b/www/utils/generated/oas-output/schemas/UpdateCartData.ts
@@ -45,6 +45,9 @@
  *   metadata:
  *     type: object
  *     description: The cart's metadata, ca hold custom key-value pairs.
+ *     externalDocs:
+ *       url: https://docs.medusajs.com/api/store#manage-metadata
+ *       description: Learn how to manage metadata
  * 
 */
 

--- a/www/utils/packages/docs-generator/src/classes/helpers/schema-factory.ts
+++ b/www/utils/packages/docs-generator/src/classes/helpers/schema-factory.ts
@@ -109,6 +109,15 @@ class SchemaFactory {
         url: "#pagination",
       },
     },
+    metadata: {
+      type: "object",
+      title: "metadata",
+      description: "Holds custom key-value pairs.",
+      externalDocs: {
+        url: "https://docs.medusajs.com/api/store#manage-metadata",
+        description: "Learn how to manage metadata",
+      },
+    },
   }
 
   /**


### PR DESCRIPTION
Add a link in `metadata` properties in OAS that link to new Manage Metadata section, and regenerate OAS