### PR TITLE
fix(product): add missing decorators to updateProductOptionValues method

### DIFF
--- a/.changeset/cold-crews-clap.md
+++ b/.changeset/cold-crews-clap.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/product": patch
+---
+
+fix(product): add missing decorators to updateProductOptionValues method

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -1784,11 +1784,13 @@ export default class ProductModuleService
     sharedContext?: Context
   ): Promise<ProductTypes.ProductOptionValueDTO[]>
 
+  @InjectManager()
+  @EmitEvents()
   // @ts-expect-error
   async updateProductOptionValues(
     idOrSelector: string | FilterableProductOptionValueProps,
     data: ProductTypes.UpdateProductOptionValueDTO,
-    sharedContext: Context = {}
+    @MedusaContext() sharedContext: Context = {}
   ): Promise<
     ProductTypes.ProductOptionValueDTO | ProductTypes.ProductOptionValueDTO[]
   > {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Add missing inject manager and emit event decorators

**Why** — Why are these changes relevant or necessary?  

I was trying to use the `updateProductOptionValues` to update a product option value's `metadata`. However, after deep debugging, I discovered that the method is injecting the context in the second parameter rather than the third.

So, if I execute the method like this:

```
const result = await productModuleService.updateProductOptionValues("optval_123", { metadata: { test: true } })
```

Then added a `console.log` at the beginning of `updateProductOptionValues` for the parameters. It logged the following:

```
optval_123 {
  __type: 'MedusaContext',
  transactionId: 'create-options-in-strapi-as-step-auto-01KA0SZKESZ3FRJ24CE8YB0Y5B',
  eventGroupId: '01KA0SZKESZ3FRJ24CE8YB0Y5B',
  isCancelling: false,
  parentStepIdempotencyKey: 'create-product-in-strapi:auto-01KA0SZKESZ3FRJ24CE8YB0Y5B:create-options-in-strapi-as-step:invoke',
  preventReleaseEvents: true,
  cancelingFromParentStep: undefined,
  idempotencyKey: 'create-options-in-strapi:create-options-in-strapi-as-step-auto-01KA0SZKESZ3FRJ24CE8YB0Y5B:update-product-option-values-metadata:compensate',
  runId: '01KA0SZKF5ZEJS2RSKQY7FBAP7'
} {}
```

The second parameter is the injected context, and the third is just empty. The expectation is that the second parameter is the data to update, and the third is the context.

This prevents updating the product option value properly.

**How** — How have these changes been implemented?

Added the `InjectManager` and `EmitEvents` decorator, which fix the issue. This approach is based on other similar methods in the class, such as `updateProductOptions`

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Before using the changes in the PR, try the following:

```
const result = await productModuleService.updateProductOptionValues("optval_123", { metadata: { test: true } })

console.log(result)
```

You'll find that the result includes unexpected data related to the context. For example:

```
{
  id: 'optval_01KA0SZKC9E82RYW0E04Q9PREA',
  value: 'X',
  metadata: null,
  option_id: 'opt_01KA0SZKC98DH05X881NRWJ07R',
  option: { id: 'opt_01KA0SZKC98DH05X881NRWJ07R' },
  created_at: 2025-11-14T09:08:45.066Z,
  updated_at: 2025-11-14T09:08:45.066Z,
  deleted_at: null,
  __type: 'MedusaContext',
  transactionId: 'create-options-in-strapi-as-step-auto-01KA0SZKESZ3FRJ24CE8YB0Y5B',
  eventGroupId: '01KA0SZKESZ3FRJ24CE8YB0Y5B',
  isCancelling: false,
  parentStepIdempotencyKey: 'create-product-in-strapi:auto-01KA0SZKESZ3FRJ24CE8YB0Y5B:create-options-in-strapi-as-step:invoke',
  preventReleaseEvents: true,
  idempotencyKey: 'create-options-in-strapi:create-options-in-strapi-as-step-auto-01KA0SZKESZ3FRJ24CE8YB0Y5B:update-product-option-values-metadata:invoke',
  runId: '01KA0SZKF5ZEJS2RSKQY7FBAP7'
}
```

If you test the changes in this PR, the result will be as expected and the data will be updated.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
