### PR TITLE
fix(stripe): add StripePromptPayService to Stripe module provider

### DIFF
--- a/.changeset/khaki-tables-mate.md
+++ b/.changeset/khaki-tables-mate.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/payment-stripe": patch
+---
+
+Fix StripePromptPayService not registered in module provider. PromptPay payments now work correctly.

--- a/packages/modules/providers/payment-stripe/src/index.ts
+++ b/packages/modules/providers/payment-stripe/src/index.ts
@@ -6,6 +6,7 @@ import {
   StripeIdealService,
   StripeProviderService,
   StripePrzelewy24Service,
+  StripePromptpayService,
 } from "./services"
 
 const services = [
@@ -15,6 +16,7 @@ const services = [
   StripeIdealService,
   StripeProviderService,
   StripePrzelewy24Service,
+  StripePromptpayService,
 ]
 
 export default ModuleProvider(Modules.PAYMENT, {


### PR DESCRIPTION
# 🐛 Fix StripePromptPayService not registered in module provider

## Description
This PR fixes a bug in the Stripe module provider where `StripePromptPayService` was implemented but not imported and registered in the `services` array.  
As a result, PromptPay payments could not be used in Medusa, even though the service exists.

## Why
Without this fix, PromptPay cannot be initialized or used with the Stripe integration, despite having the service already implemented.

## Changes
- Imported `StripePromptPayService` in `index.ts` of `payment-stripe` module provider.
- Registered `StripePromptPayService` in the `services` array.

### Before
```ts
import {
  StripeBancontactService,
  StripeBlikService,
  StripeGiropayService,
  StripeIdealService,
  StripeProviderService,
  StripePrzelewy24Service
} from "./services"

const services = [
  StripeBancontactService,
  StripeBlikService,
  StripeGiropayService,
  StripeIdealService,
  StripeProviderService,
  StripePrzelewy24Service
]
```
### After
```ts
import {
  StripeBancontactService,
  StripeBlikService,
  StripeGiropayService,
  StripeIdealService,
  StripeProviderService,
  StripePrzelewy24Service,
  StripePromptpayService,
} from "./services"

const services = [
  StripeBancontactService,
  StripeBlikService,
  StripeGiropayService,
  StripeIdealService,
  StripeProviderService,
  StripePrzelewy24Service,
  StripePromptpayService,
]
```
## Testing
- Verified that after applying the fix and restarting the server, a record for pp_stripe-promptpay_stripe is added in the database.
- Confirmed that PromptPay now appears as an available payment provider in Settings → Regions.
- Verified that the storefront checkout shows PromptPay as a selectable payment method.
