### PR TITLE
revert(): Test utils imit module fix

### DIFF
--- a/.changeset/violet-radios-crash.md
+++ b/.changeset/violet-radios-crash.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/test-utils": patch
+---
+
+revert(): Test utils imit module fix

--- a/packages/medusa-test-utils/src/init-modules.ts
+++ b/packages/medusa-test-utils/src/init-modules.ts
@@ -64,12 +64,11 @@ export async function initModules({
 
   async function shutdown() {
     const promises: Promise<void>[] = []
-    promises.push(medusaApp.onApplicationPrepareShutdown())
-    promises.push(medusaApp.onApplicationShutdown())
-
     if (shouldDestroyConnectionAutomatically) {
       promises.push((sharedPgConnection as any).context?.destroy())
       promises.push((sharedPgConnection as any).destroy())
+      promises.push(medusaApp.onApplicationPrepareShutdown())
+      promises.push(medusaApp.onApplicationShutdown())
     } else {
       if (!preventConnectionDestroyWarning) {
         logger.info(


### PR DESCRIPTION
**What**
Some modules close the redis connection as part of the *shutdown hooks, which is normal for a real world application, but in the tests, running those hooks disrupt other tests relying on this connection ot exists. Therefore, for the time being, just reverting that part until we update the connection management to work in all scenarios