### PR TITLE
feat(dashboard): add input field for tracking_url and label_url in shipment form

### DIFF
--- a/.changeset/sour-schools-return.md
+++ b/.changeset/sour-schools-return.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+add input field for tracking_url and label_url in shipment form

--- a/packages/admin/dashboard/src/i18n/translations/$schema.json
+++ b/packages/admin/dashboard/src/i18n/translations/$schema.json
@@ -5003,6 +5003,12 @@
             "trackingNumber": {
               "type": "string"
             },
+            "trackingUrl": {
+              "type": "string"
+            },
+            "labelUrl": {
+              "type": "string"
+            },
             "addTracking": {
               "type": "string"
             },
@@ -5019,6 +5025,8 @@
           "required": [
             "title",
             "trackingNumber",
+            "trackingUrl",
+            "labelUrl",
             "addTracking",
             "sendNotification",
             "sendNotificationHint",
@@ -7678,6 +7686,7 @@
             "campaign",
             "method",
             "allocation",
+            "allocationTooltip",
             "addCondition",
             "clearAll",
             "taxInclusive",

--- a/packages/admin/dashboard/src/i18n/translations/$schema.json
+++ b/packages/admin/dashboard/src/i18n/translations/$schema.json
@@ -7686,7 +7686,6 @@
             "campaign",
             "method",
             "allocation",
-            "allocationTooltip",
             "addCondition",
             "clearAll",
             "taxInclusive",

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -1330,6 +1330,8 @@
     "shipment": {
       "title": "Mark fulfillment shipped",
       "trackingNumber": "Tracking number",
+      "trackingUrl": "Tracking URL",
+      "labelUrl": "Label URL",
       "addTracking": "Add tracking number",
       "sendNotification": "Send notification",
       "sendNotificationHint": "Notify the customer about this shipment.",

--- a/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import * as zod from "zod"
 
 import { AdminFulfillment, AdminOrder } from "@medusajs/types"
-import { Button, Heading, Input, Switch, toast } from "@medusajs/ui"
+import { Button, clx, Heading, Input, Switch, toast } from "@medusajs/ui"
 import { useFieldArray, useForm } from "react-hook-form"
 
 import { Form } from "../../../../../components/common/form"
@@ -47,8 +47,8 @@ export function OrderCreateShipmentForm({
       .filter((l) => !!l.tracking_number)
       .map((l) => ({
         tracking_number: l.tracking_number,
-        tracking_url: "#",
-        label_url: "#",
+        tracking_url: l.tracking_url || "#",
+        label_url: l.label_url || "#",
       }))
 
     await createShipment(
@@ -89,33 +89,90 @@ export function OrderCreateShipmentForm({
                     {t("orders.shipment.title")}
                   </Heading>
 
-                  {labels.map((label, index) => (
-                    <Form.Field
-                      key={label.id}
-                      control={form.control}
-                      name={`labels.${index}.tracking_number`}
-                      render={({ field }) => {
-                        return (
-                          <Form.Item className="mb-4">
-                            {index === 0 && (
-                              <Form.Label>
-                                {t("orders.shipment.trackingNumber")}
-                              </Form.Label>
-                            )}
-                            <Form.Control>
-                              <Input {...field} placeholder="123-456-789" />
-                            </Form.Control>
-                            <Form.ErrorMessage />
-                          </Form.Item>
-                        )
-                      }}
-                    />
-                  ))}
+                  <div className="flex flex-col max-md:gap-y-2 max-md:divide-y">
+                    {labels.map((label, index) => (
+                      <div
+                        className={clx(
+                          "grid grid-cols-1 gap-x-4 md:grid-cols-3",
+                          { "max-md:pt-4": index > 0 }
+                        )}
+                        key={label.id}
+                      >
+                        <Form.Field
+                          key={label.id}
+                          control={form.control}
+                          name={`labels.${index}.tracking_number`}
+                          render={({ field }) => {
+                            return (
+                              <Form.Item className="mb-2">
+                                <Form.Label
+                                  className={clx({ "md:hidden": index > 0 })}
+                                >
+                                  {t("orders.shipment.trackingNumber")}
+                                </Form.Label>
+
+                                <Form.Control>
+                                  <Input {...field} placeholder="123-456-789" />
+                                </Form.Control>
+                                <Form.ErrorMessage />
+                              </Form.Item>
+                            )
+                          }}
+                        />
+                        <Form.Field
+                          key={label.id}
+                          control={form.control}
+                          name={`labels.${index}.tracking_url`}
+                          render={({ field }) => {
+                            return (
+                              <Form.Item className="mb-2">
+                                <Form.Label
+                                  className={clx({ "md:hidden": index > 0 })}
+                                >
+                                  {t("orders.shipment.trackingUrl")}
+                                </Form.Label>
+                                <Form.Control>
+                                  <Input
+                                    {...field}
+                                    placeholder="https://example.com/tracking/123"
+                                  />
+                                </Form.Control>
+                                <Form.ErrorMessage />
+                              </Form.Item>
+                            )
+                          }}
+                        />
+                        <Form.Field
+                          key={label.id}
+                          control={form.control}
+                          name={`labels.${index}.label_url`}
+                          render={({ field }) => {
+                            return (
+                              <Form.Item className="mb-2">
+                                <Form.Label
+                                  className={clx({ "md:hidden": index > 0 })}
+                                >
+                                  {t("orders.shipment.labelUrl")}
+                                </Form.Label>
+                                <Form.Control>
+                                  <Input
+                                    {...field}
+                                    placeholder="https://example.com/label/123"
+                                  />
+                                </Form.Control>
+                                <Form.ErrorMessage />
+                              </Form.Item>
+                            )
+                          }}
+                        />
+                      </div>
+                    ))}
+                  </div>
 
                   <Button
                     type="button"
                     onClick={() => append({ tracking_number: "" })}
-                    className="self-end"
+                    className="mt-2 self-end"
                     variant="secondary"
                   >
                     {t("orders.shipment.addTracking")}

--- a/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
@@ -168,7 +168,13 @@ export function OrderCreateShipmentForm({
 
                   <Button
                     type="button"
-                    onClick={() => append({ tracking_number: "" })}
+                    onClick={() =>
+                      append({
+                        tracking_number: "",
+                        label_url: "",
+                        tracking_url: "",
+                      })
+                    }
                     className="mt-2 self-end"
                     variant="secondary"
                   >

--- a/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
@@ -92,14 +92,13 @@ export function OrderCreateShipmentForm({
                   <div className="flex flex-col max-md:gap-y-2 max-md:divide-y">
                     {labels.map((label, index) => (
                       <div
+                        key={label.id}
                         className={clx(
                           "grid grid-cols-1 gap-x-4 md:grid-cols-3",
                           { "max-md:pt-4": index > 0 }
                         )}
-                        key={label.id}
                       >
                         <Form.Field
-                          key={label.id}
                           control={form.control}
                           name={`labels.${index}.tracking_number`}
                           render={({ field }) => {
@@ -120,7 +119,6 @@ export function OrderCreateShipmentForm({
                           }}
                         />
                         <Form.Field
-                          key={label.id}
                           control={form.control}
                           name={`labels.${index}.tracking_url`}
                           render={({ field }) => {
@@ -143,7 +141,6 @@ export function OrderCreateShipmentForm({
                           }}
                         />
                         <Form.Field
-                          key={label.id}
                           control={form.control}
                           name={`labels.${index}.label_url`}
                           render={({ field }) => {

--- a/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
@@ -44,7 +44,7 @@ export function OrderCreateShipmentForm({
 
   const handleSubmit = form.handleSubmit(async (data) => {
     const addedLabels = data.labels
-      .filter((l) => !!l.tracking_number && !!l.tracking_url && !!l.label_url)
+      .filter((l) => !!l.tracking_number || !!l.tracking_url || !!l.label_url)
       .map((l) => ({
         tracking_number: l.tracking_number,
         tracking_url: l.tracking_url || "#",

--- a/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
@@ -44,7 +44,7 @@ export function OrderCreateShipmentForm({
 
   const handleSubmit = form.handleSubmit(async (data) => {
     const addedLabels = data.labels
-      .filter((l) => !!l.tracking_number)
+      .filter((l) => !!l.tracking_number && !!l.tracking_url && !!l.label_url)
       .map((l) => ({
         tracking_number: l.tracking_number,
         tracking_url: l.tracking_url || "#",


### PR DESCRIPTION

## Summary

**What** — What changes are introduced in this PR?

Add input field for tracking_url and label_url in shipment creation form

**Why** — Why are these changes relevant or necessary?  

Currently there are only inputs for tracking number. For tracking_url and label_url it is hardcoded as `"#"` when submitted through the API

**How** — How have these changes been implemented?

Straightforward duplication of the existing input for tracking_number, plus some minimal styling for the layout.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Tested locally as this is a very simple change. Screenshots of layout shown below:

Below `md`:
<img width="579" height="832" alt="Screenshot 2025-10-21 at 12 19 45" src="https://github.com/user-attachments/assets/e34aaa1c-bd36-4f9b-9aa2-e546dcd3b059" />

`md` or above:
<img width="844" height="482" alt="Screenshot 2025-10-21 at 12 19 32" src="https://github.com/user-attachments/assets/0c87f3eb-8121-47e6-81a3-f4ddfdc1c34d" />


---

## Examples

N/A, as this is a UI change in the dashboard as described

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Localization added for English only.
