### PR TITLE
fix(medusa): fixes db setup command to not load connection before creating db

### DIFF
--- a/.changeset/quick-clocks-happen.md
+++ b/.changeset/quick-clocks-happen.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): fixes db setup command to not load connection before creating db

--- a/packages/medusa/src/commands/db/setup.ts
+++ b/packages/medusa/src/commands/db/setup.ts
@@ -12,7 +12,9 @@ const main = async function ({
   executeAllLinks,
   executeSafeLinks,
 }) {
-  const container = await initializeContainer(directory)
+  let container = await initializeContainer(directory, {
+    skipDbConnection: true,
+  })
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
 
   try {
@@ -20,6 +22,8 @@ const main = async function ({
     if (!created) {
       process.exit(1)
     }
+
+    container = await initializeContainer(directory)
 
     const migrated = await migrate({
       directory,


### PR DESCRIPTION
what:

Before the db is created, initialising the container attempts to connect to the database, which will result in failure. We skip the connection first and then reinitialise it after its created. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defers DB connection in the db setup command by initializing the container with skipDbConnection, then reinitializing after DB creation before running migrations.
> 
> - **Medusa CLI / DB Setup (`packages/medusa/src/commands/db/setup.ts`)**:
>   - Initialize container with `skipDbConnection: true` to avoid connecting before the DB exists.
>   - Re-initialize the container after `dbCreate` completes, then run `migrate` with the fresh `container` and `logger`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 763b45f031a8f8f38bed1a94803b4f3af3224c03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->