### PR TITLE
fix(workflow-engine-redis): use worker connection

### DIFF
--- a/.changeset/thirty-squids-swim.md
+++ b/.changeset/thirty-squids-swim.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/workflow-engine-redis": patch
+---
+
+fix(workflow-engine-redis): cleaner using worker connection

--- a/packages/modules/workflow-engine-redis/src/utils/workflow-orchestrator-storage.ts
+++ b/packages/modules/workflow-engine-redis/src/utils/workflow-orchestrator-storage.ts
@@ -118,14 +118,6 @@ export class RedisDistributedTransactionStorage
     await this.worker?.close()
     await this.jobWorker?.close()
 
-    // Clean up repeatable jobs
-    const repeatableJobs = (await this.cleanerQueue_?.getRepeatableJobs()) ?? []
-    for (const job of repeatableJobs) {
-      if (job.id === REPEATABLE_CLEARER_JOB_ID) {
-        await this.cleanerQueue_?.removeRepeatableByKey(job.key)
-      }
-    }
-
     await this.cleanerWorker_?.close()
   }
 


### PR DESCRIPTION
What:
 * Regular redis connection does not have `maxRetriesPerRequest: null`, and the worker connection hangs.