### PR TITLE
fix(core-flows): skip locking by default on subworkflows

### DIFF
--- a/.changeset/cold-impalas-boil.md
+++ b/.changeset/cold-impalas-boil.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): skip locking on sub workflows by default

--- a/packages/core/core-flows/src/cart/workflows/add-shipping-method-to-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/add-shipping-method-to-cart.ts
@@ -89,9 +89,8 @@ export const addShippingMethodToCartWorkflow = createWorkflow(
       key: input.cart_id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
-    
+
     const cart = useRemoteQueryStep({
       entry_point: "cart",
       fields: cartFieldsForRefreshSteps,
@@ -221,7 +220,6 @@ export const addShippingMethodToCartWorkflow = createWorkflow(
       }),
       releaseLockStep({
         key: cart.id,
-        skipOnSubWorkflow: true,
       })
     )
 

--- a/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
@@ -124,7 +124,6 @@ export const addToCartWorkflow = createWorkflow(
       key: input.cart_id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
 
     const cartQuery = useQueryGraphStep({
@@ -313,7 +312,11 @@ export const addToCartWorkflow = createWorkflow(
     )
 
     refreshCartItemsWorkflow.runAsStep({
-      input: { cart_id: cart.id, items: allItems, additional_data: input.additional_data },
+      input: {
+        cart_id: cart.id,
+        items: allItems,
+        additional_data: input.additional_data,
+      },
     })
 
     parallelize(
@@ -323,7 +326,6 @@ export const addToCartWorkflow = createWorkflow(
       }),
       releaseLockStep({
         key: cart.id,
-        skipOnSubWorkflow: true,
       })
     )
 

--- a/packages/core/core-flows/src/cart/workflows/create-payment-collection-for-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/create-payment-collection-for-cart.ts
@@ -93,7 +93,6 @@ export const createPaymentCollectionForCartWorkflow = createWorkflow(
       key: input.cart_id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
 
     const cart = useRemoteQueryStep({
@@ -143,7 +142,6 @@ export const createPaymentCollectionForCartWorkflow = createWorkflow(
 
     releaseLockStep({
       key: input.cart_id,
-      skipOnSubWorkflow: true,
     })
 
     return new WorkflowResponse(created[0])

--- a/packages/core/core-flows/src/cart/workflows/refresh-cart-items.ts
+++ b/packages/core/core-flows/src/cart/workflows/refresh-cart-items.ts
@@ -1,4 +1,8 @@
-import { filterObjectByKeys, isDefined, PromotionActions, } from "@medusajs/framework/utils"
+import {
+  filterObjectByKeys,
+  isDefined,
+  PromotionActions,
+} from "@medusajs/framework/utils"
 import {
   createHook,
   createWorkflow,
@@ -13,8 +17,15 @@ import { useRemoteQueryStep } from "../../common/steps/use-remote-query"
 import { acquireLockStep, releaseLockStep } from "../../locking"
 import { getVariantPriceSetsStep, updateLineItemsStep } from "../steps"
 import { validateVariantPricesStep } from "../steps/validate-variant-prices"
-import { cartFieldsForPricingContext, cartFieldsForRefreshSteps, productVariantsFields, } from "../utils/fields"
-import { prepareLineItemData, PrepareLineItemDataInput, } from "../utils/prepare-line-item-data"
+import {
+  cartFieldsForPricingContext,
+  cartFieldsForRefreshSteps,
+  productVariantsFields,
+} from "../utils/fields"
+import {
+  prepareLineItemData,
+  PrepareLineItemDataInput,
+} from "../utils/prepare-line-item-data"
 import { pricingContextResult } from "../utils/schemas"
 import { refreshCartShippingMethodsWorkflow } from "./refresh-cart-shipping-methods"
 import { refreshPaymentCollectionForCartWorkflow } from "./refresh-payment-collection"
@@ -127,7 +138,6 @@ export const refreshCartItemsWorkflow = createWorkflow(
       key: input.cart_id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
 
     const setPricingContext = createHook(
@@ -323,7 +333,6 @@ export const refreshCartItemsWorkflow = createWorkflow(
 
     releaseLockStep({
       key: input.cart_id,
-      skipOnSubWorkflow: true,
     })
 
     return new WorkflowResponse(refetchedCart, {

--- a/packages/core/core-flows/src/cart/workflows/refresh-cart-shipping-methods.ts
+++ b/packages/core/core-flows/src/cart/workflows/refresh-cart-shipping-methods.ts
@@ -8,12 +8,12 @@ import {
   WorkflowData,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
+import { AdditionalData } from "@medusajs/types"
 import { useRemoteQueryStep } from "../../common"
 import { acquireLockStep, releaseLockStep } from "../../locking"
 import { removeShippingMethodFromCartStep } from "../steps"
 import { updateShippingMethodsStep } from "../steps/update-shipping-methods"
 import { listShippingOptionsForCartWithPricingWorkflow } from "./list-shipping-options-for-cart-with-pricing"
-import { AdditionalData } from "@medusajs/types"
 
 /**
  * The details of the cart to refresh.
@@ -56,7 +56,11 @@ export const refreshCartShippingMethodsWorkflow = createWorkflow(
     name: refreshCartShippingMethodsWorkflowId,
     idempotent: false,
   },
-  (input: WorkflowData<RefreshCartShippingMethodsWorkflowInput & AdditionalData>) => {
+  (
+    input: WorkflowData<
+      RefreshCartShippingMethodsWorkflowInput & AdditionalData
+    >
+  ) => {
     const shouldExecute = transform({ input }, ({ input }) => {
       return (
         !!input.cart_id ||
@@ -104,7 +108,6 @@ export const refreshCartShippingMethodsWorkflow = createWorkflow(
       key: cart.id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
 
     const listShippingOptionsInput = transform({ cart }, ({ cart }) =>
@@ -134,7 +137,7 @@ export const refreshCartShippingMethodsWorkflow = createWorkflow(
             options: listShippingOptionsInput,
             cart_id: cart.id,
             is_return: false,
-            additional_data: input.additional_data
+            additional_data: input.additional_data,
           },
         })
 
@@ -206,7 +209,6 @@ export const refreshCartShippingMethodsWorkflow = createWorkflow(
 
       releaseLockStep({
         key: cart.id,
-        skipOnSubWorkflow: true,
       })
     })
 

--- a/packages/core/core-flows/src/cart/workflows/refresh-payment-collection.ts
+++ b/packages/core/core-flows/src/cart/workflows/refresh-payment-collection.ts
@@ -101,7 +101,6 @@ export const refreshPaymentCollectionForCartWorkflow = createWorkflow(
       key: cart.id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
 
     const validate = createHook("validate", {
@@ -161,7 +160,6 @@ export const refreshPaymentCollectionForCartWorkflow = createWorkflow(
 
     releaseLockStep({
       key: cart.id,
-      skipOnSubWorkflow: true,
     })
 
     return new WorkflowResponse(void 0, {

--- a/packages/core/core-flows/src/cart/workflows/transfer-cart-customer.ts
+++ b/packages/core/core-flows/src/cart/workflows/transfer-cart-customer.ts
@@ -8,11 +8,11 @@ import {
   WorkflowData,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
+import { AdditionalData } from "@medusajs/types"
 import { emitEventStep, useQueryGraphStep } from "../../common"
 import { acquireLockStep, releaseLockStep } from "../../locking"
 import { updateCartsStep } from "../steps"
 import { refreshCartItemsWorkflow } from "./refresh-cart-items"
-import { AdditionalData } from "@medusajs/types"
 
 /**
  * The cart ownership transfer details.
@@ -108,7 +108,6 @@ export const transferCartCustomerWorkflow = createWorkflow(
         key: cart.id,
         timeout: 2,
         ttl: 10,
-        skipOnSubWorkflow: true,
       })
 
       const cartInput = transform({ cart, customer }, ({ cart, customer }) => [
@@ -122,7 +121,11 @@ export const transferCartCustomerWorkflow = createWorkflow(
       updateCartsStep(cartInput)
 
       refreshCartItemsWorkflow.runAsStep({
-        input: { cart_id: input.id, force_refresh: true, additional_data: input.additional_data },
+        input: {
+          cart_id: input.id,
+          force_refresh: true,
+          additional_data: input.additional_data,
+        },
       })
 
       parallelize(
@@ -135,7 +138,6 @@ export const transferCartCustomerWorkflow = createWorkflow(
         }),
         releaseLockStep({
           key: cart.id,
-          skipOnSubWorkflow: true,
         })
       )
     })

--- a/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
@@ -98,7 +98,6 @@ export const updateCartPromotionsWorkflow = createWorkflow(
       key: cart.id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
 
     const validate = createHook("validate", {
@@ -151,7 +150,6 @@ export const updateCartPromotionsWorkflow = createWorkflow(
 
     releaseLockStep({
       key: cart.id,
-      skipOnSubWorkflow: true,
     })
 
     return new WorkflowResponse(void 0, {

--- a/packages/core/core-flows/src/cart/workflows/update-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-cart.ts
@@ -1,5 +1,13 @@
-import { AdditionalData, CartDTO, UpdateCartWorkflowInputDTO, } from "@medusajs/framework/types"
-import { CartWorkflowEvents, isDefined, MedusaError, } from "@medusajs/framework/utils"
+import {
+  AdditionalData,
+  CartDTO,
+  UpdateCartWorkflowInputDTO,
+} from "@medusajs/framework/types"
+import {
+  CartWorkflowEvents,
+  isDefined,
+  MedusaError,
+} from "@medusajs/framework/utils"
 import {
   createHook,
   createWorkflow,
@@ -12,7 +20,11 @@ import {
 import { emitEventStep, useQueryGraphStep } from "../../common"
 import { deleteLineItemsStep } from "../../line-item"
 import { acquireLockStep, releaseLockStep } from "../../locking"
-import { findOrCreateCustomerStep, findSalesChannelStep, updateCartsStep, } from "../steps"
+import {
+  findOrCreateCustomerStep,
+  findSalesChannelStep,
+  updateCartsStep,
+} from "../steps"
 import { validateSalesChannelStep } from "../steps/validate-sales-channel"
 import { refreshCartItemsWorkflow } from "./refresh-cart-items"
 
@@ -76,7 +88,6 @@ export const updateCartWorkflow = createWorkflow(
       key: input.id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
 
     const { data: cartToUpdate } = useQueryGraphStep({
@@ -308,7 +319,6 @@ export const updateCartWorkflow = createWorkflow(
 
     releaseLockStep({
       key: input.id,
-      skipOnSubWorkflow: true,
     })
 
     return new WorkflowResponse(void 0, {

--- a/packages/core/core-flows/src/cart/workflows/update-tax-lines.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-tax-lines.ts
@@ -144,7 +144,6 @@ export const updateTaxLinesWorkflow = createWorkflow(
       key: cart.id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
 
     const taxLineItems = getItemTaxLinesStep(
@@ -164,7 +163,6 @@ export const updateTaxLinesWorkflow = createWorkflow(
 
     releaseLockStep({
       key: cart.id,
-      skipOnSubWorkflow: true,
     })
   }
 )

--- a/packages/core/core-flows/src/line-item/workflows/delete-line-items.ts
+++ b/packages/core/core-flows/src/line-item/workflows/delete-line-items.ts
@@ -1,8 +1,8 @@
 import { createWorkflow, WorkflowData } from "@medusajs/framework/workflows-sdk"
+import { AdditionalData } from "@medusajs/types"
 import { refreshCartItemsWorkflow } from "../../cart/workflows/refresh-cart-items"
 import { acquireLockStep, releaseLockStep } from "../../locking"
 import { deleteLineItemsStep } from "../steps/delete-line-items"
-import { AdditionalData } from "@medusajs/types"
 
 /**
  * The data to delete line items from a cart.
@@ -49,7 +49,6 @@ export const deleteLineItemsWorkflow = createWorkflow(
       key: input.cart_id,
       timeout: 2,
       ttl: 10,
-      skipOnSubWorkflow: true,
     })
 
     deleteLineItemsStep(input.ids)
@@ -60,7 +59,6 @@ export const deleteLineItemsWorkflow = createWorkflow(
 
     releaseLockStep({
       key: input.cart_id,
-      skipOnSubWorkflow: true,
     })
   }
 )

--- a/packages/core/core-flows/src/locking/steps/acquire-lock.ts
+++ b/packages/core/core-flows/src/locking/steps/acquire-lock.ts
@@ -12,18 +12,18 @@ export interface AcquireLockStepInput {
   key: string | string[]
   /**
    * The maximum time to wait for acquiring the lock. If the lock cannot be acquired within this time, an error is thrown.
-   * 
+   *
    * @defaultValue 0
    */
   timeout?: number
   /**
    * The time (in seconds) to wait between each retry to acquire the lock.
-   * 
+   *
    * @defaultValue 0.3
    */
   retryInterval?: number
   /**
-   * The expiration time (in seconds) for the lock. If the lock is already acquired and the owner is the same, 
+   * The expiration time (in seconds) for the lock. If the lock is already acquired and the owner is the same,
    * the expiration time is extended by the value passed. If not specified, the lock does not expire.
    */
   ttl?: number
@@ -32,11 +32,11 @@ export interface AcquireLockStepInput {
    */
   ownerId?: string
   /**
-   * The provider name to use for locking. If no provider is passed, the default provider 
+   * The provider name to use for locking. If no provider is passed, the default provider
    * (in-memory or the provider configured in medusa-config.ts) will be used.
    */
   provider?: string
-  skipOnSubWorkflow?: boolean
+  executeOnSubWorkflow?: boolean
 }
 
 export const acquireLockStepId = "acquire-lock-step"
@@ -67,7 +67,7 @@ export const acquireLockStep = createStep(
     }
 
     const isSubWorkflow = !!parentStepIdempotencyKey
-    if (isSubWorkflow && data.skipOnSubWorkflow) {
+    if (isSubWorkflow && !data.executeOnSubWorkflow) {
       return StepResponse.skip() as any
     }
 

--- a/packages/core/core-flows/src/locking/steps/release-lock.ts
+++ b/packages/core/core-flows/src/locking/steps/release-lock.ts
@@ -10,16 +10,16 @@ export interface ReleaseLockStepInput {
    */
   key: string | string[]
   /**
-   * The ID of the lock's owner. The lock can be released either if it doesn't have an owner, 
+   * The ID of the lock's owner. The lock can be released either if it doesn't have an owner,
    * or if its owner ID matches the one passed in this property.
    */
   ownerId?: string
   /**
-   * The provider name to use for locking. If no provider is passed, 
+   * The provider name to use for locking. If no provider is passed,
    * the default provider (in-memory or the provider configured in medusa-config.ts) will be used.
    */
   provider?: string
-  skipOnSubWorkflow?: boolean
+  executeOnSubWorkflow?: boolean
 }
 
 export const releaseLockStepId = "release-lock-step"
@@ -49,7 +49,7 @@ export const releaseLockStep = createStep(
     }
 
     const isSubWorkflow = !!parentStepIdempotencyKey
-    if (isSubWorkflow && data.skipOnSubWorkflow) {
+    if (isSubWorkflow && !data.executeOnSubWorkflow) {
       return StepResponse.skip() as any
     }
 


### PR DESCRIPTION
What: invert the flag to execute acquire and release lock on subworkflows.