### PR TITLE
fix: Allow getting the token from the SDK client

### DIFF
--- a/packages/core/js-sdk/src/client.ts
+++ b/packages/core/js-sdk/src/client.ts
@@ -179,6 +179,10 @@ export class Client {
     await this.setToken_(token)
   }
 
+  async getToken() {
+    return await this.getToken_()
+  }
+
   async clearToken() {
     await this.clearToken_()
   }


### PR DESCRIPTION
My particular use-case is to be able to pass on this token to the FE so I can impersonate users. We already have setToken and clearToken, so it also makes sense to have this for completeness.