### PR TITLE
feat(notification): expose providers

### DIFF
--- a/.changeset/dry-frogs-scream.md
+++ b/.changeset/dry-frogs-scream.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/notification": patch
+---
+
+feat(notification): expose providers

--- a/packages/modules/notification/integration-tests/__tests__/notification-module-service/index.spec.ts
+++ b/packages/modules/notification/integration-tests/__tests__/notification-module-service/index.spec.ts
@@ -52,7 +52,7 @@ moduleIntegrationTestRunner<INotificationModuleService>({
           service: NotificationModuleService,
         }).linkable
 
-        expect(Object.keys(linkable)).toEqual(["notification"])
+        expect(Object.keys(linkable)).toEqual(["notification", "notificationProvider"])
 
         Object.keys(linkable).forEach((key) => {
           delete linkable[key].toJSON
@@ -66,6 +66,15 @@ moduleIntegrationTestRunner<INotificationModuleService>({
               primaryKey: "id",
               serviceName: "notification",
               field: "notification",
+            },
+          },
+          notificationProvider: {
+            id: {
+              linkable: "notification_provider_id",
+              entity: "NotificationProvider",
+              primaryKey: "id",
+              serviceName: "notification",
+              field: "notificationProvider",
             },
           },
         })

--- a/packages/modules/notification/src/services/notification-module-service.ts
+++ b/packages/modules/notification/src/services/notification-module-service.ts
@@ -18,7 +18,7 @@ import {
   NotificationStatus,
   promiseAll,
 } from "@medusajs/framework/utils"
-import { Notification } from "@models"
+import { Notification, NotificationProvider } from "@models"
 import NotificationProviderService from "./notification-provider"
 
 type InjectedDependencies = {
@@ -33,7 +33,8 @@ type InjectedDependencies = {
 export default class NotificationModuleService
   extends MedusaService<{
     Notification: { dto: NotificationTypes.NotificationDTO }
-  }>({ Notification })
+    NotificationProvider: { dto: NotificationTypes.NotificationProviderDTO }
+  }>({ Notification, NotificationProvider })
   implements INotificationModuleService
 {
   protected baseRepository_: DAL.RepositoryService
@@ -231,5 +232,9 @@ export default class NotificationModuleService
     }
 
     return createdNotifications
+  }
+
+  async getProviderForChannels(channels: string[]) {
+    return this.notificationProviderService_.getProviderForChannels(channels)
   }
 }


### PR DESCRIPTION
## Summary

**What** 

Makes notification providers available to query.graph, also exposes the getProviderForChannel method for convenience

**Why** 

There isn't currently a way to retrieve notification providers, which is necessary to implement features or retrieve data that are provider specific. For example I'm building a plugin to have a friendly UI interface for wiring up notifications and to be able to retrieve/store generic templates you need the list of providers to choose from.

**How**

The NotificationProvider model was added to the notification's module MedusaService, which is exactly what the [fullfilment](https://github.com/medusajs/medusa/blob/76fd6d14387374336263a22e71f9d53bd9c45998/packages/modules/fulfillment/src/services/fulfillment-module-service.ts#L91) and [tax](https://github.com/medusajs/medusa/blob/76fd6d14387374336263a22e71f9d53bd9c45998/packages/modules/tax/src/services/tax-module-service.ts#L46) modules do to make providers queryable.

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

