### PR TITLE
chore(): Update glob package

### DIFF
--- a/.changeset/fresh-needles-wave.md
+++ b/.changeset/fresh-needles-wave.md
@@ -1,0 +1,8 @@
+---
+"@medusajs/framework": patch
+"@medusajs/cli": patch
+"medusa-dev-cli": patch
+"@medusajs/admin-bundler": patch
+---
+
+chore(): Update glob package

--- a/packages/admin/admin-bundler/package.json
+++ b/packages/admin/admin-bundler/package.json
@@ -29,7 +29,7 @@
     "compression": "^1.8.0",
     "express": "^4.21.0",
     "get-port": "^5.1.1",
-    "glob": "^10.4.5",
+    "glob": "11.1.0",
     "outdent": "^0.8.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",

--- a/packages/cli/medusa-cli/package.json
+++ b/packages/cli/medusa-cli/package.json
@@ -43,7 +43,7 @@
     "express": "^4.21.0",
     "fs-exists-cached": "^1.0.0",
     "fs-extra": "^11.1.1",
-    "glob": "^10.4.5",
+    "glob": "11.1.0",
     "hosted-git-info": "^4.0.2",
     "inquirer": "^8.0.0",
     "is-valid-path": "^0.1.1",

--- a/packages/cli/medusa-dev-cli/package.json
+++ b/packages/cli/medusa-dev-cli/package.json
@@ -17,7 +17,7 @@
     "execa": "^5.1.1",
     "find-yarn-workspace-root": "^2.0.0",
     "fs-extra": "^11.1.1",
-    "glob": "^10.4.5",
+    "glob": "11.1.0",
     "got": "^11.8.6",
     "lodash": "^4.17.21",
     "signal-exit": "^3.0.7",

--- a/packages/core/framework/package.json
+++ b/packages/core/framework/package.json
@@ -86,7 +86,7 @@
     "cors": "^2.8.5",
     "express": "^4.21.0",
     "express-session": "^1.17.3",
-    "glob": "^10.4.5",
+    "glob": "11.1.0",
     "jsonwebtoken": "^9.0.2",
     "lodash.memoize": "^4.1.2",
     "morgan": "^1.9.1",

--- a/www/utils/packages/docs-generator/package.json
+++ b/www/utils/packages/docs-generator/package.json
@@ -25,7 +25,7 @@
     "dotenv": "^16.3.1",
     "eslint": "8.56.0",
     "fdir": "^6.5.0",
-    "glob": "^11.0.2",
+    "glob": "11.1.0",
     "minimatch": "^9.0.3",
     "openai": "^4.29.1",
     "openapi-types": "^12.1.3",

--- a/www/utils/packages/react-docs-generator/package.json
+++ b/www/utils/packages/react-docs-generator/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^11.1.0",
-    "glob": "^10.3.10",
+    "glob": "11.1.0",
     "react-docgen": "^7.0.1",
     "resolve": "^1.22.8",
     "ts-node": "^10.9.1",

--- a/www/utils/packages/scripts/package.json
+++ b/www/utils/packages/scripts/package.json
@@ -22,7 +22,7 @@
     "@linear/sdk": "^52.0.0",
     "@octokit/core": "^4.0.5",
     "chalk": "^5.3.0",
-    "glob": "^10.3.10",
+    "glob": "11.1.0",
     "randomcolor": "^0.6.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.6.2",

