### PR TITLE
fix(workflow-engine-redis): module option queueName wrongly used

### DIFF
--- a/.changeset/light-parrots-explode.md
+++ b/.changeset/light-parrots-explode.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/workflow-engine-redis": patch
+---
+
+fix(workflow-engine-redis): module option queueName wrongly used

--- a/packages/modules/workflow-engine-redis/src/loaders/redis.ts
+++ b/packages/modules/workflow-engine-redis/src/loaders/redis.ts
@@ -13,6 +13,8 @@ export default async (
   const {
     url,
     options: redisOptions,
+    jobQueueName,
+    queueName,
     pubsub,
   } = options?.redis as RedisWorkflowsOptions
 
@@ -25,8 +27,8 @@ export default async (
 
   const cnnPubSub = pubsub ?? { url, options: redisOptions }
 
-  const queueName = options?.queueName ?? "medusa-workflows"
-  const jobQueueName = options?.jobQueueName ?? "medusa-workflows-jobs"
+  const queueName_ = queueName ?? "medusa-workflows"
+  const jobQueueName_ = jobQueueName ?? "medusa-workflows-jobs"
 
   let connection
   let redisPublisher
@@ -67,8 +69,8 @@ export default async (
     redisWorkerConnection: asValue(workerConnection),
     redisPublisher: asValue(redisPublisher),
     redisSubscriber: asValue(redisSubscriber),
-    redisQueueName: asValue(queueName),
-    redisJobQueueName: asValue(jobQueueName),
+    redisQueueName: asValue(queueName_),
+    redisJobQueueName: asValue(jobQueueName_),
     redisDisconnectHandler: asValue(async () => {
       connection.disconnect()
       workerConnection.disconnect()


### PR DESCRIPTION
https://github.com/medusajs/medusa/issues/13452

**What**
Wrongly used module option for redis workflow engine