### PR TITLE
docs: fix command bar position outside modal in category images guide

### DIFF
--- a/www/apps/resources/app/how-to-tutorials/tutorials/category-images/page.mdx
+++ b/www/apps/resources/app/how-to-tutorials/tutorials/category-images/page.mdx
@@ -1385,54 +1385,51 @@ Finally, you'll render the modal. Replace the `// TODO render modal` comment wit
 
 ```tsx title="src/admin/components/category-media/category-media-modal.tsx"
 return (
-  <>
-    {/* TODO show command bar */}
+  <FocusModal open={open} onOpenChange={handleOpenChange}>
+    <FocusModal.Trigger asChild>
+      <Button size="small" variant="secondary">
+        Edit
+      </Button>
+    </FocusModal.Trigger>
 
-    <FocusModal open={open} onOpenChange={handleOpenChange}>
-      <FocusModal.Trigger asChild>
-        <Button size="small" variant="secondary">
-          Edit
-        </Button>
-      </FocusModal.Trigger>
+    <FocusModal.Content>
+      <FocusModal.Header>
+        <Heading>Edit Media</Heading>
+      </FocusModal.Header>
 
-      <FocusModal.Content>
-        <FocusModal.Header>
-          <Heading>Edit Media</Heading>
-        </FocusModal.Header>
-
-        <FocusModal.Body className="flex h-full overflow-hidden">
-          <div className="flex w-full h-full flex-col-reverse lg:grid lg:grid-cols-[1fr_560px]">
-            <CategoryImageGallery
-              existingImages={existingImages}
-              uploadedFiles={uploadedFiles}
-              currentThumbnailId={currentThumbnailId}
-            />
-            <CategoryImageUpload
-              fileInputRef={fileInputRef}
-              isUploading={uploadFilesMutation.isPending}
-              onFileSelect={handleUploadFile}
-            />
-          </div>
-        </FocusModal.Body>
-        <FocusModal.Footer>
-          <div className="flex items-center justify-end gap-x-2">
-            <FocusModal.Close asChild>
-              <Button size="small" variant="secondary">
-                Cancel
-              </Button>
-            </FocusModal.Close>
-            <Button
-              size="small"
-              onClick={handleSave}
-              isLoading={isSaving}
-            >
-              Save
+      <FocusModal.Body className="flex h-full overflow-hidden">
+        <div className="flex w-full h-full flex-col-reverse lg:grid lg:grid-cols-[1fr_560px]">
+          <CategoryImageGallery
+            existingImages={existingImages}
+            uploadedFiles={uploadedFiles}
+            currentThumbnailId={currentThumbnailId}
+          />
+          <CategoryImageUpload
+            fileInputRef={fileInputRef}
+            isUploading={uploadFilesMutation.isPending}
+            onFileSelect={handleUploadFile}
+          />
+        </div>
+        {/* TODO show command bar */}
+      </FocusModal.Body>
+      <FocusModal.Footer>
+        <div className="flex items-center justify-end gap-x-2">
+          <FocusModal.Close asChild>
+            <Button size="small" variant="secondary">
+              Cancel
             </Button>
-          </div>
-        </FocusModal.Footer>
-      </FocusModal.Content>
-    </FocusModal>
-  </>
+          </FocusModal.Close>
+          <Button
+            size="small"
+            onClick={handleSave}
+            isLoading={isSaving}
+          >
+            Save
+          </Button>
+        </div>
+      </FocusModal.Footer>
+    </FocusModal.Content>
+  </FocusModal>
 )
 ```
 

--- a/www/apps/resources/generated/edit-dates.mjs
+++ b/www/apps/resources/generated/edit-dates.mjs
@@ -6614,7 +6614,7 @@ export const generatedEditDates = {
   "app/data-model-repository-reference/methods/upsertWithReplace/page.mdx": "2025-10-28T16:02:30.479Z",
   "app/how-to-tutorials/tutorials/agentic-commerce/page.mdx": "2025-10-09T11:25:48.831Z",
   "app/storefront-development/production-optimizations/page.mdx": "2025-10-03T13:28:37.909Z",
-  "app/how-to-tutorials/tutorials/category-images/page.mdx": "2025-10-15T08:57:05.566Z",
+  "app/how-to-tutorials/tutorials/category-images/page.mdx": "2025-11-06T14:14:45.465Z",
   "app/infrastructure-modules/caching/page.mdx": "2025-10-13T11:46:36.452Z",
   "app/troubleshooting/subscribers/not-working/page.mdx": "2025-10-16T09:25:57.376Z",
   "references/js_sdk/admin/RefundReason/methods/js_sdk.admin.RefundReason.create/page.mdx": "2025-10-21T08:10:56.630Z",


### PR DESCRIPTION
Closes #13985

## Summary

**What** — What changes are introduced in this PR?

Fix the CommandBar position in the `category-media-modal.tsx` file that was causing the modal to close when the command bar is clicked.

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
