### PR TITLE
fix(core-flows): fix warning for when usage in updateOrderTaxLinesWorkflow

### DIFF
--- a/.changeset/twenty-carrots-matter.md
+++ b/.changeset/twenty-carrots-matter.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): fix warning for when usage in updateOrderTaxLinesWorkflow

--- a/packages/core/core-flows/src/order/workflows/update-tax-lines.ts
+++ b/packages/core/core-flows/src/order/workflows/update-tax-lines.ts
@@ -197,7 +197,7 @@ export const updateOrderTaxLinesWorkflow = createWorkflow(
       options: { isList: false },
     }).config({ name: "order-query" })
 
-    const items = when({ input }, ({ input }) => {
+    const items = when("get-order-line-items", { input }, ({ input }) => {
       return input.item_ids!?.length > 0
     }).then(() => {
       const { data: orderLineItems } = useQueryGraphStep({
@@ -209,7 +209,7 @@ export const updateOrderTaxLinesWorkflow = createWorkflow(
       return orderLineItems
     })
 
-    const shippingMethods = when({ input }, ({ input }) => {
+    const shippingMethods = when("get-order-shipping-methods", { input }, ({ input }) => {
       return input.shipping_method_ids!?.length > 0
     }).then(() => {
       const { data: orderShippingMethods } = useQueryGraphStep({


### PR DESCRIPTION
When starting the Medusa application i see the following in the console:

```
update-order-tax-lines: "when" name should be defined. A random one will be assigned to it, which is not recommended for production.
 ({ input }) => {
        return input.item_ids?.length > 0;
    }
update-order-tax-lines: "when" name should be defined. A random one will be assigned to it, which is not recommended for production.
 ({ input }) => {
        return input.shipping_method_ids?.length > 0;
    }
```

This PR fixes the issue by passing a step name as a first parameter to the `when` usages in `updateOrderTaxLinesWorkflow`