### PR TITLE
fix(medusa): corrected admin output dir

### DIFF
--- a/.changeset/empty-beers-taste.md
+++ b/.changeset/empty-beers-taste.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+Corrected the admin relative output dir to reflect previous file structure

--- a/.changeset/empty-beers-taste.md
+++ b/.changeset/empty-beers-taste.md
@@ -2,4 +2,4 @@
 "@medusajs/medusa": patch
 ---
 
-Corrected the admin relative output dir to reflect previous file structure
+fix(medusa): corrected admin output dir

--- a/packages/medusa/src/utils/admin-consts.ts
+++ b/packages/medusa/src/utils/admin-consts.ts
@@ -1,3 +1,3 @@
 export const ADMIN_SOURCE_DIR = "src/admin"
-export const ADMIN_RELATIVE_OUTPUT_DIR = "./public/admin"
+export const ADMIN_RELATIVE_OUTPUT_DIR = ".medusa/server/public/admin"
 export const ADMIN_ONLY_OUTPUT_DIR = ".medusa/admin"


### PR DESCRIPTION
#11386 notes a problem with starting medusa where the admin output path is slightly incorrect.

I ran into this issue again when I deleted my development database and ran `db:setup`.

Please correct me if I'm wrong but my testing led to success when I adjusted this path to reflect the structure from previous versions.