### PR TITLE
fix: Missing DB traces in instrumentation

### DIFF
--- a/.changeset/olive-news-fix.md
+++ b/.changeset/olive-news-fix.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+chore: Fix issue with missing DB traces

--- a/packages/medusa/src/commands/start.ts
+++ b/packages/medusa/src/commands/start.ts
@@ -146,7 +146,9 @@ async function start(args: {
 }) {
   const { port = 9000, host, directory, types } = args
 
-  const container = await initializeContainer(directory)
+  const container = await initializeContainer(directory, {
+    skipDbConnection: true,
+  })
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
 
   async function internalStart(generateTypes: boolean) {


### PR DESCRIPTION
**What**

Only initialize the Postgres connection after instrumentation has been registered

**Why (working theory)**

The `instrumentation-pg` package we use for instrumenting the DB queries installs patches to the `pg` module when it is loaded (to do the actual tracing). This needs to happen before the `pg` module is loaded elsewhere in the application to ensure the patched version is the one that gets cached in Node.js's module system. An example of _elsewhere_ is when the Postgres connection is established, hence why this PR skips it.
