### PR TITLE
docs: fix callback validation for third-party authentication

### DIFF
--- a/www/apps/api-reference/specs/admin/code_samples/TypeScript/auth_user_{auth_provider}_callback/post.ts
+++ b/www/apps/api-reference/specs/admin/code_samples/TypeScript/auth_user_{auth_provider}_callback/post.ts
@@ -1,4 +1,5 @@
 import Medusa from "@medusajs/js-sdk"
+import { decodeToken } from "react-jwt"
 
 export const sdk = new Medusa({
   baseUrl: import.meta.env.VITE_BACKEND_URL || "/",
@@ -8,24 +9,33 @@ export const sdk = new Medusa({
   },
 })
 
-const authToken = await sdk.auth.callback(
+const token = await sdk.auth.callback(
   "user",
-  "google",
+  "github",
   {
     code: "123",
     state: "456"
   }
 )
-
 // all subsequent requests will use the token in the header
-sdk.admin.invite.accept(
-  {
-    email: "user@gmail.com",
-    first_name: "John",
-    last_name: "Smith",
-    invite_token: "12345..."
-  },
-)
-.then(({ user }) => {
-  console.log(user)
-})
+
+const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+
+const shouldCreateUser = decodedToken.actor_id === ""
+
+if (shouldCreateUser) {
+  const user = await sdk.admin.invite.accept(
+    {
+      email: decodedToken.user_metadata.email as string,
+      first_name: "John",
+      last_name: "Smith",
+      invite_token: "12345..."
+    },
+  )
+
+  // refresh auth token
+  await sdk.auth.refresh()
+  // all subsequent requests will use the new token in the header
+} else {
+  // User already exists and is authenticated
+}

--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -64080,6 +64080,7 @@ paths:
           label: Google Provider
           source: |-
             import Medusa from "@medusajs/js-sdk"
+            import { decodeToken } from "react-jwt"
 
             export const sdk = new Medusa({
               baseUrl: import.meta.env.VITE_BACKEND_URL || "/",
@@ -64089,7 +64090,7 @@ paths:
               },
             })
 
-            await sdk.auth.callback(
+            const token = await sdk.auth.callback(
               "user",
               "google",
               {
@@ -64097,23 +64098,33 @@ paths:
                 state: "456"
               }
             )
-
             // all subsequent requests will use the token in the header
-            sdk.admin.invite.accept(
-              {
-                email: "user@gmail.com",
-                first_name: "John",
-                last_name: "Smith",
-                invite_token: "12345..."
-              },
-            )
-            .then(({ user }) => {
-              console.log(user)
-            })
+
+            const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+
+            const shouldCreateUser = decodedToken.actor_id === ""
+
+            if (shouldCreateUser) {
+              const user = await sdk.admin.invite.accept(
+                {
+                  email: decodedToken.user_metadata.email as string,
+                  first_name: "John",
+                  last_name: "Smith",
+                  invite_token: "12345..."
+                },
+              )
+
+              // refresh auth token
+              await sdk.auth.refresh()
+              // all subsequent requests will use the new token in the header
+            } else {
+              // User already exists and is authenticated
+            }
         - lang: TypeScript
           label: GitHub Provider
           source: |-
             import Medusa from "@medusajs/js-sdk"
+            import { decodeToken } from "react-jwt"
 
             export const sdk = new Medusa({
               baseUrl: import.meta.env.VITE_BACKEND_URL || "/",
@@ -64123,27 +64134,36 @@ paths:
               },
             })
 
-            const authToken = await sdk.auth.callback(
+            const token = await sdk.auth.callback(
               "user",
-              "google",
+              "github",
               {
                 code: "123",
                 state: "456"
               }
             )
-
             // all subsequent requests will use the token in the header
-            sdk.admin.invite.accept(
-              {
-                email: "user@gmail.com",
-                first_name: "John",
-                last_name: "Smith",
-                invite_token: "12345..."
-              },
-            )
-            .then(({ user }) => {
-              console.log(user)
-            })
+
+            const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+
+            const shouldCreateUser = decodedToken.actor_id === ""
+
+            if (shouldCreateUser) {
+              const user = await sdk.admin.invite.accept(
+                {
+                  email: decodedToken.user_metadata.email as string,
+                  first_name: "John",
+                  last_name: "Smith",
+                  invite_token: "12345..."
+                },
+              )
+
+              // refresh auth token
+              await sdk.auth.refresh()
+              // all subsequent requests will use the new token in the header
+            } else {
+              // User already exists and is authenticated
+            }
       tags:
         - Auth
       responses:

--- a/www/apps/api-reference/specs/store/code_samples/TypeScript/auth_customer_{auth_provider}_callback/post.ts
+++ b/www/apps/api-reference/specs/store/code_samples/TypeScript/auth_customer_{auth_provider}_callback/post.ts
@@ -13,7 +13,7 @@ export const sdk = new Medusa({
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 })
 
-await sdk.auth.callback(
+const token = await sdk.auth.callback(
   "customer",
   "github",
   {

--- a/www/apps/api-reference/specs/store/code_samples/TypeScript/auth_customer_{auth_provider}_callback/post.ts
+++ b/www/apps/api-reference/specs/store/code_samples/TypeScript/auth_customer_{auth_provider}_callback/post.ts
@@ -1,4 +1,5 @@
 import Medusa from "@medusajs/js-sdk"
+import { decodeToken } from "react-jwt"
 
 let MEDUSA_BACKEND_URL = "http://localhost:9000"
 
@@ -20,9 +21,20 @@ await sdk.auth.callback(
     state: "456"
   }
 )
-
 // all subsequent requests will use the token in the header
-const { customer } = await sdk.store.customer.create({
-  email: "customer@gmail.com",
-  password: "supersecret"
-})
+
+const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+
+const shouldCreateCustomer = decodedToken.actor_id === ""
+
+if (shouldCreateCustomer) {
+  const { customer } = await sdk.store.customer.create({
+    email: decodedToken.user_metadata.email as string,
+  })
+
+  // refresh auth token
+  await sdk.auth.refresh()
+  // all subsequent requests will use the new token in the header
+} else {
+  // Customer already exists and is authenticated
+}

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -347,7 +347,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
-            await sdk.auth.callback(
+            const token = await sdk.auth.callback(
               "customer",
               "github",
               {

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -290,6 +290,7 @@ paths:
           label: Google Provider
           source: |-
             import Medusa from "@medusajs/js-sdk"
+            import { decodeToken } from "react-jwt"
 
             let MEDUSA_BACKEND_URL = "http://localhost:9000"
 
@@ -303,7 +304,7 @@ paths:
               publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
             })
 
-            await sdk.auth.callback(
+            const token = await sdk.auth.callback(
               "customer",
               "google",
               {
@@ -311,16 +312,28 @@ paths:
                 state: "456"
               }
             )
-
             // all subsequent requests will use the token in the header
-            const { customer } = await sdk.store.customer.create({
-              email: "customer@gmail.com",
-              password: "supersecret"
-            })
+
+            const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+
+            const shouldCreateCustomer = decodedToken.actor_id === ""
+
+            if (shouldCreateCustomer) {
+              const { customer } = await sdk.store.customer.create({
+                email: decodedToken.user_metadata.email as string,
+              })
+
+              // refresh auth token
+              await sdk.auth.refresh()
+              // all subsequent requests will use the new token in the header
+            } else {
+              // Customer already exists and is authenticated
+            }
         - lang: TypeScript
           label: GitHub Provider
           source: |-
             import Medusa from "@medusajs/js-sdk"
+            import { decodeToken } from "react-jwt"
 
             let MEDUSA_BACKEND_URL = "http://localhost:9000"
 
@@ -342,12 +355,23 @@ paths:
                 state: "456"
               }
             )
-
             // all subsequent requests will use the token in the header
-            const { customer } = await sdk.store.customer.create({
-              email: "customer@gmail.com",
-              password: "supersecret"
-            })
+
+            const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+
+            const shouldCreateCustomer = decodedToken.actor_id === ""
+
+            if (shouldCreateCustomer) {
+              const { customer } = await sdk.store.customer.create({
+                email: decodedToken.user_metadata.email as string,
+              })
+
+              // refresh auth token
+              await sdk.auth.refresh()
+              // all subsequent requests will use the new token in the header
+            } else {
+              // Customer already exists and is authenticated
+            }
       tags:
         - Auth
       responses:

--- a/www/apps/resources/app/commerce-modules/auth/authentication-route/page.mdx
+++ b/www/apps/resources/app/commerce-modules/auth/authentication-route/page.mdx
@@ -256,6 +256,18 @@ In your frontend, decode the token using tools like [react-jwt](https://www.npmj
 - If the decoded data has an `actor_id` property, the user is already registered. So, use this token for subsequent authenticated requests.
 - If not, use the token in the header of a request that creates the user, such as the [Create Customer API route](!api!/store#customers_postcustomers).
 
+The decoded data may look like this:
+
+```json
+{
+  "actor_id": "", // Empty if the user is not registered
+  "user_metadata": {
+    "email": "Whitney_Schultz@gmail.com"
+  }
+  // other fields...
+}
+```
+
 ---
 
 ## Refresh Token Route

--- a/www/apps/resources/app/storefront-development/customers/third-party-login/page.mdx
+++ b/www/apps/resources/app/storefront-development/customers/third-party-login/page.mdx
@@ -355,15 +355,12 @@ Finally, you'll add to the page a function that validates the authentication cal
 
 Add in the place of the new `TODO` the `validateCallback` function that runs when the page first loads to validate the authentication:
 
-<CodeTabs group="authenticated-request">
-  <CodeTab label="React" value="react">
-  
 export const validateReactHighlights = [
   ["2", "sendCallback", "Validate the callback in Medusa and retrieve the authentication token"],
-  ["4", "shouldCreateCustomer", "Check if the decoded token has an `actor_id` property to decide whether a customer needs to be created"],
-  ["7", "createCustomer", "Create a customer if the decoded token doesn't have `actor_id`"],
-  ["9", "refreshToken", "Fetch a new token for the created customer"],
-  ["13", "retrieve", "Retrieve the customer's details as an example of testing authentication"]
+  ["6", "shouldCreateCustomer", "Check if the decoded token has an `actor_id` property to decide whether a customer needs to be created"],
+  ["9", "createCustomer", "Create a customer if the decoded token doesn't have `actor_id`"],
+  ["11", "refreshToken", "Fetch a new token for the created customer"],
+  ["15", "retrieve", "Retrieve the customer's details as an example of testing authentication"]
 ]
 
 ```tsx highlights={validateReactHighlights}
@@ -387,45 +384,8 @@ const validateCallback = async () => {
   setLoading(false)
 }
 
-
 // TODO run validateCallback when the page loads
 ```
-
-  </CodeTab>
-  <CodeTab label="JS SDK" value="js-sdk">
-  
-export const validateFetchHighlights = [
-  ["2", "sendCallback", "Validate the callback in Medusa and retrieve the authentication token"],
-  ["4", "shouldCreateCustomer", "Check if the decoded token has an `actor_id` property to decide whether a customer needs to be created"],
-  ["7", "createCustomer", "Create a customer if the decoded token doesn't have `actor_id`"],
-  ["9", "refreshToken", "Fetch a new token for the created customer"],
-  ["13", "retrieve", "Retrieve the customer's details as an example of testing authentication"]
-]
-
-```ts highlights={validateFetchHighlights}
-const validateCallback = async () => {
-  const token = await sendCallback()
-
-  const shouldCreateCustomer = (decodeToken(token) as { actor_id: string }).actor_id === ""
-
-  if (shouldCreateCustomer) {
-    await createCustomer()
-
-    await refreshToken()
-  }
-
-  // use token to send authenticated requests
-  const { customer: customerData } =  await sdk.store.customer.retrieve()
-
-  setCustomer(customerData)
-  setLoading(false)
-}
-
-// TODO run validateCallback when the page loads
-```
-
-  </CodeTab>
-</CodeTabs>
 
 The `validateCallback` function uses the functions added earlier to implement the following flow:
 
@@ -527,15 +487,17 @@ export default function GoogleCallback() {
   const validateCallback = async () => {
     const token = await sendCallback()
 
-    const shouldCreateCustomer = (decodeToken(token) as { actor_id: string }).actor_id === ""
+    const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+
+    const shouldCreateCustomer = decodedToken.actor_id === ""
 
     if (shouldCreateCustomer) {
-      await createCustomer()
+      await createCustomer(decodedToken.user_metadata.email as string)
 
       await refreshToken()
     }
 
-    // all subsequent requests are authenticated
+    // use token to send authenticated requests
     const { customer: customerData } =  await sdk.store.customer.retrieve()
 
     setCustomer(customerData)

--- a/www/apps/resources/generated/edit-dates.mjs
+++ b/www/apps/resources/generated/edit-dates.mjs
@@ -1,7 +1,7 @@
 export const generatedEditDates = {
   "app/commerce-modules/auth/auth-providers/emailpass/page.mdx": "2025-01-13T11:31:35.361Z",
   "app/commerce-modules/auth/auth-providers/page.mdx": "2025-05-20T07:51:40.707Z",
-  "app/commerce-modules/auth/authentication-route/page.mdx": "2025-03-04T09:13:45.919Z",
+  "app/commerce-modules/auth/authentication-route/page.mdx": "2025-11-24T07:39:10.358Z",
   "app/commerce-modules/auth/examples/page.mdx": "2024-10-15T15:02:13.794Z",
   "app/commerce-modules/auth/module-options/page.mdx": "2025-03-11T08:56:10.338Z",
   "app/commerce-modules/auth/page.mdx": "2025-04-17T08:48:17.286Z",
@@ -830,7 +830,7 @@ export const generatedEditDates = {
   "references/types/interfaces/types.BaseClaim/page.mdx": "2025-09-12T14:10:39.219Z",
   "app/commerce-modules/auth/auth-providers/github/page.mdx": "2025-01-13T11:31:35.361Z",
   "app/commerce-modules/auth/auth-providers/google/page.mdx": "2025-01-13T11:31:35.361Z",
-  "app/storefront-development/customers/third-party-login/page.mdx": "2025-09-17T11:42:53.434Z",
+  "app/storefront-development/customers/third-party-login/page.mdx": "2025-11-24T07:27:46.836Z",
   "references/types/HttpTypes/types/types.HttpTypes.AdminWorkflowRunResponse/page.mdx": "2024-12-09T13:21:34.761Z",
   "references/types/HttpTypes/types/types.HttpTypes.BatchResponse/page.mdx": "2025-04-11T09:04:46.523Z",
   "references/types/WorkflowsSdkTypes/types/types.WorkflowsSdkTypes.Acknowledgement/page.mdx": "2024-12-09T13:21:35.873Z",

--- a/www/utils/generated/oas-output/operations/admin/post_auth_[actor_type]_[auth_provider]_callback.ts
+++ b/www/utils/generated/oas-output/operations/admin/post_auth_[actor_type]_[auth_provider]_callback.ts
@@ -26,6 +26,7 @@
  *     label: Google Provider
  *     source: |-
  *       import Medusa from "@medusajs/js-sdk"
+ *       import { decodeToken } from "react-jwt"
  * 
  *       export const sdk = new Medusa({
  *         baseUrl: import.meta.env.VITE_BACKEND_URL || "/",
@@ -35,7 +36,7 @@
  *         },
  *       })
  * 
- *       await sdk.auth.callback(
+ *       const token = await sdk.auth.callback(
  *         "user",
  *         "google",
  *         {
@@ -43,23 +44,33 @@
  *           state: "456"
  *         }
  *       )
- *       
  *       // all subsequent requests will use the token in the header
- *       sdk.admin.invite.accept(
- *         {
- *           email: "user@gmail.com",
- *           first_name: "John",
- *           last_name: "Smith",
- *           invite_token: "12345..."
- *         },
- *       )
- *       .then(({ user }) => {
- *         console.log(user)
- *       })
+ * 
+ *       const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+ *       
+ *       const shouldCreateUser = decodedToken.actor_id === ""
+ *       
+ *       if (shouldCreateUser) {
+ *         const user = await sdk.admin.invite.accept(
+ *           {
+ *             email: decodedToken.user_metadata.email as string,
+ *             first_name: "John",
+ *             last_name: "Smith",
+ *             invite_token: "12345..."
+ *           },
+ *         )
+ * 
+ *         // refresh auth token
+ *         await sdk.auth.refresh()
+ *         // all subsequent requests will use the new token in the header
+ *       } else {
+ *         // User already exists and is authenticated
+ *       }
  *   - lang: TypeScript
  *     label: GitHub Provider
  *     source: |-
  *       import Medusa from "@medusajs/js-sdk"
+ *       import { decodeToken } from "react-jwt"
  * 
  *       export const sdk = new Medusa({
  *         baseUrl: import.meta.env.VITE_BACKEND_URL || "/",
@@ -69,27 +80,36 @@
  *         },
  *       })
  * 
- *       const authToken = await sdk.auth.callback(
+ *       const token = await sdk.auth.callback(
  *         "user",
- *         "google",
+ *         "github",
  *         {
  *           code: "123",
  *           state: "456"
  *         }
  *       )
- *       
  *       // all subsequent requests will use the token in the header
- *       sdk.admin.invite.accept(
- *         {
- *           email: "user@gmail.com",
- *           first_name: "John",
- *           last_name: "Smith",
- *           invite_token: "12345..."
- *         },
- *       )
- *       .then(({ user }) => {
- *         console.log(user)
- *       })
+ * 
+ *       const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+ *       
+ *       const shouldCreateUser = decodedToken.actor_id === ""
+ *       
+ *       if (shouldCreateUser) {
+ *         const user = await sdk.admin.invite.accept(
+ *           {
+ *             email: decodedToken.user_metadata.email as string,
+ *             first_name: "John",
+ *             last_name: "Smith",
+ *             invite_token: "12345..."
+ *           },
+ *         )
+ * 
+ *         // refresh auth token
+ *         await sdk.auth.refresh()
+ *         // all subsequent requests will use the new token in the header
+ *       } else {
+ *         // User already exists and is authenticated
+ *       }
  * tags:
  *   - Auth
  * responses:

--- a/www/utils/generated/oas-output/operations/store/post_auth_[actor_type]_[auth_provider]_callback.ts
+++ b/www/utils/generated/oas-output/operations/store/post_auth_[actor_type]_[auth_provider]_callback.ts
@@ -82,7 +82,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
- *       await sdk.auth.callback(
+ *       const token = await sdk.auth.callback(
  *         "customer",
  *         "github",
  *         {

--- a/www/utils/generated/oas-output/operations/store/post_auth_[actor_type]_[auth_provider]_callback.ts
+++ b/www/utils/generated/oas-output/operations/store/post_auth_[actor_type]_[auth_provider]_callback.ts
@@ -25,6 +25,7 @@
  *     label: Google Provider
  *     source: |-
  *       import Medusa from "@medusajs/js-sdk"
+ *       import { decodeToken } from "react-jwt"
  * 
  *       let MEDUSA_BACKEND_URL = "http://localhost:9000"
  * 
@@ -38,7 +39,7 @@
  *         publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
  *       })
  * 
- *       await sdk.auth.callback(
+ *       const token = await sdk.auth.callback(
  *         "customer",
  *         "google",
  *         {
@@ -46,16 +47,28 @@
  *           state: "456"
  *         }
  *       )
- * 
  *       // all subsequent requests will use the token in the header
- *       const { customer } = await sdk.store.customer.create({
- *         email: "customer@gmail.com",
- *         password: "supersecret"
- *       })
+ * 
+ *       const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+ *       
+ *       const shouldCreateCustomer = decodedToken.actor_id === ""
+ * 
+ *       if (shouldCreateCustomer) {
+ *         const { customer } = await sdk.store.customer.create({
+ *           email: decodedToken.user_metadata.email as string,
+ *         })
+ * 
+ *         // refresh auth token
+ *         await sdk.auth.refresh()
+ *         // all subsequent requests will use the new token in the header
+ *       } else {
+ *         // Customer already exists and is authenticated
+ *       }
  *   - lang: TypeScript
  *     label: GitHub Provider
  *     source: |-
  *       import Medusa from "@medusajs/js-sdk"
+ *       import { decodeToken } from "react-jwt"
  * 
  *       let MEDUSA_BACKEND_URL = "http://localhost:9000"
  * 
@@ -77,12 +90,23 @@
  *           state: "456"
  *         }
  *       )
- * 
  *       // all subsequent requests will use the token in the header
- *       const { customer } = await sdk.store.customer.create({
- *         email: "customer@gmail.com",
- *         password: "supersecret"
- *       })
+ * 
+ *       const decodedToken = decodeToken(token) as { actor_id: string, user_metadata: Record<string, unknown> }
+ *       
+ *       const shouldCreateCustomer = decodedToken.actor_id === ""
+ * 
+ *       if (shouldCreateCustomer) {
+ *         const { customer } = await sdk.store.customer.create({
+ *           email: decodedToken.user_metadata.email as string,
+ *         })
+ * 
+ *         // refresh auth token
+ *         await sdk.auth.refresh()
+ *         // all subsequent requests will use the new token in the header
+ *       } else {
+ *         // Customer already exists and is authenticated
+ *       }
  * tags:
  *   - Auth
  * responses:


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix third-party authentication snippets to use the email retrieved from the third-party provider when creating the user.

Closes DX-2191

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates admin/store callback examples and docs to decode JWT, conditionally create the user/customer using email from `user_metadata`, then refresh the token; mirrors changes in OpenAPI samples and storefront guide.
> 
> - **API Reference Code Samples**:
>   - Update `auth_*_{auth_provider}_callback` examples (JS/TS) for admin and store to:
>     - Capture callback `token`, `decodeToken`, check `actor_id === ""`.
>     - Create user/customer using `decodedToken.user_metadata.email`.
>     - Refresh auth via `sdk.auth.refresh()`.
>     - Adjust TS sample provider label to GitHub where applicable.
> - **OpenAPI Examples** (`openapi.full.yaml`, generated `oas-output`):
>   - Align embedded code samples with the new decode/create/refresh flow for admin and store callbacks.
> - **Docs**:
>   - Authentication route: add decoded token example and clarify when to create user and refresh token.
>   - Storefront third-party login guide: streamline callback validation section to decode token, create customer with decoded email, refresh token, and retrieve customer; update highlights and examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 262c39e79bcfecd0680e242e308ec75ddbbb2463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->