--- a/www/utils/packages/typedoc-config/package.json
+++ b/www/utils/packages/typedoc-config/package.json
@@ -11,7 +11,7 @@
   "main": "_base.js",
   "version": "0.0.0",
   "dependencies": {
-    "glob": "^10.3.10"
+    "glob": "11.1.0"
   },
   "devDependencies": {
     "types": "*"

--- a/www/utils/packages/typedoc-plugin-custom/package.json
+++ b/www/utils/packages/typedoc-plugin-custom/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "eslint": "^9.13.0",
-    "glob": "^10.3.10",
+    "glob": "11.1.0",
     "minimatch": "^10.0.1",
     "utils": "*",
     "yaml": "^2.3.3"

--- a/www/utils/packages/typedoc-plugin-workflows/package.json
+++ b/www/utils/packages/typedoc-plugin-workflows/package.json
@@ -38,7 +38,7 @@
     "@medusajs/core-flows": "link:../../../../packages/core/core-flows",
     "@medusajs/workflows-sdk": "link:../../../../packages/core/workflows-sdk",
     "eslint": "^8.53.0",
-    "glob": "^10.3.10",
+    "glob": "11.1.0",
     "utils": "*",
     "yaml": "^2.3.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3134,7 +3134,7 @@ __metadata:
     compression: ^1.8.0
     express: ^4.21.0
     get-port: ^5.1.1
-    glob: ^10.4.5
+    glob: 11.1.0
     outdent: ^0.8.0
     postcss: ^8.4.38
     tailwindcss: ^3.4.3
@@ -3338,7 +3338,7 @@ __metadata:
     express: ^4.21.0
     fs-exists-cached: ^1.0.0
     fs-extra: ^11.1.1
-    glob: ^10.4.5
+    glob: 11.1.0
     hosted-git-info: ^4.0.2
     inquirer: ^8.0.0
     is-valid-path: ^0.1.1
@@ -3590,7 +3590,7 @@ __metadata:
     cors: ^2.8.5
     express: ^4.21.0
     express-session: ^1.17.3
-    glob: ^10.4.5
+    glob: 11.1.0
     jsonwebtoken: ^9.0.2
     lodash.memoize: ^4.1.2
     morgan: ^1.9.1
@@ -17583,7 +17583,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7, glob@npm:^10.4.5":
+"glob@npm:11.1.0":
+  version: 11.1.0
+  resolution: "glob@npm:11.1.0"
+  dependencies:
+    foreground-child: ^3.3.1
+    jackspeak: ^4.1.1
+    minimatch: ^10.1.1
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^2.0.0
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 1ceae07f23e316a6fa74581d9a74be6e8c2e590d2f7205034dd5c0435c53f5f7b712c2be00c3b65bf0a49294a1c6f4b98cd84c7637e29453b5aa13b79f1763a2
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:
@@ -20735,7 +20751,7 @@ __metadata:
     execa: ^5.1.1
     find-yarn-workspace-root: ^2.0.0
     fs-extra: ^11.1.1
-    glob: ^10.4.5
+    glob: 11.1.0
     got: ^11.8.6
     lodash: ^4.17.21
     signal-exit: ^3.0.7
@@ -20929,7 +20945,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.3":
+"minimatch@npm:^10.0.3, minimatch@npm:^10.1.1":
   version: 10.1.1
   resolution: "minimatch@npm:10.1.1"
   dependencies:


### PR DESCRIPTION
**What**
Update glob package to patched version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins `glob` to 11.1.0 across multiple packages and updates lockfile; adds changeset with patch bumps.
> 
> - **Dependencies**:
>   - Pin `glob` to `11.1.0` in:
>     - `packages/admin/admin-bundler/package.json`
>     - `packages/cli/medusa-cli/package.json`
>     - `packages/cli/medusa-dev-cli/package.json`
>     - `packages/core/framework/package.json`
>     - `www/utils/packages/docs-generator/package.json`
>     - `www/utils/packages/react-docs-generator/package.json`
>     - `www/utils/packages/scripts/package.json`
>     - `www/utils/packages/typedoc-config/package.json`
>     - `www/utils/packages/typedoc-plugin-custom/package.json`
>     - `www/utils/packages/typedoc-plugin-workflows/package.json`
>   - Update `yarn.lock` to reflect `glob@11.1.0` and related transitive deps.
> - **Changesets**:
>   - Add `.changeset/fresh-needles-wave.md` with patch releases for `@medusajs/framework`, `@medusajs/cli`, `medusa-dev-cli`, and `@medusajs/admin-bundler`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae212264cbcb2ade1a85389f7946d17d2f2650ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->