### PR TITLE
feat(admin-bundler): forward env vars to plugin admin extensions

### DIFF
--- a/.changeset/sharp-apples-kiss.md
+++ b/.changeset/sharp-apples-kiss.md
@@ -2,4 +2,4 @@
 "@medusajs/admin-bundler": patch
 ---
 
-feat(admin-bundler): forward env vars to plugin admin extentions
+feat(admin-bundler): forward env vars to plugin admin extensions

--- a/.changeset/sharp-apples-kiss.md
+++ b/.changeset/sharp-apples-kiss.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/admin-bundler": patch
+---
+
+feat(admin-bundler): forward env vars to plugin admin extentions

--- a/packages/admin/admin-bundler/src/utils/config.ts
+++ b/packages/admin/admin-bundler/src/utils/config.ts
@@ -76,11 +76,13 @@ export async function getViteConfig(
       .replace(/^@/, "")
       .replace(/[^a-zA-Z0-9]/g, "_")
       .toUpperCase()
+    const pluginEnv: Record<string, string | undefined> = {}
     for (const envVar in process.env) {
       if (envVar.startsWith(`PLUGIN_${normalizedName}_`)) {
-        baseConfig.define![envVar] = JSON.stringify(process.env[envVar]);
+        pluginEnv[envVar] = process.env[envVar];
       }
     }
+    baseConfig.define!["process.env"] = JSON.stringify(pluginEnv);
   }
 
   if (options.vite) {

--- a/packages/admin/admin-bundler/src/utils/config.ts
+++ b/packages/admin/admin-bundler/src/utils/config.ts
@@ -70,6 +70,19 @@ export async function getViteConfig(
     ],
   }
 
+  // Inject plugin environment variables as vite defines
+  for (const plugin of options.plugins ?? []) {
+    const normalizedName = plugin.replace(/\/admin$/, "")
+      .replace(/^@/, "")
+      .replace(/[^a-zA-Z0-9]/g, "_")
+      .toUpperCase()
+    for (const envVar in process.env) {
+      if (envVar.startsWith(`PLUGIN_${normalizedName}_`)) {
+        baseConfig.define![envVar] = JSON.stringify(process.env[envVar]);
+      }
+    }
+  }
+
   if (options.vite) {
     const customConfig = options.vite(baseConfig)
     return mergeConfig(baseConfig, customConfig)

--- a/packages/admin/admin-bundler/src/utils/config.ts
+++ b/packages/admin/admin-bundler/src/utils/config.ts
@@ -71,12 +71,12 @@ export async function getViteConfig(
   }
 
   // Inject plugin environment variables with vite define
-  const pluginEnv = Object.fromEntries(
-    Object.entries(process.env).filter(([key]) =>
-      key.startsWith("PLUGIN_")
-    )
-  )
-  pluginEnv["BACKEND_URL"] = backendUrl
+  const pluginEnv: Record<string, string | undefined> = { BACKEND_URL: backendUrl }
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith("PLUGIN_")) {
+      pluginEnv[key.replace(/^PLUGIN_/, "")] = value
+    }
+  }
   baseConfig.define!["process.env"] = JSON.stringify(pluginEnv)
 
   if (options.vite) {

--- a/packages/admin/admin-bundler/src/utils/config.ts
+++ b/packages/admin/admin-bundler/src/utils/config.ts
@@ -70,20 +70,14 @@ export async function getViteConfig(
     ],
   }
 
-  // Inject plugin environment variables as vite defines
-  for (const plugin of options.plugins ?? []) {
-    const normalizedName = plugin.replace(/\/admin$/, "")
-      .replace(/^@/, "")
-      .replace(/[^a-zA-Z0-9]/g, "_")
-      .toUpperCase()
-    const pluginEnv: Record<string, string | undefined> = {}
-    for (const envVar in process.env) {
-      if (envVar.startsWith(`PLUGIN_${normalizedName}_`)) {
-        pluginEnv[envVar] = process.env[envVar];
-      }
-    }
-    baseConfig.define!["process.env"] = JSON.stringify(pluginEnv);
-  }
+  // Inject plugin environment variables with vite define
+  const pluginEnv = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) =>
+      key.startsWith("PLUGIN_")
+    )
+  )
+  pluginEnv["BACKEND_URL"] = backendUrl
+  baseConfig.define!["process.env"] = JSON.stringify(pluginEnv)
 
   if (options.vite) {
     const customConfig = options.vite(baseConfig)


### PR DESCRIPTION
Closes #11815

As explained in the issue, the only way to expose env vars to vite in plugins is via the vite-config "define" object, this has to be done by end-users with `admin: vite: () => ({ define: { ... }}) ` in medusa-config.ts
This PR adds a convention that automatically does that for env vars in the form `PLUGIN_<var>`

Note: ~~plugin authors should be careful to check if the variable is actually *declared* with `typeof NAME !== "undefined`, otherwise it could throw a ReferenceError.~~
I was able to create a "fake" process.env that is always defined, so if the env var is mispelled/not supplied by end-users it is simply undefined instead of throwing. There is this weird distinction that one must use import.meta.env only in the actual backend and process.env only inside plugins, but I don't think we can do better.


EXAMPLE:
If you have a plugin and you want to use an env var "TEST"

End-users: to the .env file add PLUGIN_TEST="1234"

Plugin authors: simply use "process.env.TEST" in any widget or extension route