### PR TITLE
fix(utils): Query filters API should have nested optional props

### DIFF
--- a/packages/core/core-flows/src/common/steps/__fixtures__/remote-query.ts
+++ b/packages/core/core-flows/src/common/steps/__fixtures__/remote-query.ts
@@ -2,10 +2,19 @@ export interface SimpleProduct {
   id: string
   title: string
   description: string
+  variants: Variant[]
+}
+
+export interface Variant {
+  id: string
+  title: string
+  sku: string
+  product_id: string
 }
 
 export interface FixtureEntryPoints {
   simple_product: SimpleProduct
+  variant: Variant
 }
 
 declare module "@medusajs/types/dist/modules-sdk/remote-query-entry-points" {

--- a/packages/core/core-flows/src/common/steps/__tests__/use-query-graph-step.spec.ts
+++ b/packages/core/core-flows/src/common/steps/__tests__/use-query-graph-step.spec.ts
@@ -1,10 +1,10 @@
+import { MedusaContainer } from "@medusajs/framework"
+import { asFunction, createContainer } from "@medusajs/framework/awilix"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { createWorkflow, WorkflowResponse } from "@medusajs/workflows-sdk"
 import { expectTypeOf } from "expect-type"
 import { FixtureEntryPoints } from "../__fixtures__/remote-query"
 import { useQueryGraphStep } from "../use-query-graph"
-import { MedusaContainer } from "@medusajs/framework"
-import { asFunction, createContainer } from "@medusajs/framework/awilix"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 describe("useQueryGraphStep", () => {
   let container!: MedusaContainer
@@ -28,6 +28,9 @@ describe("useQueryGraphStep", () => {
         fields: ["*"],
         filters: {
           id: "123",
+          variants: {
+            id: "123",
+          },
         },
         options: {
           isList: false,

--- a/packages/core/types/src/modules-sdk/to-remote-query.ts
+++ b/packages/core/types/src/modules-sdk/to-remote-query.ts
@@ -1,7 +1,12 @@
-import { Prettify } from "../common"
+import { Prettify as CorePrettify } from "../common"
 import { OperatorMap } from "../dal"
 import { RemoteQueryEntryPoints } from "./remote-query-entry-points"
 
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
+}
+
+type Prettify<T> = DeepPartial<CorePrettify<T>>
 type ExcludedProps = "__typename"
 type Depth = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 type CleanupObject<T> = Prettify<Omit<Exclude<T, symbol>, ExcludedProps>>
@@ -83,16 +88,20 @@ export type RemoteQueryFilters<
   Exclusion extends string[] = [],
   Lim extends number = Depth[3]
 > = RemoteQueryFilterOperators<
-  InternalRemoteQueryFilters<
-    TEntry,
-    RemoteQueryEntryPointsLevel,
-    Exclusion,
-    Lim
+  DeepPartial<
+    InternalRemoteQueryFilters<
+      TEntry,
+      RemoteQueryEntryPointsLevel,
+      Exclusion,
+      Lim
+    >
   >
 > &
-  InternalRemoteQueryFilters<
-    TEntry,
-    RemoteQueryEntryPointsLevel,
-    Exclusion,
-    Lim
+  DeepPartial<
+    InternalRemoteQueryFilters<
+      TEntry,
+      RemoteQueryEntryPointsLevel,
+      Exclusion,
+      Lim
+    >
   >


### PR DESCRIPTION
**What**
Currently, filters from query API are expecting all props from nested object to be present. This pr will make all of them optional as expected for the filters