### PR TITLE
fix: update morgan logging skip condition to include SKIP_HTTP_LOGS environment

### DIFF
--- a/packages/medusa/src/loaders/express.ts
+++ b/packages/medusa/src/loaders/express.ts
@@ -11,8 +11,11 @@ type Options = {
   configModule: ConfigModule
 }
 
-export default async ({ app, configModule }: Options): Promise<{
-  app: Express,
+export default async ({
+  app,
+  configModule,
+}: Options): Promise<{
+  app: Express
   shutdown: () => Promise<void>
 }> => {
   let sameSite: string | boolean = false
@@ -46,7 +49,7 @@ export default async ({ app, configModule }: Options): Promise<{
   if (configModule?.projectConfig?.redis_url) {
     const RedisStore = createStore(session)
     redisClient = new Redis(
-      configModule.projectConfig.redis_url, 
+      configModule.projectConfig.redis_url,
       configModule.projectConfig.redis_options ?? {}
     )
     sessionOpts.store = new RedisStore({
@@ -58,7 +61,9 @@ export default async ({ app, configModule }: Options): Promise<{
   app.set("trust proxy", 1)
   app.use(
     morgan("combined", {
-      skip: () => process.env.NODE_ENV === "test",
+      skip: () =>
+        process.env.SKIP_HTTP_LOGS === "true" ||
+        process.env.NODE_ENV === "test",
     })
   )
   app.use(cookieParser())


### PR DESCRIPTION
For now we are not able to disable morgan HTTP logs on production, since we have to set `NODE_ENV=production`. This change will allow us to use an additional `SKIP_HTTP_LOGS` environment variable to disable HTTP logs on production, which during high traffic are really problematic because they:

- Make logs difficult to parse: HTTP request logs create noise that makes it hard to find potential errors and bugs in the application logs
- Impact performance: Excessive logging operations consume CPU cycles and I/O resources, especially under heavy load
- Consume storage: Large volumes of HTTP logs quickly fill up disk space and increase log storage costs
- Overwhelm monitoring systems: Log aggregation tools can struggle with the high volume of repetitive HTTP entries

This environment variable provides a clean way to maintain detailed HTTP logging in development while keeping production logs focused on application errors and important business events.