### PR TITLE
fix(order): save return's location ID from input

### DIFF
--- a/.changeset/dull-dodos-kick.md
+++ b/.changeset/dull-dodos-kick.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/order": patch
+---
+
+fix(order): save return's location ID from input

--- a/packages/modules/order/src/services/actions/create-return.ts
+++ b/packages/modules/order/src/services/actions/create-return.ts
@@ -22,6 +22,7 @@ function createReturnReference(em, data, order) {
     status: ReturnStatus.REQUESTED,
     no_notification: data.no_notification,
     refund_amount: (data.refund_amount as unknown) ?? null,
+    location_id: data.location_id ?? null,
   })
 }
 


### PR DESCRIPTION
Save a return's location ID when creating it, which is essential for storefront creation