### PR TITLE
fix(dashboard): promotion expired status check when limit is null

### DIFF
--- a/.changeset/bright-spoons-float.md
+++ b/.changeset/bright-spoons-float.md
@@ -1,5 +1,5 @@
 ---
-"@medusajs/dashboard": major
+"@medusajs/dashboard": patch
 ---
 
 Fix promotion expired status check when limit is null

--- a/.changeset/bright-spoons-float.md
+++ b/.changeset/bright-spoons-float.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": major
+---
+
+Fix promotion expired status check when limit is null

--- a/packages/admin/dashboard/src/lib/promotions.ts
+++ b/packages/admin/dashboard/src/lib/promotions.ts
@@ -39,7 +39,9 @@ export const getPromotionStatus = (promotion: HttpTypes.AdminPromotion) => {
 
   const campaignBudget = campaign.budget
   const overBudget =
-    campaignBudget && campaignBudget.used! > campaignBudget.limit!
+    campaignBudget &&
+    campaignBudget.limit &&
+    campaignBudget.used! > campaignBudget.limit!
 
   if ((campaign.ends_at && new Date(campaign.ends_at) < date) || overBudget) {
     return promotionStatusMap[PromotionStatus.EXPIRED]


### PR DESCRIPTION
This PR fixes an UI issue on the promotion status when limit is null, see also here:

<img width="1196" height="395" alt="Scherm­afbeelding 2025-09-01 om 17 39 04" src="https://github.com/user-attachments/assets/0eea5dab-f21c-47f1-ac17-a3bbf90f9119" />
