### PR TITLE
fix(product, types): add missing types for variant images and thumbnails

### DIFF
--- a/.changeset/warm-groups-lay.md
+++ b/.changeset/warm-groups-lay.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/product": patch
+"@medusajs/types": patch
+---
+
+fix(product, types): add missing types for variant images and thumbnails

--- a/packages/core/types/src/http/product/admin/entitites.ts
+++ b/packages/core/types/src/http/product/admin/entitites.ts
@@ -59,11 +59,6 @@ export interface AdminProductVariant extends BaseProductVariant {
    * The variant's inventory items.
    */
   inventory_items?: AdminProductVariantInventoryItemLink[] | null
-
-  /**
-   * The variant's images.
-   */
-  images?: AdminProductImage[] | null
 }
 export interface AdminProductOption extends BaseProductOption {
   /**

--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -164,6 +164,10 @@ export interface BaseProductVariant {
    */
   thumbnail: string | null
   /**
+   * 
+   */
+  images: BaseProductVariantImage[] | null
+  /**
    * Whether the variant can be ordered even if it's out of stock.
    */
   allow_backorder: boolean | null
@@ -319,6 +323,21 @@ export interface BaseProductImage {
    * Key-value pairs of custom data.
    */
   metadata?: Record<string, unknown> | null
+}
+
+export interface BaseProductVariantImage {
+  /**
+   * The product variant image's ID.
+   */
+  id: string
+  /**
+   * The variant associated with the image.
+   */
+  variant?: BaseProductVariant | null
+  /**
+   * The image associated with the variant.
+   */
+  image?: BaseProductImage | null
 }
 
 export interface BaseProductOptionValue {

--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -164,9 +164,9 @@ export interface BaseProductVariant {
    */
   thumbnail: string | null
   /**
-   * 
+   * The variant's images.
    */
-  images: BaseProductVariantImage[] | null
+  images: BaseProductImage[] | null
   /**
    * Whether the variant can be ordered even if it's out of stock.
    */
@@ -323,21 +323,6 @@ export interface BaseProductImage {
    * Key-value pairs of custom data.
    */
   metadata?: Record<string, unknown> | null
-}
-
-export interface BaseProductVariantImage {
-  /**
-   * The product variant image's ID.
-   */
-  id: string
-  /**
-   * The variant associated with the image.
-   */
-  variant?: BaseProductVariant | null
-  /**
-   * The image associated with the variant.
-   */
-  image?: BaseProductImage | null
 }
 
 export interface BaseProductOptionValue {

--- a/packages/modules/product/src/schema/index.ts
+++ b/packages/modules/product/src/schema/index.ts
@@ -60,6 +60,7 @@ type ProductVariant {
   width: Float
   options: [ProductOptionValue!]!
   images: [ProductImage!]!
+  thumbnail: String
   metadata: JSON
   product: Product
   product_id: String


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

- Add missing `images` field of variants to the HTTP types
- Add missing `thumbnail` field to product variant schema, which leads to the thumbnail missing from auto generated types

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
