### PR TITLE
chore(event-bus-*): Do not emit if no subscribers:

### DIFF
--- a/.changeset/curly-apricots-double.md
+++ b/.changeset/curly-apricots-double.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/event-bus-local": patch
+"@medusajs/event-bus-redis": patch
+---
+
+chore(event-vus-*): Do not emit if no subscribers:

--- a/integration-tests/modules/__tests__/cart/store/cart.completion.ts
+++ b/integration-tests/modules/__tests__/cart/store/cart.completion.ts
@@ -1017,7 +1017,7 @@ medusaIntegrationTestRunner({
               eventGroupId
             ) ?? []
 
-          expect(grouppedEventBefore).toHaveLength(1)
+          expect(grouppedEventBefore).toHaveLength(17)
           expect(grouppedEventAfter).toHaveLength(0) // events have been compensated
 
           expect(errors[0].error.message).toBe(

--- a/packages/modules/event-bus-redis/src/services/__tests__/event-bus.ts
+++ b/packages/modules/event-bus-redis/src/services/__tests__/event-bus.ts
@@ -3,13 +3,6 @@ import { Queue, Worker } from "bullmq"
 import { Redis } from "ioredis"
 import RedisEventBusService from "../event-bus-redis"
 
-// const redisURL = "redis://localhost:6379"
-// const client = new Redis(6379, redisURL, {
-//   // Lazy connect to properly handle connection errors
-//   lazyConnect: true,
-//   maxRetriesPerRequest: 0,
-// })
-
 jest.mock("bullmq")
 jest.mock("ioredis")
 
@@ -96,6 +89,8 @@ describe("RedisEventBusService", () => {
       })
 
       it("should add job to queue with default options", async () => {
+        eventBus.subscribe("eventName", () => Promise.resolve())
+
         await eventBus.emit([
           {
             name: "eventName",
@@ -119,6 +114,8 @@ describe("RedisEventBusService", () => {
       })
 
       it("should add job to queue with custom options passed directly upon emitting", async () => {
+        eventBus.subscribe("eventName", () => Promise.resolve())
+
         await eventBus.emit([{ name: "eventName", data: { hi: "1234" } }], {
           attempts: 3,
           backoff: 5000,
@@ -157,6 +154,8 @@ describe("RedisEventBusService", () => {
 
         queue = (eventBus as any).queue_
         queue.addBulk = jest.fn()
+
+        eventBus.subscribe("eventName", () => Promise.resolve())
 
         await eventBus.emit(
           [
@@ -201,6 +200,8 @@ describe("RedisEventBusService", () => {
 
         queue = (eventBus as any).queue_
         queue.addBulk = jest.fn()
+
+        eventBus.subscribe("eventName", () => Promise.resolve())
 
         await eventBus.emit(
           {
@@ -268,12 +269,15 @@ describe("RedisEventBusService", () => {
           },
         ]
 
+        eventBus.subscribe("ungrouped-event-2", () => Promise.resolve())
+        eventBus.subscribe("grouped-event-1", () => Promise.resolve())
+        eventBus.subscribe("grouped-event-2", () => Promise.resolve())
+        eventBus.subscribe("grouped-event-3", () => Promise.resolve())
+
         redis.unlink = jest.fn()
 
         await eventBus.emit(events, options)
 
-        // Expect 1 event to have been send
-        // Expect 2 pushes to redis as there are 2 groups of events to push
         expect(queue.addBulk).toHaveBeenCalledTimes(1)
         expect(redis.rpush).toHaveBeenCalledTimes(2)
         expect(redis.unlink).not.toHaveBeenCalled()
@@ -331,6 +335,149 @@ describe("RedisEventBusService", () => {
         expect(redis.unlink).toHaveBeenCalledWith("staging:test-group-2")
       })
     })
+
+    describe("Events without subscribers", () => {
+      beforeEach(async () => {
+        jest.clearAllMocks()
+
+        eventBus = new RedisEventBusService(moduleDeps, simpleModuleOptions, {
+          scope: "internal",
+        })
+
+        queue = (eventBus as any).queue_
+        queue.addBulk = jest.fn()
+        redis = (eventBus as any).eventBusRedisConnection_
+        redis.rpush = jest.fn()
+      })
+
+      it("should not add events to queue when there are no subscribers", async () => {
+        await eventBus.emit([
+          {
+            name: "eventWithoutSubscribers",
+            data: { test: "data" },
+          },
+        ])
+
+        expect(queue.addBulk).not.toHaveBeenCalled()
+      })
+
+      it("should still call interceptors even when there are no subscribers", async () => {
+        const callInterceptorsSpy = jest.spyOn(
+          eventBus as any,
+          "callInterceptors"
+        )
+
+        await eventBus.emit([
+          {
+            name: "eventWithoutSubscribers",
+            data: { test: "data" },
+          },
+        ])
+
+        expect(callInterceptorsSpy).toHaveBeenCalledTimes(1)
+        expect(callInterceptorsSpy).toHaveBeenCalledWith(
+          {
+            name: "eventWithoutSubscribers",
+            data: { test: "data" },
+          },
+          { isGrouped: false }
+        )
+
+        expect(queue.addBulk).not.toHaveBeenCalled()
+
+        callInterceptorsSpy.mockRestore()
+      })
+
+      it("should add events to queue only for events with subscribers using wildcard", async () => {
+        eventBus.subscribe("*", () => Promise.resolve())
+
+        await eventBus.emit([
+          {
+            name: "anyEvent",
+            data: { test: "data" },
+          },
+        ])
+
+        expect(queue.addBulk).toHaveBeenCalledTimes(1)
+      })
+
+      it("should not add grouped events to queue when releasing if there are no subscribers", async () => {
+        const options = { delay: 1000 }
+        const event = {
+          name: "grouped-event-no-sub",
+          data: { hi: "1234" },
+          metadata: { eventGroupId: "test-group-no-sub" },
+        }
+
+        await eventBus.emit(event, options)
+
+        expect(redis.rpush).toHaveBeenCalledTimes(1)
+        expect(queue.addBulk).not.toHaveBeenCalled()
+
+        const [builtEvent] = (eventBus as any).buildEvents([event], options)
+
+        redis.lrange = jest.fn((key) => {
+          if (key === "staging:test-group-no-sub") {
+            return Promise.resolve([JSON.stringify(builtEvent)])
+          }
+          return Promise.resolve([])
+        })
+
+        redis.unlink = jest.fn()
+        queue.addBulk = jest.fn()
+
+        await eventBus.releaseGroupedEvents("test-group-no-sub")
+
+        expect(queue.addBulk).not.toHaveBeenCalled()
+
+        expect(redis.unlink).toHaveBeenCalledWith("staging:test-group-no-sub")
+      })
+
+      it("should still call interceptors for grouped events without subscribers", async () => {
+        const options = { delay: 1000 }
+        const event = {
+          name: "grouped-event-no-sub-2",
+          data: { hi: "1234" },
+          metadata: { eventGroupId: "test-group-no-sub-2" },
+        }
+
+        await eventBus.emit(event, options)
+
+        const [builtEvent] = (eventBus as any).buildEvents([event], options)
+
+        redis.lrange = jest.fn((key) => {
+          if (key === "staging:test-group-no-sub-2") {
+            return Promise.resolve([JSON.stringify(builtEvent)])
+          }
+          return Promise.resolve([])
+        })
+
+        redis.unlink = jest.fn()
+        queue.addBulk = jest.fn()
+
+        const callInterceptorsSpy = jest.spyOn(
+          eventBus as any,
+          "callInterceptors"
+        )
+
+        await eventBus.releaseGroupedEvents("test-group-no-sub-2")
+
+        expect(callInterceptorsSpy).toHaveBeenCalledTimes(1)
+        expect(callInterceptorsSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "grouped-event-no-sub-2",
+          }),
+          {
+            isGrouped: true,
+            eventGroupId: "test-group-no-sub-2",
+          }
+        )
+
+        expect(queue.addBulk).not.toHaveBeenCalled()
+
+        callInterceptorsSpy.mockRestore()
+      })
+    })
   })
 
   describe("worker_", () => {
@@ -352,7 +499,6 @@ describe("RedisEventBusService", () => {
           return Promise.resolve()
         })
 
-        // TODO: The typing for this is all over the place
         await eventBus.worker_({
           name: "eventName",
           data: { data: { test: 1 } },


### PR DESCRIPTION
RESOLVES CORE-1187
**What**
Do not emit or add to queue events that have no subscribers, this will prevent using unnecessary memory and resources from the providers. Currently, those events when consumed can slow down the queue drain velocity and instances resources to end up not calling any subscribers and mark the event as completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip emitting/queueing events without subscribers (but still run interceptors), add wildcard handling, and update grouped-event release logic and tests for local and redis event buses.
> 
> - **Event Bus (Local)**
>   - Only emit to `eventEmitter` when `listenerCount(event)` > 0; still emit to `*` if wildcard subscribers exist.
>   - Always invoke `callInterceptors` (even with zero subscribers); respect `internal` logging flag and log subscriber counts.
>   - On grouped release, emit per-event only if subscribers exist; still emit to `*` when present.
>   - Tests updated to cover no-subscriber cases, wildcard `*`, grouped release behavior, and async emission waits.
> - **Event Bus (Redis)**
>   - When emitting, enqueue only events that have subscribers (including wildcard `*`); still invoke interceptors.
>   - On grouped release, enqueue only events with subscribers; always invoke interceptors; cleanup unchanged.
>   - Tests updated for no-subscriber flows, wildcard `*`, grouped queue/release logic, and job option merges.
> - **Integration**
>   - Cart completion test assertion updated to expect `17` grouped events pre-compensation.
> - **Changeset**
>   - Patch bumps for `@medusajs/event-bus-local` and `@medusajs/event-bus-redis`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2fb73d359d2218e43efd974b8f37a7278ea54b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->