### PR TITLE
chore(core-flows): use directory convention for locking steps

### DIFF
--- a/.changeset/tricky-bobcats-brake.md
+++ b/.changeset/tricky-bobcats-brake.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+chore(core-flows): use directory convention for locking steps

--- a/packages/core/core-flows/src/cart/workflows/complete-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/complete-cart.ts
@@ -26,8 +26,8 @@ import {
   useQueryGraphStep,
   useRemoteQueryStep,
 } from "../../common"
-import { acquireLockStep } from "../../locking/acquire-lock"
-import { releaseLockStep } from "../../locking/release-lock"
+import { acquireLockStep } from "../../locking/steps/acquire-lock"
+import { releaseLockStep } from "../../locking/steps/release-lock"
 import { addOrderTransactionStep } from "../../order/steps/add-order-transaction"
 import { createOrdersStep } from "../../order/steps/create-orders"
 import { authorizePaymentSessionStep } from "../../payment/steps/authorize-payment-session"

--- a/packages/core/core-flows/src/locking/index.ts
+++ b/packages/core/core-flows/src/locking/index.ts
@@ -1,2 +1,2 @@
-export * from "./acquire-lock"
-export * from "./release-lock"
+export * from "./steps/acquire-lock"
+export * from "./steps/release-lock"

--- a/packages/core/core-flows/src/locking/steps/acquire-lock.ts
+++ b/packages/core/core-flows/src/locking/steps/acquire-lock.ts
@@ -6,18 +6,43 @@ import { setTimeout } from "timers/promises"
  * The keys to be locked
  */
 export interface AcquireLockStepInput {
+  /**
+   * The keys to be locked
+   */
   key: string | string[]
-  timeout?: number // in seconds. Defaults to 0
-  retryInterval?: number // in seconds. Defaults to 0.3
-  ttl?: number // in seconds
+  /**
+   * The maximum time to wait for acquiring the lock. If the lock cannot be acquired within this time, an error is thrown.
+   * 
+   * @defaultValue 0
+   */
+  timeout?: number
+  /**
+   * The time (in seconds) to wait between each retry to acquire the lock.
+   * 
+   * @defaultValue 0.3
+   */
+  retryInterval?: number
+  /**
+   * The expiration time (in seconds) for the lock. If the lock is already acquired and the owner is the same, 
+   * the expiration time is extended by the value passed. If not specified, the lock does not expire.
+   */
+  ttl?: number
+  /**
+   * The owner ID for the lock. If specified, only the owner can release the lock or extend its expiration time.
+   */
   ownerId?: string
+  /**
+   * The provider name to use for locking. If no provider is passed, the default provider 
+   * (in-memory or the provider configured in medusa-config.ts) will be used.
+   */
   provider?: string
   skipOnSubWorkflow?: boolean
 }
 
 export const acquireLockStepId = "acquire-lock-step"
 /**
- * This step acquires a lock for a given key.
+ * This step acquires a lock for a given key. Learn more about locks in the [Locking Module](https://docs.medusajs.com/resources/infrastructure-modules/locking)
+ * guide.
  *
  * @example
  * const data = acquireLockStep({

--- a/packages/core/core-flows/src/locking/steps/release-lock.ts
+++ b/packages/core/core-flows/src/locking/steps/release-lock.ts
@@ -5,19 +5,31 @@ import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
  * The locked keys to be released
  */
 export interface ReleaseLockStepInput {
+  /**
+   * The keys to be released
+   */
   key: string | string[]
+  /**
+   * The ID of the lock's owner. The lock can be released either if it doesn't have an owner, 
+   * or if its owner ID matches the one passed in this property.
+   */
   ownerId?: string
+  /**
+   * The provider name to use for locking. If no provider is passed, 
+   * the default provider (in-memory or the provider configured in medusa-config.ts) will be used.
+   */
   provider?: string
   skipOnSubWorkflow?: boolean
 }
 
 export const releaseLockStepId = "release-lock-step"
 /**
- * This step releases a lock for a given key.
+ * This step releases a lock for a given key. Learn more about locks in the [Locking Module](https://docs.medusajs.com/resources/infrastructure-modules/locking)
+ * guide.
  *
  * @example
  * const data = releaseLockStep({
- *   "key": "my-lock-key"
+ *   key: "my-lock-key"
  * })
  */
 export const releaseLockStep = createStep(


### PR DESCRIPTION
Change the Locking steps to be under the `locking/steps` directory, which matches the convention of other workflows and steps in `core-flows`. This is necessary for the reference in our documentation, as we rely on this convention