### PR TITLE
fix(product): Correctly fetch category descendants by handle

### DIFF
--- a/.changeset/cuddly-kiwis-roll.md
+++ b/.changeset/cuddly-kiwis-roll.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/product": patch
+"integration-tests-http": patch
+---
+
+Fixes an issue where product category descendants were not retrieved when filtering by handle.

--- a/.changeset/cuddly-kiwis-roll.md
+++ b/.changeset/cuddly-kiwis-roll.md
@@ -1,6 +1,5 @@
 ---
 "@medusajs/product": patch
-"integration-tests-http": patch
 ---
 
-Fixes an issue where product category descendants were not retrieved when filtering by handle.
+fix(product): Correctly fetch category descendants by handle

--- a/integration-tests/http/__tests__/product-category/admin/product-category.spec.ts
+++ b/integration-tests/http/__tests__/product-category/admin/product-category.spec.ts
@@ -598,6 +598,33 @@ medusaIntegrationTestRunner({
         )
       })
 
+      it("filters based on handle and retrieves descendants tree", async () => {
+        const response = await api.get(
+          `/admin/product-categories?handle=${productCategoryParent.handle}&include_descendants_tree=true`,
+          adminHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.product_categories).toEqual([
+          expect.objectContaining({
+            id: productCategoryParent.id,
+            handle: productCategoryParent.handle,
+            category_children: [
+              expect.objectContaining({
+                id: productCategory.id,
+                handle: productCategory.handle,
+                category_children: [
+                  expect.objectContaining({
+                    id: productCategoryChild.id,
+                    handle: productCategoryChild.handle,
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ])
+      })
+
       it("filters based on free text on name and handle columns", async () => {
         const response = await api.get(
           `/admin/product-categories?q=men&limit=1`,

--- a/integration-tests/http/__tests__/product-category/admin/product-category.spec.ts
+++ b/integration-tests/http/__tests__/product-category/admin/product-category.spec.ts
@@ -598,7 +598,7 @@ medusaIntegrationTestRunner({
         )
       })
 
-      it("filters based on handle and retrieves descendants tree", async () => {
+      it("should filter by handle and retrieve descendants tree", async () => {
         const response = await api.get(
           `/admin/product-categories?handle=${productCategoryParent.handle}&include_descendants_tree=true`,
           adminHeaders

--- a/packages/modules/product/src/repositories/product-category.ts
+++ b/packages/modules/product/src/repositories/product-category.ts
@@ -179,6 +179,7 @@ export class ProductCategoryRepository extends DALUtils.MikroOrmBaseTreeReposito
     } as MikroOptions<any>
 
     delete where.id
+    delete where.handle
     delete where.mpath
     delete where.parent_category_id
 


### PR DESCRIPTION
This PR fixes the issue #13518  where product category descendants were not retrieved when
filtering by handle with the include_descendants_tree flag. The handle filter was not
being correctly removed before the descendant tree query was executed.