### PR TITLE
feat(store): add id filtering to store collections endpoint

### DIFF
--- a/.changeset/fix-collection-store-circular-type.md
+++ b/.changeset/fix-collection-store-circular-type.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": patch
+---
+
+fix(types): resolve circular type reference in StoreCollectionListParams interface

--- a/packages/core/js-sdk/src/store/index.ts
+++ b/packages/core/js-sdk/src/store/index.ts
@@ -184,7 +184,7 @@ export class Store {
      * Learn more about the `fields` property in the [API reference](https://docs.medusajs.com/api/store#select-fields-and-relations).
      */
     list: async (
-      query?: FindParams & HttpTypes.StoreCollectionFilters,
+      query?: FindParams & HttpTypes.StoreCollectionListParams,
       headers?: ClientHeaders
     ) => {
       return this.client.fetch<HttpTypes.StoreCollectionListResponse>(
@@ -478,7 +478,7 @@ export class Store {
 
   /**
    * Related guides: [How to implement carts in the storefront](https://docs.medusajs.com/resources/storefront-development/cart).
-   * 
+   *
    * @tags cart
    */
   public cart = {

--- a/packages/core/types/src/http/collection/store/queries.ts
+++ b/packages/core/types/src/http/collection/store/queries.ts
@@ -1,5 +1,8 @@
-import { BaseCollectionListParams } from "../common"
+import { BaseFilterable } from "../../../dal"
+import { BaseCollectionListParams, BaseCollectionParams } from "../common"
 
-export interface StoreCollectionFilters
-  extends Omit<BaseCollectionListParams, "id"> {
-}
+export interface StoreCollectionListParams
+  extends BaseCollectionListParams,
+    BaseFilterable<StoreCollectionListParams> {}
+
+export interface StoreCollectionParams extends BaseCollectionParams {}

--- a/packages/core/types/src/http/collection/store/queries.ts
+++ b/packages/core/types/src/http/collection/store/queries.ts
@@ -1,8 +1,6 @@
-import { BaseFilterable } from "../../../dal"
 import { BaseCollectionListParams, BaseCollectionParams } from "../common"
 
 export interface StoreCollectionListParams
-  extends BaseCollectionListParams,
-    BaseFilterable<StoreCollectionListParams> {}
+  extends Omit<BaseCollectionListParams, "deleted_at"> {}
 
 export interface StoreCollectionParams extends BaseCollectionParams {}

--- a/packages/medusa/src/api/store/collections/route.ts
+++ b/packages/medusa/src/api/store/collections/route.ts
@@ -10,7 +10,7 @@ import {
 } from "@medusajs/framework/utils"
 
 export const GET = async (
-  req: AuthenticatedMedusaRequest<HttpTypes.StoreCollectionFilters>,
+  req: AuthenticatedMedusaRequest<HttpTypes.StoreCollectionListParams>,
   res: MedusaResponse<HttpTypes.StoreCollectionListResponse>
 ) => {
   const remoteQuery = req.scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)

--- a/packages/medusa/src/api/store/collections/validators.ts
+++ b/packages/medusa/src/api/store/collections/validators.ts
@@ -10,6 +10,7 @@ export const StoreGetCollectionParams = createSelectParams()
 
 export const StoreGetCollectionsParamsFields = z.object({
   q: z.string().optional(),
+  id: z.union([z.string(), z.array(z.string())]).optional(),
   title: z.union([z.string(), z.array(z.string())]).optional(),
   handle: z.union([z.string(), z.array(z.string())]).optional(),
   created_at: createOperatorMap().optional(),


### PR DESCRIPTION
Same as these PRs : #13174 #13495 

Added support for filtering collections by id in the store API.
This aligns the collections endpoint with the product categories/tags/types endpoint, which already supports the id parameter.

- ✅ Add id parameter to StoreGetCollectionsParamsFields
- ✅ Support single ID or multiple IDs filtering
- ✅ Align with other store endpoints (/store/product-categories, /store/product-tags, etc.)

