### PR TITLE
fix(utils):Fix on precision for high quantities for items when promotion is applied

### DIFF
--- a/.changeset/moody-eggs-appear.md
+++ b/.changeset/moody-eggs-appear.md
@@ -1,0 +1,6 @@
+---
+"integration-tests-http": patch
+"@medusajs/utils": patch
+---
+
+Fix on precision for high quantities for items when promotion is applied

--- a/packages/core/utils/src/totals/promotion/index.ts
+++ b/packages/core/utils/src/totals/promotion/index.ts
@@ -6,7 +6,10 @@ import {
 import { MathBN } from "../math"
 
 function getPromotionValueForPercentage(promotion, lineItemAmount) {
-  return MathBN.mult(MathBN.div(promotion.value, 100), lineItemAmount)
+  return MathBN.convert(
+    MathBN.mult(MathBN.div(promotion.value, 100), lineItemAmount),
+    2
+  )
 }
 
 function getPromotionValueForFixed(promotion, lineItemAmount, lineItemsAmount) {
@@ -25,7 +28,10 @@ function getPromotionValueForFixed(promotion, lineItemAmount, lineItemsAmount) {
       promotionValueForItem
     )
 
-    return MathBN.mult(promotionValueForItem, MathBN.div(percentage, 100))
+    return MathBN.convert(
+      MathBN.mult(promotionValueForItem, MathBN.div(percentage, 100)),
+      2
+    )
   }
   return promotion.value
 }

--- a/packages/core/utils/src/totals/promotion/index.ts
+++ b/packages/core/utils/src/totals/promotion/index.ts
@@ -25,10 +25,7 @@ function getPromotionValueForFixed(promotion, lineItemAmount, lineItemsAmount) {
       promotionValueForItem
     )
 
-    return MathBN.mult(
-      promotionValueForItem,
-      MathBN.div(percentage, 100)
-    ).precision(4)
+    return MathBN.mult(promotionValueForItem, MathBN.div(percentage, 100))
   }
   return promotion.value
 }


### PR DESCRIPTION
As identified by @pepijn-vanvlaanderen here:
- https://github.com/medusajs/medusa/issues/13129

I investigated the problem and traced it to a precision error in legacy code sections. This flaw caused incorrect adjustment calculations when item quantities reached higher values.

Also added a test case to make sure this is not happening again ;-)