### PR TITLE
feat(payment-stripe): Allow passing shared payment token in Stripe

### DIFF
--- a/.changeset/dirty-clocks-joke.md
+++ b/.changeset/dirty-clocks-joke.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/payment-stripe": patch
+---
+
+feat(@medusajs/payment-stripe): Allow passing shared payment token in Stripe

--- a/.changeset/dirty-clocks-joke.md
+++ b/.changeset/dirty-clocks-joke.md
@@ -2,4 +2,4 @@
 "@medusajs/payment-stripe": patch
 ---
 
-feat(@medusajs/payment-stripe): Allow passing shared payment token in Stripe
+feat(payment-stripe): Allow passing shared payment token in Stripe

--- a/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
+++ b/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
@@ -127,6 +127,11 @@ abstract class StripeBase extends AbstractPaymentProvider<StripeOptions> {
 
     res.return_url = extra?.return_url as string | undefined
 
+    // @ts-expect-error - Need to update Stripe SDK
+    res.shared_payment_token = extra?.shared_payment_token as
+      | string
+      | undefined
+
     return res
   }
 


### PR DESCRIPTION
Allow passing shared payment token in Stripe, which is useful for Agentic Commerce