### PR TITLE
docs-util: remove inferring of query parameters

### DIFF
--- a/www/utils/packages/docs-generator/src/classes/helpers/oas-schema.ts
+++ b/www/utils/packages/docs-generator/src/classes/helpers/oas-schema.ts
@@ -228,7 +228,10 @@ class OasSchemaHelper {
     return clonedSchema
   }
 
-  isSchemaEmpty(schema: OpenApiSchema): boolean {
+  isSchemaEmpty(schema?: OpenApiSchema): boolean {
+    if (!schema || !Object.keys(schema).length) {
+      return true
+    }
     switch (schema.type) {
       case "object":
         const isPropertiesEmpty =


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Remove previous method of inferring query parameters (for pagination and fields). Instead, rely on supplied types only.

Closes DX-2216

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
