### PR TITLE
fix: adjust confirm draft order edit worfklow input types

### DIFF
--- a/packages/core/core-flows/src/draft-order/workflows/confirm-draft-order-edit.ts
+++ b/packages/core/core-flows/src/draft-order/workflows/confirm-draft-order-edit.ts
@@ -21,9 +21,9 @@ export interface ConfirmDraftOrderEditWorkflowInput {
    */
   order_id: string
   /**
-   * The ID of the user confirming the edit.
+   * The ID of the user confirming the changes.
    */
-  confirmed_by: string
+  confirmed_by?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

`confirmDraftOrderEditWorkflow` Workflow input types

**Why** — Why are these changes relevant or necessary?  

`confirmed_by` is marked as required, but is (correctly) [documented](https://docs.medusajs.com/resources/references/medusa-workflows/confirmOrderEditRequestWorkflow#input) as optional, as the step requiring this property also has it marked required and handles it appropriately. 

**How** — How have these changes been implemented?

Making the `confirmed_by` property optional in the workflow input type.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

I don't think there's a need for that.

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `confirmed_by` optional in `confirmDraftOrderEditWorkflow` input and update related doc wording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3af48767135666975b0eeeeb33041560bfdbdb26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->