### PR TITLE
fix(): Prevent ci to fail if lock file does not exists

### DIFF
--- a/.github/workflows/test-cli-with-database.yml
+++ b/.github/workflows/test-cli-with-database.yml
@@ -65,7 +65,7 @@ jobs:
         run: corepack enable
 
       - name: Install new app dependencies (via resolutions)
-        run: rm package-lock.json && yarn install --no-immutable
+        run: rm -f package-lock.json && yarn install --no-immutable
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
         working-directory: ../cli-test


### PR DESCRIPTION
**What**
Prevent CI from failing if the package-lock does not exists when removing it