### PR TITLE
use truncate in db teardown

### DIFF
--- a/packages/medusa-test-utils/src/database.ts
+++ b/packages/medusa-test-utils/src/database.ts
@@ -228,7 +228,6 @@ export const dbTestUtilFactory = (): any => ({
       const runRawQuery = this.pgConnection_.raw.bind(this.pgConnection_)
       schema ??= "public"
 
-      await runRawQuery(`SET session_replication_role = 'replica';`)
       const { rows: tableNames } = await runRawQuery(`SELECT table_name
                                               FROM information_schema.tables
                                               WHERE table_schema = '${schema}';`)
@@ -237,6 +236,7 @@ export const dbTestUtilFactory = (): any => ({
       const mainPartitionTables = ["index_data", "index_relation"]
       let hasIndexTables = false
 
+      const tablesToTruncate: string[] = []
       for (const { table_name } of tableNames) {
         if (mainPartitionTables.includes(table_name)) {
           hasIndexTables = true
@@ -249,15 +249,15 @@ export const dbTestUtilFactory = (): any => ({
           continue
         }
 
-        await runRawQuery(`DELETE FROM ${schema}."${table_name}";`)
+        tablesToTruncate.push(`${schema}."${table_name}"`)
       }
+      await runRawQuery(`TRUNCATE ${tablesToTruncate.join(", ")};`)
 
       if (hasIndexTables) {
-        await runRawQuery(`TRUNCATE TABLE ${schema}.index_data;`)
-        await runRawQuery(`TRUNCATE TABLE ${schema}.index_relation;`)
+        await runRawQuery(
+          `TRUNCATE ${schema}.index_data, ${schema}.index_relation;`
+        )
       }
-
-      await runRawQuery(`SET session_replication_role = 'origin';`)
     } catch (error) {
       logger.error("Error during database teardown:", error)
       throw error

--- a/packages/medusa-test-utils/src/database.ts
+++ b/packages/medusa-test-utils/src/database.ts
@@ -251,7 +251,9 @@ export const dbTestUtilFactory = (): any => ({
 
         tablesToTruncate.push(`${schema}."${table_name}"`)
       }
-      await runRawQuery(`TRUNCATE ${tablesToTruncate.join(", ")};`)
+      if (tablesToTruncate.length > 0) {
+        await runRawQuery(`TRUNCATE ${tablesToTruncate.join(", ")};`)
+      }
 
       if (hasIndexTables) {
         await runRawQuery(


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Using TRUNCATE instead of DELETE in tests db teardown

**Why** — Why are these changes relevant or necessary?  

We are getting intermittent test failures during the DB teardown due to foreign key constraints. This is currently being prevented by doing `SET session_replication_role = 'replica';` which effectively disables constraint checks, but the DELETE calls are being done on the `pg_connection_`, which is a pool, and hence doesn't always return the same session. I've verified this by logging `SHOW session_replication_role;` before each DELETE and seeing it change midway through the DELETE loop from `replica` to `origin`.

**How** — How have these changes been implemented?

I've switched to doing a single TRUNCATE call on all tables at once, which also manages to bypass foreign key constraints. A downside here is that if tables are being accessed by another session, the TRUNCATE will error out with a deadlock warning. I suppose this is not an issue cause this runs after tests are done, but good to be aware of. An alternative would probably be to use the same currently used approach, but running the `SET replication` and the DELETEs in a transaction.

Using TRUNCATE also seemed to cut down tests duration by 15%, but that's based on just a couple runs.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

I reproduced the issue in our repo by running the flaky test 100 times in a loop, and it consistently failed around 15 times. Re-running with these changes fixes the issue.

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---
