### PR TITLE
docs: update GitHub link in ticket booking example

### DIFF
--- a/www/apps/resources/app/recipes/ticket-booking/example/page.mdx
+++ b/www/apps/resources/app/recipes/ticket-booking/example/page.mdx
@@ -53,7 +53,7 @@ By following this tutorial, you will learn how to:
 
 <CardList items={[
   {
-    href: "https://github.com/medusajs/examples/tree/main/ticket-booking-system",
+    href: "https://github.com/medusajs/examples/tree/main/ticket-booking",
     title: "Full Code",
     text: "Find the full code for this tutorial in this repository.",
     icon: Github,


### PR DESCRIPTION
Updates link in the ticket booking example to the correct url

fixes: https://github.com/medusajs/examples/issues/78