### PR TITLE
feat(medusa,types,file-local,file-s3): delete file automatically when possible upon image deletion

### DIFF
--- a/.changeset/tough-glasses-relate.md
+++ b/.changeset/tough-glasses-relate.md
@@ -1,0 +1,8 @@
+---
+"@medusajs/file-local": patch
+"@medusajs/file-s3": patch
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+feat(medusa,types,file-local,file-s3): delete file automatically when possible upon image deletion

--- a/packages/core/types/src/file/provider.ts
+++ b/packages/core/types/src/file/provider.ts
@@ -132,6 +132,14 @@ export interface IFileProvider {
   ): Promise<void>
 
   /**
+   * This method is used to delete a file by url from the storage.
+   * 
+   * @param {string} url - The url of the file to remove.
+   * @returns {Promise<void>} Resolves when the file is deleted successfully.
+   */
+  deleteByUrl?(url: string): Promise<void>
+
+  /**
    * This method is used to retrieve a download URL of the file. For some file services, such as S3, a presigned URL indicates a temporary URL to get access to a file.
    *
    * If your file service doesn’t perform or offer a similar functionality, you can just return the URL to download the file.

--- a/packages/medusa/src/subscribers/image-deleted.ts
+++ b/packages/medusa/src/subscribers/image-deleted.ts
@@ -6,8 +6,10 @@ export default async function imageDeletedHandler({ event, container }: Subscrib
     const query = container.resolve(ContainerRegistrationKeys.QUERY)
     const fileModuleService = container.resolve(Modules.FILE)
 
+    logger.info('[imageDeletedHandler] executing')
+
     const { data: [image] } = await query.graph({
-        entity: 'image',
+        entity: 'product_image',
         fields: ['url'],
         filters: {
             id: event.data.id

--- a/packages/medusa/src/subscribers/image-deleted.ts
+++ b/packages/medusa/src/subscribers/image-deleted.ts
@@ -1,0 +1,41 @@
+import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework";
+import { ContainerRegistrationKeys, Modules, ProductEvents } from "@medusajs/framework/utils";
+
+export default async function imageDeletedHandler({ event, container }: SubscriberArgs<{ id: string }>) {
+    const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const fileModuleService = container.resolve(Modules.FILE)
+
+    const { data: [image] } = await query.graph({
+        entity: 'image',
+        fields: ['url'],
+        filters: {
+            id: event.data.id
+        },
+    })
+
+    const url  = image?.url
+    if (!url) {
+        return
+    }
+
+    const fileProvider = fileModuleService.getProvider()
+    if (!fileProvider.deleteByUrl) {
+        logger.warn(`Unable to delete file ${url} 'deleteByUrl' method not implemented in current file provider`)
+        return
+    }
+
+    try {
+        await fileProvider.deleteByUrl(url)
+        logger.info(`File ${url} deleted automatically upon image deletion`)
+    } catch (error) {
+        logger.error(`Failed to delete file ${url} with currently installed file provider: ${JSON.stringify(error, Object.getOwnPropertyNames(error))}`)
+    }
+}
+
+export const config: SubscriberConfig = {
+    event: [ProductEvents.PRODUCT_IMAGE_DELETED],
+    context: {
+        subscriberId: 'image-deleted-handler'
+    }
+}

--- a/packages/modules/providers/file-local/src/services/local-file.ts
+++ b/packages/modules/providers/file-local/src/services/local-file.ts
@@ -105,6 +105,11 @@ export class LocalFileService extends AbstractFileProviderService {
     return
   }
 
+  async deleteByUrl(url: string): Promise<void> {
+    const fileKey = this.getFileKey(url)
+    return this.delete({ fileKey })
+  }
+
   async getDownloadStream(
     file: FileTypes.ProviderGetFileDTO
   ): Promise<Readable> {
@@ -175,6 +180,16 @@ export class LocalFileService extends AbstractFileProviderService {
     const baseUrl = new URL(this.backendUrl_)
     baseUrl.pathname = path.join(baseUrl.pathname, fileKey)
     return baseUrl.href
+  }
+
+  private getFileKey = (url: string) => {
+    const parsedUrl = new URL(url)
+    const basePath = new URL(this.backendUrl_).pathname
+    const fullPath = parsedUrl.pathname
+
+    const fileKeyPath = fullPath.startsWith(basePath) ? fullPath.slice(basePath.length) : fullPath
+    const fileKey = fileKeyPath.startsWith('/') ? fileKeyPath.slice(1) : fileKeyPath
+    return fileKey
   }
 
   private async ensureDirExists(baseDir: string, dirPath: string) {

--- a/packages/modules/providers/file-s3/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/file-s3/integration-tests/__tests__/services.spec.ts
@@ -39,11 +39,12 @@ describe.skip("S3 File Plugin", () => {
     it("uploads, reads, and then deletes a file successfully", async () => {
       const fileContent = await fs.readFile(fixtureImagePath)
       const fixtureAsBinary = fileContent.toString("binary")
+      const fixtureAsBase64 = fileContent.toString("base64")
 
       const resp = await s3Service.upload({
         filename: "catphoto.jpg",
         mimeType: "image/jpeg",
-        content: fixtureAsBinary,
+        content: fixtureAsBase64,
         access,
       })
 
@@ -84,7 +85,7 @@ describe.skip("S3 File Plugin", () => {
 
   it("gets a presigned upload URL and uploads a file successfully", async () => {
     const fileContent = await fs.readFile(fixtureImagePath)
-    const fixtureAsBinary = fileContent.toString("binary")
+    const fixtureAsBase64 = fileContent.toString("base64")
 
     const resp = await s3Service.getPresignedUploadUrl({
       filename: "catphoto.jpg",
@@ -118,14 +119,14 @@ describe.skip("S3 File Plugin", () => {
         .then((r) => r.data)
     )
 
-    expect(signedUrlFile.toString("binary")).toEqual(fixtureAsBinary)
+    expect(signedUrlFile.toString("base64")).toEqual(fixtureAsBase64)
 
     await s3Service.delete({ fileKey: resp.key })
   })
 
   it("gets a presigned upload URL for a nested filename structure and uploads a file successfully", async () => {
     const fileContent = await fs.readFile(fixtureImagePath)
-    const fixtureAsBinary = fileContent.toString("binary")
+    const fixtureAsBase64 = fileContent.toString("base64")
 
     const resp = await s3Service.getPresignedUploadUrl({
       filename: "testfolder/catphoto.jpg",
@@ -156,29 +157,29 @@ describe.skip("S3 File Plugin", () => {
         .then((r) => r.data)
     )
 
-    expect(signedUrlFile.toString("binary")).toEqual(fixtureAsBinary)
+    expect(signedUrlFile.toString("base64")).toEqual(fixtureAsBase64)
 
     await s3Service.delete({ fileKey: resp.key })
   })
 
   it("deletes multiple files in bulk", async () => {
     const fileContent = await fs.readFile(fixtureImagePath)
-    const fixtureAsBinary = fileContent.toString("binary")
+    const fixtureAsBase64 = fileContent.toString("base64")
 
     const cat = await s3Service.upload({
       filename: "catphoto.jpg",
       mimeType: "image/jpeg",
-      content: fixtureAsBinary,
+      content: fixtureAsBase64,
     })
     const cat1 = await s3Service.upload({
       filename: "catphoto-1.jpg",
       mimeType: "image/jpeg",
-      content: fixtureAsBinary,
+      content: fixtureAsBase64,
     })
     const cat2 = await s3Service.upload({
       filename: "catphoto-2.jpg",
       mimeType: "image/jpeg",
-      content: fixtureAsBinary,
+      content: fixtureAsBase64,
     })
 
     await s3Service.delete([
@@ -186,5 +187,42 @@ describe.skip("S3 File Plugin", () => {
       { fileKey: cat1.key },
       { fileKey: cat2.key },
     ])
+  })
+
+  it("deletes a file by URL", async () => {
+    const fileContent = await fs.readFile(fixtureImagePath)
+    const fixtureAsBase64 = fileContent.toString("base64")
+
+    const resp = await s3Service.upload({
+      filename: "delete-by-url-test.jpg",
+      mimeType: "image/jpeg",
+      content: fixtureAsBase64,
+      access: "private",
+    })
+
+    const signedUrl = await s3Service.getPresignedDownloadUrl({
+      fileKey: resp.key,
+    })
+
+    const fileBeforeDeletion = await axios
+      .get(signedUrl, { responseType: "arraybuffer" })
+      .then((r) => r.data)
+      .catch((e) => e)
+
+    expect(Buffer.from(fileBeforeDeletion).toString("base64")).toEqual(
+      fixtureAsBase64
+    )
+
+    await s3Service.deleteByUrl(resp.url)
+
+    const signedUrlAfterDeletion = await s3Service.getPresignedDownloadUrl({
+      fileKey: resp.key,
+    })
+
+    const { response } = await axios
+      .get(signedUrlAfterDeletion, { responseType: "arraybuffer" })
+      .catch((e) => e)
+
+    expect(response.status).toEqual(404)
   })
 })

--- a/packages/modules/providers/file-s3/src/services/s3-file.ts
+++ b/packages/modules/providers/file-s3/src/services/s3-file.ts
@@ -198,6 +198,11 @@ export class S3FileService extends AbstractFileProviderService {
     }
   }
 
+  async deleteByUrl(url: string) {
+    const fileKey = this.getFileKey(url)
+    return await this.delete({ fileKey })
+  }
+
   async getPresignedDownloadUrl(
     fileData: FileTypes.ProviderGetFileDTO
   ): Promise<string> {
@@ -287,5 +292,15 @@ export class S3FileService extends AbstractFileProviderService {
     )
 
     return Buffer.from(await response.Body!.transformToByteArray())
+  }
+
+  private getFileKey = (url: string) => {
+    const parsedUrl = new URL(url)
+    const basePath = new URL(this.config_.fileUrl).pathname
+    const fullPath = parsedUrl.pathname
+
+    const fileKeyPath = fullPath.startsWith(basePath) ? fullPath.slice(basePath.length) : fullPath
+    const fileKey = fileKeyPath.startsWith('/') ? fileKeyPath.slice(1) : fileKeyPath
+    return fileKey
   }
 }


### PR DESCRIPTION
## Summary

Adds `deleteByUrl` method to the `IFileProvider` interface to allow deleting a file by its url. This is necessary since there is currently no link between our `image` model and its corresponding file representation in the file provider. This includes the implementation of said method in the `S3FileService` and `LocalFileService`.

A core subscriber listening to the `ProductEvents.PRODUCT_IMAGE_DELETED` resolves the currently installed file provider (which could be different from the one the image file was created with, in case it was swapped between the moment it was created and its deletion) and tries to call the method if it is implemented, to delete the corresponding file based on the image url we store.

Messages that are logged are:

- warn message if the `deleteByUrl` method is not implemented in the currently installed file provider
- error message if the method execution throws. For cases where the image was created with a different provider, this would be expected
- info indicating the file was deleted successfully if no problem arises

For the problematic logs, the image url is included to make it obvious to what resource and provider this corresponds to, so any further action can be taken by the user to delete it.

*Please provide answer here*

File deletion isn't performed and "fails" silently from a user's perspective when an image is deleted.

*Please provide answer here*

Added a new `deleteByUrl` method to the file provider interface and we try to call it with a core subscriber when an image deletion event is fired.

*Please provide answer here*

Integration tests

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #8548 
closes CORE-708
