### PR TITLE
fix(core-flows): prevent completing cart from webhook when order already exists

### DIFF
--- a/.changeset/plain-windows-end.md
+++ b/.changeset/plain-windows-end.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): prevent completing cart from webhook when order already exists

--- a/packages/core/core-flows/src/payment/workflows/process-payment.ts
+++ b/packages/core/core-flows/src/payment/workflows/process-payment.ts
@@ -73,9 +73,22 @@ export const processPaymentWorkflow = createWorkflow(
     const cartId = transform(
       { cartPaymentCollection },
       ({ cartPaymentCollection }) => {
-        return cartPaymentCollection.data[0].cart_id
+        return cartPaymentCollection.data[0]?.cart_id
       }
     )
+
+    const { data: order } = useQueryGraphStep({
+        entity: "order_cart",
+        fields: ["id"],
+        filters: {
+          cart_id: cartId
+        },
+        options: {
+            isList: false
+        }
+      }).config({
+        name: "cart-order-query",
+      })
 
     when("lock-cart-when-available", { cartId }, ({ cartId }) => {
       return !!cartId
@@ -158,8 +171,8 @@ export const processPaymentWorkflow = createWorkflow(
       })
     })
 
-    when({ cartPaymentCollection }, ({ cartPaymentCollection }) => {
-      return !!cartPaymentCollection.data.length
+    when({ cartPaymentCollection, order }, ({ cartPaymentCollection, order }) => {
+      return !!cartPaymentCollection.data.length && !order
     }).then(() => {
       completeCartAfterPaymentStep({
         cart_id: cartPaymentCollection.data[0].cart_id,


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Avoid completing the cart via process payment webhook when an order for the cart already exist. This is useful in cases where payments are issued after the order is generated, for example, for payments corresponding to order edits. 

**Why** — Why are these changes relevant or necessary?  

In some cases, calling the `completeCartWorkflow` for this scenarios failed and triggered compensation incorrectly cancelling the complete order. 

**How** — How have these changes been implemented?

Query if there is any existing order linked to the cart and add a check that prevents calling the `completeCartAfterPaymentStep` inside `processPaymentWorkflow` if a order exists. This guarantees we complete the cart for the first payment and just handle subsequent payments for things like edits.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes ENTSUP-373
