### PR TITLE
feat: Add support for multiple active keys at a time

### DIFF
--- a/.changeset/tender-points-judge.md
+++ b/.changeset/tender-points-judge.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/api-key": patch
+---
+
+Allow creating multiple active API keys at a time

--- a/packages/modules/api-key/src/migrations/.snapshot-medusa-api-key.json
+++ b/packages/modules/api-key/src/migrations/.snapshot-medusa-api-key.json
@@ -142,6 +142,7 @@
           "keyName": "IDX_api_key_deleted_at",
           "columnNames": [],
           "composite": false,
+          "constraint": false,
           "primary": false,
           "unique": false,
           "expression": "CREATE INDEX IF NOT EXISTS \"IDX_api_key_deleted_at\" ON \"api_key\" (deleted_at) WHERE deleted_at IS NULL"
@@ -150,14 +151,34 @@
           "keyName": "IDX_api_key_token_unique",
           "columnNames": [],
           "composite": false,
+          "constraint": false,
           "primary": false,
           "unique": false,
           "expression": "CREATE UNIQUE INDEX IF NOT EXISTS \"IDX_api_key_token_unique\" ON \"api_key\" (token) WHERE deleted_at IS NULL"
         },
         {
+          "keyName": "IDX_api_key_revoked_at",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_api_key_revoked_at\" ON \"api_key\" (revoked_at) WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_api_key_redacted",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_api_key_redacted\" ON \"api_key\" (redacted) WHERE deleted_at IS NULL"
+        },
+        {
           "keyName": "IDX_api_key_type",
           "columnNames": [],
           "composite": false,
+          "constraint": false,
           "primary": false,
           "unique": false,
           "expression": "CREATE INDEX IF NOT EXISTS \"IDX_api_key_type\" ON \"api_key\" (type) WHERE deleted_at IS NULL"
@@ -168,12 +189,15 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     }
-  ]
+  ],
+  "nativeEnums": {}
 }

--- a/packages/modules/api-key/src/migrations/Migration20251015123842.ts
+++ b/packages/modules/api-key/src/migrations/Migration20251015123842.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20251015123842 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_api_key_revoked_at" ON "api_key" (revoked_at) WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_api_key_redacted" ON "api_key" (redacted) WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "IDX_api_key_revoked_at";`);
+    this.addSql(`drop index if exists "IDX_api_key_redacted";`);
+  }
+
+}

--- a/packages/modules/api-key/src/models/api-key.ts
+++ b/packages/modules/api-key/src/models/api-key.ts
@@ -19,6 +19,12 @@ const ApiKey = model
       unique: true,
     },
     {
+      on: ["revoked_at"],
+    },
+    {
+      on: ["redacted"],
+    },
+    {
       on: ["type"],
     },
   ])


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

We've removed the limitation of having at most 2 active secret keys at a time

**Why** — Why are these changes relevant or necessary?  

The module can be used in different contexts, some of which require a lot more active api keys

**How** — How have these changes been implemented?

Removed validation of number of active keys

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Module's integration tests + http tests.

---

## Examples

N/A
---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable
