### PR TITLE
Add provider data to notifications

### DIFF
--- a/.changeset/stale-suits-lose.md
+++ b/.changeset/stale-suits-lose.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/notification": patch
+"@medusajs/core-flows": patch
+"@medusajs/types": patch
+---
+
+add provider_data to notification model

--- a/packages/core/core-flows/src/notification/steps/send-notifications.ts
+++ b/packages/core/core-flows/src/notification/steps/send-notifications.ts
@@ -39,6 +39,10 @@ export type SendNotificationsStepInput = {
    */
   data?: Record<string, unknown> | null
   /**
+   * Additional data specific to the provider or channel. For example, cc and bcc for emails.
+   */
+  provider_data?: Record<string, unknown> | null
+  /**
    * The type of trigger that caused the notification to be sent. For example, `order_created`.
    */
   trigger_type?: string | null

--- a/packages/core/types/src/notification/common.ts
+++ b/packages/core/types/src/notification/common.ts
@@ -64,6 +64,10 @@ export interface NotificationDTO {
    */
   data: Record<string, unknown> | null
   /**
+   * Additional data specific to the provider or channel. For example, cc and bcc for emails.
+   */
+  provider_data?: Record<string, unknown> | null
+  /**
    * The event name, the workflow, or anything else that can help to identify what triggered the notification.
    */
   trigger_type?: string | null

--- a/packages/core/types/src/notification/mutations.ts
+++ b/packages/core/types/src/notification/mutations.ts
@@ -28,6 +28,10 @@ export interface CreateNotificationDTO {
    */
   data?: Record<string, unknown> | null
   /**
+   * Additional data specific to the provider or channel. For example, cc and bcc for emails.
+   */
+  provider_data?: Record<string, unknown> | null
+  /**
    * The content that gets passed over to the provider.
    */
   content?: NotificationContent | null

--- a/packages/core/types/src/notification/provider.ts
+++ b/packages/core/types/src/notification/provider.ts
@@ -31,6 +31,10 @@ export type ProviderSendNotificationDTO = {
    */
   data?: Record<string, unknown> | null
   /**
+   * Additional data specific to the provider or channel. For example, cc and bcc for emails.
+   */
+  provider_data?: Record<string, unknown> | null
+  /**
    * The content that gets passed to the provider.
    */
   content?: NotificationContent | null

--- a/packages/modules/notification/integration-tests/__tests__/notification-module-service/index.spec.ts
+++ b/packages/modules/notification/integration-tests/__tests__/notification-module-service/index.spec.ts
@@ -80,7 +80,8 @@ moduleIntegrationTestRunner<INotificationModuleService>({
           from: "sender@verified.com",
           template: "some-template",
           channel: "email",
-          data: {},
+          data: { link: "http://test.com" },
+          provider_data: { cc: "cc@test.com" },
         } as CreateNotificationDTO
 
         const result = await service.createNotifications(notification)
@@ -91,7 +92,8 @@ moduleIntegrationTestRunner<INotificationModuleService>({
           from: "sender@verified.com",
           template: "some-template",
           channel: "email",
-          data: {},
+          data: { link: "http://test.com" },
+          provider_data: { cc: "cc@test.com" },
           provider_id: "test-provider",
           external_id: "external_id",
           status: NotificationStatus.SUCCESS,

--- a/packages/modules/notification/integration-tests/__tests__/notification-module-service/medusa-cloud-email.spec.ts
+++ b/packages/modules/notification/integration-tests/__tests__/notification-module-service/medusa-cloud-email.spec.ts
@@ -20,6 +20,9 @@ const testNotification = {
   data: {
     link: "https://test.com",
   },
+  provider_data: {
+    cc: "cc@test.com",
+  },
 }
 
 moduleIntegrationTestRunner<INotificationModuleService>({
@@ -58,6 +61,9 @@ moduleIntegrationTestRunner<INotificationModuleService>({
             data: {
               link: "https://test.com",
             },
+            provider_data: {
+              cc: "cc@test.com",
+            },
             provider_id: "cloud",
             external_id: "external_id_1",
             status: NotificationStatus.SUCCESS,
@@ -78,6 +84,9 @@ moduleIntegrationTestRunner<INotificationModuleService>({
           template: "some-template",
           data: {
             link: "https://test.com",
+          },
+          provider_data: {
+            cc: "cc@test.com",
           },
         })
       })

--- a/packages/modules/notification/src/migrations/.snapshot-medusa-notification.json
+++ b/packages/modules/notification/src/migrations/.snapshot-medusa-notification.json
@@ -169,6 +169,15 @@
           "nullable": true,
           "mappedType": "json"
         },
+        "provider_data": {
+          "name": "provider_data",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
         "trigger_type": {
           "name": "trigger_type",
           "type": "text",

--- a/packages/modules/notification/src/migrations/Migration20251121150408.ts
+++ b/packages/modules/notification/src/migrations/Migration20251121150408.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20251121150408 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "notification" add column if not exists "provider_data" jsonb null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "notification" drop column if exists "provider_data";`);
+  }
+
+}

--- a/packages/modules/notification/src/models/notification.ts
+++ b/packages/modules/notification/src/models/notification.ts
@@ -13,6 +13,8 @@ export const Notification = model.define("notification", {
   template: model.text().nullable(),
   // The data that gets passed over to the provider for rendering the notification.
   data: model.json().nullable(),
+  // Additional data specific to the channel or provider. For example, cc and bcc for emails.
+  provider_data: model.json().nullable(),
   // This can be the event name, the workflow, or anything else that can help to identify what triggered the notification.
   trigger_type: model.text().nullable(),
   // The ID of the resource this notification is for, if applicable. Useful for displaying relevant information in the UI

--- a/packages/modules/notification/src/providers/medusa-cloud-email.ts
+++ b/packages/modules/notification/src/providers/medusa-cloud-email.ts
@@ -39,6 +39,7 @@ export class MedusaCloudEmailNotificationProvider extends AbstractNotificationPr
           attachments: notification.attachments,
           template: notification.template,
           data: notification.data,
+          provider_data: notification.provider_data,
           content: notification.content,
         }),
       })


### PR DESCRIPTION
## Summary

**What** —
Add a providerData field to notifications

**Why** —
We need the ability to pass dynamic fields to specific providers. E.g. CC and BCC for emails

**How** —
Just adding the field to the model

**Testing** —
Added the field to existing tests

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `provider_data` to notifications (types, workflow input, DB model/migration) and forwards it in the Medusa Cloud Email provider, with tests updated accordingly.
> 
> - **Data/Schema**:
>   - Add `provider_data` (`jsonb`) to `notification` model and DB via migration `Migration20251121150408` and snapshot update.
> - **Types/DTOs**:
>   - Add optional `provider_data` to `CreateNotificationDTO`, `NotificationDTO`, and `ProviderSendNotificationDTO`.
> - **Workflows**:
>   - Extend `send-notifications` step input with `provider_data`.
> - **Providers**:
>   - Medusa Cloud Email: include `provider_data` in outgoing request payload.
> - **Tests**:
>   - Update integration tests to pass and assert `provider_data` propagation.
> - **Changeset**:
>   - Patch bumps for `@medusajs/notification`, `@medusajs/core-flows`, `@medusajs/types`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f114c75c974a145ef60213637d7c41bc605a0bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->