### PR TITLE
fix(core-flows): update SendNotificationsStepInput

### DIFF
--- a/.changeset/heavy-shirts-fold.md
+++ b/.changeset/heavy-shirts-fold.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): update SendNotificationsStepInput

--- a/packages/core/core-flows/src/notification/steps/send-notifications.ts
+++ b/packages/core/core-flows/src/notification/steps/send-notifications.ts
@@ -1,4 +1,4 @@
-import type { INotificationModuleService } from "@medusajs/framework/types"
+import type { Attachment, INotificationModuleService, NotificationContent } from "@medusajs/framework/types"
 import { Modules } from "@medusajs/framework/utils"
 import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
 
@@ -19,7 +19,11 @@ export type SendNotificationsStepInput = {
    * The ID of the template to use for the notification. This template ID may be defined
    * in a third-party service used to send the notification.
    */
-  template: string
+  template?: string | null
+  /**
+   * The content that gets passed over to the provider.
+   */
+  content?: NotificationContent | null
   /**
    * The data to use in the notification template. This data may be used to personalize
    * the notification, such as the user's name or the order number.
@@ -51,6 +55,10 @@ export type SendNotificationsStepInput = {
    * is sent multiple times, the key ensures that the notification is sent only once.
    */
   idempotency_key?: string | null
+  /**
+   * Optional attachments for the notification.
+   */
+  attachments?: Attachment[] | null
 }[]
 
 export const sendNotificationsStepId = "send-notifications"


### PR DESCRIPTION
## Summary

**What** 

Updated the SendNotificationsStepInput type with the missing fields from CreateNotificationDTO

**Why** 

2.11.2 made the "template" property optional, which causes type errors since the step still expects a non-null template.

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable
