### PR TITLE
fix(medusa): priced products region_id regression

### DIFF
--- a/.changeset/few-shoes-worry.md
+++ b/.changeset/few-shoes-worry.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+Fix regression preventing region_id to be resolved from store's default region when retrieving priced products

--- a/packages/medusa/src/api/utils/middlewares/products/normalize-data-for-context.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/normalize-data-for-context.ts
@@ -77,7 +77,7 @@ export function normalizeDataForContext(options: PricingContextOptions = {}) {
 
     // Finally, try to get it from the store defaults if not available
     if (!regionId) {
-      const stores = await refetchEntities({
+      const { data: stores } = await refetchEntities({
         entity: "store",
         scope: req.scope,
         fields: ["id", "default_region_id"],


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Small fix to allow the region_id to be resolved from the store's default region id when not provided through filterable fields

**Why** — Why are these changes relevant or necessary?  

In previous PR we introduced a regression caused by not destructuring the store query result

**How** — How have these changes been implemented?

Destructuring the query result accordingly when getting the store

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes SUP-2626
fixes #13941
