### PR TITLE
Include expected Sentry opentelemetry 1.x peer deps

### DIFF
--- a/www/apps/resources/app/integrations/guides/sentry/page.mdx
+++ b/www/apps/resources/app/integrations/guides/sentry/page.mdx
@@ -99,7 +99,7 @@ To set up instrumentation in Medusa, you need to install the dependencies necess
 So, run the following command to install the necessary Sentry dependencies:
 
 ```bash npm2yarn
-npm install @sentry/node @opentelemetry/api @opentelemetry/exporter-trace-otlp-grpc @sentry/opentelemetry-node
+npm install @sentry/node @opentelemetry/api @opentelemetry/exporter-trace-otlp-grpc @sentry/opentelemetry-node @opentelemetry/core@1.x @opentelemetry/sdk-trace-base@1.x @opentelemetry/semantic-conventions@1.x
 ```
 
 ### b. Configure Instrumentation


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Include expected opentelemetry 1.x dependencies by Sentry

*Please provide answer here*

**Why** — Why are these changes relevant or necessary?  

Warning message was shown otherwise and there was no clear indication as to what exact version of the necessary opentelemetry packages the Sentry dependency would use

**How** — How have these changes been implemented?

Added the necessary dependencies to the installation command of the guide

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Tested in local project the warnings went away and Sentry still worked as expected

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes SUP-2616

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Sentry integration guide to include required OpenTelemetry 1.x packages in the npm install command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d67cd5b61bcebecf9f0d87685a98b7f3419166d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->