### PR TITLE
chore(js-sdk): add ignore tag to views

### DIFF
--- a/packages/core/js-sdk/src/admin/index.ts
+++ b/packages/core/js-sdk/src/admin/index.ts
@@ -229,6 +229,7 @@ export class Admin {
   public plugin: Plugin
   /**
    * @tags views
+   * @ignore
    */
   public views: Views
 


### PR DESCRIPTION
Add `@ignore` TSDoc tag for views until it's ready for use, which ensures it's not included in the JS SDK reference