### PR TITLE
fix(dashboard): reference global vite bin from scripts

### DIFF
--- a/.changeset/funky-schools-hang.md
+++ b/.changeset/funky-schools-hang.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): reference global vite bin from scripts

--- a/packages/admin/dashboard/package.json
+++ b/packages/admin/dashboard/package.json
@@ -3,10 +3,10 @@
   "version": "2.11.3",
   "scripts": {
     "generate:static": "node ./scripts/generate-currencies.js && prettier --write ./src/lib/currencies.ts",
-    "dev": "vite",
+    "dev": "../../../node_modules/.bin/vite",
     "build": "yarn run -T tsup && node ./scripts/generate-types.js",
-    "build:preview": "vite build",
-    "preview": "vite preview",
+    "build:preview": "../../../node_modules/.bin/vite build",
+    "preview": "../../../node_modules/.bin/vite preview",
     "test": "../../../node_modules/.bin/vitest --run",
     "i18n:validate": "node ./scripts/i18n/validate-translation.js",
     "i18n:schema": "node ./scripts/i18n/generate-schema.js",


### PR DESCRIPTION
## Summary

**Why** — Why are these changes relevant or necessary?  

Vite isn't installed locally in the dashboard package anymore, so bin is not accessable.