### PR TITLE
fix: Update type Providers

### DIFF
--- a/.changeset/tame-turtles-look.md
+++ b/.changeset/tame-turtles-look.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": minor
+---
+
+Update Providers to enable mixed provider entries.

--- a/packages/core/types/src/caching/index.ts
+++ b/packages/core/types/src/caching/index.ts
@@ -1,6 +1,6 @@
 import { IModuleService, ModuleJoinerConfig } from "../modules-sdk"
 
-type Providers = string[] | { 
+type Providers = (string | { 
   /**
    * The ID of the provider to use, as set in `medusa-config.ts`.
    */
@@ -10,7 +10,7 @@ type Providers = string[] | {
    * in the provider is used, or the default TTL of the Caching Module if not configured in the provider.
    */ 
   ttl?: number
-}[]
+})[]
 
 /**
  * @since v2.11.0


### PR DESCRIPTION
## Summary

**What**
Update Providers type to accept both types simultaneously

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow `Providers` to accept mixed `string` and `{ id, ttl? }` entries, update `set` signature and examples, and add a minor changeset for `@medusajs/types`.
> 
> - **Types**:
>   - Update `Providers` in `packages/core/types/src/caching/index.ts` to `(string | { id: string; ttl?: number })[]`.
>   - `ICachingModuleService.set` `providers` now uses `Providers`.
> - **Docs/Examples**:
>   - Update examples in `index.ts` to demonstrate mixed provider entries for `set`.
> - **Changeset**:
>   - Add `.changeset/tame-turtles-look.md` with a minor bump for `@medusajs/types`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bc6def618a36f7890fd9a4555630f360b1ef3ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->