### PR TITLE
fix(core-flows): lock mark as delivered fulfillment/order flows

### DIFF
--- a/.changeset/new-owls-heal.md
+++ b/.changeset/new-owls-heal.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): lock mark as delivered fulfillment/order flows


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Add locking to `markFulfillmentAsDeliveredWorkflow` and `markOrderFulfillmentAsDeliveredWorkflow` flows to avoid race conditions.

**Why** — Why are these changes relevant or necessary?  

Without locking, race conditions could arise from multiple workers executing the workflows at the same time. If both execute at the same time before the other updates the fulfillment status to delivered, the check we put for undelivered workflows will be true for both and we'll duplicate the underlying order changes.

**How** — How have these changes been implemented?

Included locking by fulfillment id inside `markFulfillmentAsDeliveredWorkflow` when used as standalone.

Included locking by order id inside `markOrderFulfillmentAsDeliveredWorkflow` so that it guarantees `markFulfillmentAsDeliveredWorkflow` locks when called as a sub workflow.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?



---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes ENTSUP-399 
