### PR TITLE
fixes #14071 mongolian currency typo

### DIFF
--- a/packages/admin/dashboard/src/lib/data/currencies.ts
+++ b/packages/admin/dashboard/src/lib/data/currencies.ts
@@ -435,7 +435,7 @@ export const currencies: Record<string, CurrencyInfo> = {
   },
   MNT: {
     code: "MNT",
-    name: "Mongolian Tugrig",
+    name: "Mongolian Tugrik",
     symbol_native: "₮",
     decimal_digits: 0,
   },

--- a/packages/core/utils/src/defaults/currencies.ts
+++ b/packages/core/utils/src/defaults/currencies.ts
@@ -650,7 +650,7 @@ export const defaultCurrencies: Record<string, Currency> = {
   },
   MNT: {
     symbol: "MNT",
-    name: "Mongolian Tugrig",
+    name: "Mongolian Tugrik",
     symbol_native: "₮",
     decimal_digits: 0,
     rounding: 0,


### PR DESCRIPTION
## Summary

Fixes #14071 
changed the mongolian currency name typo 
changed from "tugrig" to "tugrik"


Changed in two files 
packages->core->utils->src->defaults->currencies.ts
packages->admin->dashboard->src->lib->data->currencies.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects Mongolian currency name from "Tugrig" to "Tugrik" in `packages/admin/dashboard` and `packages/core/utils` currency datasets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c70adb08c0763bc6e599422bd65ccfbb53de1ccb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->