### PR TITLE
Added shipping method data to tax module context

### DIFF
--- a/.changeset/late-seals-mix.md
+++ b/.changeset/late-seals-mix.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/core-flows": patch
+"@medusajs/types": patch
+---
+
+Added shipping method data to tax module context

--- a/packages/core/core-flows/src/tax/steps/get-item-tax-lines.ts
+++ b/packages/core/core-flows/src/tax/steps/get-item-tax-lines.ts
@@ -91,6 +91,12 @@ function normalizeTaxModuleContext(
     },
     customer,
     is_return: isReturn ?? false,
+    shipping_methods: orderOrCart.shipping_methods?.map((method) => ({
+      id: method.id,
+      name: method.name,
+      shipping_option_id: method.shipping_option_id,
+      amount: method.amount,
+    })),
   }
 }
 

--- a/packages/core/types/src/tax/common.ts
+++ b/packages/core/types/src/tax/common.ts
@@ -490,6 +490,31 @@ export interface TaxCalculationContext {
    * Whether the tax lines are calculated for an order return.
    */
   is_return?: boolean
+
+  /**
+   * The shipping method details.
+   */
+  shipping_methods?: {
+    /**
+     * The associated shipping method's ID.
+     */
+    id: string
+
+    /**
+     * The name of the shipping method.
+     */
+    name: string
+
+    /**
+     * The associated shipping options's ID.
+     */
+    shipping_option_id: string
+
+    /**
+     * The amount of the shipping method.
+     */
+    amount: number
+  }[]
 }
 
 /**


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Added shipping method data to the normalize tax module context.

**Why** — Why are these changes relevant or necessary?  

We need to override the tax provider to set taxes based on the shipping method (when it is a pickup). I.e. we have pickup locations in the Netherlands, but we also ship abroad. When someone from Germany chooses to pickup, the tax needs to be overriden to the Dutch VAT. 

To make this possible we need the shipping method data in the taxCalculationContext of the getTaxLines in the CustomTaxProvider.

**How** — How have these changes been implemented?

Extensions have been made to the `normalizeTaxModuleContext` function

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

We implemented the patch locally and seen the data passed through properly.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
  async getTaxLines(
    itemLines: TaxTypes.ItemTaxCalculationLine[],
    shippingLines: TaxTypes.ShippingTaxCalculationLine[],
    taxCalculationContext: TaxTypes.TaxCalculationContext
  ): Promise<(TaxTypes.ItemTaxLineDTO | TaxTypes.ShippingTaxLineDTO)[]> {
    const shippingOptionIds = taxCalculationContext.shipping_methods?.map(sm => sm.shipping_option_id) ?? [];
    
    // If a customer chooses pickup in shop/warehouse, use Dutch tax rate
    let hasPickOption = false;
    if (shippingOptionIds.length > 0) {
      const result = await this.getShippingOptions(shippingOptionIds);
      hasPickOption = result.length > 0;
    }
    
    ...
}
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---
