### PR TITLE
fix(types): missing service zone in shipping option

### DIFF
--- a/.changeset/forty-foxes-live.md
+++ b/.changeset/forty-foxes-live.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": patch
+---
+
+fix(types): missing service zone in shipping option

--- a/packages/core/types/src/http/fulfillment/store/index.ts
+++ b/packages/core/types/src/http/fulfillment/store/index.ts
@@ -90,3 +90,104 @@ export interface StoreCartShippingOption {
    */
   insufficient_inventory: boolean
 }
+
+export type StoreCartShippingOptionWithServiceZone = StoreCartShippingOption & {
+  /**
+   * The associated service zone.
+   */
+  service_zone: {
+    /**
+     * The service zone's ID.
+     */
+    id: string
+    /**
+     * The fulfillment set's id.
+     */
+    fulfillment_set_id: string
+    /**
+     * The details of the associated fulfillment set.
+     */
+    fulfillment_set: {
+      /**
+       * The fulfillment set's ID.
+       */
+      id: string
+      /**
+       * The fulfillment set's type.
+       */
+      type: string
+      /**
+       * The fulfillment set's location.
+       */
+      location: {
+        /**
+         * The location's ID.
+         */
+        id: string
+        /**
+         * The address details.
+         */
+        address: StoreFulfillmentAddress
+      }
+    }
+  }
+}
+
+interface StoreFulfillmentAddress {
+  /**
+   * The address's ID.
+   */
+  id: string
+  /**
+   * The address's company.
+   */
+  company: string | null
+  /**
+   * The address's first line.
+   */
+  address_1: string | null
+  /**
+   * The address's last line.
+   */
+  address_2: string | null
+  /**
+   * The address's city.
+   */
+  city: string | null
+  /**
+   * The address's country code.
+   *
+   * @example
+   * us
+   */
+  country_code: string | null
+  /**
+   * The address's lower-case [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) province.
+   */
+  province: string | null
+  /**
+   * The address's postal code.
+   */
+  postal_code: string | null
+  /**
+   * The address's phone number.
+   */
+  phone: string | null
+  /**
+   * Key-value pairs of custom data.
+   */
+  metadata: Record<string, unknown> | null
+  /**
+   * The date the address was created.
+   */
+  created_at: string
+  /**
+   * The date the address was updated.
+   */
+  updated_at: string
+  /**
+   * The date the address was deleted.
+   */
+  deleted_at: string | null
+}
+

--- a/packages/core/types/src/http/shipping-option/store/responses.ts
+++ b/packages/core/types/src/http/shipping-option/store/responses.ts
@@ -1,4 +1,4 @@
-import { StoreCartShippingOption } from "../../fulfillment"
+import { StoreCartShippingOption, StoreCartShippingOptionWithServiceZone, } from "../../fulfillment"
 
 /**
  * The response of listing the shipping options for a cart.
@@ -7,7 +7,7 @@ export interface StoreShippingOptionListResponse {
   /**
    * The shipping options for the cart.
    */
-  shipping_options: StoreCartShippingOption[]
+  shipping_options: StoreCartShippingOptionWithServiceZone[]
 }
 
 /**


### PR DESCRIPTION
Idea is to partly fix this [issue](https://github.com/medusajs/nextjs-starter-medusa/issues/497)