### PR TITLE
Inject config module in tests

### DIFF
--- a/.changeset/silly-hats-unite.md
+++ b/.changeset/silly-hats-unite.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/test-utils": patch
+---
+
+inject configModule in moduleIntegrationTestRunner

--- a/packages/medusa-test-utils/src/__fixtures__/test-module/index.ts
+++ b/packages/medusa-test-utils/src/__fixtures__/test-module/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import TestService from "./service"
+
+export const TEST_MODULE = "test"
+
+export default Module(TEST_MODULE, {
+  service: TestService,
+})

--- a/packages/medusa-test-utils/src/__fixtures__/test-module/service.ts
+++ b/packages/medusa-test-utils/src/__fixtures__/test-module/service.ts
@@ -1,0 +1,17 @@
+export default class TestService {
+  private dependencies: Record<string, any>
+  private options: any
+
+  constructor(dependencies: Record<string, any>, options: any) {
+    this.dependencies = dependencies
+    this.options = options
+  }
+
+  async getDependencies(): Promise<Record<string, any>> {
+    return this.dependencies
+  }
+
+  async getOptions(): Promise<any> {
+    return this.options
+  }
+}

--- a/packages/medusa-test-utils/src/__fixtures__/test-module/services/internal.ts
+++ b/packages/medusa-test-utils/src/__fixtures__/test-module/services/internal.ts
@@ -1,0 +1,11 @@
+export default class InternalService {
+  private dependencies: Record<string, any>
+
+  constructor(dependencies: Record<string, any>) {
+    this.dependencies = dependencies
+  }
+
+  async getDependencies(): Promise<Record<string, any>> {
+    return this.dependencies
+  }
+}

--- a/packages/medusa-test-utils/src/__tests__/module-test-runner.spec.ts
+++ b/packages/medusa-test-utils/src/__tests__/module-test-runner.spec.ts
@@ -1,0 +1,53 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import TestService from "../__fixtures__/test-module/service"
+import InternalService from "../__fixtures__/test-module/services/internal"
+import { moduleIntegrationTestRunner } from "../module-test-runner"
+
+moduleIntegrationTestRunner<TestService>({
+  moduleName: "test",
+  resolve: "./__fixtures__/test-module",
+  moduleOptions: {
+    option1: "value1",
+  },
+  testSuite: ({ service }) => {
+    describe("Module Test Runner", () => {
+      it("should inject all basic dependencies on the main service", async () => {
+        const dependencies = await service.getDependencies()
+        expect(dependencies[ContainerRegistrationKeys.LOGGER]).toBeDefined()
+        expect(
+          dependencies[ContainerRegistrationKeys.PG_CONNECTION]
+        ).toBeDefined()
+        expect(dependencies[Modules.EVENT_BUS]).toBeDefined()
+        expect(dependencies["baseRepository"]).toBeDefined()
+
+        const configModule =
+          dependencies[ContainerRegistrationKeys.CONFIG_MODULE]
+        expect(configModule).toBeDefined()
+        expect(configModule["test"]?.options?.option1).toBe("value1")
+      })
+
+      it("should inject internal services on the main service", async () => {
+        const dependencies = await service.getDependencies()
+        expect(dependencies["internalService"]).toBeInstanceOf(InternalService)
+      })
+
+      it("should inject basic dependencies on internal services", async () => {
+        const internalService = (await service.getDependencies())[
+          "internalService"
+        ] as InternalService
+        const dependencies = await internalService.getDependencies()
+        expect(dependencies[ContainerRegistrationKeys.LOGGER]).toBeDefined()
+        expect(
+          dependencies[ContainerRegistrationKeys.PG_CONNECTION]
+        ).toBeDefined()
+        expect(dependencies[Modules.EVENT_BUS]).toBeDefined()
+        expect(dependencies["baseRepository"]).toBeDefined()
+
+        const configModule =
+          dependencies[ContainerRegistrationKeys.CONFIG_MODULE]
+        expect(configModule).toBeDefined()
+        expect(configModule["test"]?.options?.option1).toBe("value1")
+      })
+    })
+  },
+})

