### PR TITLE
fix(draft-order): use correct backend URL in sdk creation

### DIFF
--- a/.changeset/hungry-terms-report.md
+++ b/.changeset/hungry-terms-report.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/draft-order": patch
+---
+
+fix(draft-order): use correct backend URL in sdk creation

--- a/packages/plugins/draft-order/src/admin/lib/queries/sdk.ts
+++ b/packages/plugins/draft-order/src/admin/lib/queries/sdk.ts
@@ -1,7 +1,7 @@
 import Medusa from "@medusajs/js-sdk"
 
 export const sdk = new Medusa({
-  baseUrl: "/",
+  baseUrl: __BACKEND_URL__ || "/",
   auth: {
     type: "session",
   },

--- a/packages/plugins/draft-order/src/admin/vite-env.d.ts
+++ b/packages/plugins/draft-order/src/admin/vite-env.d.ts
@@ -1,0 +1,1 @@
+declare const __BACKEND_URL__: string | undefined


### PR DESCRIPTION
Closes #13337 

If the admin server is deployed separately, the sdk object needs the correct url i.e. `__BACKEND_URL__`. This is how it's done already in the `dashboard` package.