### PR TITLE
fix(medusa): avoid throwing on error on set step failure endpoint

### DIFF
--- a/.changeset/humble-weeks-tease.md
+++ b/.changeset/humble-weeks-tease.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): avoid throwing on error on set step failure endpoint

--- a/packages/medusa/src/api/admin/workflows-executions/[workflow_id]/steps/failure/route.ts
+++ b/packages/medusa/src/api/admin/workflows-executions/[workflow_id]/steps/failure/route.ts
@@ -45,6 +45,8 @@ export const POST = async (
       context: {
         requestId: req.requestId,
       },
+      throwOnError: false,
+      logOnError: true,
     },
   })
 


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Avoid throwing on error when calling the set step failure endpoint, since it will naturally throw when marking the step as failed and would cause a 500 error be returned to the caller.

**Why** — Why are these changes relevant or necessary?  

Without this configuration, the caller would naturally (and incorrectly) believe the marking of the step as failed wasn't performed correctly, due to the 500 error returned.

**How** — How have these changes been implemented?

Added the configs `throwOnError` as false and `logOnError` as true when setting the step as failed.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
