### PR TITLE
fix(admin): support metadata in product images validation

### DIFF
--- a/packages/medusa/src/api/admin/products/validators.ts
+++ b/packages/medusa/src/api/admin/products/validators.ts
@@ -227,7 +227,14 @@ export const CreateProduct = z
     description: z.string().nullish(),
     is_giftcard: booleanString().optional().default(false),
     discountable: booleanString().optional().default(true),
-    images: z.array(z.object({ url: z.string() })).optional(),
+    images: z
+      .array(
+        z.object({
+          url: z.string(),
+          metadata: z.record(z.unknown()).nullish(),
+        })
+      )
+      .optional(),
     thumbnail: z.string().nullish(),
     handle: z.string().optional(),
     status: statusEnum.nullish().default(ProductStatus.DRAFT),
@@ -265,7 +272,15 @@ export const UpdateProduct = z
     status: statusEnum.optional(),
     subtitle: z.string().nullish(),
     description: z.string().nullish(),
-    images: z.array(z.object({ url: z.string() })).optional(),
+    images: z
+      .array(
+        z.object({
+          id: z.string().optional(),
+          url: z.string().optional(),
+          metadata: z.record(z.unknown()).nullish(),
+        })
+      )
+      .optional(),
     thumbnail: z.string().nullish(),
     handle: z.string().nullish(),
     type_id: z.string().nullish(),


### PR DESCRIPTION
Previously, the product images validator only accepted the 'url' field, which caused the 'id' and 'metadata' fields to be silently stripped out during validation. This prevented users from updating image metadata via the admin API.

This change updates both CreateProduct and UpdateProduct validators to properly support the full image object structure:
- id (optional): for updating existing images
- url (optional for updates, required for creation)
- metadata (optional): for storing custom key-value pairs

This aligns the API validation with the underlying ProductImageDTO type system which already supports these fields.