### PR TITLE
feat: add metadata to shipping options api endpoints

### DIFF
--- a/integration-tests/http/__tests__/shipping-option/admin/shipping-option.spec.ts
+++ b/integration-tests/http/__tests__/shipping-option/admin/shipping-option.spec.ts
@@ -292,6 +292,54 @@ medusaIntegrationTestRunner({
             metadata: null,
           })
         })
+
+        it("should retrieve a shipping option with metadata successfully", async () => {
+          const shippingOptionPayload = {
+            name: "Test shipping option with metadata",
+            service_zone_id: fulfillmentSet.service_zones[0].id,
+            shipping_profile_id: shippingProfile.id,
+            provider_id: "manual_test-provider",
+            price_type: "flat",
+            type: {
+              label: "Test type",
+              description: "Test description",
+              code: "test-code",
+            },
+            prices: [{ currency_code: "usd", amount: 1000 }],
+            metadata: {
+              priority: "high",
+              tracking: "enabled",
+              carrier: "express",
+              specialHandling: true,
+            },
+          }
+
+          const {
+            data: { shipping_option: shippingOption },
+          } = await api.post(
+            `/admin/shipping-options`,
+            shippingOptionPayload,
+            adminHeaders
+          )
+
+          const shippingOptionRes = await api.get(
+            `/admin/shipping-options/${shippingOption.id}`,
+            adminHeaders
+          )
+
+          expect(shippingOptionRes.data.shipping_option).toEqual(
+            expect.objectContaining({
+              id: expect.any(String),
+              name: "Test shipping option with metadata",
+              metadata: {
+                priority: "high",
+                tracking: "enabled",
+                carrier: "express",
+                specialHandling: true,
+              },
+            })
+          )
+        })
       })
 
       describe("POST /admin/shipping-options", () => {

--- a/packages/core/types/src/http/shipping-option/admin/payloads.ts
+++ b/packages/core/types/src/http/shipping-option/admin/payloads.ts
@@ -55,21 +55,21 @@ export interface AdminUpdateShippingOptionType {
 interface AdminShippingOptionPriceRulePayload {
   /**
    * The operator of the shipping option price rule.
-   * 
+   *
    * @example
    * "eq"
    */
   operator: string
   /**
    * The attribute of the shipping option price rule.
-   * 
+   *
    * @example
    * "region_id"
    */
   attribute: string
   /**
    * The value of the shipping option price rule.
-   * 
+   *
    * @example
    * "region_123"
    */
@@ -88,7 +88,7 @@ export interface AdminCreateShippingOptionPriceWithCurrency
   extends AdminShippingOptionPriceWithRules {
   /**
    * The currency code of the shipping option price.
-   * 
+   *
    * @example
    * "usd"
    */
@@ -115,21 +115,21 @@ export interface AdminCreateShippingOption {
   /**
    * The name of the shipping option. Customers can
    * view this name during checkout.
-   * 
+   *
    * @example
    * "Standard Shipping"
    */
   name: string
   /**
    * The ID of the service zone that the shipping option belongs to.
-   * 
+   *
    * Learn more in the [Shipping Options](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#service-zone-restrictions)
    * documentation.
    */
   service_zone_id: string
   /**
    * The ID of the shipping profile that the shipping option belongs to.
-   * 
+   *
    * Learn more in the [Shipping Options](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#shipping-profile-and-types)
    * documentation.
    */
@@ -137,7 +137,7 @@ export interface AdminCreateShippingOption {
   /**
    * Additional data that is useful for third-party fulfillment providers
    * that process fulfillments for the shipping option.
-   * 
+   *
    * Learn more in the [Shipping Options](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#data-property)
    * documentation.
    */
@@ -152,7 +152,7 @@ export interface AdminCreateShippingOption {
   provider_id: string
   /**
    * The type of shipping option.
-   * 
+   *
    * Learn more in the [Shipping Option](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#shipping-profile-and-types)
    * documentation.
    */
@@ -173,11 +173,15 @@ export interface AdminCreateShippingOption {
   )[]
   /**
    * The rules of the shipping option.
-   * 
+   *
    * Learn more in the [Shipping Option Rules](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#shipping-option-rules)
    * documentation.
    */
   rules?: AdminCreateShippingOptionRule[]
+  /**
+   * Custom key-value pairs that can be added to the shipping option.
+   */
+  metadata?: Record<string, unknown>
 }
 
 export interface AdminUpdateShippingOptionRule
@@ -197,7 +201,7 @@ export interface AdminUpdateShippingOptionPriceWithCurrency
   id?: string
   /**
    * The currency code of the shipping option price.
-   * 
+   *
    * @example
    * "usd"
    */
@@ -229,7 +233,7 @@ export interface AdminUpdateShippingOption {
   /**
    * The name of the shipping option. Customers can
    * view this name during checkout.
-   * 
+   *
    * @example
    * "Standard Shipping"
    */
@@ -249,14 +253,14 @@ export interface AdminUpdateShippingOption {
   provider_id?: string
   /**
    * The ID of the shipping profile that the shipping option belongs to.
-   * 
+   *
    * Learn more in the [Shipping Options](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#shipping-profile-and-types)
    * documentation.
    */
   shipping_profile_id?: string
   /**
    * The type of shipping option.
-   * 
+   *
    * Learn more in the [Shipping Options](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#shipping-profile-and-types)
    * documentation.
    */
@@ -277,11 +281,15 @@ export interface AdminUpdateShippingOption {
   )[]
   /**
    * The rules of the shipping option.
-   * 
+   *
    * Learn more in the [Shipping Option Rules](https://docs.medusajs.com/resources/commerce-modules/fulfillment/shipping-option#shipping-option-rules)
    * documentation.
    */
   rules?: (AdminUpdateShippingOptionRule | AdminCreateShippingOptionRule)[]
+  /**
+   * Custom key-value pairs that can be added to the shipping option.
+   */
+  metadata?: Record<string, unknown>
 }
 
 export interface AdminUpdateShippingOptionRules {

--- a/packages/medusa/src/api/admin/shipping-options/validators.ts
+++ b/packages/medusa/src/api/admin/shipping-options/validators.ts
@@ -142,6 +142,7 @@ export const AdminCreateShippingOption = z
       AdminCreateShippingOptionPriceWithRegion
     ).array(),
     rules: AdminCreateShippingOptionRule.array().optional(),
+    metadata: z.record(z.unknown()).optional(),
   })
   .strict()
   .refine((data) => isDefined(data.type_id) !== isDefined(data.type), {
@@ -170,6 +171,7 @@ export const AdminUpdateShippingOption = z
     rules: AdminUpdateShippingOptionRule.or(AdminCreateShippingOptionRule)
       .array()
       .optional(),
+    metadata: z.record(z.unknown()).optional(),
   })
   .strict()
   .refine(

--- a/packages/medusa/src/api/store/shipping-options/query-config.ts
+++ b/packages/medusa/src/api/store/shipping-options/query-config.ts
@@ -6,6 +6,7 @@ export const defaultStoreShippingOptionsFields = [
   "shipping_profile_id",
   "fulfillment_provider_id",
   "shipping_option_type_id",
+  "metadata",
 ]
 
 export const listTransformQueryConfig = {


### PR DESCRIPTION
Re-open #12722 (changes under the www/apps/api-reference/specs directory removed)

In Medusa v1, the /store/shipping-options endpoint exposed metadata for shipping options. This functionality was missing in v2, preventing developers from storing and retrieving custom key-value pairs on shipping options.

This PR restores metadata support for shipping options across both admin and store APIs.

Admin API:

- ✅ POST /admin/shipping-options now accepts metadata
- ✅ POST /admin/shipping-options/{id} now accepts metadata
- ✅ GET /admin/shipping-options & GET /admin/shipping-options/{id} already exposed metadata (unchanged)

Store API:

- ✅ GET /store/shipping-options now exposes metadata