### PR TITLE
chore(core-flows): send error on csv parsing error

### DIFF
--- a/.changeset/two-dragons-visit.md
+++ b/.changeset/two-dragons-visit.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+chore(core-flows): send error on csv parsing error

--- a/packages/core/core-flows/src/product/steps/normalize-products-to-chunks.ts
+++ b/packages/core/core-flows/src/product/steps/normalize-products-to-chunks.ts
@@ -1,11 +1,13 @@
-import { parse, Parser } from "csv-parse"
+import { CsvError, parse, Parser } from "csv-parse"
 import type { HttpTypes, IFileModuleService } from "@medusajs/framework/types"
 import {
   CSVNormalizer,
+  MedusaError,
   Modules,
   productValidators,
 } from "@medusajs/framework/utils"
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { MedusaErrorTypes } from "@medusajs/utils"
 
 /**
  * The CSV file content to parse.
@@ -238,6 +240,11 @@ export const normalizeCsvToChunksStep = createStep(
           })
         )
       } catch (error) {
+        if (error instanceof CsvError) {
+          return reject(
+            new MedusaError(MedusaErrorTypes.INVALID_DATA, error.message)
+          )
+        }
         reject(error)
       }
     })


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Sending the errors thrown from the CSV lib we are using. Right now, we are just sending "Unexpected error" although we do have a human readable error thrown by the CSV lib we use
<img width="1948" height="1518" alt="CleanShot 2025-10-14 at 15 02 30@2x" src="https://github.com/user-attachments/assets/c563e809-90b9-4a47-a923-34b2f42c09ae" />

**Why** — Why are these changes relevant or necessary?  

As noted by some users, merchants are in the dark if they don't look at their logs to find the errors

**How** — How have these changes been implemented?

If the error thrown is of type CsvError, we send the message. Here is the [doc](https://csv.js.org/parse/errors/)

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Manual testing

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

CLOSES #13453 
CLOSES CORE-1249