### PR TITLE
fix(fulfillment) Variants changed from managed inventory to unmanaged are now fulfillable

### DIFF
--- a/.changeset/dull-donkeys-ring.md
+++ b/.changeset/dull-donkeys-ring.md
@@ -2,4 +2,4 @@
 "@medusajs/core-flows": patch
 ---
 
-(fix) Variants changed from managed inventory to unmanaged are now fulfillable
+fix(fulfillment) Variants changed from managed inventory to unmanaged are now fulfillable

--- a/.changeset/dull-donkeys-ring.md
+++ b/.changeset/dull-donkeys-ring.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+(fix) Variants changed from managed inventory to unmanaged are now fulfillable

--- a/packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts
+++ b/packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts
@@ -168,8 +168,8 @@ function prepareRegisterDeliveryData({
         const iitem = iitems.find(
           (i) => i.inventory.id === fitem.inventory_item_id
         )
-
-        quantity = MathBN.div(quantity, iitem!.required_quantity)
+        if(iitem)
+          quantity = MathBN.div(quantity, iitem.required_quantity)
       }
 
       return {


### PR DESCRIPTION


## Summary

**What** — What changes are introduced in this PR?

Null check on inventory items during fulfiment quantity calculation

**Why** — Why are these changes relevant or necessary?  

Currently, under certain conditions a variant can end up with the inventory items list having a length greater than 1, but containing undefined in the list, or the fulfilment not having an associated inventory item id.  This change fixes this case

---

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a guard to only adjust delivered quantity if a matching inventory item is found, preventing errors for unmanaged variants or missing inventory_item_id; includes changeset (patch).
> 
> - **Core Flows**
>   - **Order workflow** (`packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts`):
>     - When preparing delivery data, only divide `quantity` by `required_quantity` if a matching `inventory_item` is found (`iitem` null-check), avoiding crashes when variants lack an associated inventory item.
> - **Changeset**: Adds patch entry for `@medusajs/core-flows`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd011d8baad55057f4cde9cfa57e6c7827ab5879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->