### PR TITLE
chore(core-flows): throw error on invalid promo code

### DIFF
--- a/.changeset/ninety-kangaroos-grin.md
+++ b/.changeset/ninety-kangaroos-grin.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": minor
+---
+
+chore(code-flows): throw error on invalid promo code

--- a/integration-tests/http/__tests__/cart/store/cart.spec.ts
+++ b/integration-tests/http/__tests__/cart/store/cart.spec.ts
@@ -2815,6 +2815,25 @@ medusaIntegrationTestRunner({
           )
         })
 
+        it("should throw an error when adding a promotion that does not exist", async () => {
+          const invalidPromoCode = "SOME_INVALID_PROMO_CODE"
+
+          try {
+            await api.post(
+              `/store/carts/${cart.id}/promotions`,
+              { promo_codes: [invalidPromoCode] },
+              storeHeaders
+            )
+            fail()
+          } catch (e) {
+            expect(e.response.status).toEqual(400)
+            expect(e.response.data.type).toEqual("invalid_data")
+            expect(e.response.data.message).toEqual(
+              `The promotion code ${invalidPromoCode} is invalid`
+            )
+          }
+        })
+
         it("should remove promotion adjustments when promotion is deleted", async () => {
           let cartBeforeRemovingPromotion = (
             await api.get(`/store/carts/${cart.id}`, storeHeaders)

--- a/integration-tests/http/__tests__/cart/store/cart.spec.ts
+++ b/integration-tests/http/__tests__/cart/store/cart.spec.ts
@@ -2818,20 +2818,19 @@ medusaIntegrationTestRunner({
         it("should throw an error when adding a promotion that does not exist", async () => {
           const invalidPromoCode = "SOME_INVALID_PROMO_CODE"
 
-          try {
-            await api.post(
+          const { response } = await api
+            .post(
               `/store/carts/${cart.id}/promotions`,
               { promo_codes: [invalidPromoCode] },
               storeHeaders
             )
-            fail()
-          } catch (e) {
-            expect(e.response.status).toEqual(400)
-            expect(e.response.data.type).toEqual("invalid_data")
-            expect(e.response.data.message).toEqual(
-              `The promotion code ${invalidPromoCode} is invalid`
-            )
-          }
+            .catch((e) => e)
+
+          expect(response.status).toEqual(400)
+          expect(response.data.type).toEqual("invalid_data")
+          expect(response.data.message).toEqual(
+            `The promotion code ${invalidPromoCode} is invalid`
+          )
         })
 
         it("should remove promotion adjustments when promotion is deleted", async () => {


### PR DESCRIPTION
**What**: Added a mechanism to throw an error when applying an invalid promo code
**Why**: This improves the developer experience when building storefronts by allowing them to handle invalid discount codes directly from the API response, rather than checking cart promotions after the API request.
**How**: When replacing or adding a promo code, check that the code exists in the database and if not, throw an error
**Testing**: integration tests

CLOSES: CMRC-1020