### PR TITLE
fix(medusa,file-local,file-s3,core-flows): fix csv parsing special characters

### DIFF
--- a/.changeset/rude-mirrors-hang.md
+++ b/.changeset/rude-mirrors-hang.md
@@ -1,0 +1,8 @@
+---
+"@medusajs/medusa": patch
+"@medusajs/file-local": patch
+"@medusajs/file-s3": patch
+"@medusajs/core-flows": patch
+---
+
+fix(medusa,file-local,file-s3,core-flows): fix csv parsing special characters

--- a/packages/core/core-flows/src/product/steps/normalize-products-to-chunks.ts
+++ b/packages/core/core-flows/src/product/steps/normalize-products-to-chunks.ts
@@ -1,11 +1,11 @@
 import { parse, Parser } from "csv-parse"
 import type { HttpTypes, IFileModuleService } from "@medusajs/framework/types"
 import {
-  Modules,
   CSVNormalizer,
+  Modules,
   productValidators,
 } from "@medusajs/framework/utils"
-import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 
 /**
  * The CSV file content to parse.
@@ -203,9 +203,11 @@ export const normalizeCsvToChunksStep = createStep(
       try {
         const file = container.resolve(Modules.FILE)
         const contents = await file.getDownloadStream(fileKey)
+
         const transformer = parse({
           columns: true,
           skip_empty_lines: true,
+          bom: true,
         })
 
         contents.on("error", reject)

--- a/packages/core/core-flows/src/product/steps/normalize-products-to-chunks.ts
+++ b/packages/core/core-flows/src/product/steps/normalize-products-to-chunks.ts
@@ -207,7 +207,6 @@ export const normalizeCsvToChunksStep = createStep(
         const transformer = parse({
           columns: true,
           skip_empty_lines: true,
-          bom: true,
         })
 
         contents.on("error", reject)

--- a/packages/core/core-flows/src/product/utils/csvtojson.ts
+++ b/packages/core/core-flows/src/product/utils/csvtojson.ts
@@ -9,6 +9,7 @@ export const convertCsvToJson = <T extends object>(
   return csv2json(data, {
     preventCsvInjection: true,
     delimiter: { field: detectDelimiter(data) },
+    excelBOM: true,
   }) as T[]
 }
 

--- a/packages/core/core-flows/src/product/utils/csvtojson.ts
+++ b/packages/core/core-flows/src/product/utils/csvtojson.ts
@@ -9,7 +9,6 @@ export const convertCsvToJson = <T extends object>(
   return csv2json(data, {
     preventCsvInjection: true,
     delimiter: { field: detectDelimiter(data) },
-    excelBOM: true,
   }) as T[]
 }
 

--- a/packages/medusa/src/api/admin/uploads/route.ts
+++ b/packages/medusa/src/api/admin/uploads/route.ts
@@ -24,7 +24,7 @@ export const POST = async (
       files: input?.map((f) => ({
         filename: f.originalname,
         mimeType: f.mimetype,
-        content: f.buffer.toString("binary"),
+        content: f.buffer.toString("base64"),
         access: "public",
       })),
     },

--- a/packages/modules/providers/file-local/src/services/local-file.ts
+++ b/packages/modules/providers/file-local/src/services/local-file.ts
@@ -57,24 +57,21 @@ export class LocalFileService extends AbstractFileProviderService {
     const filePath = this.getUploadFilePath(baseDir, fileKey)
     const fileUrl = this.getUploadFileUrl(fileKey)
 
-    // Detect if content is base64 or raw string
-    // Base64 from upload route will have specific pattern, but CSV/JSON content will be raw string
     let content: Buffer
     try {
-      // Try to decode as base64 first
-      const decoded = Buffer.from(file.content as string, "base64")
-      // Check if the decoded content re-encodes to the same base64 string
-      // This validates it was actually base64
+      // Try Base64
+      const decoded = Buffer.from(file.content, "base64")
       if (decoded.toString("base64") === file.content) {
         content = decoded
       } else {
-        // Not valid base64, treat as UTF-8 string
-        content = Buffer.from(file.content as string, "utf8")
+        // Fallback: assume UTF-8 (JSON, CSV, etc.)
+        content = Buffer.from(file.content, "utf8")
       }
     } catch {
-      // If decoding fails, treat as UTF-8 string
-      content = Buffer.from(file.content as string, "utf8")
+      // Last-resort fallback: binary
+      content = Buffer.from(file.content, "binary")
     }
+
     await fs.writeFile(filePath, content)
 
     return {

--- a/packages/modules/providers/file-local/src/services/local-file.ts
+++ b/packages/modules/providers/file-local/src/services/local-file.ts
@@ -57,7 +57,24 @@ export class LocalFileService extends AbstractFileProviderService {
     const filePath = this.getUploadFilePath(baseDir, fileKey)
     const fileUrl = this.getUploadFileUrl(fileKey)
 
-    const content = Buffer.from(file.content as string, "binary")
+    // Detect if content is base64 or raw string
+    // Base64 from upload route will have specific pattern, but CSV/JSON content will be raw string
+    let content: Buffer
+    try {
+      // Try to decode as base64 first
+      const decoded = Buffer.from(file.content as string, "base64")
+      // Check if the decoded content re-encodes to the same base64 string
+      // This validates it was actually base64
+      if (decoded.toString("base64") === file.content) {
+        content = decoded
+      } else {
+        // Not valid base64, treat as UTF-8 string
+        content = Buffer.from(file.content as string, "utf8")
+      }
+    } catch {
+      // If decoding fails, treat as UTF-8 string
+      content = Buffer.from(file.content as string, "utf8")
+    }
     await fs.writeFile(filePath, content)
 
     return {

--- a/packages/modules/providers/file-local/src/services/local-file.ts
+++ b/packages/modules/providers/file-local/src/services/local-file.ts
@@ -59,12 +59,10 @@ export class LocalFileService extends AbstractFileProviderService {
 
     let content: Buffer
     try {
-      // Try Base64
       const decoded = Buffer.from(file.content, "base64")
       if (decoded.toString("base64") === file.content) {
         content = decoded
       } else {
-        // Fallback: assume UTF-8 (JSON, CSV, etc.)
         content = Buffer.from(file.content, "utf8")
       }
     } catch {

--- a/packages/modules/providers/file-s3/src/services/s3-file.ts
+++ b/packages/modules/providers/file-s3/src/services/s3-file.ts
@@ -120,24 +120,21 @@ export class S3FileService extends AbstractFileProviderService {
       parsedFilename.ext
     }`
 
-    // Detect if content is base64 or raw string
-    // Base64 from upload route will have specific pattern, but CSV/JSON content will be raw string
     let content: Buffer
     try {
-      // Try to decode as base64 first
+      // Try Base64
       const decoded = Buffer.from(file.content, "base64")
-      // Check if the decoded content re-encodes to the same base64 string
-      // This validates it was actually base64
       if (decoded.toString("base64") === file.content) {
         content = decoded
       } else {
-        // Not valid base64, treat as UTF-8 string
+        // Fallback: assume UTF-8 (JSON, CSV, etc.)
         content = Buffer.from(file.content, "utf8")
       }
     } catch {
-      // If decoding fails, treat as UTF-8 string
-      content = Buffer.from(file.content, "utf8")
+      // Last-resort fallback: binary
+      content = Buffer.from(file.content, "binary")
     }
+
     const command = new PutObjectCommand({
       // We probably also want to support a separate bucket altogether for private files
       // protected private_bucket_: string

--- a/packages/modules/providers/file-s3/src/services/s3-file.ts
+++ b/packages/modules/providers/file-s3/src/services/s3-file.ts
@@ -120,7 +120,24 @@ export class S3FileService extends AbstractFileProviderService {
       parsedFilename.ext
     }`
 
-    const content = Buffer.from(file.content, "binary")
+    // Detect if content is base64 or raw string
+    // Base64 from upload route will have specific pattern, but CSV/JSON content will be raw string
+    let content: Buffer
+    try {
+      // Try to decode as base64 first
+      const decoded = Buffer.from(file.content, "base64")
+      // Check if the decoded content re-encodes to the same base64 string
+      // This validates it was actually base64
+      if (decoded.toString("base64") === file.content) {
+        content = decoded
+      } else {
+        // Not valid base64, treat as UTF-8 string
+        content = Buffer.from(file.content, "utf8")
+      }
+    } catch {
+      // If decoding fails, treat as UTF-8 string
+      content = Buffer.from(file.content, "utf8")
+    }
     const command = new PutObjectCommand({
       // We probably also want to support a separate bucket altogether for private files
       // protected private_bucket_: string

--- a/packages/modules/providers/file-s3/src/services/s3-file.ts
+++ b/packages/modules/providers/file-s3/src/services/s3-file.ts
@@ -122,12 +122,10 @@ export class S3FileService extends AbstractFileProviderService {
 
     let content: Buffer
     try {
-      // Try Base64
       const decoded = Buffer.from(file.content, "base64")
       if (decoded.toString("base64") === file.content) {
         content = decoded
       } else {
-        // Fallback: assume UTF-8 (JSON, CSV, etc.)
         content = Buffer.from(file.content, "utf8")
       }
     } catch {


### PR DESCRIPTION
This is another attempt to fixing the issue with special characters. Issue seemed to stem from the fact that we encoded files as `binary`, which seems to be causing our problem with special characters

I tested locally by importing a CSV. I added `Hẹ hẹ xin chào mọi người 🌍🚀! Привет мир! こんにちは世界! مرحبا بالعالم! नमस्ते दुनिया! ⚡️🔥💾`, which looks like a final boss to me haha.

Only thing that did not seem to follow are the unicodes, but I don't think that is too big of a deal
<img width="1153" height="716" alt="CleanShot 2025-10-01 at 13 28 53" src="https://github.com/user-attachments/assets/0fa7202b-7d3c-4358-b437-6b2821f15f33" />


What other flows should I test to make sure nothing broke? I tested importing an image for a product also and it is fine, but I would be curious to know if you have other flows in mind

FIXES #12483 
FIXES #12873
FIXES #13021
CLOSES CORE-1226