### PR TITLE
fix(admin): fix admin promotion list sort

### DIFF
--- a/.changeset/six-squids-vanish.md
+++ b/.changeset/six-squids-vanish.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+🐛 Fix admin promotion list sort

--- a/packages/admin/dashboard/src/hooks/table/query/use-promotion-table-query.tsx
+++ b/packages/admin/dashboard/src/hooks/table/query/use-promotion-table-query.tsx
@@ -11,17 +11,18 @@ export const usePromotionTableQuery = ({
   pageSize = 20,
 }: UsePromotionTableQueryProps) => {
   const queryObject = useQueryParams(
-    ["offset", "q", "created_at", "updated_at"],
+    ["offset", "q", "order", "created_at", "updated_at"],
     prefix
   )
 
-  const { offset, q, created_at, updated_at } = queryObject
+  const { offset, q, order, created_at, updated_at } = queryObject
 
   const searchParams: HttpTypes.AdminGetPromotionsParams = {
     limit: pageSize,
     created_at: created_at ? JSON.parse(created_at) : undefined,
     updated_at: updated_at ? JSON.parse(updated_at) : undefined,
     offset: offset ? Number(offset) : 0,
+    order,
     q,
   }
 


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fixed sorting functionality on the Promotion list admin page by adding the missing `order` parameter to the `usePromotionTableQuery` hook.

**Why** — Why are these changes relevant or necessary?  

The sorting feature on the Promotion list page was not working because the `usePromotionTableQuery` hook was not including the `order` parameter in its query parameters. This meant that when users tried to sort promotions by "Created At" or "Updated At" using the orderBy dropdown, the sort parameter was not being sent to the API, and the list remained unsorted.

**How** — How have these changes been implemented?

Modified `packages/admin/dashboard/src/hooks/table/query/use-promotion-table-query.tsx` to:

1. Added "order" to the useQueryParams array
2. Extracted order from the queryObject
3. Passed order to the searchParams that are sent to the API

This brings the promotion table query hook in line with other table query hooks (e.g., `useOrderTableQuery`, `useCampaignTableQuery`, `useCollectionTableQuery`) which already include the order parameter.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

1. Navigate to the Promotions list page (`/promotions`)
2. Click on the "Sort by" dropdown in the table header
3. Select "Created At" (ascending or descending)
4. Verify that the promotions list is sorted correctly by creation date
5. Select "Updated At" (ascending or descending)
6. Verify that the promotions list is sorted correctly by update date
7. Confirm that the URL query parameters include the `order` parameter when sorting is applied

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

This fix follows the same pattern used in other table query hooks throughout the admin dashboard. All other entity list pages (Orders, Collections, Campaigns, Products, Customers, Regions, etc.) already have this parameter and their sorting works correctly. This change simply brings the Promotions list into consistency with the rest of the application.