### PR TITLE
fix(dashboard): preserve old image ids when deleting a product image

### DIFF
--- a/.changeset/eight-zoos-add.md
+++ b/.changeset/eight-zoos-add.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): preserve old image ids when deleting a product image

--- a/packages/admin/dashboard/src/routes/products/product-detail/components/product-media-section/product-media-section.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-detail/components/product-media-section/product-media-section.tsx
@@ -68,7 +68,7 @@ export const ProductMediaSection = ({ product }: ProductMedisaSectionProps) => {
 
     const mediaToKeep = product.images
       .filter((i) => !ids.includes(i.id))
-      .map((i) => ({ url: i.url }))
+      .map((i) => ({ id: i.id, url: i.url }))
 
     await mutateAsync(
       {

--- a/packages/admin/dashboard/src/routes/products/product-media/components/product-media-gallery/product-media-gallery.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-media/components/product-media-gallery/product-media-gallery.tsx
@@ -90,7 +90,7 @@ export const ProductMediaGallery = ({ product }: ProductMediaGalleryProps) => {
     const mediaToKeep =
       product.images
         ?.filter((i) => i.id !== current.id)
-        .map((i) => ({ url: i.url })) || []
+        .map((i) => ({ id: i.id, url: i.url })) || []
 
     if (curr === media.length - 1) {
       setCurr((prev) => prev - 1)


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Pass preserved image ids so upsert doesn't replace them since ids are important for image <> variant relationship

**Why** — Why are these changes relevant or necessary?  

Images were deleted by calling upsert with preserved images. Since the id wasn't passed, images were recreated.

**How** — How have these changes been implemented?

Pass ids of preserved images on delete

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Manual testing

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

