### PR TITLE
fix(dashboard): handle large resource count in tax rule override edit form

### DIFF
--- a/.changeset/quick-goats-exercise.md
+++ b/.changeset/quick-goats-exercise.md
@@ -2,4 +2,4 @@
 "@medusajs/dashboard": patch
 ---
 
-fix(dashboard): handle larege resource count in tax rule override edit form
+fix(dashboard): handle large resource count in tax rule override edit form

--- a/.changeset/quick-goats-exercise.md
+++ b/.changeset/quick-goats-exercise.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): handle larege resource count in tax rule override edit form

--- a/packages/admin/dashboard/src/routes/tax-regions/common/components/target-item/target-item.tsx
+++ b/packages/admin/dashboard/src/routes/tax-regions/common/components/target-item/target-item.tsx
@@ -1,17 +1,30 @@
 import { XMarkMini } from "@medusajs/icons"
 import { IconButton, Text } from "@medusajs/ui"
+import { useProduct } from "../../../../../hooks/api"
 
 type TargetItemProps = {
   index: number
   onRemove: (index: number) => void
   label: string
+  value: string
 }
 
-export const TargetItem = ({ index, label, onRemove }: TargetItemProps) => {
+export const TargetItem = ({
+  index,
+  label,
+  onRemove,
+  value,
+}: TargetItemProps) => {
+  const { product } = useProduct(
+    value,
+    { fields: "id,title" },
+    { enabled: !label }
+  )
+
   return (
     <div className="bg-ui-bg-field-component shadow-borders-base flex items-center justify-between gap-2 rounded-md px-2 py-0.5">
       <Text size="small" leading="compact">
-        {label}
+        {label || product?.title}
       </Text>
       <IconButton
         size="small"

--- a/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-edit/components/tax-region-tax-override-edit-form/tax-region-tax-override-edit-form.tsx
+++ b/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-edit/components/tax-region-tax-override-edit-form/tax-region-tax-override-edit-form.tsx
@@ -82,8 +82,6 @@ export const TaxRegionTaxOverrideEditForm = ({
   const { handleSuccess } = useRouteModal()
   const { setIsOpen } = useStackedModal()
 
-  console.log(initialValues)
-
   const form = useForm<z.infer<typeof TaxRegionTaxRateEditSchema>>({
     defaultValues: {
       name: taxRate.name,

--- a/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-edit/components/tax-region-tax-override-edit-form/tax-region-tax-override-edit-form.tsx
+++ b/packages/admin/dashboard/src/routes/tax-regions/tax-region-tax-override-edit/components/tax-region-tax-override-edit-form/tax-region-tax-override-edit-form.tsx
@@ -38,6 +38,8 @@ import {
 import { createTaxRulePayload } from "../../../common/utils"
 import { InitialRuleValues } from "../../types"
 
+export const DISPLAY_OVERRIDE_ITEMS_LIMIT = 10
+
 type TaxRegionTaxOverrideEditFormProps = {
   taxRate: HttpTypes.AdminTaxRate
   initialValues: InitialRuleValues
@@ -79,6 +81,8 @@ export const TaxRegionTaxOverrideEditForm = ({
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
   const { setIsOpen } = useStackedModal()
+
+  console.log(initialValues)
 
   const form = useForm<z.infer<typeof TaxRegionTaxRateEditSchema>>({
     defaultValues: {
@@ -272,7 +276,7 @@ export const TaxRegionTaxOverrideEditForm = ({
   }
 
   const getFieldHandler = (type: TaxRateRuleReferenceType) => {
-    const { fields, remove, append } = getControls(type)
+    const { fields, remove, prepend } = getControls(type)
     const modalId = getStackedModalId(type)
 
     return (references: TaxRateRuleReference[]) => {
@@ -296,7 +300,7 @@ export const TaxRegionTaxOverrideEditForm = ({
         }
       }
 
-      append(fieldsToAdd)
+      prepend(fieldsToAdd) // to display newer items first
       setIsOpen(modalId, false)
     }
   }
@@ -588,17 +592,33 @@ export const TaxRegionTaxOverrideEditForm = ({
                                 <div className="flex flex-col gap-y-1.5">
                                   <Divider variant="dashed" />
                                   <div className="flex flex-col gap-y-1.5 px-1.5">
-                                    {fields.map((field, index) => {
-                                      return (
-                                        <TargetItem
-                                          key={field.id}
-                                          index={index}
-                                          label={field.label}
-                                          onRemove={remove}
-                                        />
-                                      )
-                                    })}
+                                    {fields
+                                      .slice(0, DISPLAY_OVERRIDE_ITEMS_LIMIT)
+                                      .map((field, index) => {
+                                        return (
+                                          <TargetItem
+                                            key={field.id}
+                                            index={index}
+                                            label={field.label}
+                                            value={field.value}
+                                            onRemove={remove}
+                                          />
+                                        )
+                                      })}
                                   </div>
+                                  {fields.length >
+                                    DISPLAY_OVERRIDE_ITEMS_LIMIT && (
+                                    <div className="flex flex-col gap-y-1.5 px-1.5">
+                                      {/* <Divider variant="dashed" /> */}
+                                      <div className="text-ui-fg-muted txt-small flex flex-col gap-y-1.5 px-1.5">
+                                        {t("general.plusCountMore", {
+                                          count:
+                                            fields.length -
+                                            DISPLAY_OVERRIDE_ITEMS_LIMIT,
+                                        })}
+                                      </div>
+                                    </div>
+                                  )}
                                 </div>
                               ) : null}
                             </div>


### PR DESCRIPTION
**Why**
- request to fetch resources would be too large since we construct it by passing the IDs of the resources as a query param

---

https://github.com/user-attachments/assets/3b62bf49-d43d-4beb-9c4a-b49d576d0f2c

---

CLOSES CORE-1075

