### PR TITLE
Quote column names in indexes

### DIFF
--- a/.changeset/poor-bottles-sniff.md
+++ b/.changeset/poor-bottles-sniff.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+quote column names in created indexes

--- a/packages/core/utils/src/common/__tests__/create-psql-index-helper.spec.ts
+++ b/packages/core/utils/src/common/__tests__/create-psql-index-helper.spec.ts
@@ -37,7 +37,7 @@ describe("createPsqlIndexStatementHelper", function () {
     expect(indexStatement.expression).toEqual(
       `CREATE INDEX IF NOT EXISTS "${options.name}" ON "${
         options.tableName
-      }" (${options.columns.join(", ")})`
+      }" (${options.columns.map((column) => `"${column}"`).join(", ")})`
     )
   })
 
@@ -53,7 +53,9 @@ describe("createPsqlIndexStatementHelper", function () {
     expect(indexStatement.expression).toEqual(
       `CREATE INDEX IF NOT EXISTS "${options.name}" ON "${
         options.tableName
-      }" (${options.columns.join(", ")}) WHERE ${options.where}`
+      }" (${options.columns.map((column) => `"${column}"`).join(", ")}) WHERE ${
+        options.where
+      }`
     )
   })
 
@@ -70,7 +72,9 @@ describe("createPsqlIndexStatementHelper", function () {
     expect(indexStatement.toString()).toEqual(
       `CREATE INDEX IF NOT EXISTS "${options.name}" ON "${
         options.tableName
-      }" USING GIN (${options.columns.join(", ")}) WHERE ${options.where}`
+      }" USING GIN (${options.columns
+        .map((column) => `"${column}"`)
+        .join(", ")}) WHERE ${options.where}`
     )
   })
 
@@ -86,7 +90,9 @@ describe("createPsqlIndexStatementHelper", function () {
     expect(indexStatement.expression).toEqual(
       `CREATE UNIQUE INDEX IF NOT EXISTS "IDX_table_name_column_name_1_column_name_2_unique" ON "${
         options.tableName
