### PR TITLE
fix(dashboard): update orders page filters to match interface expected by old DataTable component

### DIFF
--- a/.changeset/loud-pianos-sniff.md
+++ b/.changeset/loud-pianos-sniff.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): update orders page filters to match interface expected by old DataTable component


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix admin panel orders page filters.

**Why** — Why are these changes relevant or necessary?  

You are unable to filter orders in their list page.

**How** — How have these changes been implemented?

Updated the filters interface to match the ones expected by the old DataTable component, since it was using the interface the new DataTable component expects. The former identifies the filter by `key` while the latter does it by `id`.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Verified at runtime that i was able to apply filters correctly in the orders list page

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #13595 
closes CORE-1191
