### PR TITLE
fix(orchestration): fetch fields from link entities

### DIFF
--- a/.changeset/wacky-feet-follow.md
+++ b/.changeset/wacky-feet-follow.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/orchestration": patch
+---
+
+fix(orchestration): fetch fields from link entity

--- a/packages/core/orchestration/src/joiner/remote-joiner.ts
+++ b/packages/core/orchestration/src/joiner/remote-joiner.ts
@@ -1385,6 +1385,7 @@ export class RemoteJoiner {
 
       const extraExtends = {
         fields: existingExpand?.fields,
+        args: existingExpand?.args,
         ...(midProp === fullAliasProp ? expand : {}),
         property: midProp,
         isAliasMapping: !existingExpand,

--- a/packages/core/orchestration/src/joiner/remote-joiner.ts
+++ b/packages/core/orchestration/src/joiner/remote-joiner.ts
@@ -1384,6 +1384,7 @@ export class RemoteJoiner {
       const existingExpand = expands.find((exp) => exp.property === midProp)
 
       const extraExtends = {
+        fields: existingExpand?.fields,
         ...(midProp === fullAliasProp ? expand : {}),
         property: midProp,
         isAliasMapping: !existingExpand,


### PR DESCRIPTION
**What**
Fix missing link fields when fetching link data as a relation and specifying specific fields


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates `fields` and `args` when expanding alias path segments in `RemoteJoiner` so link entity fields are included during fetch; adds changeset for patch release.
> 
> - **Orchestration**:
>   - `packages/core/orchestration/src/joiner/remote-joiner.ts`
>     - In `parseAlias`, when constructing intermediate alias path expands (`extraExtends`), now includes `fields` and `args` from any existing expand for that path, in addition to the terminal expand.
>     - Preserves argument forwarding by merging args when `forwardArgumentsOnPath` matches.
> - **Release**:
>   - Adds changeset: `.changeset/wacky-feet-follow.md` for `@medusajs/orchestration` patch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f51676c60b958d18d0bed19a6506e3241414123. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->