### PR TITLE
fix(medusa): plugin:db:generate skip modules with no data models

### DIFF
--- a/.changeset/funny-sheep-vanish.md
+++ b/.changeset/funny-sheep-vanish.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): plugin:db:generate skip modules with no data models

--- a/packages/medusa/src/commands/plugin/db/generate.ts
+++ b/packages/medusa/src/commands/plugin/db/generate.ts
@@ -114,6 +114,10 @@ async function generateMigrations(
     logger.info(
       `Generating migrations for module ${moduleDescriptor.serviceName}...`
     )
+    if (moduleDescriptor.entities.length === 0) {
+      logger.info(`No entities found for module ${moduleDescriptor.serviceName}, skipping...`)
+      continue
+    }
 
     const mikroOrmConfig = defineMikroOrmCliConfig(
       moduleDescriptor.serviceName,


### PR DESCRIPTION
Currently the plugin:db:generate command panics if one of the modules doesn't define any data models. This makes it impossible to generate migrations if you have a mix of modules with and without data models.   
I added a simple check to skip these modules when creating the migrations.

Steps to repro:
```
npx create-medusa-app --plugin
cd my-medusa-plugin
# create a module with an empty service and no data models
npx medusa db:plugin:generate
```

Full error:
```
info:    Generating migrations...
info:    Generating migrations for module postmarkModuleService...
info:    ----------------------------------------------------------------------------
error:   defineMikroOrmCliConfig failed with: entities is required
Error: defineMikroOrmCliConfig failed with: entities is required
    at defineMikroOrmCliConfig (/Users/leonardo/dev/medusa-plugin-postmark/node_modules/@medusajs/utils/src/modules-sdk/mikro-orm-cli-config-builder.ts:41:11)
    at generateMigrations (/Users/leonardo/dev/medusa-plugin-postmark/node_modules/@medusajs/medusa/src/commands/plugin/db/generate.ts:124:26)
    at main (/Users/leonardo/dev/medusa-plugin-postmark/node_modules/@medusajs/medusa/src/commands/plugin/db/generate.ts:49:11)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
```

I didnt bother with writing an issue since I had the fix ready and it's very small, but lmk if I should in the future
