### PR TITLE
fix(dashboard, order): set return status on cancel

### DIFF
--- a/.changeset/gentle-terms-tease.md
+++ b/.changeset/gentle-terms-tease.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/dashboard": patch
+"@medusajs/order": patch
+---
+
+fix(dashboard, order): set return status on cancel

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-activity-section/order-timeline.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-activity-section/order-timeline.tsx
@@ -1,4 +1,4 @@
-import { Button, Text, Tooltip, clx, usePrompt } from "@medusajs/ui"
+import { Button, Text, Tooltip, clx, toast, usePrompt } from "@medusajs/ui"
 import { Collapsible as RadixCollapsible } from "radix-ui"
 
 import { PropsWithChildren, ReactNode, useMemo, useState } from "react"
@@ -785,7 +785,9 @@ const ReturnBody = ({
       return
     }
 
-    await cancelReturnRequest()
+    await cancelReturnRequest().catch((error) => {
+      toast.error(error.message)
+    })
   }
 
   const numberOfItems = orderReturn.items.reduce((acc, item) => {
@@ -842,7 +844,9 @@ const ClaimBody = ({
       return
     }
 
-    await cancelClaim()
+    await cancelClaim().catch((error) => {
+      toast.error(error.message)
+    })
   }
 
   const outboundItems = (claim.additional_items || []).reduce(
@@ -916,7 +920,9 @@ const ExchangeBody = ({
       return
     }
 
-    await cancelExchange()
+    await cancelExchange().catch((error) => {
+      toast.error(error.message)
+    })
   }
 
   const outboundItems = (exchange.additional_items || []).reduce(
@@ -1015,7 +1021,9 @@ const TransferOrderRequestBody = ({
       return
     }
 
-    await cancelTransfer()
+    await cancelTransfer().catch((error) => {
+      toast.error(error.message)
+    })
   }
 
   /**

--- a/packages/modules/order/src/services/actions/cancel-return.ts
+++ b/packages/modules/order/src/services/actions/cancel-return.ts
@@ -4,7 +4,11 @@ import {
   OrderTypes,
   ReturnDTO,
 } from "@medusajs/framework/types"
-import { ChangeActionType, promiseAll } from "@medusajs/framework/utils"
+import {
+  ChangeActionType,
+  promiseAll,
+  ReturnStatus,
+} from "@medusajs/framework/utils"
 
 async function createOrderChange(
   service,
@@ -90,6 +94,7 @@ export async function cancelReturn(
         {
           data: {
             canceled_at: new Date(),
+            status: ReturnStatus.CANCELED,
           },
           selector: {
             id: returnOrder.id,


### PR DESCRIPTION
**What**
- set order return status when cancelled
- display errors in toast when order timeline cancel actions fail

---

CLOSES CORE-1200