### PR TITLE
fix(js-sdk): add missing query param to deleteLineItem jsdoc

### DIFF
--- a/.changeset/tiny-seahorses-hang.md
+++ b/.changeset/tiny-seahorses-hang.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/js-sdk": patch
+---
+
+add missing query param to deleteLineItem jsdoc

--- a/packages/core/js-sdk/src/store/index.ts
+++ b/packages/core/js-sdk/src/store/index.ts
@@ -683,6 +683,7 @@ export class Store {
      *
      * @param cartId - The cart's ID.
      * @param lineItemId - The item's ID.
+     * @param query - Configure the fields to retrieve in the cart.
      * @param headers - Headers to pass in the request.
      * @returns The deletion's details.
      *


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Add missing jsdoc param to deleteLineItem

**Why** — Why are these changes relevant or necessary?  

Exposed jsdoc does not align with actual implementastion

**How** — How have these changes been implemented?

Add missing jsdoc param

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Not tested

---

## Examples

```ts
medusa.store.cart.deleteLineItem(cartId, lineId, query, headers);
```
gives error
`Expected 2-3 arguments, but got 4.`

---

## Checklist

Please ensure the following before requesting a review:

- [X] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [X] I have linked the related issue(s) if applicable

---

## Additional Context

Fixes #13829 

Note that this is my first contribution to Medusa. I'm not sure if this change is enough, but this is what I could find.