### PR TITLE
Move Order Complete Emit on Cart Complete later in the flow

### DIFF
--- a/.changeset/red-paws-rest.md
+++ b/.changeset/red-paws-rest.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+Move cart complete order placed event later in the workflow, to stop the event being emitted when payment fails and the workflow is reverted

--- a/packages/core/core-flows/src/cart/workflows/complete-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/complete-cart.ts
@@ -362,10 +362,6 @@ export const completeCartWorkflow = createWorkflow(
         updateCartsStep([updateCompletedAt]),
         reserveInventoryStep(formatedInventoryItems),
         registerUsageStep(promotionUsage),
-        emitEventStep({
-          eventName: OrderWorkflowEvents.PLACED,
-          data: { id: createdOrder.id },
-        })
       )
 
       /**
@@ -412,6 +408,11 @@ export const completeCartWorkflow = createWorkflow(
       createHook("orderCreated", {
         order_id: createdOrder.id,
         cart_id: cart.id,
+      })
+
+      emitEventStep({
+        eventName: OrderWorkflowEvents.PLACED,
+        data: { id: createdOrder.id },
       })
 
       return createdOrder


### PR DESCRIPTION
Emit the order placed event later in the flow, so it is not emitted if the cart-complete is rolled back due to payment failure or any other issue occurring later in the workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Emit `OrderWorkflowEvents.PLACED` after order creation (post-payment) instead of during the earlier parallel steps, preventing emission when the workflow reverts.
> 
> - **Core Flows (complete-cart)**:
>   - Move `emitEventStep` for `OrderWorkflowEvents.PLACED` from the early `parallelize(...)` block to after `orderCreated` hook (post payment authorization/transactions).
>   - Ensures the order placed event is only emitted after successful order creation/payment, avoiding emission on failure/rollback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e46d204a4a0cbb8e26a34d430acd267bfcc466c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->