### PR TITLE
Add config to allow processing to be authorized in stripe base payments

### DIFF
--- a/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
+++ b/packages/modules/providers/payment-stripe/src/core/stripe-base.ts
@@ -605,7 +605,7 @@ abstract class StripeBase extends AbstractPaymentProvider<StripeOptions> {
         return { status: PaymentSessionStatus.PENDING, data: paymentIntent }
       case "requires_confirmation":
       case "processing":
-        return { status: PaymentSessionStatus.PENDING, data: paymentIntent }
+        return { status: this.options_.authorizeOnProcessing?PaymentSessionStatus.AUTHORIZED:PaymentSessionStatus.PENDING, data: paymentIntent }
       case "requires_action":
         return {
           status: PaymentSessionStatus.REQUIRES_MORE,

--- a/packages/modules/providers/payment-stripe/src/types/index.ts
+++ b/packages/modules/providers/payment-stripe/src/types/index.ts
@@ -16,6 +16,10 @@ export interface StripeOptions {
    */
   automaticPaymentMethods?: boolean
   /**
+   * Automatically authorize the payment when processing (default is false)
+   */
+  authorizeOnProcessing?: boolean
+  /**
    * Set a default description on the intent if the context does not provide one
    */
   paymentDescription?: string


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Added a configurable option `authorizeOnProcessing` to the `payment-stripe` provider that allows transactions in Stripe that may take longer to be processed by the complete cart workflow. 

Configuration example:
```js
providers: [
  {
    resolve: "@medusajs/medusa/payment-stripe",
    id: "stripe",
    options: {
      authorizeOnProcessing: true
    },
  },
],
```

When enabled, the payment can be automatically captured through the webhook or manually captured in the admin backend. The order remains in a pending/authorized state (shown as "orange") until Stripe changes the payment intent status to `succeeded`.

The solution treats payment intents with status `processing` as `authorized` when the `authorizeOnProcessing` flag is set to `true`. When `false`, it falls back to the previous behavior.

**Why** — Why are these changes relevant or necessary?

Stripe-based payments that have a delayed capturing cycle currently cause cart completion to fail. This feature provides a workaround for users who need to support such payment methods by explicitly enabling this behavior through configuration.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

I tested approximately 5 different payment methods in Stripe to ensure existing functionality works as expected. The changes now allow delayed payment methods to function properly during cart completion.

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Comments

I recognize that an ideal solution would introduce a more robust way of handling carts or orders with pending payments (e.g., a "parking" mechanism). However, this PR serves as a pragmatic workaround until a more comprehensive solution can be developed. In the meantime, this feature enables support for payment methods that would otherwise block cart completion.