### PR TITLE
feat(admin-vite-plugin,dashboard): support for react-router's splat and optional segments

### DIFF
--- a/.changeset/mean-mugs-sparkle.md
+++ b/.changeset/mean-mugs-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/admin-vite-plugin": patch
+"@medusajs/dashboard": patch
+---
+
+feat(admin-vite-plugin,dashboard): support for react-router's splat and optional segments

--- a/packages/admin/admin-vite-plugin/src/routes/helpers.ts
+++ b/packages/admin/admin-vite-plugin/src/routes/helpers.ts
@@ -4,7 +4,11 @@ export function getRoute(file: string): string {
   const importPath = normalizePath(file)
   return importPath
     .replace(/.*\/admin\/(routes)/, "")
-    .replace(/\[([^\]]+)\]/g, ":$1")
+    .replace("[[*]]", "*?")               // optional splat
+    .replace("[*]", "*")                  // splat
+    .replace(/\(([^\[\]\)]+)\)/g, "$1?")  // optional static,  (foo)
+    .replace(/\[\[([^\]]+)\]\]/g, ":$1?") // optional dynamic, [[foo]]
+    .replace(/\[([^\]]+)\]/g, ":$1")      // dynamic,          [foo]
     .replace(
       new RegExp(
         `/page\\.(${VALID_FILE_EXTENSIONS.map((ext) => ext.slice(1)).join(

--- a/packages/admin/dashboard/src/dashboard-app/dashboard-app.tsx
+++ b/packages/admin/dashboard/src/dashboard-app/dashboard-app.tsx
@@ -39,6 +39,13 @@ type DashboardAppProps = {
   plugins: DashboardPlugin[]
 }
 
+/**
+ * Matches segments that are optional and at the end of the path.
+ * Example: /path/to/:id?
+ * Such paths can be added to the menu items without the optional segment.
+ */
+const OPTIONAL_LAST_SEGMENT_MATCH = /\/([^\/])+\?$/
+
 export class DashboardApp {
   private widgets: WidgetMap
   private menus: MenuMap
@@ -124,10 +131,11 @@ export class DashboardApp {
     allMenuItems.sort((a, b) => a.path.length - b.path.length)
 
     allMenuItems.forEach((item) => {
-      if (item.path.includes("/:")) {
+      item.path = item.path.replace(OPTIONAL_LAST_SEGMENT_MATCH, "")
+      if (item.path.includes("/:") || item.path.endsWith("/*")) {
         if (process.env.NODE_ENV === "development") {
           console.warn(
-            `[@medusajs/dashboard] Menu item for path "${item.path}" can't be added to the sidebar as it contains a parameter.`
+            `[@medusajs/dashboard] Menu item for path "${item.path}" can't be added to the sidebar as it contains a mandatory parameter.`
           )
         }
         return


### PR DESCRIPTION
Closes #12348

This PR adds support for the missing route segment types available in react-router, namely splat(called catch-all in next.js) routes and optional static/dynamic/splat routes.

1. Added translation from folder name to react-router symbol with the 4 .replace() lines
Most people will only ever use optional splat and dynamic but I saw no reason to exclude the other two. I chose `[[*]], [*], [[id]], (static)` to somewhat align with next.js and the existing [id]. I used `*` instead of `...` since that's what useParams() returns.   
Just my initial take, I can change the naming if needed or remove `[*]` and `(static)` if it's too much(they are somewhat useless after all)

2. Allow routes with an optional segment at the end to be displayed in the sidebar menu items

3. Fixed edge-case for splat routes in the logic for generating the react-router map, explained in comment