--- a/packages/medusa-test-utils/src/__tests__/module-test-runner.spec.ts
+++ b/packages/medusa-test-utils/src/__tests__/module-test-runner.spec.ts
@@ -23,7 +23,7 @@ moduleIntegrationTestRunner<TestService>({
         const configModule =
           dependencies[ContainerRegistrationKeys.CONFIG_MODULE]
         expect(configModule).toBeDefined()
-        expect(configModule["test"]?.options?.option1).toBe("value1")
+        expect(configModule.modules["test"]?.options?.option1).toBe("value1")
       })
 
       it("should inject internal services on the main service", async () => {
@@ -46,7 +46,7 @@ moduleIntegrationTestRunner<TestService>({
         const configModule =
           dependencies[ContainerRegistrationKeys.CONFIG_MODULE]
         expect(configModule).toBeDefined()
-        expect(configModule["test"]?.options?.option1).toBe("value1")
+        expect(configModule.modules["test"]?.options?.option1).toBe("value1")
       })
     })
   },

--- a/packages/medusa-test-utils/src/module-test-runner.ts
+++ b/packages/medusa-test-utils/src/module-test-runner.ts
@@ -183,7 +183,9 @@ class ModuleTestRunner<TService = any> {
         [ContainerRegistrationKeys.PG_CONNECTION]: this.connection,
         [Modules.EVENT_BUS]: new MockEventBusService(),
         [ContainerRegistrationKeys.LOGGER]: console,
-        [ContainerRegistrationKeys.CONFIG_MODULE]: this.modulesConfig,
+        [ContainerRegistrationKeys.CONFIG_MODULE]: {
+          modules: this.modulesConfig,
+        },
         ...this.injectedDependencies,
       },
       modulesConfig: this.modulesConfig,

--- a/packages/medusa-test-utils/src/module-test-runner.ts
+++ b/packages/medusa-test-utils/src/module-test-runner.ts
@@ -1,3 +1,4 @@
+import { logger } from "@medusajs/framework/logger"
 import {
   ContainerRegistrationKeys,
   DmlEntity,
@@ -8,7 +9,6 @@ import {
   normalizeImportPathWithSource,
   toMikroOrmEntities,
 } from "@medusajs/framework/utils"
-import { logger } from "@medusajs/framework/logger"
 import * as fs from "fs"
 import { getDatabaseURL, getMikroOrmWrapper, TestDatabase } from "./database"
 import { initModules, InitModulesOptions } from "./init-modules"
@@ -183,6 +183,7 @@ class ModuleTestRunner<TService = any> {
         [ContainerRegistrationKeys.PG_CONNECTION]: this.connection,
         [Modules.EVENT_BUS]: new MockEventBusService(),
         [ContainerRegistrationKeys.LOGGER]: console,
+        [ContainerRegistrationKeys.CONFIG_MODULE]: this.modulesConfig,
         ...this.injectedDependencies,
       },
       modulesConfig: this.modulesConfig,


### PR DESCRIPTION
## Summary

Injecting configModule in `moduleIntegrationTestRunner`

**Why**
[These docs](https://docs.medusajs.com/learn/fundamentals/modules/multiple-services) instruct to use `configModule.modules[BLOG_MODULE].options` in internal services to access options, which works fine, but not with the `moduleIntegrationTestRunner`, where the injected `configModule` is `undefined`.

**How**
Just adding `configModule` to the `injectedDependencies`

**Testing**
Added a module integration test for it and other basic expected injections

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Inject CONFIG_MODULE into moduleIntegrationTestRunner and add integration tests with fixtures to verify dependency injection and options propagation.
> 
> - **Test Utils (`packages/medusa-test-utils`)**:
>   - Inject `ContainerRegistrationKeys.CONFIG_MODULE` into `moduleIntegrationTestRunner` via `injectedDependencies`, populated with `modulesConfig` to expose module options to services.
> - **Tests**:
>   - Add fixture module (`__fixtures__/test-module`) and internal service to validate dependency injection.
>   - Add integration tests (`__tests__/module-test-runner.spec.ts`) asserting injections on main and internal services, including `CONFIG_MODULE` and options propagation.
> - **Changeset**:
>   - Patch bump for `@medusajs/test-utils`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47e41951a1fa2294a21ee49f425cbf3c57526e82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->