### PR TITLE
chore(): remove ssl_mode from url and also use sslmode

### DIFF
--- a/.changeset/tiny-guests-wait.md
+++ b/.changeset/tiny-guests-wait.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/framework": patch
+"@medusajs/utils": patch
+---
+
+chore(): remove ssl_mode from url and also use sslmode

--- a/packages/core/framework/src/database/pg-connection-loader.ts
+++ b/packages/core/framework/src/database/pg-connection-loader.ts
@@ -38,7 +38,15 @@ export async function pgConnectionLoader(): Promise<
 
   delete driverOptions.pool
 
-  const clientUrl = connectionString?.replace(/[?&]ssl_mode=[^&]*/gi, "")
+  const clientUrl = connectionString?.replace(
+    /(\?|&)ssl_mode=[^&]*(&|$)/gi,
+    (match, prefix, suffix) => {
+      if (prefix === "?" && suffix === "&") return "?"
+      if (prefix === "?" && suffix === "") return ""
+      if (prefix === "&") return suffix
+      return ""
+    }
+  )
 
   const pgConnection = ModulesSdkUtils.createPgConnection({
     clientUrl,

--- a/packages/core/framework/src/database/pg-connection-loader.ts
+++ b/packages/core/framework/src/database/pg-connection-loader.ts
@@ -38,8 +38,10 @@ export async function pgConnectionLoader(): Promise<
 
   delete driverOptions.pool
 
+  const clientUrl = connectionString?.replace(/[?&]ssl_mode=[^&]*/gi, "")
+
   const pgConnection = ModulesSdkUtils.createPgConnection({
-    clientUrl: connectionString,
+    clientUrl,
     schema,
     driverOptions,
     pool: {

--- a/packages/core/utils/src/modules-sdk/__tests__/load-database-config.spec.ts
+++ b/packages/core/utils/src/modules-sdk/__tests__/load-database-config.spec.ts
@@ -169,7 +169,30 @@ describe("loadDatabaseConfig", function () {
     let config = loadDatabaseConfig("product", options)
 
     expect(config).toEqual({
-      clientUrl: options.database.clientUrl,
+      clientUrl: "postgres://https://test.com:5432/medusa-test",
+      driverOptions: {
+        connection: {
+          ssl: false,
+        },
+      },
+      debug: false,
+      schema: "",
+    })
+  })
+
+  it("should return the local configuration using the client url sslmode=disable", function () {
+    process.env.DATABASE_URL = "postgres://localhost:5432/medusa"
+    const options = {
+      database: {
+        clientUrl:
+          "postgres://https://test.com:5432/medusa-test?sslmode=disable",
+      },
+    }
+
+    let config = loadDatabaseConfig("product", options)
+
+    expect(config).toEqual({
+      clientUrl: "postgres://https://test.com:5432/medusa-test?sslmode=disable",
       driverOptions: {
         connection: {
           ssl: false,
@@ -185,14 +208,14 @@ describe("loadDatabaseConfig", function () {
     const options = {
       database: {
         clientUrl:
-          "postgres://https://test.com:5432/medusa-test?ssl_mode=disable",
+          "postgres://https://test.com:5432/medusa-test?ssl_mode=false",
       },
     }
 
     let config = loadDatabaseConfig("product", options)
 
     expect(config).toEqual({
-      clientUrl: options.database.clientUrl,
+      clientUrl: "postgres://https://test.com:5432/medusa-test",
       driverOptions: {
         connection: {
           ssl: false,

--- a/packages/core/utils/src/modules-sdk/load-module-database-config.ts
+++ b/packages/core/utils/src/modules-sdk/load-module-database-config.ts
@@ -112,6 +112,6 @@ export function loadDatabaseConfig(
    * the database
    * driver but rather an internal parameter used by us.
    */
-  database.clientUrl = database.clientUrl?.replace(/[?&]ssl_mode=\w+/i, "")
+  database.clientUrl = database.clientUrl?.replace(/[?&]ssl_mode=[^&]*/gi, "")
   return database
 }

--- a/packages/core/utils/src/modules-sdk/load-module-database-config.ts
+++ b/packages/core/utils/src/modules-sdk/load-module-database-config.ts
@@ -31,7 +31,9 @@ function getDefaultDriverOptions(clientUrl: string) {
   }
 
   if (clientUrl) {
-    return clientUrl.match(/localhost|127\.0\.0\.1|ssl_mode=(disable|false)/i)
+    return clientUrl.match(
+      /localhost|127\.0\.0\.1|ssl_mode=(disable|false)|sslmode=(disable)/i
+    )
       ? localOptions
       : remoteOptions
   }
@@ -105,5 +107,11 @@ export function loadDatabaseConfig(
     )
   }
 
+  /**
+   * Remove the ssl_mode parameter since it is not supported by
+   * the database
+   * driver but rather an internal parameter used by us.
+   */
+  database.clientUrl = database.clientUrl?.replace(/[?&]ssl_mode=\w+/i, "")
   return database
 }

--- a/packages/core/utils/src/modules-sdk/load-module-database-config.ts
+++ b/packages/core/utils/src/modules-sdk/load-module-database-config.ts
@@ -112,6 +112,14 @@ export function loadDatabaseConfig(
    * the database
    * driver but rather an internal parameter used by us.
    */
-  database.clientUrl = database.clientUrl?.replace(/[?&]ssl_mode=[^&]*/gi, "")
+  database.clientUrl = database.clientUrl?.replace(
+    /(\?|&)ssl_mode=[^&]*(&|$)/gi,
+    (match, prefix, suffix) => {
+      if (prefix === "?" && suffix === "&") return "?"
+      if (prefix === "?" && suffix === "") return ""
+      if (prefix === "&") return suffix
+      return ""
+    }
+  )
   return database
 }


### PR DESCRIPTION
RESOLVES CORE-1193
https://github.com/medusajs/medusa/issues/13498

**What**
Remove ssl_mode from the client url as it is an internal identifier but also identify connection options from sslmode without removing it from the url as it is a postgres option