### PR TITLE
fix some typos

### DIFF
--- a/integration-tests/api/__tests__/admin/order-edit/order-edit.js.txt
+++ b/integration-tests/api/__tests__/admin/order-edit/order-edit.js.txt
@@ -2227,7 +2227,7 @@ describe("/admin/order-edits", () => {
       )
     })
 
-    it("update an exising order edit item change of type update on multiple line item update", async () => {
+    it("update an existing order edit item change of type update on multiple line item update", async () => {
       const api = useApi()
 
       const {
@@ -2402,7 +2402,7 @@ describe("/admin/order-edits", () => {
       )
     })
 
-    it("update an exising order edit item change of type update on multiple line item update with correct totals including discounts", async () => {
+    it("update an existing order edit item change of type update on multiple line item update with correct totals including discounts", async () => {
       const api = useApi()
 
       const region = await simpleRegionFactory(dbConnection, { tax_rate: 10 })

--- a/www/apps/resources/generated/generated-troubleshooting-sidebar.mjs
+++ b/www/apps/resources/generated/generated-troubleshooting-sidebar.mjs
@@ -145,7 +145,7 @@ const generatedgeneratedTroubleshootingSidebarSidebar = {
               "isPathHref": true,
               "type": "link",
               "path": "/troubleshooting/query/filter-linked",
-              "title": "Not Exising Property",
+              "title": "Not Existing Property",
               "children": []
             },
             {

--- a/www/apps/resources/sidebars/troubleshooting.mjs
+++ b/www/apps/resources/sidebars/troubleshooting.mjs
@@ -95,7 +95,7 @@ export const troubleshootingSidebar = [
           {
             type: "link",
             path: "/troubleshooting/query/filter-linked",
-            title: "Not Exising Property",
+            title: "Not Existing Property",
           },
           {
             type: "link",

--- a/www/utils/packages/docs-generator/src/classes/kinds/oas.ts
+++ b/www/utils/packages/docs-generator/src/classes/kinds/oas.ts
@@ -2478,7 +2478,7 @@ class OasKindGenerator extends FunctionKindGenerator {
     }
 
     if (oldSchemaObj?.deprecated !== newSchemaObj?.deprecated) {
-      // avoid many changes to exising OAS
+      // avoid many changes to existing OAS
       if (!newSchemaObj?.deprecated) {
         if (oldSchemaObj!.deprecated) {
           wasUpdated = true
@@ -2491,7 +2491,7 @@ class OasKindGenerator extends FunctionKindGenerator {
     }
 
     if (oldSchemaObj?.["x-featureFlag"] !== newSchemaObj?.["x-featureFlag"]) {
-      // avoid many changes to exising OAS
+      // avoid many changes to existing OAS
       if (!newSchemaObj?.["x-featureFlag"]) {
         if (oldSchemaObj!["x-featureFlag"]) {
           wasUpdated = true


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?
I have been reading docs and found the word **Exising** several times. Raised PR for the typo.

**Why** — Why are these changes relevant or necessary?  

Its just a typo (its unclear what Exising means at present)

**How** — How have these changes been implemented?
Replacing the word

**Testing** — How have these changes been tested, or how can the reviewer test the feature?
N/A

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces "Exising" with "Existing" in test titles, troubleshooting sidebar titles, and OAS generator comments.
> 
> - **Docs/Resources**:
>   - Update troubleshooting sidebar title from `Not Exising Property` to `Not Existing Property` in `www/apps/resources/.../troubleshooting.mjs` and generated file.
> - **Tests**:
>   - Fix test descriptions using "exising" to "existing" in `integration-tests/api/__tests__/admin/order-edit/order-edit.js.txt`.
> - **OAS Generator**:
>   - Correct comment typos from "exising" to "existing" in `www/utils/packages/docs-generator/src/classes/kinds/oas.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a5604e6f2691ec0008a120851a32d08126353ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->