### PR TITLE
docs: optimize script to ignore builds

### DIFF
--- a/www/apps/api-reference/vercel.json
+++ b/www/apps/api-reference/vercel.json
@@ -7,5 +7,5 @@
   "installCommand": "yarn install",
   "buildCommand": "turbo run build",
   "outputDirectory": ".next",
-  "ignoreCommand": "bash ../../ignore-build-script.sh"
+  "ignoreCommand": "bash ../../ignore-build-script.sh api-reference"
 }

--- a/www/apps/book/vercel.json
+++ b/www/apps/book/vercel.json
@@ -3,5 +3,5 @@
   "installCommand": "yarn install",
   "buildCommand": "turbo run build",
   "outputDirectory": ".next",
-  "ignoreCommand": "bash ../../ignore-build-script.sh"
+  "ignoreCommand": "bash ../../ignore-build-script.sh book"
 }

--- a/www/apps/cloud/vercel.json
+++ b/www/apps/cloud/vercel.json
@@ -3,5 +3,5 @@
   "installCommand": "yarn install",
   "buildCommand": "turbo run build",
   "outputDirectory": ".next",
-  "ignoreCommand": "bash ../../ignore-build-script.sh"
+  "ignoreCommand": "bash ../../ignore-build-script.sh cloud"
 }

--- a/www/apps/resources/vercel.json
+++ b/www/apps/resources/vercel.json
@@ -3,5 +3,5 @@
   "installCommand": "yarn install",
   "buildCommand": "turbo run build",
   "outputDirectory": ".next",
-  "ignoreCommand": "bash ../../ignore-build-script.sh"
+  "ignoreCommand": "bash ../../ignore-build-script.sh resources"
 }

--- a/www/apps/ui/vercel.json
+++ b/www/apps/ui/vercel.json
@@ -3,7 +3,7 @@
   "installCommand": "yarn install",
   "buildCommand": "turbo run build",
   "outputDirectory": ".next",
-  "ignoreCommand": "bash ../../ignore-build-script.sh",
+  "ignoreCommand": "bash ../../ignore-build-script.sh ui",
   "redirects": [
     {
       "source": "/ui/hooks/use-toast",

--- a/www/apps/user-guide/vercel.json
+++ b/www/apps/user-guide/vercel.json
@@ -3,5 +3,5 @@
   "installCommand": "yarn install",
   "buildCommand": "turbo run build",
   "outputDirectory": ".next",
-  "ignoreCommand": "bash ../../ignore-build-script.sh"
+  "ignoreCommand": "bash ../../ignore-build-script.sh user-guide"
 }

--- a/www/ignore-build-script.sh
+++ b/www/ignore-build-script.sh
@@ -5,20 +5,60 @@ if [[ "$1" == "docs-old" ]]; then
   exit 0;
 fi
 
+PROJECT_NAME="$1"
+
+echo "PROJECT_NAME: $PROJECT_NAME"
 echo "VERCEL_ENV: $VERCEL_ENV"
 echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "SCRIPT_DIR: $SCRIPT_DIR"
 
+# Check for changes in the www directory (original logic)
 $(git diff HEAD^ HEAD --quiet ${SCRIPT_DIR})
 diffResult=$?
 
-echo "DIFF RESULT: $diffResult"
+echo "DIFF RESULT (www): $diffResult"
+
+# For preview environments, also check project-specific directories
+if [[ "$VERCEL_ENV" == "preview" && -n "$PROJECT_NAME" ]]; then
+  # Check for changes in the specific project directory
+  PROJECT_DIR="${SCRIPT_DIR}/apps/${PROJECT_NAME}"
+  if [[ -d "$PROJECT_DIR" ]]; then
+    $(git diff HEAD^ HEAD --quiet ${PROJECT_DIR})
+    projectDiffResult=$?
+    echo "DIFF RESULT (project ${PROJECT_NAME}): $projectDiffResult"
+  else
+    projectDiffResult=0
+    echo "Project directory ${PROJECT_DIR} does not exist"
+  fi
+  
+  # Check for changes in www/packages directory
+  PACKAGES_DIR="${SCRIPT_DIR}/packages"
+  if [[ -d "$PACKAGES_DIR" ]]; then
+    $(git diff HEAD^ HEAD --quiet ${PACKAGES_DIR})
+    packagesDiffResult=$?
+    echo "DIFF RESULT (packages): $packagesDiffResult"
+  else
+    packagesDiffResult=0
+    echo "Packages directory ${PACKAGES_DIR} does not exist"
+  fi
+  
+  # For preview, build if there are changes in project dir OR packages dir
+  previewShouldBuild=$((projectDiffResult + packagesDiffResult))
+  if [[ $previewShouldBuild -gt 0 ]]; then
+    previewShouldBuild=1
+  fi
+  echo "PREVIEW SHOULD BUILD: $previewShouldBuild"
+fi
 
 if [[ ("$VERCEL_ENV" == "production" && $diffResult -eq 1) || "$VERCEL_GIT_COMMIT_REF" = "docs/"* ]] ; then
-  # Proceed with the build
-  echo "✅ - Build can proceed"
+  # Proceed with the build for production with changes or docs branches
+  echo "✅ - Build can proceed (production with changes or docs branch)"
+  exit 1;
+elif [[ "$VERCEL_ENV" == "preview" && -n "$PROJECT_NAME" && $previewShouldBuild -eq 1 ]]; then
+  # Proceed with the build for preview if there are changes in project or packages directory
+  echo "✅ - Build can proceed (preview with project/packages changes)"
   exit 1;
 else
   # Don't build


### PR DESCRIPTION
Improve on script that ignores builds in Vercel to only build if there are changes in the project's directory or the `www/packages` directory