### PR TITLE
feat(admin): change admin order list default sort

### DIFF
--- a/.changeset/hot-laws-give.md
+++ b/.changeset/hot-laws-give.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+feat(admin): Change admin order list default sort

--- a/packages/admin/dashboard/src/hooks/table/query/use-order-table-query.tsx
+++ b/packages/admin/dashboard/src/hooks/table/query/use-order-table-query.tsx
@@ -46,7 +46,7 @@ export const useOrderTableQuery = ({
     created_at: created_at ? JSON.parse(created_at) : undefined,
     updated_at: updated_at ? JSON.parse(updated_at) : undefined,
     region_id: region_id?.split(","),
-    order: order ? order : "-display_id",
+    order: order ? order : "-created_at",
     q,
   }
 


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Changed the default sort order for the admin Orders list page from `display_id` (descending) to `created_at` (descending).

**Why** — Why are these changes relevant or necessary?  

The admin order list page should directly display the most recent orders first, as this is the most common use case for merchants checking their orders. The previous default sort by `display_id` (descending) has two issues:

1. Display IDs can be random: Depending on the configuration and system implementation, display_id values may not follow a sequential pattern, making them unreliable for chronological ordering
2. Recency matters most: Merchants typically want to see their newest orders first when they open the orders page to process recent purchases, handle customer inquiries, or monitor sales activity

Sorting by `created_at` (descending) ensures that the most recently created orders always appear at the top of the list by default, providing a consistent and intuitive user experience.

**How** — How have these changes been implemented?

Modified `packages/admin/dashboard/src/hooks/table/query/use-order-table-query.tsx` to change the default `order` parameter from `-display_id` to `-created_at`. The fallback only applies when no explicit sort order is specified by the user via the URL query parameters.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

1. Navigate to the Orders list page (`/orders`) without any query parameters
2. Verify that orders are sorted by creation date in descending order (newest orders first)
3. Verify that the most recently created order appears at the top of the list
4. Test that manual sorting still works by using the "Sort by" dropdown
5. Confirm that when you select a different sort option, it overrides the default
6. Clear the sort parameter and reload the page to verify it defaults back to `created_at` descending

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

This change improves the default user experience for merchants using the admin dashboard. While users can still sort by any available field (including display_id) using the sort dropdown, the default behavior now matches the most common merchant workflow: checking and processing the most recent orders first.
The change only affects the default sort order when no explicit order parameter is present in the URL. All existing functionality for custom sorting remains intact.

See also: #13009 
