### PR TITLE
fix(medusa): Use the correct boolean validator

### DIFF
--- a/packages/medusa/src/api/store/shipping-options/validators.ts
+++ b/packages/medusa/src/api/store/shipping-options/validators.ts
@@ -1,5 +1,8 @@
 import { z } from "zod"
-import { applyAndAndOrOperators } from "../../utils/common-validators"
+import {
+  applyAndAndOrOperators,
+  booleanString,
+} from "../../utils/common-validators"
 import { createFindParams, createSelectParams } from "../../utils/validators"
 
 export const StoreGetShippingOptionsParams = createSelectParams()
@@ -7,7 +10,7 @@ export const StoreGetShippingOptionsParams = createSelectParams()
 export const StoreGetShippingOptionsFields = z
   .object({
     cart_id: z.string(),
-    is_return: z.boolean().optional(),
+    is_return: booleanString().optional(),
   })
   .strict()
 


### PR DESCRIPTION
**what**
Use the correct boolean validator for `StoreGetShippingOptionsFields`