### PR TITLE
feat(dashboard): include product material in product general section

### DIFF
--- a/.changeset/clean-webs-bet.md
+++ b/.changeset/clean-webs-bet.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+feat(dashboard): include product material in product general section

--- a/packages/admin/dashboard/src/routes/products/product-detail/components/product-general-section/product-general-section.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-detail/components/product-general-section/product-general-section.tsx
@@ -102,6 +102,7 @@ export const ProductGeneralSection = ({
       <SectionRow title={t("fields.description")} value={product.description} />
       <SectionRow title={t("fields.subtitle")} value={product.subtitle} />
       <SectionRow title={t("fields.handle")} value={`/${product.handle}`} />
+      <SectionRow title={t("fields.material")} value={`${product.material}`} />
       <SectionRow
         title={t("fields.discountable")}
         value={product.discountable ? t("fields.true") : t("fields.false")}

--- a/packages/admin/dashboard/src/routes/products/product-detail/components/product-general-section/product-general-section.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-detail/components/product-general-section/product-general-section.tsx
@@ -102,7 +102,7 @@ export const ProductGeneralSection = ({
       <SectionRow title={t("fields.description")} value={product.description} />
       <SectionRow title={t("fields.subtitle")} value={product.subtitle} />
       <SectionRow title={t("fields.handle")} value={`/${product.handle}`} />
-      <SectionRow title={t("fields.material")} value={`${product.material}`} />
+      <SectionRow title={t("fields.material")} value={product.material} />
       <SectionRow
         title={t("fields.discountable")}
         value={product.discountable ? t("fields.true") : t("fields.false")}


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Include `material` field in the product detail summary UI section, to match the structure of the same edit UI, which includes the field.

**Why** — Why are these changes relevant or necessary?  

Without this there is no UI to see the current value of the `material` field/

**How** — How have these changes been implemented?

Added a section row including the `material` field in the product detail summary section.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Verified the field shos up as expected in the admin dashboard.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #14019 
closes SUP-2686