### PR TITLE
fix(event-bus-redis): Improve logging

### DIFF
--- a/.changeset/olive-meals-nail.md
+++ b/.changeset/olive-meals-nail.md
@@ -1,5 +1,5 @@
 ---
-"@medusajs/event-bus-redis": minor
+"@medusajs/event-bus-redis": patch
 ---
 
 Improve event-bus-redis error logging

--- a/.changeset/olive-meals-nail.md
+++ b/.changeset/olive-meals-nail.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/event-bus-redis": minor
+---
+
+Improve event-bus-redis error logging

--- a/packages/modules/event-bus-redis/src/services/__tests__/event-bus.ts
+++ b/packages/modules/event-bus-redis/src/services/__tests__/event-bus.ts
@@ -404,7 +404,7 @@ describe("RedisEventBusService", () => {
           1,
           "An error occurred while processing eventName:"
         )
-        expect(loggerMock.warn).toHaveBeenNthCalledWith(2, new Error("fail1"))
+        expect(loggerMock.warn).toHaveBeenNthCalledWith(2, expect.stringContaining("fail1: Error: fail1"))
 
         expect(loggerMock.warn).toHaveBeenNthCalledWith(
           3,
@@ -418,6 +418,43 @@ describe("RedisEventBusService", () => {
         )
 
         expect(test.sort()).toEqual(["hi", "fail1", "hi2", "fail2"].sort())
+      })
+
+      it("should process event with failing subscribers and handle error messages correctly", async () => {
+        const test: string[] = []
+
+        eventBus.subscribe("eventName", () => {
+          test.push("fail1")
+          return Promise.reject(new Error("fail1"))
+        })
+
+        eventBus.subscribe("eventName", () => {
+          test.push("fail2")
+          return Promise.reject({ error: "fail2"})
+        })
+
+        await eventBus.worker_({
+          name: "eventName",
+          data: { data: { test: 1 } },
+          opts: { attempts: 1 },
+          update: (data) => data,
+        } as any)
+
+        expect(loggerMock.warn).toHaveBeenCalledTimes(5)
+        
+        expect(loggerMock.warn).toHaveBeenNthCalledWith(
+          1,
+          "An error occurred while processing eventName:"
+        )
+        expect(loggerMock.warn).toHaveBeenNthCalledWith(2, expect.stringContaining("fail1: Error: fail1"))
+
+        expect(loggerMock.warn).toHaveBeenNthCalledWith(
+          3,
+          "An error occurred while processing eventName:"
+        )
+        expect(loggerMock.warn).toHaveBeenNthCalledWith(4, '{"error":"fail2"}')
+
+        expect(test).toEqual(["fail1", "fail2"])
       })
 
       it("should retry processing when subcribers fail, if configured - final attempt", async () => {

--- a/packages/modules/event-bus-redis/src/services/__tests__/event-bus.ts
+++ b/packages/modules/event-bus-redis/src/services/__tests__/event-bus.ts
@@ -404,7 +404,7 @@ describe("RedisEventBusService", () => {
           1,
           "An error occurred while processing eventName:"
         )
-        expect(loggerMock.warn).toHaveBeenNthCalledWith(2, expect.stringContaining("fail1: Error: fail1"))
+        expect(loggerMock.warn).toHaveBeenNthCalledWith(2, expect.stringContaining("Error: fail1"))
 
         expect(loggerMock.warn).toHaveBeenNthCalledWith(
           3,
@@ -446,7 +446,7 @@ describe("RedisEventBusService", () => {
           1,
           "An error occurred while processing eventName:"
         )
-        expect(loggerMock.warn).toHaveBeenNthCalledWith(2, expect.stringContaining("fail1: Error: fail1"))
+        expect(loggerMock.warn).toHaveBeenNthCalledWith(2, expect.stringContaining("Error: fail1"))
 
         expect(loggerMock.warn).toHaveBeenNthCalledWith(
           3,

--- a/packages/modules/event-bus-redis/src/services/event-bus-redis.ts
+++ b/packages/modules/event-bus-redis/src/services/event-bus-redis.ts
@@ -12,6 +12,7 @@ import {
 import { BulkJobOptions, Queue, Worker } from "bullmq"
 import { Redis } from "ioredis"
 import { BullJob, EventBusRedisModuleOptions, Options } from "../types"
+import { formatError } from "../utils"
 
 type InjectedDependencies = {
   logger: Logger
@@ -345,8 +346,7 @@ export default class RedisEventBusService extends AbstractEventBusModuleService 
           })
         } catch (err) {
           this.logger_?.warn(`An error occurred while processing ${name}:`)
-          this.logger_?.warn(err)
-
+          this.logger_?.warn(formatError(err))
           return err
         }
       })

--- a/packages/modules/event-bus-redis/src/utils/format-error.ts
+++ b/packages/modules/event-bus-redis/src/utils/format-error.ts
@@ -1,0 +1,15 @@
+export function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return `${err.message}: ${err.stack}`
+  }
+  
+  if (typeof err === 'object' && err !== null) {
+    try {
+      return JSON.stringify(err)
+    } catch (e) {
+      return String(err)
+    }
+  }
+  
+  return String(err)
+}

--- a/packages/modules/event-bus-redis/src/utils/format-error.ts
+++ b/packages/modules/event-bus-redis/src/utils/format-error.ts
@@ -1,9 +1,11 @@
+import { isObject } from "@medusajs/framework/utils"
+
 export function formatError(err: unknown): string {
   if (err instanceof Error) {
     return err.stack || String(err)
   }
   
-  if (typeof err === 'object' && err !== null) {
+  if (isObject(err)) {
     try {
       return JSON.stringify(err)
     } catch (e) {

--- a/packages/modules/event-bus-redis/src/utils/format-error.ts
+++ b/packages/modules/event-bus-redis/src/utils/format-error.ts
@@ -1,6 +1,6 @@
 export function formatError(err: unknown): string {
   if (err instanceof Error) {
-    return `${err.message}: ${err.stack}`
+    return err.stack || String(err)
   }
   
   if (typeof err === 'object' && err !== null) {

--- a/packages/modules/event-bus-redis/src/utils/index.ts
+++ b/packages/modules/event-bus-redis/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./format-error"


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Improve `event-bus-redis` logging to handle different error instances.

**Why** — Why are these changes relevant or necessary?  

Subscriber errors weren't handling errors correctly resulting in:
```
warn:    [object Object]
```

**How** — How have these changes been implemented?

Added a util function `formatError` to improve error handling.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Unit tests were added to better handle these use cases.
---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

CLOSES CORE-1269

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `event-bus-redis` error logging by formatting various error types and updating tests accordingly.
> 
> - **Event Bus (Redis)**:
>   - **Logging**: Use `formatError` to log subscriber errors in `services/event-bus-redis.ts` instead of logging raw values.
>   - **Utils**: Add `utils/format-error.ts` and export via `utils/index.ts` to normalize `Error`, objects, and primitives (prefer stack/JSON).
>   - **Tests**: Update expectations in `services/__tests__/event-bus.ts` and add a case for non-`Error` objects to validate formatted warnings.
> - **Changeset**: Add patch changeset for `@medusajs/event-bus-redis`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a4511208bd7bcc1c605cba1797a6c8534d43eab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->