### PR TITLE
fix(dashboard): campaign budget labels improvements

### DIFF
--- a/.changeset/shaggy-tigers-warn.md
+++ b/.changeset/shaggy-tigers-warn.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): budget labels and remove promo code

--- a/packages/admin/dashboard/src/i18n/translations/$schema.json
+++ b/packages/admin/dashboard/src/i18n/translations/$schema.json
@@ -8397,6 +8397,12 @@
                 },
                 "totalUsedByAttribute": {
                   "type": "string"
+                },
+                "totalUsedByAttributeCustomerId": {
+                  "type": "string"
+                },
+                "totalUsedByAttributeEmail": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -8406,7 +8412,9 @@
                 "used",
                 "budgetAttribute",
                 "budgetAttributeTooltip",
-                "totalUsedByAttribute"
+                "totalUsedByAttribute",
+                "totalUsedByAttributeCustomerId",
+                "totalUsedByAttributeEmail"
               ],
               "additionalProperties": false
             },

--- a/packages/admin/dashboard/src/i18n/translations/$schema.json
+++ b/packages/admin/dashboard/src/i18n/translations/$schema.json
@@ -8345,6 +8345,19 @@
         "budget": {
           "type": "object",
           "properties": {
+            "attribute": {
+              "type": "object",
+              "properties": {
+                "customer_id": {
+                  "type": "string"
+                },
+                "customer_email": {
+                  "type": "string"
+                }
+              },
+              "required": ["customer_id", "customer_email"],
+              "additionalProperties": false
+            },
             "create": {
               "type": "object",
               "properties": {
@@ -8432,11 +8445,22 @@
                     "title": {
                       "type": "string"
                     },
+                    "titleCustomerId": {
+                      "type": "string"
+                    },
+                    "titleEmail": {
+                      "type": "string"
+                    },
                     "description": {
                       "type": "string"
                     }
                   },
-                  "required": ["title", "description"],
+                  "required": [
+                    "title",
+                    "titleCustomerId",
+                    "titleEmail",
+                    "description"
+                  ],
                   "additionalProperties": false
                 }
               },
@@ -8454,7 +8478,14 @@
               "additionalProperties": false
             }
           },
-          "required": ["create", "details", "fields", "type", "edit"],
+          "required": [
+            "attribute",
+            "create",
+            "details",
+            "fields",
+            "type",
+            "edit"
+          ],
           "additionalProperties": false
         },
         "promotions": {

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -2255,7 +2255,7 @@
         "limit": "Limit",
         "used": "Used",
         "budgetAttribute": "Limit usage per",
-        "budgetAttributeTooltip": "Define how many times the promotion can be used by a specific customer or email.",
+        "budgetAttributeTooltip": "Define how many times the promotion can be used by each customer or email.",
         "totalUsedByAttribute": "Budget limit per: {{attribute}}",
         "totalUsedByAttributeCustomerId": "Budget limit per customer",
         "totalUsedByAttributeEmail": "Budget limit per email"

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -2240,6 +2240,10 @@
       }
     },
     "budget": {
+      "attribute": {
+        "customer_id": "customer",
+        "customer_email": "email"
+      },
       "create": {
         "hint": "Create a budget for the campaign.",
         "header": "Campaign Budget"
@@ -2265,6 +2269,8 @@
         },
         "useByAttribute": {
           "title": "Usage by attribute (customer id, email, etc.)",
+          "titleCustomerId": "Usage per customer",
+          "titleEmail": "Usage per email",
           "description": "Set a limit on how many times the promotion can be used by a specific attribute value."
         }
       },

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -2256,7 +2256,9 @@
         "used": "Used",
         "budgetAttribute": "Limit usage per",
         "budgetAttributeTooltip": "Define how many times the promotion can be used by a specific customer or email.",
