### PR TITLE
fix(dashboard): rules form operator change

### DIFF
--- a/.changeset/orange-bats-sing.md
+++ b/.changeset/orange-bats-sing.md
@@ -2,4 +2,4 @@
 "@medusajs/dashboard": patch
 ---
 
-fix(dashboard): fules form operator change
+fix(dashboard): rules form operator change

--- a/.changeset/orange-bats-sing.md
+++ b/.changeset/orange-bats-sing.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): fules form operator change

--- a/packages/admin/dashboard/src/i18n/translations/$schema.json
+++ b/packages/admin/dashboard/src/i18n/translations/$schema.json
@@ -10805,6 +10805,12 @@
         },
         "loading": {
           "type": "string"
+        },
+        "selectValue": {
+          "type": "string"
+        },
+        "selectValues": {
+          "type": "string"
         }
       },
       "required": [
@@ -10817,7 +10823,9 @@
         "from",
         "to",
         "beaware",
-        "loading"
+        "loading",
+        "selectValue",
+        "selectValues"
       ],
       "additionalProperties": false
     },

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -2909,7 +2909,9 @@
     "from": "From",
     "to": "To",
     "beaware": "Be aware",
-    "loading": "Loading"
+    "loading": "Loading",
+    "selectValue": "Select Value",
+    "selectValues": "Select Values"
   },
   "fields": {
     "amount": "Amount",

--- a/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
@@ -6,14 +6,13 @@ import {
 import { Input } from "@medusajs/ui"
 import { useWatch } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { useEffect, useRef } from "react"
+import { useEffect } from "react"
 
 import { Form } from "../../../../../../components/common/form"
 import { Combobox } from "../../../../../../components/inputs/combobox"
 import { useStore } from "../../../../../../hooks/api"
 import { useComboboxData } from "../../../../../../hooks/use-combobox-data"
 import { sdk } from "../../../../../../lib/client"
-import { isDirty } from "zod"
 
 type RuleValueFormFieldType = {
   form: any
@@ -56,8 +55,6 @@ export const RuleValueFormField = ({
   applicationMethodTargetType,
 }: RuleValueFormFieldType) => {
   const { t } = useTranslation()
-
-  const firstRender = useRef(true)
 
   const attribute = attributes?.find(
     (attr) => attr.value === fieldRule.attribute

--- a/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
@@ -6,13 +6,14 @@ import {
 import { Input } from "@medusajs/ui"
 import { useWatch } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 
 import { Form } from "../../../../../../components/common/form"
 import { Combobox } from "../../../../../../components/inputs/combobox"
 import { useStore } from "../../../../../../hooks/api"
 import { useComboboxData } from "../../../../../../hooks/use-combobox-data"
 import { sdk } from "../../../../../../lib/client"
+import { isDirty } from "zod"
 
 type RuleValueFormFieldType = {
   form: any
@@ -56,6 +57,8 @@ export const RuleValueFormField = ({
 }: RuleValueFormFieldType) => {
   const { t } = useTranslation()
 
+  const firstRender = useRef(true)
+
   const attribute = attributes?.find(
     (attr) => attr.value === fieldRule.attribute
   )
@@ -88,6 +91,15 @@ export const RuleValueFormField = ({
   })
 
   useEffect(() => {
+    const hasDirtyRules = Object.keys(form.formState.dirtyFields).length > 0
+
+    /**
+     * Don't reset values if fileds didn't change - this is to prevent reset of form on initial render when editing an existing rule
+     */
+    if (!hasDirtyRules) {
+      return
+    }
+
     if (watchOperator === "eq") {
       form.setValue(name, "")
     } else {

--- a/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
@@ -5,6 +5,9 @@ import {
 } from "@medusajs/types"
 import { Input } from "@medusajs/ui"
 import { useWatch } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { useEffect } from "react"
+
 import { Form } from "../../../../../../components/common/form"
 import { Combobox } from "../../../../../../components/inputs/combobox"
 import { useStore } from "../../../../../../hooks/api"
@@ -51,6 +54,8 @@ export const RuleValueFormField = ({
   ruleType,
   applicationMethodTargetType,
 }: RuleValueFormFieldType) => {
+  const { t } = useTranslation()
+
   const attribute = attributes?.find(
     (attr) => attr.value === fieldRule.attribute
   )
@@ -81,6 +86,14 @@ export const RuleValueFormField = ({
     control: form.control,
     name: operator,
   })
+
+  useEffect(() => {
+    if (watchOperator === "eq") {
+      form.setValue(name, "")
+    } else {
+      form.setValue(name, [])
+    }
+  }, [watchOperator])
 
   return (
     <Form.Field
@@ -126,11 +139,13 @@ export const RuleValueFormField = ({
                 <Combobox
                   {...field}
                   {...comboboxData}
-                  multiple={watchOperator !== "eq"}
                   ref={ref}
                   placeholder={
-                    watchOperator === "eq" ? "Select Value" : "Select Values"
+                    watchOperator === "eq"
+                      ? t("labels.selectValue")
+                      : t("labels.selectValues")
                   }
+                  disabled={!watchOperator}
                   onChange={onChange}
                 />
               </Form.Control>


### PR DESCRIPTION
**What**
- fix condition rules form sometimes rendering multi and single selects unrelated to the attribute operator selected
- reset rule value when operator is changed
- disable selecting rule values untill operator is selected
- translate labels