### PR TITLE
chore(util): avoid promotion value precision limit

### DIFF
--- a/.changeset/clever-deers-shout.md
+++ b/.changeset/clever-deers-shout.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+chore(utils): avoid limit precision for promotion value

--- a/packages/core/utils/src/totals/math.ts
+++ b/packages/core/utils/src/totals/math.ts
@@ -4,7 +4,7 @@ import { isDefined } from "../common"
 import { BigNumber } from "./big-number"
 
 export const MEDUSA_EPSILON = new BigNumber(
-  process.env.MEDUSA_EPSILON || "0.000001"
+  process.env.MEDUSA_EPSILON || "0.0001"
 )
 
 type BNInput = BigNumberInput | BigNumber

--- a/packages/core/utils/src/totals/math.ts
+++ b/packages/core/utils/src/totals/math.ts
@@ -3,6 +3,10 @@ import { BigNumber as BigNumberJS } from "bignumber.js"
 import { isDefined } from "../common"
 import { BigNumber } from "./big-number"
 
+export const MEDUSA_EPSILON = new BigNumber(
+  process.env.MEDUSA_EPSILON || "0.000001"
+)
+
 type BNInput = BigNumberInput | BigNumber
 export class MathBN {
   static convert(num: BNInput, decimalPlaces?: number): BigNumberJS {

--- a/packages/core/utils/src/totals/promotion/index.ts
+++ b/packages/core/utils/src/totals/promotion/index.ts
@@ -3,7 +3,7 @@ import {
   ApplicationMethodAllocation,
   ApplicationMethodType,
 } from "../../promotion"
-import { MathBN } from "../math"
+import { MathBN, MEDUSA_EPSILON } from "../math"
 
 function getPromotionValueForPercentage(promotion, lineItemAmount) {
   return MathBN.mult(MathBN.div(promotion.value, 100), lineItemAmount)
@@ -98,8 +98,8 @@ export function calculateAdjustmentAmountFromPromotion(
     )
     const applicableAmount = MathBN.sub(lineItemAmount, promotion.applied_value)
 
-    if (MathBN.lte(applicableAmount, 0)) {
-      return applicableAmount
+    if (MathBN.lte(applicableAmount, MEDUSA_EPSILON)) {
+      return MathBN.convert(0)
     }
 
     const promotionValue = getPromotionValue(
@@ -147,7 +147,7 @@ export function calculateAdjustmentAmountFromPromotion(
     maximumPromotionAmount
   )
 
-  if (MathBN.lte(applicableAmount, 0)) {
+  if (MathBN.lte(applicableAmount, MEDUSA_EPSILON)) {
     return MathBN.convert(0)
   }
 

--- a/packages/core/utils/src/totals/promotion/index.ts
+++ b/packages/core/utils/src/totals/promotion/index.ts
@@ -6,10 +6,7 @@ import {
 import { MathBN } from "../math"
 
 function getPromotionValueForPercentage(promotion, lineItemAmount) {
-  return MathBN.convert(
-    MathBN.mult(MathBN.div(promotion.value, 100), lineItemAmount),
-    2
-  )
+  return MathBN.mult(MathBN.div(promotion.value, 100), lineItemAmount)
 }
 
 function getPromotionValueForFixed(promotion, lineItemAmount, lineItemsAmount) {
@@ -28,10 +25,7 @@ function getPromotionValueForFixed(promotion, lineItemAmount, lineItemsAmount) {
       promotionValueForItem
     )
 
-    return MathBN.convert(
-      MathBN.mult(promotionValueForItem, MathBN.div(percentage, 100)),
-      2
-    )
+    return MathBN.mult(promotionValueForItem, MathBN.div(percentage, 100))
   }
   return promotion.value
 }


### PR DESCRIPTION
What:
 - Removes precision limit from promotion calculations
 - introduce `MEDUSA_EPSILON` environment variable to use as comparison when a small number needs to be considered 0.