### PR TITLE
fix(dashboard): add offset and limit to query parameters in useTableConfiguration

### DIFF
--- a/.changeset/spicy-swans-grab.md
+++ b/.changeset/spicy-swans-grab.md
@@ -1,5 +1,5 @@
 ---
-"@medusajs/dashboard": major
+"@medusajs/dashboard": minor
 ---
 
 add offset and limit to query parameters in useTableConfiguration

--- a/.changeset/spicy-swans-grab.md
+++ b/.changeset/spicy-swans-grab.md
@@ -1,5 +1,5 @@
 ---
-"@medusajs/dashboard": minor
+"@medusajs/dashboard": patch
 ---
 
 add offset and limit to query parameters in useTableConfiguration

--- a/.changeset/spicy-swans-grab.md
+++ b/.changeset/spicy-swans-grab.md
@@ -2,4 +2,4 @@
 "@medusajs/dashboard": patch
 ---
 
-add offset and limit to query parameters in useTableConfiguration
+fix(dashboard): add offset and limit to query parameters in useTableConfiguration

--- a/.changeset/spicy-swans-grab.md
+++ b/.changeset/spicy-swans-grab.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": major
+---
+
+add offset and limit to query parameters in useTableConfiguration

--- a/packages/admin/dashboard/src/hooks/table/use-table-configuration.tsx
+++ b/packages/admin/dashboard/src/hooks/table/use-table-configuration.tsx
@@ -68,7 +68,7 @@ export function useTableConfiguration({
   })
 
   const queryParams = useQueryParams(
-    ["q", "order", ...filters.map(f => f.id)],
+    ["q", "order", "offset", "limit", ...filters.map(f => f.id)],
     queryPrefix
   )
 


### PR DESCRIPTION
This pull request introduces a minor update to the table configuration functionality in the dashboard package. The main change is the addition of pagination support through `offset` and `limit` query parameters.

This fix pagination with `view_configurations:true`

Pagination improvements:

* [`packages/admin/dashboard/src/hooks/table/use-table-configuration.tsx`](diffhunk://#diff-2cf338f1bf284cf3568eabc51107b9a3d51a4b830a81baae2362f608f7c8a55aL71-R71): Updated the `useTableConfiguration` hook to include `offset` and `limit` in the query parameters, enabling pagination for table data.
* [`.changeset/spicy-swans-grab.md`](diffhunk://#diff-1bada2c80b4c3b4ee3c8782ee24ca0183b1bee09aafd7fe130c481152458f1a4R1-R5): Documented the change as a minor update to `@medusajs/dashboard`, specifying the addition of `offset` and `limit` to query parameters in `useTableConfiguration`.