-        "totalUsedByAttribute": "Budget limit per: {{attribute}}"
+        "totalUsedByAttribute": "Budget limit per: {{attribute}}",
+        "totalUsedByAttributeCustomerId": "Budget limit per customer",
+        "totalUsedByAttributeEmail": "Budget limit per email"
       },
       "type": {
         "spend": {

--- a/packages/admin/dashboard/src/routes/campaigns/campaign-detail/components/campaign-budget/campaign-budget.tsx
+++ b/packages/admin/dashboard/src/routes/campaigns/campaign-detail/components/campaign-budget/campaign-budget.tsx
@@ -27,7 +27,12 @@ export const CampaignBudget = ({ campaign }: CampaignBudgetProps) => {
           >
             {campaign.budget?.type === "use_by_attribute"
               ? t("campaigns.budget.fields.totalUsedByAttribute", {
-                  attribute: campaign.budget?.attribute,
+                  attribute: t(
+                    `campaigns.budget.attribute.${campaign.budget?.attribute}`,
+                    {
+                      defaultValue: campaign.budget?.attribute,
+                    }
+                  ),
                 })
               : t("campaigns.fields.budget_limit")}
           </Heading>

--- a/packages/admin/dashboard/src/routes/campaigns/campaign-detail/components/campaign-budget/campaign-budget.tsx
+++ b/packages/admin/dashboard/src/routes/campaigns/campaign-detail/components/campaign-budget/campaign-budget.tsx
@@ -11,6 +11,22 @@ type CampaignBudgetProps = {
 export const CampaignBudget = ({ campaign }: CampaignBudgetProps) => {
   const { t } = useTranslation()
 
+  const getTranslation = () => {
+    const budget = campaign.budget
+
+    if (budget?.type === "use_by_attribute") {
+      if (budget?.attribute === "customer_id") {
+        return t(`campaigns.budget.fields.totalUsedByAttributeCustomerId`)
+      } else if (budget?.attribute === "customer_email") {
+        return t(`campaigns.budget.fields.totalUsedByAttributeEmail`)
+      }
+      return t(`campaigns.budget.fields.totalUsedByAttribute`, {
+        attribute: budget?.attribute,
+      })
+    }
+    return t(`campaigns.fields.budget_limit`)
+  }
+
   return (
     <Container className="flex flex-col gap-y-4 px-6 py-4">
       <div className="flex justify-between">
@@ -25,16 +41,7 @@ export const CampaignBudget = ({ campaign }: CampaignBudgetProps) => {
             className="text-ui-fg-subtle ms-10 mt-[1.5px] font-normal"
             level="h3"
           >
-            {campaign.budget?.type === "use_by_attribute"
-              ? t("campaigns.budget.fields.totalUsedByAttribute", {
-                  attribute: t(
-                    `campaigns.budget.attribute.${campaign.budget?.attribute}`,
-                    {
-                      defaultValue: campaign.budget?.attribute,
-                    }
-                  ),
-                })
-              : t("campaigns.fields.budget_limit")}
+            {getTranslation()}
           </Heading>
         </div>
 

--- a/packages/admin/dashboard/src/routes/campaigns/common/components/create-campaign-form-fields/create-campaign-form-fields.tsx
+++ b/packages/admin/dashboard/src/routes/campaigns/common/components/create-campaign-form-fields/create-campaign-form-fields.tsx
@@ -382,10 +382,11 @@ export const CreateCampaignFormFields = ({ form, fieldScope = "" }) => {
                           label: t("fields.email"),
                           value: "customer_email",
                         },
-                        {
-                          label: t("fields.promotionCode"),
-                          value: "promotion_code",
-                        },
+                        // TEMP disable promotion code for now
+                        // {
+                        //   label: t("fields.promotionCode"),
+                        //   value: "promotion_code",
+                        // },
                       ]}
                     ></Combobox>
                   </Form.Control>

--- a/packages/admin/dashboard/src/routes/promotions/promotion-add-campaign/components/add-campaign-promotion-form/campaign-details.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/promotion-add-campaign/components/add-campaign-promotion-form/campaign-details.tsx
@@ -9,6 +9,21 @@ const translationKeyMap = {
   use_by_attribute: "useByAttribute",
 }
 
+const getTranslationKey = (budget: AdminCampaign["budget"]) => {
+  const translationKey = translationKeyMap[budget?.type] || "-"
+
+  if (budget?.type === "use_by_attribute") {
+    if (budget?.attribute === "customer_id") {
+      return `campaigns.budget.type.useByAttribute.titleCustomerId`
+    } else if (budget?.attribute === "customer_email") {
+      return `campaigns.budget.type.useByAttribute.titleEmail`
+    }
+    return `campaigns.budget.type.useByAttribute.title`
+  }
+
+  return `campaigns.budget.type.${translationKey}.title`
+}
+
 type CampaignDetailsProps = {
   campaign?: AdminCampaign
 }
@@ -84,12 +99,9 @@ export const CampaignDetails = ({ campaign }: CampaignDetailsProps) => {
 
           <div className="flex items-center gap-1">
             <Text className="txt-small truncate">
-              {t(
-                `campaigns.budget.type.${translationKeyMap[campaign.budget?.type]}.title`,
-                {
-                  defaultValue: "-",
-                }
-              )}
+              {t(getTranslationKey(campaign.budget), {
+                defaultValue: "-",
+              })}
             </Text>
           </div>
         </div>


### PR DESCRIPTION
**What**
- improve labels and translations for the campaigns budget domain
- disable `promotion code` budget attribute