### PR TITLE
chore(locking-redis): default ttl to acquire lock

### DIFF
--- a/.changeset/moody-timers-hang.md
+++ b/.changeset/moody-timers-hang.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/locking-redis": patch
+---
+
+chore(locking-redis): default TTL to acquire lock

--- a/packages/modules/providers/locking-redis/src/services/redis-lock.ts
+++ b/packages/modules/providers/locking-redis/src/services/redis-lock.ts
@@ -155,6 +155,7 @@ export class RedisLockingProvider implements ILockingProvider {
     },
     cancellationToken?: { cancelled: boolean }
   ): Promise<void> {
+    const ONE_MINUTE = 60
     keys = Array.isArray(keys) ? keys : [keys]
 
     const timeout = Math.max(args?.expire ?? this.waitLockingTimeout, 1)
@@ -177,7 +178,7 @@ export class RedisLockingProvider implements ILockingProvider {
           const result = await this.redisClient.acquireLock(
             keyName,
             ownerId,
-            args?.expire ? timeoutSeconds : 0,
+            args?.expire ? timeoutSeconds : ONE_MINUTE,
             awaitQueue
           )
 

--- a/packages/modules/providers/locking-redis/src/services/redis-lock.ts
+++ b/packages/modules/providers/locking-redis/src/services/redis-lock.ts
@@ -115,12 +115,13 @@ export class RedisLockingProvider implements ILockingProvider {
       promises.push(this.getTimeout(timeoutSeconds, cancellationToken))
     }
 
+    const ONE_MINUTE = 60
     promises.push(
       this.acquire_(
         keys,
         {
           awaitQueue: true,
-          expire: args?.timeout ? timeoutSeconds : 0,
+          expire: args?.timeout ? timeoutSeconds : ONE_MINUTE,
         },
         cancellationToken
       )
@@ -155,7 +156,6 @@ export class RedisLockingProvider implements ILockingProvider {
     },
     cancellationToken?: { cancelled: boolean }
   ): Promise<void> {
-    const ONE_MINUTE = 60
     keys = Array.isArray(keys) ? keys : [keys]
 
     const timeout = Math.max(args?.expire ?? this.waitLockingTimeout, 1)
@@ -178,7 +178,7 @@ export class RedisLockingProvider implements ILockingProvider {
           const result = await this.redisClient.acquireLock(
             keyName,
             ownerId,
-            args?.expire ? timeoutSeconds : ONE_MINUTE,
+            args?.expire ? timeoutSeconds : 0,
             awaitQueue
           )
 


### PR DESCRIPTION
What:
 - Add default TTL of one minute if none expiration is provided.