### PR TITLE
feat(payment-stripe): merge custom metadata along with session_id on payment initiation

### DIFF
--- a/.changeset/cool-brooms-travel.md
+++ b/.changeset/cool-brooms-travel.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/payment-stripe": patch
+---
+
+Allow Stripe metadata to be send on payment creation

--- a/.changeset/cool-brooms-travel.md
+++ b/.changeset/cool-brooms-travel.md
@@ -2,4 +2,4 @@
 "@medusajs/payment-stripe": patch
 ---
 
-Allow Stripe metadata to be send on payment creation
+feat(payment-stripe): merge custom metadata along with session_id on payment initiation

--- a/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
+++ b/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
@@ -248,7 +248,7 @@ abstract class StripeBase extends AbstractPaymentProvider<StripeOptions> {
     const intentRequest: Stripe.PaymentIntentCreateParams = {
       amount: getSmallestUnit(amount, currency_code),
       currency: currency_code,
-      metadata: { session_id: data?.session_id as string },
+      metadata: { ...(data?.metadata ?? {}), session_id: data?.session_id as string },
       ...additionalParameters,
     }
 


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Combining the data.metadata passed in by callers with session_id as needed by medusa itself

**Why** — Why are these changes relevant or necessary?  

Currently, if you attempt to pass metadata to stripe, it will not be passed through, as the metadata field is hardcoded as `session_id: data?.session_id as string
` meaninig that custom metadata is unavailable.

**How** — How have these changes been implemented?

Spreading the contents of data.metadata if present, and combining that with session_id.



---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
