### PR TITLE
fix(): allow pr labeler to fail

### DIFF
--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   team-labeler:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
     - id: label-the-PR
       uses: actions/labeler@v5


### PR DESCRIPTION
This is an attempt to allowing merging contributor PRs without having to force-merge