### PR TITLE
docs: how to send notifications to admin dashboard panel

### DIFF
--- a/www/apps/resources/app/infrastructure-modules/notification/local/page.mdx
+++ b/www/apps/resources/app/infrastructure-modules/notification/local/page.mdx
@@ -74,3 +74,69 @@ module.exports = defineConfig({
     </Table.Row>
   </Table.Body>
 </Table>
+
+---
+
+## Send Notifications to the Admin Notification Panel
+
+The local notification provider can also be used to send notifications to the [admin notification panel](!user-guide!#check-notifications). 
+You can send notifications to the admin dashboard when a certain action occurs using a subscriber, a custom workflow or a workflow hook.
+
+For example, you might want to send an admin notification whenever an order is placed. To do so, create a [subscriber](!docs!/learn/fundamentals/events-and-subscribers) at `src/subscribers/order-placed.ts` with the following content:
+
+export const highlights = [
+  ["11", "notificationModuleService", "Resolve the Notification Module."],
+  ["13", "createNotifications", "Create the notification to be sent."],
+  [
+    "15",
+    '"feed"',
+    "By specifying the `feed` channel, the local provider will be used to send the notification.",
+  ],
+  ["16", '"admin-ui"', "The ID of the template used for admin dashboard notifications"],
+  ["17", "data", "The data for the notification, it has to contain `title` and `description`"],
+]
+
+```ts title="src/subscribers/order-placed.ts" highlights={highlights} collapsibleLines="1-7" expandButtonLabel="Show Imports"
+import type {
+  SubscriberArgs,
+  SubscriberConfig,
+} from "@medusajs/framework"
+import { Modules } from "@medusajs/framework/utils"
+
+export default async function orderPlacedHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const notificationModuleService = container.resolve(Modules.NOTIFICATION)
+
+  await notificationModuleService.createNotifications({
+    to: "",
+    channel: "feed",
+    template: "admin-ui",
+    data: {
+      title: "New order",
+      description: `A new order has been placed`,
+    },
+  })
+}
+
+export const config: SubscriberConfig = {
+  event: "order.placed",
+}
+```
+
+In this subscriber, you:
+
+- Resolve the Notification Module's main service from the [Medusa container](!docs!/learn/fundamentals/medusa-container).
+- Use the `createNotifications` method of the Notification Module's main service to create a notification to be sent to the admin dashboard. By specifying the `feed` channel, the Local Notification Module Provider is used to send the notification.
+- The `template` property of the `createNotifications` method's parameter has to be equal to `admin-ui`.
+- The `data` property allows you to customize the content of the admin notification. It can only contain `title`and `description`.
+
+Then, start the Medusa application:
+
+```bash npm2yarn
+npm run dev
+```
+
+And place an order. This runs the subscriber and sends a notification to the dashboard's notification panel.
+

--- a/www/apps/resources/app/infrastructure-modules/notification/local/page.mdx
+++ b/www/apps/resources/app/infrastructure-modules/notification/local/page.mdx
@@ -79,10 +79,10 @@ module.exports = defineConfig({
 
 ## Send Notifications to the Admin Notification Panel
 
-The local notification provider can also be used to send notifications to the [admin notification panel](!user-guide!#check-notifications). 
+The Local Notification Module Provider can also be used to send notifications to the [Medusa Admin's notification panel](!user-guide!#check-notifications). 
 You can send notifications to the admin dashboard when a certain action occurs using a subscriber, a custom workflow or a workflow hook.
 
-For example, you might want to send an admin notification whenever an order is placed. To do so, create a [subscriber](!docs!/learn/fundamentals/events-and-subscribers) at `src/subscribers/order-placed.ts` with the following content:
+For example, to send an admin notification whenever an order is placed, create a [subscriber](!docs!/learn/fundamentals/events-and-subscribers) at `src/subscribers/order-placed.ts` with the following content:
 
 export const highlights = [
   ["11", "notificationModuleService", "Resolve the Notification Module."],
@@ -90,13 +90,13 @@ export const highlights = [
   [
     "15",
     '"feed"',
-    "By specifying the `feed` channel, the local provider will be used to send the notification.",
+    "By specifying the `feed` channel, the Local Notification Module Provider will be used to send the notification.",
   ],
   ["16", '"admin-ui"', "The ID of the template used for admin dashboard notifications"],
-  ["17", "data", "The data for the notification, it has to contain `title` and `description`"],
+  ["17", "data", "The data for the notification. It must contain `title` and `description` properties."],
 ]
 
-```ts title="src/subscribers/order-placed.ts" highlights={highlights} collapsibleLines="1-7" expandButtonLabel="Show Imports"
+```ts title="src/subscribers/order-placed.ts" highlights={highlights} collapsibleLines="1-6" expandButtonLabel="Show Imports"
 import type {
   SubscriberArgs,
   SubscriberConfig,
@@ -129,14 +129,16 @@ In this subscriber, you:
 
 - Resolve the Notification Module's main service from the [Medusa container](!docs!/learn/fundamentals/medusa-container).
 - Use the `createNotifications` method of the Notification Module's main service to create a notification to be sent to the admin dashboard. By specifying the `feed` channel, the Local Notification Module Provider is used to send the notification.
-- The `template` property of the `createNotifications` method's parameter has to be equal to `admin-ui`.
-- The `data` property allows you to customize the content of the admin notification. It can only contain `title`and `description`.
+- The `template` property of the `createNotifications` method's parameter must be set to `admin-ui`.
+- The `data` property allows you to customize the content of the admin notification. It must contain `title` and `description` properties.
 
-Then, start the Medusa application:
+### Test Sending Notification
+
+To test this out, start the Medusa application:
 
 ```bash npm2yarn
 npm run dev
 ```
 
-And place an order. This runs the subscriber and sends a notification to the dashboard's notification panel.
+Then, place an order. The subscriber will run, sending a notification to the Medusa Admin's notification panel.
 


### PR DESCRIPTION
I just found out, digging through the code, how to send notifications to the notification panel in the admin dashboard. I figured it deserves a mention in the docs since it's quite a useful feature and right now it's very hard to find.

I've added it as a section to the local notification provider, by adapting the similar example section from the sendgrid provider. Let me know if it should be moved elsewhere or if any changes are needed