### PR TITLE
docs-utils: fix type error in react-docs-generator

### DIFF
--- a/www/utils/packages/react-docs-generator/src/commands/generate.ts
+++ b/www/utils/packages/react-docs-generator/src/commands/generate.ts
@@ -100,10 +100,6 @@ export default async function ({
           mkdirSync(filePath)
         }
 
-        if (spec.displayName === "Drawer.Content") {
-          console.log("here", spec)
-        }
-
         // write spec to output path
         writeFileSync(
           path.join(filePath, `${spec.displayName}.json`),

--- a/www/utils/packages/react-docs-generator/src/utils/get-typescript-ts-type.ts
+++ b/www/utils/packages/react-docs-generator/src/utils/get-typescript-ts-type.ts
@@ -16,6 +16,7 @@ export function getTypescriptTsType(
   if (
     !convertedType &&
     "links" in symbol &&
+    symbol.links &&
     "type" in (symbol.links as Record<string, unknown>)
   ) {
     const symbolTypeLink = (symbol.links as Record<string, unknown>)


### PR DESCRIPTION
Closes DX-2290

## Summary

**What** — What changes are introduced in this PR?

Fix a type error that occurs due to unsafe type check on symbols in the react-docs-generator tool.

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