-      }" (${options.columns.join(", ")}) WHERE ${options.where}`
+      }" (${options.columns.map((column) => `"${column}"`).join(", ")}) WHERE ${
+        options.where
+      }`
     )
   })
 

--- a/packages/core/utils/src/common/create-psql-index-helper.ts
+++ b/packages/core/utils/src/common/create-psql-index-helper.ts
@@ -60,7 +60,9 @@ export function createPsqlIndexStatementHelper({
     tableReference = `"${tableName}"`
   }
 
-  columns = Array.isArray(columns) ? columns.join(", ") : columns
+  columns = Array.isArray(columns)
+    ? columns.map((column) => `"${column}"`).join(", ")
+    : columns
   name = name || `IDX_${tableName}_${columnsName}${unique ? "_unique" : ""}`
 
   const typeStr = type ? ` USING ${type}` : ""

--- a/packages/core/utils/src/dml/__tests__/entity-builder.spec.ts
+++ b/packages/core/utils/src/dml/__tests__/entity-builder.spec.ts
@@ -2109,16 +2109,16 @@ describe("Entity builder", () => {
         {
           name: "IDX_user_id",
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_id" ON "user" (id) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_id" ON "user" ("id") WHERE deleted_at IS NULL',
         },
         {
           name: "IDX_user_email_unique",
           expression:
-            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_email_unique" ON "user" (email) WHERE deleted_at IS NULL',
+            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_email_unique" ON "user" ("email") WHERE deleted_at IS NULL',
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" (deleted_at) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" ("deleted_at") WHERE deleted_at IS NULL',
           name: "IDX_user_deleted_at",
         },
       ])
@@ -2229,16 +2229,16 @@ describe("Entity builder", () => {
         {
           name: "IDX_user_id",
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_id" ON "platform"."user" (id) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_id" ON "platform"."user" ("id") WHERE deleted_at IS NULL',
         },
         {
           name: "IDX_user_email_unique",
           expression:
-            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_email_unique" ON "platform"."user" (email) WHERE deleted_at IS NULL',
+            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_email_unique" ON "platform"."user" ("email") WHERE deleted_at IS NULL',
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "platform"."user" (deleted_at) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "platform"."user" ("deleted_at") WHERE deleted_at IS NULL',
           name: "IDX_user_deleted_at",
         },
       ])
@@ -2348,16 +2348,16 @@ describe("Entity builder", () => {
         {
           name: "IDX_user_id",
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_id" ON "user" (id) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_id" ON "user" ("id") WHERE deleted_at IS NULL',
         },
         {
           name: "IDX_user_myEmail_unique",
           expression:
-            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_myEmail_unique" ON "user" (myEmail) WHERE deleted_at IS NULL',
+            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_myEmail_unique" ON "user" ("myEmail") WHERE deleted_at IS NULL',
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" (deleted_at) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" ("deleted_at") WHERE deleted_at IS NULL',
           name: "IDX_user_deleted_at",
         },
       ])
@@ -3945,32 +3945,32 @@ describe("Entity builder", () => {
       expect(metaData.indexes).toEqual([
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_group_id" ON "user" (group_id) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_group_id" ON "user" ("group_id") WHERE deleted_at IS NULL',
           name: "IDX_user_group_id",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" (deleted_at) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" ("deleted_at") WHERE deleted_at IS NULL',
           name: "IDX_user_deleted_at",
         },
         {
           expression:
-            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_email_account_unique" ON "user" (email, account) WHERE deleted_at IS NULL',
+            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_email_account_unique" ON "user" ("email", "account") WHERE deleted_at IS NULL',
           name: "IDX_user_email_account_unique",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_email_account" ON "user" (email, account) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_email_account" ON "user" ("email", "account") WHERE deleted_at IS NULL',
           name: "IDX_user_email_account",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_organization_account" ON "user" (organization, account) WHERE email IS NOT NULL AND deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_organization_account" ON "user" ("organization", "account") WHERE email IS NOT NULL AND deleted_at IS NULL',
           name: "IDX_user_organization_account",
         },
         {
           expression:
-            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_unique-name" ON "user" (organization, account, group_id) WHERE deleted_at IS NULL',
+            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_unique-name" ON "user" ("organization", "account", "group_id") WHERE deleted_at IS NULL',
           name: "IDX_unique-name",
         },
       ])
@@ -4026,37 +4026,37 @@ describe("Entity builder", () => {
       expect(metaData.indexes).toEqual([
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_group_id" ON "user" (group_id) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_group_id" ON "user" ("group_id") WHERE deleted_at IS NULL',
           name: "IDX_user_group_id",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" (deleted_at) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" ("deleted_at") WHERE deleted_at IS NULL',
           name: "IDX_user_deleted_at",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_organization_account" ON "user" (organization, account) WHERE email IS NOT NULL AND deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_organization_account" ON "user" ("organization", "account") WHERE email IS NOT NULL AND deleted_at IS NULL',
           name: "IDX_user_organization_account",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX-email-account-special" ON "user" (organization, account) WHERE email IS NOT NULL AND account IS NULL AND deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX-email-account-special" ON "user" ("organization", "account") WHERE email IS NOT NULL AND account IS NULL AND deleted_at IS NULL',
           name: "IDX-email-account-special",
         },
         {
           expression:
-            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_unique-name" ON "user" (organization, account, group_id) WHERE deleted_at IS NULL',
+            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_unique-name" ON "user" ("organization", "account", "group_id") WHERE deleted_at IS NULL',
           name: "IDX_unique-name",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_organization_group_id" ON "user" (organization, group_id) WHERE is_owner IS FALSE AND deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_organization_group_id" ON "user" ("organization", "group_id") WHERE is_owner IS FALSE AND deleted_at IS NULL',
           name: "IDX_user_organization_group_id",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_account_group_id" ON "user" (account, group_id) WHERE is_owner IS TRUE AND deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_account_group_id" ON "user" ("account", "group_id") WHERE is_owner IS TRUE AND deleted_at IS NULL',
           name: "IDX_user_account_group_id",
         },
       ])
@@ -4122,12 +4122,12 @@ describe("Entity builder", () => {
       expect(metaData.indexes).toEqual([
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_group_id" ON "user" (group_id) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_group_id" ON "user" ("group_id") WHERE deleted_at IS NULL',
           name: "IDX_user_group_id",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" (deleted_at) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_user_deleted_at" ON "user" ("deleted_at") WHERE deleted_at IS NULL',
           name: "IDX_user_deleted_at",
         },
       ])
@@ -4138,12 +4138,12 @@ describe("Entity builder", () => {
       expect(settingMetadata.indexes).toEqual([
         {
           expression:
-            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_setting_user_id_unique" ON "setting" (user_id) WHERE deleted_at IS NULL',
+            'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_setting_user_id_unique" ON "setting" ("user_id") WHERE deleted_at IS NULL',
           name: "IDX_setting_user_id_unique",
         },
         {
           expression:
-            'CREATE INDEX IF NOT EXISTS "IDX_setting_deleted_at" ON "setting" (deleted_at) WHERE deleted_at IS NULL',
+            'CREATE INDEX IF NOT EXISTS "IDX_setting_deleted_at" ON "setting" ("deleted_at") WHERE deleted_at IS NULL',
           name: "IDX_setting_deleted_at",
         },
       ])


### PR DESCRIPTION
## Summary

**What**

Quote column names on index DDL

**Why**

Generated migration is invalid if index contains a column with a name which is a reserved word in Postgres

Just quoting the column names

**Testing**
Unit tests


## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---
