### PR TITLE
fix(): Prevent promotion filtering to exceed psql limits

### DIFF
--- a/.changeset/sour-rockets-grin.md
+++ b/.changeset/sour-rockets-grin.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/promotion": patch
+---
+
+fix(): Prevent promotion filtering to exceed psql limits

--- a/packages/modules/promotion/integration-tests/__tests__/services/promotion-module/compute-actions.spec.ts
+++ b/packages/modules/promotion/integration-tests/__tests__/services/promotion-module/compute-actions.spec.ts
@@ -353,7 +353,7 @@ moduleIntegrationTestRunner({
               value: 100,
               target_rules: [
                 {
-                  attribute: "product.id",
+                  attribute: "items.product.id",
                   operator: "eq",
                   values: ["prod_tshirt0"], // Only applies to product 0
                 },

--- a/packages/modules/promotion/src/services/promotion-module.ts
+++ b/packages/modules/promotion/src/services/promotion-module.ts
@@ -466,7 +466,10 @@ export default class PromotionModuleService
 
     if (!preventAutoPromotions) {
       const rulePrefilteringFilters =
-        buildPromotionRuleQueryFilterFromContext(applicationContext)
+        await buildPromotionRuleQueryFilterFromContext(
+          applicationContext,
+          sharedContext
+        )
 
       let prefilteredAutomaticPromotionIds: string[] = []
 


### PR DESCRIPTION
**What**

When the context can be big, we switch to a simple query to retrieve the available rule attribute in db to stip out the attribute from the context from which we dont care