### PR TITLE
docs: fix saved payment method guide

### DIFF
--- a/www/apps/resources/app/how-to-tutorials/tutorials/saved-payment-methods/page.mdx
+++ b/www/apps/resources/app/how-to-tutorials/tutorials/saved-payment-methods/page.mdx
@@ -575,9 +575,9 @@ const StripeSavedPaymentMethodsContainer = ({
     SavedPaymentMethod[]
   >([])
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
-    string | undefined
+    string | null
   >(
-    paymentSession?.data?.payment_method_id as string | undefined
+    paymentSession?.data?.payment_method as string | null
   )
 
   useEffect(() => {
@@ -723,7 +723,7 @@ Then, add a new state variable that keeps track of whether the customer is using
 
 ```ts title="src/modules/checkout/components/payment-container/index.tsx" badgeLabel="Storefront" badgeColor="blue"
 const [isUsingSavedPaymentMethod, setIsUsingSavedPaymentMethod] = useState(
-  paymentSession?.data?.payment_method_id !== undefined
+  paymentSession?.data?.payment_method !== null
 )
 ```
 
@@ -867,7 +867,7 @@ So, you need to update the `confirmCardPayment` usage to support passing the ID 
 In `src/modules/checkout/components/payment-button/index.tsx`, find the `handlePayment` method and update its first `if` condition:
 
 ```ts title="src/modules/checkout/components/payment-button/index.tsx" badgeLabel="Storefront" badgeColor="blue"
-if (!stripe || !elements || (!card && !session?.data.payment_method_id) || !cart) {
+if (!stripe || !elements || (!card && !session?.data.payment_method) || !cart) {
   setSubmitting(false)
   return
 }
@@ -884,7 +884,7 @@ export const confirmPaymentHighlights = [
 ```ts title="src/modules/checkout/components/payment-button/index.tsx" badgeLabel="Storefront" badgeColor="blue" highlights={confirmPaymentHighlights}
 await stripe
 .confirmCardPayment(session?.data.client_secret as string, {
-  payment_method: session?.data.payment_method_id as string || {
+  payment_method: session?.data.payment_method as string || {
     card: card!,
     billing_details: {
       name:

--- a/www/apps/resources/generated/edit-dates.mjs
+++ b/www/apps/resources/generated/edit-dates.mjs
@@ -6236,7 +6236,7 @@ export const generatedEditDates = {
   "references/events/events.Region/page.mdx": "2025-05-20T07:51:40.897Z",
   "references/events/events.Sales_Channel/page.mdx": "2025-05-20T07:51:40.897Z",
   "references/events/events.User/page.mdx": "2025-05-20T07:51:40.897Z",
-  "app/how-to-tutorials/tutorials/saved-payment-methods/page.mdx": "2025-05-20T07:51:40.714Z",
+  "app/how-to-tutorials/tutorials/saved-payment-methods/page.mdx": "2025-09-11T13:03:49.152Z",
   "references/core_flows/Cart/Workflows_Cart/functions/core_flows.Cart.Workflows_Cart.refundPaymentAndRecreatePaymentSessionWorkflow/page.mdx": "2025-08-14T12:59:35.141Z",
   "references/core_flows/Cart/Workflows_Cart/variables/core_flows.Cart.Workflows_Cart.refundPaymentAndRecreatePaymentSessionWorkflowId/page.mdx": "2025-05-20T07:51:40.757Z",
   "references/core_flows/Draft_Order/Workflows_Draft_Order/variables/core_flows.Draft_Order.Workflows_Draft_Order.convertDraftOrderWorkflowId/page.mdx": "2025-05-20T07:51:40.768Z",


### PR DESCRIPTION
Fix saved payment methods guide using `payment_method_id` instead of `payment_method`

Closes DX-2000