### PR TITLE
fix(dashboard): Added the __BASE__ prefix to the datatable row on click - FIXES 14117

### DIFF
--- a/.changeset/yummy-mice-sell.md
+++ b/.changeset/yummy-mice-sell.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+Fix DataTable row click to always prepend __BASE__ (or "/") to row URLs when opening new tabs or windows.

--- a/packages/admin/dashboard/src/components/data-table/data-table.tsx
+++ b/packages/admin/dashboard/src/components/data-table/data-table.tsx
@@ -303,7 +303,8 @@ export const DataTable = <TData,>({
       }
 
       const href = rowHref(row)
-      const hrefWithBasePath = `${__BASE__ || "/"}${href}`
+      const basePath = __BASE__ || "/"
+      const hrefWithBasePath = `${basePath === "/" ? "" : basePath}${href}`
 
       if (event.metaKey || event.ctrlKey || event.button === 1) {
         window.open(hrefWithBasePath, "_blank", "noreferrer")

--- a/packages/admin/dashboard/src/components/data-table/data-table.tsx
+++ b/packages/admin/dashboard/src/components/data-table/data-table.tsx
@@ -303,14 +303,15 @@ export const DataTable = <TData,>({
       }
 
       const href = rowHref(row)
+      const hrefWithBasePath = `${__BASE__ || "/"}${href}`
 
       if (event.metaKey || event.ctrlKey || event.button === 1) {
-        window.open(href, "_blank", "noreferrer")
+        window.open(hrefWithBasePath, "_blank", "noreferrer")
         return
       }
 
       if (event.shiftKey) {
-        window.open(href, undefined, "noreferrer")
+        window.open(hrefWithBasePath, undefined, "noreferrer")
         return
       }
 


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Pushed a fix at the `DataTable` level to take into account the base path when using `window.open`


**Why** — Why are these changes relevant or necessary?  

Without the base path in the URL, it will navigate to a non existent page

**How** — How have these changes been implemented?

By adding the base path as a prefix to the URL when using meta keys while clicking on a row

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

- Enable `view_configurations` FF, which will lead to the usage of configurable table
- Try to open a order or a product by maintaining the meta key or shift

---

## Examples
- N/A

---

## Checklist

Please ensure the following before requesting a review:

- [X] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [X] I have verified the code works as intended locally
- [X] I have linked the related issue(s) if applicable

---

## Additional Context

Related to :
https://github.com/medusajs/medusa/issues/14117

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures DataTable row clicks open correct URLs by prefixing `__BASE__` (or `/`) when launching new tabs/windows.
> 
> - **Dashboard/UI**:
>   - Update `packages/admin/dashboard/src/components/data-table/data-table.tsx` to prefix row `href` with `__BASE__` (or `/`) for `window.open` on meta/ctrl/middle-click and shift-click.
> - **Release**:
>   - Add changeset marking `@medusajs/dashboard` as a patch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f937900b642294fba55d07e34b754493121a224b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->