### PR TITLE
add from to notification model

### DIFF
--- a/.changeset/yummy-squids-sniff.md
+++ b/.changeset/yummy-squids-sniff.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/notification": patch
+"@medusajs/core-flows": patch
+"@medusajs/types": patch
+---
+
+add from to notification model

--- a/packages/core/core-flows/src/notification/steps/send-notifications.ts
+++ b/packages/core/core-flows/src/notification/steps/send-notifications.ts
@@ -1,4 +1,8 @@
-import type { Attachment, INotificationModuleService, NotificationContent } from "@medusajs/framework/types"
+import type {
+  Attachment,
+  INotificationModuleService,
+  NotificationContent,
+} from "@medusajs/framework/types"
 import { Modules } from "@medusajs/framework/utils"
 import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
 
@@ -11,6 +15,11 @@ export type SendNotificationsStepInput = {
    * the channel. For example, the email address for the email channel.
    */
   to: string
+  /**
+   * The address to send the notification from, depending on
+   * the channel. For example, the email address for the email channel.
+   */
+  from?: string | null
   /**
    * The channel to send the notification through. For example, `email`.
    */

--- a/packages/core/types/src/notification/common.ts
+++ b/packages/core/types/src/notification/common.ts
@@ -148,6 +148,10 @@ export interface FilterableNotificationProps
    */
   to?: string | string[] | OperatorMap<string | string[]>
   /**
+   * Filter based on the recipient of the notification.
+   */
+  from?: string | string[] | OperatorMap<string | string[]>
+  /**
    * Filter based on the channel through which the notification is sent, such as 'email' or 'sms'
    */
   channel?: string | string[] | OperatorMap<string | string[]>

--- a/packages/core/types/src/notification/mutations.ts
+++ b/packages/core/types/src/notification/mutations.ts
@@ -12,6 +12,10 @@ export interface CreateNotificationDTO {
    */
   to: string
   /**
+   * The sender of the notification. It can be email, phone number, or username, depending on the channel.
+   */
+  from?: string | null
+  /**
    * The channel through which the notification is sent, such as `email` or `sms`.
    */
   channel: string

--- a/packages/modules/notification/integration-tests/__tests__/notification-module-service/index.spec.ts
+++ b/packages/modules/notification/integration-tests/__tests__/notification-module-service/index.spec.ts
@@ -1,4 +1,7 @@
-import { INotificationModuleService } from "@medusajs/framework/types"
+import {
+  CreateNotificationDTO,
+  INotificationModuleService,
+} from "@medusajs/framework/types"
 import {
   CommonEvents,
   composeMessage,
@@ -74,19 +77,27 @@ moduleIntegrationTestRunner<INotificationModuleService>({
       it("should send a notification and stores it in the database", async () => {
         const notification = {
           to: "admin@medusa.com",
+          from: "sender@verified.com",
           template: "some-template",
           channel: "email",
           data: {},
-        }
+        } as CreateNotificationDTO
 
         const result = await service.createNotifications(notification)
-        expect(result).toEqual(
-          expect.objectContaining({
-            provider_id: "test-provider",
-            external_id: "external_id",
-            status: NotificationStatus.SUCCESS,
-          })
-        )
+        const retrieved = await service.retrieveNotification(result.id)
+
+        const expected = {
+          to: "admin@medusa.com",
+          from: "sender@verified.com",
+          template: "some-template",
+          channel: "email",
+          data: {},
+          provider_id: "test-provider",
+          external_id: "external_id",
+          status: NotificationStatus.SUCCESS,
+        }
+        expect(result).toEqual(expect.objectContaining(expected))
+        expect(retrieved).toEqual(expect.objectContaining(expected))
       })
 
       it("should send a notification and don't store the content in the database", async () => {

--- a/packages/modules/notification/integration-tests/__tests__/notification-module-service/medusa-cloud-email.spec.ts
+++ b/packages/modules/notification/integration-tests/__tests__/notification-module-service/medusa-cloud-email.spec.ts
@@ -14,6 +14,7 @@ const successMedusaCloudEmailResponse = {
 
 const testNotification = {
   to: "customer@test.com",
+  from: "sender@verified.com",
   template: "some-template",
   channel: "email",
   data: {
@@ -50,6 +51,13 @@ moduleIntegrationTestRunner<INotificationModuleService>({
         const result = await service.createNotifications(testNotification)
         expect(result).toEqual(
           expect.objectContaining({
+            to: "customer@test.com",
+            from: "sender@verified.com",
+            template: "some-template",
+            channel: "email",
+            data: {
+              link: "https://test.com",
+            },
             provider_id: "cloud",
             external_id: "external_id_1",
             status: NotificationStatus.SUCCESS,
@@ -66,6 +74,7 @@ moduleIntegrationTestRunner<INotificationModuleService>({
         )
         expect(JSON.parse(request.body)).toEqual({
           to: "customer@test.com",
+          from: "sender@verified.com",
           template: "some-template",
           data: {
             link: "https://test.com",

--- a/packages/modules/notification/src/migrations/.snapshot-medusa-notification.json
+++ b/packages/modules/notification/src/migrations/.snapshot-medusa-notification.json
@@ -96,7 +96,7 @@
           "constraint": false,
           "primary": false,
           "unique": false,
-          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_notification_provider_deleted_at\" ON \"notification_provider\" (deleted_at) WHERE deleted_at IS NULL"
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_notification_provider_deleted_at\" ON \"notification_provider\" (\"deleted_at\") WHERE deleted_at IS NULL"
         },
         {
           "keyName": "notification_provider_pkey",
@@ -131,6 +131,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "mappedType": "text"
+        },
+        "from": {
+          "name": "from",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
           "mappedType": "text"
         },
         "channel": {
@@ -290,7 +299,7 @@
           "constraint": false,
           "primary": false,
           "unique": false,
-          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_notification_receiver_id\" ON \"notification\" (receiver_id) WHERE deleted_at IS NULL"
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_notification_receiver_id\" ON \"notification\" (\"receiver_id\") WHERE deleted_at IS NULL"
         },
         {
           "keyName": "IDX_notification_idempotency_key_unique",
@@ -299,7 +308,7 @@
           "constraint": false,
           "primary": false,
           "unique": false,
-          "expression": "CREATE UNIQUE INDEX IF NOT EXISTS \"IDX_notification_idempotency_key_unique\" ON \"notification\" (idempotency_key) WHERE deleted_at IS NULL"
+          "expression": "CREATE UNIQUE INDEX IF NOT EXISTS \"IDX_notification_idempotency_key_unique\" ON \"notification\" (\"idempotency_key\") WHERE deleted_at IS NULL"
         },
         {
           "keyName": "IDX_notification_provider_id",
@@ -308,7 +317,7 @@
           "constraint": false,
           "primary": false,
           "unique": false,
-          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_notification_provider_id\" ON \"notification\" (provider_id) WHERE deleted_at IS NULL"
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_notification_provider_id\" ON \"notification\" (\"provider_id\") WHERE deleted_at IS NULL"
         },
         {
           "keyName": "IDX_notification_deleted_at",
@@ -317,7 +326,7 @@
           "constraint": false,
           "primary": false,
           "unique": false,
-          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_notification_deleted_at\" ON \"notification\" (deleted_at) WHERE deleted_at IS NULL"
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_notification_deleted_at\" ON \"notification\" (\"deleted_at\") WHERE deleted_at IS NULL"
         },
         {
           "keyName": "notification_pkey",

--- a/packages/modules/notification/src/migrations/Migration20251121123942.ts
+++ b/packages/modules/notification/src/migrations/Migration20251121123942.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20251121123942 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "notification" add column if not exists "from" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "notification" drop column if exists "from";`);
+  }
+
+}

--- a/packages/modules/notification/src/models/notification.ts
+++ b/packages/modules/notification/src/models/notification.ts
@@ -6,6 +6,8 @@ export const Notification = model.define("notification", {
   id: model.id({ prefix: "noti" }).primaryKey(),
   // This can be an email, phone number, or username, depending on the channel.
   to: model.text().searchable(),
+  // This can be an email, phone number, or username, depending on the channel.
+  from: model.text().searchable().nullable(),
   channel: model.text(),
   // The template name in the provider's system.
   template: model.text().nullable(),


### PR DESCRIPTION
## Summary

**What** —
Add `from` to notification model. It's currently being passed down to the providers correctly at runtime, but it's not in `CreateNotificationDTO` or in the DB model either.

**Why** —
Typescript currently shows an error if you pass a `from` to createNotifications.

**How** —
Just adding the field to the model.

**Testing** —
There's an assertion now on the field being saved to the DB
## Examples

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `from` sender to notifications across types and workflow, persists it via migration, and updates tests/Medusa Cloud payloads.
> 
> - **Notification Model/DB**:
>   - Add nullable `from` field to `models/notification` and migration `Migration20251121123942` to store it in `notification` table.
>   - Update schema snapshot to include `from`.
> - **Types**:
>   - Extend `CreateNotificationDTO`, `NotificationDTO`, and `FilterableNotificationProps` with optional `from`.
> - **Workflows**:
>   - Include optional `from` in `SendNotificationsStepInput` in `core-flows/src/notification/steps/send-notifications.ts`.
> - **Providers/Integration Tests**:
>   - Update tests to assert `from` is saved and forwarded, including Medusa Cloud email request payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c48a1bdb7a1a93cfac98b997c96cb8a875f47a2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->