### PR TITLE
fix(): Module test runner lifecycle does not shutdown properly

### DIFF
--- a/.changeset/late-feet-think.md
+++ b/.changeset/late-feet-think.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/test-utils": patch
+---
+
+fix(): Module test runner lifecycle does not shutdown properly


### PR DESCRIPTION
**What**
The test runner was preventing prepare shutdown and shutdown hooks from running if the pg connection is part of the dependencies of a module