### PR TITLE
fix(draft-order): email reset when changing customer

### DIFF
--- a/.changeset/new-cameras-roll.md
+++ b/.changeset/new-cameras-roll.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/draft-order": patch
+---
+
+fix(draft-order): email reset when changing customer

--- a/packages/plugins/draft-order/src/admin/routes/draft-orders/@create/page.tsx
+++ b/packages/plugins/draft-order/src/admin/routes/draft-orders/@create/page.tsx
@@ -322,12 +322,10 @@ const CustomerField = ({ control, setValue }: CustomerFieldProps) => {
 
       const customerEmail = label?.match(/\((.*@.*)\)$/)?.[1] || label
 
-      if (!email && customerEmail) {
-        setValue("email", customerEmail, {
-          shouldDirty: true,
-          shouldTouch: true,
-        })
-      }
+      setValue("email", customerEmail || "", {
+        shouldDirty: true,
+        shouldTouch: true,
+      })
     },
     [email, setValue, customers.options]
   )


### PR DESCRIPTION
## Summary

**What** — correctly set the email when another customer is selected in the create flow

---

CLOSES CORE-1252

