### PR TITLE
feat(medusa,dashboard): Add metadata UI to product tags domain

### DIFF
--- a/.changeset/smooth-shoes-cover.md
+++ b/.changeset/smooth-shoes-cover.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/dashboard": patch
+"@medusajs/medusa": patch
+---
+
+fix(medusa,dashboard): Retrieve `metadata` for product_tags by default and add metadta UI to product tag domain in admin dashboard

--- a/packages/admin/dashboard/src/dashboard-app/routes/get-route.map.tsx
+++ b/packages/admin/dashboard/src/dashboard-app/routes/get-route.map.tsx
@@ -1329,6 +1329,13 @@ export function getRouteMap({
                       lazy: () =>
                         import("../../routes/product-tags/product-tag-edit"),
                     },
+                    {
+                      path: "metadata/edit",
+                      lazy: () =>
+                        import(
+                          "../../routes/product-tags/product-tag-metadata"
+                        ),
+                    },
                   ],
                 },
               ],

--- a/packages/admin/dashboard/src/routes/product-tags/product-tag-detail/product-tag-detail.tsx
+++ b/packages/admin/dashboard/src/routes/product-tags/product-tag-detail/product-tag-detail.tsx
@@ -40,6 +40,7 @@ export const ProductTagDetail = () => {
         before: getWidgets("product_tag.details.before"),
       }}
       showJSON
+      showMetadata
       data={product_tag}
     >
       <ProductTagGeneralSection productTag={product_tag} />

--- a/packages/admin/dashboard/src/routes/product-tags/product-tag-metadata/index.ts
+++ b/packages/admin/dashboard/src/routes/product-tags/product-tag-metadata/index.ts
@@ -1,0 +1,1 @@
+export { ProductTagMetadata as Component } from "./product-tag-metadata"

--- a/packages/admin/dashboard/src/routes/product-tags/product-tag-metadata/product-tag-metadata.tsx
+++ b/packages/admin/dashboard/src/routes/product-tags/product-tag-metadata/product-tag-metadata.tsx
@@ -1,0 +1,26 @@
+import { useParams } from "react-router-dom"
+import { MetadataForm } from "../../../components/forms/metadata-form/metadata-form"
+import { useProductTag, useUpdateProductTag } from "../../../hooks/api"
+
+export const ProductTagMetadata = () => {
+  const { id } = useParams()
+
+  const { product_tag, isPending, isError, error } = useProductTag(id!)
+
+  const { mutateAsync, isPending: isMutating } = useUpdateProductTag(
+    product_tag?.id!
+  )
+
+  if (isError) {
+    throw error
+  }
+
+  return (
+    <MetadataForm
+      metadata={product_tag?.metadata}
+      hook={mutateAsync}
+      isPending={isPending}
+      isMutating={isMutating}
+    />
+  )
+}

--- a/packages/medusa/src/api/admin/product-tags/query-config.ts
+++ b/packages/medusa/src/api/admin/product-tags/query-config.ts
@@ -3,6 +3,7 @@ export const defaultAdminProductTagFields = [
   "value",
   "created_at",
   "updated_at",
+  "metadata",
 ]
 
 export const retrieveProductTagTransformQueryConfig = {


### PR DESCRIPTION
👋 

**What**
- Adds metadata UI to product tag domain
- Adds `"metadata"` to query-config for `defaultAdminProductTagFields`

Fixes https://github.com/medusajs/medusa/issues/13194