### PR TITLE
feat(admin): add id filter to collections endpoint

### DIFF
--- a/.changeset/clever-deers-shout.md
+++ b/.changeset/clever-deers-shout.md
@@ -1,5 +1,5 @@
 ---
-"@medusajs/utils": patch
+"@medusajs/medusa": patch
 ---
 
-chore(utils): avoid limit precision for promotion value
+Add missing `id` param filter to the collection validator to align with product categories validator.

--- a/.changeset/clever-deers-shout.md
+++ b/.changeset/clever-deers-shout.md
@@ -1,5 +1,5 @@
 ---
-"@medusajs/medusa": patch
+"@medusajs/utils": patch
 ---
 
-Add missing `id` param filter to the collection validator to align with product categories validator.
+chore(utils): avoid limit precision for promotion value

--- a/.changeset/collection-id-fix.md
+++ b/.changeset/collection-id-fix.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+Add missing `id` param filter to the collection validator to align with product categories validator.

--- a/.changeset/collection-id-param-fix.md
+++ b/.changeset/collection-id-param-fix.md
@@ -1,5 +1,0 @@
----
-"@medusajs/medusa": patch
----
-
-Add missing `id` param filter to the collection validator to align with product categories validator.

--- a/.changeset/collection-id-param-fix.md
+++ b/.changeset/collection-id-param-fix.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+Add missing `id` param filter to the collection validator to align with product categories validator.

--- a/packages/medusa/src/api/admin/collections/validators.ts
+++ b/packages/medusa/src/api/admin/collections/validators.ts
@@ -11,6 +11,7 @@ export const AdminGetCollectionParams = createSelectParams()
 
 export const AdminGetCollectionsParamsFields = z.object({
   q: z.string().optional(),
+  id: z.union([z.string(), z.array(z.string())]).optional(),
   title: z.union([z.string(), z.array(z.string())]).optional(),
   handle: z.union([z.string(), z.array(z.string())]).optional(),
   created_at: createOperatorMap().optional(),


### PR DESCRIPTION
## Summary
Added support for filtering collections by `id` in the admin API.  
This aligns the collections endpoint with the product categories endpoint, which already supports the `id` parameter.

## Changes
- Updated `AdminGetCollectionsParams` in `validators.ts` to include `id` as an optional query parameter.
- Allows filtering by single `id` or multiple `id` values.

## Why
Consistency across admin endpoints and easier API usage when retrieving specific collections.

## Related Issue
Fixes #13147
