### PR TITLE
fix(medusa,utils,types): inventory management nullable

### DIFF
--- a/.changeset/chilly-timers-jog.md
+++ b/.changeset/chilly-timers-jog.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/types": patch
+"@medusajs/utils": patch
+"@medusajs/medusa": patch
+---
+
+"fix(medusa,utils,types): inventory management nullable

--- a/.changeset/chilly-timers-jog.md
+++ b/.changeset/chilly-timers-jog.md
@@ -4,4 +4,4 @@
 "@medusajs/medusa": patch
 ---
 
-"fix(medusa,utils,types): inventory management nullable
+fix(medusa,utils,types): inventory management nullable

--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -173,10 +173,10 @@ export interface BaseProductVariant {
    * This field is only retrieved in the [Get Product](https://docs.medusajs.com/api/store#products_getproductsid)
    * and [List Products](https://docs.medusajs.com/api/store#products_getproducts) API routes if you
    * pass `+variants.inventory_quantity` in the `fields` query parameter.
-   * 
+   *
    * Learn more in the [Retrieve Product Variant's Inventory](https://docs.medusajs.com/resources/storefront-development/products/inventory) storefront guide.
    */
-  inventory_quantity?: number
+  inventory_quantity?: number | null
   /**
    * The variant's HS code.
    */

--- a/packages/core/utils/src/product/get-variant-availability.ts
+++ b/packages/core/utils/src/product/get-variant-availability.ts
@@ -9,7 +9,7 @@ export type VariantAvailabilityResult = {
     /**
      * The available inventory quantity for the variant in the sales channel.
      */
-    availability: number
+    availability: number | null
     /**
      * The ID of the sales channel for which the availability was computed.
      */
@@ -18,7 +18,7 @@ export type VariantAvailabilityResult = {
 }
 
 /**
- * Computes the varaint availability for a list of variants in a given sales channel
+ * Computes the variant availability for a list of variants in a given sales channel
  *
  * The availability algorithm works as follows:
  * 1. For each variant, we retrieve its inventory items.
@@ -76,7 +76,7 @@ export async function getTotalVariantAvailability(
   data: TotalVariantAvailabilityData
 ): Promise<{
   [variant_id: string]: {
-    availability: number
+    availability: number | null
   }
 }> {
   const { variantInventoriesMap, locationIds } = await getDataForComputation(
@@ -116,7 +116,7 @@ const computeVariantAvailability = (
   variantInventoryItems: VariantItems[],
   channelLocationsSet: Set<string>,
   { requireChannelCheck } = { requireChannelCheck: true }
-) => {
+): number | null => {
   const inventoryQuantities: number[] = []
 
   for (const link of variantInventoryItems) {
@@ -143,7 +143,7 @@ const computeVariantAvailability = (
     inventoryQuantities.push(maxInventoryQuantity)
   }
 
-  return inventoryQuantities.length ? Math.min(...inventoryQuantities) : 0
+  return inventoryQuantities.length ? Math.min(...inventoryQuantities) : null
 }
 
 type VariantAvailabilityData = {

--- a/packages/medusa/src/api/utils/middlewares/products/__tests__/variant-inventory-quantity.spec.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/__tests__/variant-inventory-quantity.spec.ts
@@ -81,20 +81,24 @@ describe("variant-inventory-quantity", () => {
         "variant-3": { availability: 20 },
         "variant-4": { availability: null },
       }
+      const _variants = [
+        ...variants,
+        { id: "variant-4", manage_inventory: true },
+      ]
 
       ;(getTotalVariantAvailability as jest.Mock).mockResolvedValueOnce(
         mockAvailability
       )
 
-      await wrapVariantsWithTotalInventoryQuantity(req as MedusaRequest, [
-        ...variants,
-        { id: "variant-4", manage_inventory: true },
-      ])
+      await wrapVariantsWithTotalInventoryQuantity(
+        req as MedusaRequest,
+        _variants
+      )
 
-      expect(variants[0].inventory_quantity).toBe(10)
-      expect(variants[1].inventory_quantity).toBe(5)
-      expect(variants[2].inventory_quantity).toBeUndefined()
-      expect(variants[3].inventory_quantity).toBeNull()
+      expect(_variants[0].inventory_quantity).toBe(10)
+      expect(_variants[1].inventory_quantity).toBe(5)
+      expect(_variants[2].inventory_quantity).toBeUndefined()
+      expect(_variants[3].inventory_quantity).toBeNull()
     })
   })
 

--- a/packages/medusa/src/api/utils/middlewares/products/__tests__/variant-inventory-quantity.spec.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/__tests__/variant-inventory-quantity.spec.ts
@@ -7,8 +7,8 @@ import {
 } from "@medusajs/framework/utils"
 import { MedusaRequest, MedusaStoreRequest } from "@medusajs/framework/http"
 import {
-  wrapVariantsWithTotalInventoryQuantity,
   wrapVariantsWithInventoryQuantityForSalesChannel,
+  wrapVariantsWithTotalInventoryQuantity,
 } from "../variant-inventory-quantity"
 
 jest.mock("@medusajs/framework/utils", () => {
@@ -79,20 +79,22 @@ describe("variant-inventory-quantity", () => {
         "variant-1": { availability: 10 },
         "variant-2": { availability: 5 },
         "variant-3": { availability: 20 },
+        "variant-4": { availability: null },
       }
 
       ;(getTotalVariantAvailability as jest.Mock).mockResolvedValueOnce(
         mockAvailability
       )
 
-      await wrapVariantsWithTotalInventoryQuantity(
-        req as MedusaRequest,
-        variants
-      )
+      await wrapVariantsWithTotalInventoryQuantity(req as MedusaRequest, [
+        ...variants,
+        { id: "variant-4", manage_inventory: true },
+      ])
 
       expect(variants[0].inventory_quantity).toBe(10)
       expect(variants[1].inventory_quantity).toBe(5)
       expect(variants[2].inventory_quantity).toBeUndefined()
+      expect(variants[3].inventory_quantity).toBeNull()
     })
   })
 

--- a/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/variant-inventory-quantity.ts
@@ -65,7 +65,7 @@ export const wrapVariantsWithInventoryQuantityForSalesChannel = async (
 
 type VariantInput = {
   id: string
-  inventory_quantity?: number
+  inventory_quantity?: number | null
   manage_inventory?: boolean
 }
 


### PR DESCRIPTION
We should return `inventory_quantity: null` in case of no inventory set. 0 should be reserved for the "Out of stock" scenario, and null will be the "Not available" scenario