### PR TITLE
docs: add clarification for set cart's customer API route

### DIFF
--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_carts_{id}_customer/post.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_carts_{id}_customer/post.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to set the cart's customer
 sdk.store.cart.transferCart("cart_123")
 .then(({ cart }) => {
   console.log(cart)

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me/get.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me/get.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to retrieve their details
 sdk.store.customer.retrieve()
 .then(({ customer }) => {
   console.log(customer)

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me/post.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me/post.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to update their details
 sdk.store.customer.update({
   first_name: "John"
 })

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses/get.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses/get.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to list their addresses
 sdk.store.customer.listAddress()
 .then(({ addresses, count, offset, limit }) => {
   console.log(addresses)

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses/post.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses/post.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to create an address
 sdk.store.customer.createAddress({
   country_code: "us"
 })

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses_{address_id}/delete.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses_{address_id}/delete.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to delete their address
 sdk.store.customer.deleteAddress("caddr_123")
 .then(({ deleted, parent: customer }) => {
   console.log(customer)

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses_{address_id}/get.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses_{address_id}/get.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to retrieve their address
 sdk.store.customer.retrieveAddress(
   "caddr_123"
 )

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses_{address_id}/post.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_customers_me_addresses_{address_id}/post.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to update their address
 sdk.store.customer.updateAddress(
   "caddr_123",
   {

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_orders/get.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_orders/get.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to list their orders
 sdk.store.order.list()
 .then(({ orders, count, offset, limit }) => {
   console.log(orders)

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_orders_{id}_transfer_cancel/post.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_orders_{id}_transfer_cancel/post.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to cancel the order transfer
 sdk.store.order.cancelTransfer(
   "order_123",
   {},

--- a/www/apps/api-reference/specs/store/code_samples/JavaScript/store_orders_{id}_transfer_request/post.js
+++ b/www/apps/api-reference/specs/store/code_samples/JavaScript/store_orders_{id}_transfer_request/post.js
@@ -12,6 +12,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
+// TODO must be authenticated as the customer to request the order transfer
 sdk.store.order.requestTransfer(
   "order_123",
   {

--- a/www/apps/api-reference/specs/store/code_samples/Shell/store_carts_{id}_customer/post.sh
+++ b/www/apps/api-reference/specs/store/code_samples/Shell/store_carts_{id}_customer/post.sh
@@ -1,2 +1,3 @@
 curl -X POST '{backend_url}/store/carts/{id}/customer' \
+-H 'Authorization: Bearer {access_token}' \
 -H 'x-publishable-api-key: {your_publishable_api_key}'

--- a/www/apps/api-reference/specs/store/code_samples/Shell/store_customers_me_addresses_{address_id}/delete.sh
+++ b/www/apps/api-reference/specs/store/code_samples/Shell/store_customers_me_addresses_{address_id}/delete.sh
@@ -1,3 +1,3 @@
 curl -X DELETE '{backend_url}/store/customers/me/addresses/{address_id}' \
--H 'x-publishable-api-key: {your_publishable_api_key}' \
--H 'Authorization: Bearer {access_token}'
+-H 'Authorization: Bearer {access_token}' \
+-H 'x-publishable-api-key: {your_publishable_api_key}'

--- a/www/apps/api-reference/specs/store/code_samples/Shell/store_orders/get.sh
+++ b/www/apps/api-reference/specs/store/code_samples/Shell/store_orders/get.sh
@@ -1,2 +1,3 @@
 curl '{backend_url}/store/orders' \
+-H 'Authorization: Bearer {access_token}' \
 -H 'x-publishable-api-key: {your_publishable_api_key}'

--- a/www/apps/api-reference/specs/store/code_samples/Shell/store_orders_{id}_transfer_cancel/post.sh
+++ b/www/apps/api-reference/specs/store/code_samples/Shell/store_orders_{id}_transfer_cancel/post.sh
@@ -1,2 +1,3 @@
 curl -X POST '{backend_url}/store/orders/{id}/transfer/cancel' \
+-H 'Authorization: Bearer {access_token}' \
 -H 'x-publishable-api-key: {your_publishable_api_key}'

--- a/www/apps/api-reference/specs/store/code_samples/Shell/store_orders_{id}_transfer_request/post.sh
+++ b/www/apps/api-reference/specs/store/code_samples/Shell/store_orders_{id}_transfer_request/post.sh
@@ -1,2 +1,3 @@
 curl -X POST '{backend_url}/store/orders/{id}/transfer/request' \
+-H 'Authorization: Bearer {access_token}' \
 -H 'x-publishable-api-key: {your_publishable_api_key}'

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -1265,13 +1265,13 @@ paths:
   /store/carts/{id}/customer:
     post:
       operationId: PostCartsIdCustomer
-      summary: Set Cart's Customer
-      x-sidebar-summary: Set Customer
-      description: Set the customer of the cart. This is useful when you create the cart for a guest customer, then they log in with their account.
+      summary: Change Cart's Customer to Logged-in Customer
+      x-sidebar-summary: Change Customer
+      description: Change the cart's customer to the currently logged-in customer. This is useful when you create the cart for a guest customer, then they log in with their account.
       externalDocs:
         url: https://docs.medusajs.com/resources/storefront-development/cart/update#set-carts-customer
         description: 'Storefront guide: How to set the cart''s customer.'
-      x-authenticated: false
+      x-authenticated: true
       parameters:
         - name: id
           in: path
@@ -1318,6 +1318,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to set the cart's customer
             sdk.store.cart.transferCart("cart_123")
             .then(({ cart }) => {
               console.log(cart)
@@ -1326,6 +1327,7 @@ paths:
           label: cURL
           source: |-
             curl -X POST '{backend_url}/store/carts/{id}/customer' \
+            -H 'Authorization: Bearer {access_token}' \
             -H 'x-publishable-api-key: {your_publishable_api_key}'
       tags:
         - Carts
@@ -1361,6 +1363,9 @@ paths:
           description: Emitted when the customer in the cart is transferred.
           deprecated: false
           since: 2.8.0
+      security:
+        - cookie_auth: []
+        - jwt_token: []
   /store/carts/{id}/gift-cards:
     post:
       operationId: PostCartsIdGiftCards
@@ -3349,6 +3354,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to retrieve their details
             sdk.store.customer.retrieve()
             .then(({ customer }) => {
               console.log(customer)
@@ -3433,6 +3439,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to update their details
             sdk.store.customer.update({
               first_name: "John"
             })
@@ -3623,6 +3630,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to list their addresses
             sdk.store.customer.listAddress()
             .then(({ addresses, count, offset, limit }) => {
               console.log(addresses)
@@ -3708,6 +3716,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to create an address
             sdk.store.customer.createAddress({
               country_code: "us"
             })
@@ -3811,6 +3820,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to retrieve their address
             sdk.store.customer.retrieveAddress(
               "caddr_123"
             )
@@ -3904,6 +3914,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to update their address
             sdk.store.customer.updateAddress(
               "caddr_123",
               {
@@ -4001,6 +4012,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to delete their address
             sdk.store.customer.deleteAddress("caddr_123")
             .then(({ deleted, parent: customer }) => {
               console.log(customer)
@@ -4009,8 +4021,8 @@ paths:
           label: cURL
           source: |-
             curl -X DELETE '{backend_url}/store/customers/me/addresses/{address_id}' \
-            -H 'x-publishable-api-key: {your_publishable_api_key}' \
-            -H 'Authorization: Bearer {access_token}'
+            -H 'Authorization: Bearer {access_token}' \
+            -H 'x-publishable-api-key: {your_publishable_api_key}'
       tags:
         - Customers
       responses:
@@ -4343,6 +4355,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to list their orders
             sdk.store.order.list()
             .then(({ orders, count, offset, limit }) => {
               console.log(orders)
@@ -4351,6 +4364,7 @@ paths:
           label: cURL
           source: |-
             curl '{backend_url}/store/orders' \
+            -H 'Authorization: Bearer {access_token}' \
             -H 'x-publishable-api-key: {your_publishable_api_key}'
       tags:
         - Orders
@@ -4643,6 +4657,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to cancel the order transfer
             sdk.store.order.cancelTransfer(
               "order_123",
               {},
@@ -4657,6 +4672,7 @@ paths:
           label: cURL
           source: |-
             curl -X POST '{backend_url}/store/orders/{id}/transfer/cancel' \
+            -H 'Authorization: Bearer {access_token}' \
             -H 'x-publishable-api-key: {your_publishable_api_key}'
       tags:
         - Orders
@@ -4844,6 +4860,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
+            // TODO must be authenticated as the customer to request the order transfer
             sdk.store.order.requestTransfer(
               "order_123",
               {
@@ -4861,6 +4878,7 @@ paths:
           label: cURL
           source: |-
             curl -X POST '{backend_url}/store/orders/{id}/transfer/request' \
+            -H 'Authorization: Bearer {access_token}' \
             -H 'x-publishable-api-key: {your_publishable_api_key}'
       tags:
         - Orders

--- a/www/apps/api-reference/specs/store/paths/store_carts_{id}_customer.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_carts_{id}_customer.yaml
@@ -1,15 +1,16 @@
 post:
   operationId: PostCartsIdCustomer
-  summary: Set Cart's Customer
-  x-sidebar-summary: Set Customer
+  summary: Change Cart's Customer to Logged-in Customer
+  x-sidebar-summary: Change Customer
   description: >-
-    Set the customer of the cart. This is useful when you create the cart for a
-    guest customer, then they log in with their account.
+    Change the cart's customer to the currently logged-in customer. This is
+    useful when you create the cart for a guest customer, then they log in with
+    their account.
   externalDocs:
     url: >-
       https://docs.medusajs.com/resources/storefront-development/cart/update#set-carts-customer
     description: 'Storefront guide: How to set the cart''s customer.'
-  x-authenticated: false
+  x-authenticated: true
   parameters:
     - name: id
       in: path
@@ -88,3 +89,6 @@ post:
       description: Emitted when the customer in the cart is transferred.
       deprecated: false
       since: 2.8.0
+  security:
+    - cookie_auth: []
+    - jwt_token: []

--- a/www/apps/resources/app/storefront-development/cart/update/page.mdx
+++ b/www/apps/resources/app/storefront-development/cart/update/page.mdx
@@ -69,6 +69,7 @@ This API route is only available after [Medusa v2.0.5](https://github.com/medusa
 </Note>
 
 ```ts
+// TODO must be authenticated as the customer to set the cart's customer
 sdk.store.cart.transferCart(cartId)
 .then(({ cart }) => {
   // use cart...

--- a/www/utils/generated/events-output.json
+++ b/www/utils/generated/events-output.json
@@ -720,8 +720,8 @@
     "description": "Emitted when a payment is captured.",
     "workflows": [
       "capturePaymentWorkflow",
-      "processPaymentWorkflow",
-      "markPaymentCollectionAsPaid"
+      "markPaymentCollectionAsPaid",
+      "processPaymentWorkflow"
     ],
     "deprecated": false
   },

--- a/www/utils/generated/oas-output/operations/store/delete_store_customers_me_addresses_[address_id].ts
+++ b/www/utils/generated/oas-output/operations/store/delete_store_customers_me_addresses_[address_id].ts
@@ -58,6 +58,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to delete their address
  *       sdk.store.customer.deleteAddress("caddr_123")
  *       .then(({ deleted, parent: customer }) => {
  *         console.log(customer)
@@ -66,8 +67,8 @@
  *     label: cURL
  *     source: |-
  *       curl -X DELETE '{backend_url}/store/customers/me/addresses/{address_id}' \
- *       -H 'x-publishable-api-key: {your_publishable_api_key}' \
- *       -H 'Authorization: Bearer {access_token}'
+ *       -H 'Authorization: Bearer {access_token}' \
+ *       -H 'x-publishable-api-key: {your_publishable_api_key}'
  * tags:
  *   - Customers
  * responses:

--- a/www/utils/generated/oas-output/operations/store/get_store_customers_me.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_customers_me.ts
@@ -52,6 +52,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to retrieve their details
  *       sdk.store.customer.retrieve()
  *       .then(({ customer }) => {
  *         console.log(customer)

--- a/www/utils/generated/oas-output/operations/store/get_store_customers_me_addresses.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_customers_me_addresses.ts
@@ -141,6 +141,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to list their addresses
  *       sdk.store.customer.listAddress()
  *       .then(({ addresses, count, offset, limit }) => {
  *         console.log(addresses)

--- a/www/utils/generated/oas-output/operations/store/get_store_customers_me_addresses_[address_id].ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_customers_me_addresses_[address_id].ts
@@ -55,6 +55,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to retrieve their address
  *       sdk.store.customer.retrieveAddress(
  *         "caddr_123"
  *       )

--- a/www/utils/generated/oas-output/operations/store/get_store_orders.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_orders.ts
@@ -147,6 +147,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to list their orders
  *       sdk.store.order.list()
  *       .then(({ orders, count, offset, limit }) => {
  *         console.log(orders)
@@ -155,6 +156,7 @@
  *     label: cURL
  *     source: |-
  *       curl '{backend_url}/store/orders' \
+ *       -H 'Authorization: Bearer {access_token}' \
  *       -H 'x-publishable-api-key: {your_publishable_api_key}'
  * tags:
  *   - Orders

--- a/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_customer.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_carts_[id]_customer.ts
@@ -1,13 +1,13 @@
 /**
  * @oas [post] /store/carts/{id}/customer
  * operationId: PostCartsIdCustomer
- * summary: Set Cart's Customer
- * x-sidebar-summary: Set Customer
- * description: Set the customer of the cart. This is useful when you create the cart for a guest customer, then they log in with their account.
+ * summary: Change Cart's Customer to Logged-in Customer
+ * x-sidebar-summary: Change Customer
+ * description: Change the cart's customer to the currently logged-in customer. This is useful when you create the cart for a guest customer, then they log in with their account.
  * externalDocs:
  *   url: https://docs.medusajs.com/resources/storefront-development/cart/update#set-carts-customer
  *   description: "Storefront guide: How to set the cart's customer."
- * x-authenticated: false
+ * x-authenticated: true
  * parameters:
  *   - name: id
  *     in: path
@@ -55,6 +55,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to set the cart's customer
  *       sdk.store.cart.transferCart("cart_123")
  *       .then(({ cart }) => {
  *         console.log(cart)
@@ -63,6 +64,7 @@
  *     label: cURL
  *     source: |-
  *       curl -X POST '{backend_url}/store/carts/{id}/customer' \
+ *       -H 'Authorization: Bearer {access_token}' \
  *       -H 'x-publishable-api-key: {your_publishable_api_key}'
  * tags:
  *   - Carts
@@ -98,6 +100,9 @@
  *     description: Emitted when the customer in the cart is transferred.
  *     deprecated: false
  *     since: 2.8.0
+ * security:
+ *   - cookie_auth: []
+ *   - jwt_token: []
  * 
 */
 

--- a/www/utils/generated/oas-output/operations/store/post_store_customers_me.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_customers_me.ts
@@ -55,6 +55,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to update their details
  *       sdk.store.customer.update({
  *         first_name: "John"
  *       })

--- a/www/utils/generated/oas-output/operations/store/post_store_customers_me_addresses.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_customers_me_addresses.ts
@@ -57,6 +57,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to create an address
  *       sdk.store.customer.createAddress({
  *         country_code: "us"
  *       })

--- a/www/utils/generated/oas-output/operations/store/post_store_customers_me_addresses_[address_id].ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_customers_me_addresses_[address_id].ts
@@ -63,6 +63,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to update their address
  *       sdk.store.customer.updateAddress(
  *         "caddr_123",
  *         {

--- a/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_cancel.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_cancel.ts
@@ -52,6 +52,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to cancel the order transfer
  *       sdk.store.order.cancelTransfer(
  *         "order_123",
  *         {},
@@ -66,6 +67,7 @@
  *     label: cURL
  *     source: |-
  *       curl -X POST '{backend_url}/store/orders/{id}/transfer/cancel' \
+ *       -H 'Authorization: Bearer {access_token}' \
  *       -H 'x-publishable-api-key: {your_publishable_api_key}'
  * tags:
  *   - Orders

--- a/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_request.ts
+++ b/www/utils/generated/oas-output/operations/store/post_store_orders_[id]_transfer_request.ts
@@ -58,6 +58,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
+ *       // TODO must be authenticated as the customer to request the order transfer
  *       sdk.store.order.requestTransfer(
  *         "order_123",
  *         {
@@ -75,6 +76,7 @@
  *     label: cURL
  *     source: |-
  *       curl -X POST '{backend_url}/store/orders/{id}/transfer/request' \
+ *       -H 'Authorization: Bearer {access_token}' \
  *       -H 'x-publishable-api-key: {your_publishable_api_key}'
  * tags:
  *   - Orders

--- a/www/utils/generated/route-examples-output/route-examples.json
+++ b/www/utils/generated/route-examples-output/route-examples.json
@@ -1008,7 +1008,7 @@
     "js-sdk": "sdk.store.cart.complete(\"cart_123\")\n.then((data) => {\n  if(data.type === \"cart\") {\n    // an error occurred\n    console.log(data.error, data.cart)\n  } else {\n    // order placed successfully\n    console.log(data.order)\n  }\n})"
   },
   "POST /store/carts/{id}/customer": {
-    "js-sdk": "sdk.store.cart.transferCart(\"cart_123\")\n.then(({ cart }) => {\n  console.log(cart)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to set the cart's customer\nsdk.store.cart.transferCart(\"cart_123\")\n.then(({ cart }) => {\n  console.log(cart)\n})"
   },
   "GET /store/shipping-options": {
     "js-sdk": "sdk.store.fulfillment.listCartOptions({\n  cart_id: \"cart_123\"\n})\n.then(({ shipping_options }) => {\n  console.log(shipping_options)\n})"
@@ -1023,16 +1023,16 @@
     "js-sdk": "sdk.store.payment.initiatePaymentSession(\n  cart, // assuming you already have the cart object.\n  {\n    provider_id: \"pp_stripe_stripe\",\n    data: {\n      // any data relevant for the provider.\n    }\n  }\n)\n.then(({ payment_collection }) => {\n  console.log(payment_collection)\n})"
   },
   "GET /store/orders": {
-    "js-sdk": "sdk.store.order.list()\n.then(({ orders, count, offset, limit }) => {\n  console.log(orders)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to list their orders\nsdk.store.order.list()\n.then(({ orders, count, offset, limit }) => {\n  console.log(orders)\n})"
   },
   "GET /store/orders/{id}": {
     "js-sdk": "sdk.store.order.retrieve(\"order_123\")\n.then(({ order }) => {\n  console.log(order)\n})"
   },
   "POST /store/orders/{id}/transfer/request": {
-    "js-sdk": "sdk.store.order.requestTransfer(\n  \"order_123\",\n  {\n    description: \"I want to transfer this order to my friend.\"\n  },\n  {},\n  {\n    Authorization: `Bearer ${token}`\n  }\n)\n.then(({ order }) => {\n  console.log(order)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to request the order transfer\nsdk.store.order.requestTransfer(\n  \"order_123\",\n  {\n    description: \"I want to transfer this order to my friend.\"\n  },\n  {},\n  {\n    Authorization: `Bearer ${token}`\n  }\n)\n.then(({ order }) => {\n  console.log(order)\n})"
   },
   "POST /store/orders/{id}/transfer/cancel": {
-    "js-sdk": "sdk.store.order.cancelTransfer(\n  \"order_123\",\n  {},\n  {\n    Authorization: `Bearer ${token}`\n  }\n)\n.then(({ order }) => {\n  console.log(order)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to cancel the order transfer\nsdk.store.order.cancelTransfer(\n  \"order_123\",\n  {},\n  {\n    Authorization: `Bearer ${token}`\n  }\n)\n.then(({ order }) => {\n  console.log(order)\n})"
   },
   "POST /store/orders/{id}/transfer/accept": {
     "js-sdk": "sdk.store.order.acceptTransfer(\n  \"order_123\",\n  {\n    token: \"transfer_token\"\n  },\n  {\n    Authorization: `Bearer ${token}`\n  }\n)\n.then(({ order }) => {\n  console.log(order)\n})"
@@ -1044,24 +1044,24 @@
     "js-sdk": "const token = await sdk.auth.register(\"customer\", \"emailpass\", {\n  \"email\": \"customer@gmail.com\",\n  \"password\": \"supersecret\"\n})\n\nsdk.store.customer.create(\n  {\n    \"email\": \"customer@gmail.com\"\n  },\n  {},\n  {\n    Authorization: `Bearer ${token}`\n  }\n)\n.then(({ customer }) => {\n  console.log(customer)\n})"
   },
   "POST /store/customers/me": {
-    "js-sdk": "sdk.store.customer.update({\n  first_name: \"John\"\n})\n.then(({ customer }) => {\n  console.log(customer)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to update their details\nsdk.store.customer.update({\n  first_name: \"John\"\n})\n.then(({ customer }) => {\n  console.log(customer)\n})"
   },
   "GET /store/customers/me": {
-    "js-sdk": "sdk.store.customer.retrieve()\n.then(({ customer }) => {\n  console.log(customer)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to retrieve their details\nsdk.store.customer.retrieve()\n.then(({ customer }) => {\n  console.log(customer)\n})"
   },
   "POST /store/customers/me/addresses": {
-    "js-sdk": "sdk.store.customer.createAddress({\n  country_code: \"us\"\n})\n.then(({ customer }) => {\n  console.log(customer)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to create an address\nsdk.store.customer.createAddress({\n  country_code: \"us\"\n})\n.then(({ customer }) => {\n  console.log(customer)\n})"
   },
   "POST /store/customers/me/addresses/{addressid}": {
-    "js-sdk": "sdk.store.customer.updateAddress(\n  \"caddr_123\",\n  {\n    country_code: \"us\"\n  }\n)\n.then(({ customer }) => {\n  console.log(customer)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to update their address\nsdk.store.customer.updateAddress(\n  \"caddr_123\",\n  {\n    country_code: \"us\"\n  }\n)\n.then(({ customer }) => {\n  console.log(customer)\n})"
   },
   "GET /store/customers/me/addresses": {
-    "js-sdk": "sdk.store.customer.listAddress()\n.then(({ addresses, count, offset, limit }) => {\n  console.log(addresses)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to list their addresses\nsdk.store.customer.listAddress()\n.then(({ addresses, count, offset, limit }) => {\n  console.log(addresses)\n})"
   },
   "GET /store/customers/me/addresses/{addressid}": {
-    "js-sdk": "sdk.store.customer.retrieveAddress(\n  \"caddr_123\"\n)\n.then(({ address }) => {\n  console.log(address)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to retrieve their address\nsdk.store.customer.retrieveAddress(\n  \"caddr_123\"\n)\n.then(({ address }) => {\n  console.log(address)\n})"
   },
   "DELETE /store/customers/me/addresses/{addressid}": {
-    "js-sdk": "sdk.store.customer.deleteAddress(\"caddr_123\")\n.then(({ deleted, parent: customer }) => {\n  console.log(customer)\n})"
+    "js-sdk": "// TODO must be authenticated as the customer to delete their address\nsdk.store.customer.deleteAddress(\"caddr_123\")\n.then(({ deleted, parent: customer }) => {\n  console.log(customer)\n})"
   }
 }

--- a/www/utils/packages/docs-generator/src/classes/kinds/oas.ts
+++ b/www/utils/packages/docs-generator/src/classes/kinds/oas.ts
@@ -129,6 +129,10 @@ class OasKindGenerator extends FunctionKindGenerator {
       startsWith: "store/store-credit-accounts",
       requiresAuthentication: true,
     },
+    {
+      exact: "store/carts/[id]/customer",
+      requiresAuthentication: true,
+    },
   ]
   readonly RESPONSE_TYPE_NAMES = ["MedusaResponse"]
   readonly FIELD_QUERY_PARAMS = ["fields", "expand"]


### PR DESCRIPTION
Clarify that the `/store/carts/[id]/customer` API route sets the cart's customer to the logged-in customer. Also, add this clarification regarding authentication for mutliple store routes.

Closes DX-2088