### PR TITLE
chore(): Add new regression tests to the remote joiner

### DIFF
--- a/packages/core/orchestration/src/__fixtures__/joiner/data.ts
+++ b/packages/core/orchestration/src/__fixtures__/joiner/data.ts
@@ -186,4 +186,62 @@ export const remoteJoinerData = {
       user_id: 1,
     },
   ],
+  link: [
+    {
+      id: 1,
+      url: "https://example.com/post-1",
+      product_id: 101,
+      post_id: 501,
+      metadata: {
+        source: "blog",
+        category: "tech",
+      },
+    },
+    {
+      id: 2,
+      url: "https://example.com/post-2",
+      product_id: 102,
+      post_id: 502,
+      metadata: {
+        source: "news",
+        category: "general",
+      },
+    },
+    {
+      id: 3,
+      url: "https://example.com/post-3",
+      product_id: 103,
+      post_id: 503,
+      metadata: {
+        source: "forum",
+        category: "discussion",
+      },
+    },
+  ],
+  post: [
+    {
+      id: 501,
+      title: "First Post",
+      content: "Content of first post",
+      author: "John Doe",
+      published: true,
+      views: 1000,
+    },
+    {
+      id: 502,
+      title: "Second Post",
+      content: "Content of second post",
+      author: "Jane Smith",
+      published: true,
+      views: 2500,
+    },
+    {
+      id: 503,
+      title: "Third Post",
+      content: "Content of third post",
+      author: "Bob Johnson",
+      published: false,
+      views: 150,
+    },
+  ],
 }

--- a/packages/core/orchestration/src/__tests__/joiner/remote-joiner.ts
+++ b/packages/core/orchestration/src/__tests__/joiner/remote-joiner.ts
@@ -13,6 +13,9 @@ const container = {
       list: (...args) => {
         return serviceMock[serviceName].apply(this, args)
       },
+      getByProductId: (...args) => {
+        return serviceMock[serviceName].apply(this, args)
+      },
     }
   },
 } as MedusaContainer
@@ -609,5 +612,120 @@ describe("RemoteJoiner", () => {
       fields: ["name", "id"],
       options: { id: expect.arrayContaining([103, 102]) },
     })
+  })
+
+  it("should not lose fields when querying with specific nested fields and wildcard on deeply nested relations", async () => {
+    // Test scenario: product.name + links.metadata + links.post.*
+    // This ensures that when we have:
+    // - A specific field from the root entity (product.name)
+    // - A specific field from an intermediate relation (links.metadata)
+    // - A wildcard on a relation accessed through that intermediate (links.post.*)
+    // ...the intermediate field (links.metadata) is not lost
+    const query = {
+      alias: "product",
+      fields: ["id", "name"],
+      expands: [
+        {
+          property: "links",
+          fields: ["metadata"],
+        },
+        {
+          property: "posts",
+          fields: ["*"],
+        },
+      ],
+      args: [
+        {
+          name: "filters",
+          value: {
+            id: "101",
+          },
+        },
+      ],
+    }
+
+    const result = await joiner.query(query)
+
+    // Verify productService was called
+    expect(serviceMock.productService).toHaveBeenCalledTimes(1)
+    expect(serviceMock.productService).toHaveBeenCalledWith({
+      args: [
+        {
+          name: "filters",
+          value: {},
+        },
+      ],
+      fields: expect.arrayContaining(["name"]),
+      expands: undefined,
+      // {
+      //   posts: {
+      //     fields: ["*"],
+      //   },
+      // },
+      options: { id: ["101"] },
+    })
+
+    // Verify linkService was called with product_id filter
+    // Note: metadata is a field on link, not a relation, so it appears in fields array
+    expect(serviceMock.linkService).toHaveBeenCalledTimes(1)
+    expect(serviceMock.linkService).toHaveBeenCalledWith({
+      args: undefined,
+      expands: undefined,
+      fields: expect.arrayContaining(["metadata", "product_id"]),
+      options: { product_id: expect.arrayContaining([101, 102, 103]) },
+    })
+
+    // Verify postService was called for the post wildcard
+    // Note: wildcard "*" is passed as ["*", "id"], not undefined
+    expect(serviceMock.postService).toHaveBeenCalledTimes(1)
+    expect(serviceMock.postService).toHaveBeenCalledWith({
+      args: undefined,
+      expands: undefined,
+      fields: ["*", "id"], // "*" is in the fields array along with the primary key
+      options: { id: [501, 502, 503] }, // All posts are fetched
+    })
+
+    // Verify result structure - all fields should be present
+    // Result comes back in productService format with { rows: [...] }
+    expect(result.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 101,
+          name: "Product 1",
+          links: expect.objectContaining({
+            metadata: expect.objectContaining({
+              source: expect.any(String),
+              category: expect.any(String),
+            }),
+          }),
+          posts: expect.objectContaining({
+            id: 501,
+            title: expect.any(String),
+            content: expect.any(String),
+            author: expect.any(String),
+            published: expect.any(Boolean),
+            views: expect.any(Number),
+          }),
+        }),
+      ])
+    )
+
+    // Critical assertion: metadata must not be lost
+    const firstProduct = result.rows[0]
+    expect(firstProduct.links).toBeDefined()
+    expect(firstProduct.links).toHaveProperty("metadata")
+    expect(firstProduct.links.metadata).toEqual({
+      source: "blog",
+      category: "tech",
+    })
+
+    // posts.* should include all fields
+    expect(firstProduct).toHaveProperty("posts")
+    expect(firstProduct.posts).toHaveProperty("id")
+    expect(firstProduct.posts).toHaveProperty("title")
+    expect(firstProduct.posts).toHaveProperty("content")
+    expect(firstProduct.posts).toHaveProperty("author")
+    expect(firstProduct.posts).toHaveProperty("published")
+    expect(firstProduct.posts).toHaveProperty("views")
   })
 })

--- a/packages/core/orchestration/src/__tests__/joiner/remote-joiner.ts
+++ b/packages/core/orchestration/src/__tests__/joiner/remote-joiner.ts
@@ -615,7 +615,6 @@ describe("RemoteJoiner", () => {
   })
 
   it("should not lose fields when querying with specific nested fields and wildcard on deeply nested relations", async () => {
-    // Test scenario: product.name + links.metadata + links.post.*
     // This ensures that when we have:
     // - A specific field from the root entity (product.name)
     // - A specific field from an intermediate relation (links.metadata)
@@ -646,7 +645,6 @@ describe("RemoteJoiner", () => {
 
     const result = await joiner.query(query)
 
-    // Verify productService was called
     expect(serviceMock.productService).toHaveBeenCalledTimes(1)
     expect(serviceMock.productService).toHaveBeenCalledWith({
       args: [
@@ -657,16 +655,9 @@ describe("RemoteJoiner", () => {
       ],
       fields: expect.arrayContaining(["name"]),
       expands: undefined,
-      // {
-      //   posts: {
-      //     fields: ["*"],
-      //   },
-      // },
       options: { id: ["101"] },
     })
 
-    // Verify linkService was called with product_id filter
-    // Note: metadata is a field on link, not a relation, so it appears in fields array
     expect(serviceMock.linkService).toHaveBeenCalledTimes(1)
     expect(serviceMock.linkService).toHaveBeenCalledWith({
       args: undefined,
@@ -675,18 +666,14 @@ describe("RemoteJoiner", () => {
       options: { product_id: expect.arrayContaining([101, 102, 103]) },
     })
 
-    // Verify postService was called for the post wildcard
-    // Note: wildcard "*" is passed as ["*", "id"], not undefined
     expect(serviceMock.postService).toHaveBeenCalledTimes(1)
     expect(serviceMock.postService).toHaveBeenCalledWith({
       args: undefined,
       expands: undefined,
-      fields: ["*", "id"], // "*" is in the fields array along with the primary key
+      fields: ["*", "id"],
       options: { id: [501, 502, 503] }, // All posts are fetched
     })
 
-    // Verify result structure - all fields should be present
-    // Result comes back in productService format with { rows: [...] }
     expect(result.rows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/packages/core/orchestration/src/__tests__/joiner/remote-joiner.ts
+++ b/packages/core/orchestration/src/__tests__/joiner/remote-joiner.ts
@@ -633,29 +633,17 @@ describe("RemoteJoiner", () => {
           fields: ["*"],
         },
       ],
-      args: [
-        {
-          name: "filters",
-          value: {
-            id: "101",
-          },
-        },
-      ],
+      args: undefined,
     }
 
     const result = await joiner.query(query)
 
     expect(serviceMock.productService).toHaveBeenCalledTimes(1)
     expect(serviceMock.productService).toHaveBeenCalledWith({
-      args: [
-        {
-          name: "filters",
-          value: {},
-        },
-      ],
-      fields: expect.arrayContaining(["name"]),
+      args: undefined,
+      fields: expect.arrayContaining(["id", "name"]),
       expands: undefined,
-      options: { id: ["101"] },
+      options: { id: undefined },
     })
 
     expect(serviceMock.linkService).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
**What**
Add missing tests for pr https://github.com/medusajs/medusa/pull/14097

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds link/post datasets and joiner configs, extends mocks, and adds a test ensuring nested wildcard expansions retain intermediate fields.
> 
> - **Tests**:
>   - Add test validating that querying `product` with `links.metadata` and `posts.*` retains intermediate `links.metadata` fields.
> - **Fixtures/Mocks**:
>   - Add `link` and `post` datasets in `__fixtures__/joiner/data.ts`.
>   - Extend `serviceConfigs` to include `link` (as link module) and `post` services with relationships, inverse relations, and `extends` field aliases (`product.posts`, `post.product`).
>   - Update mocks: include `linkService` and `postService`, add filtering by `product_id`/`id`, and wire `getByProductId` for inverse calls.
>   - Broaden `serviceConfigs` type to `(JoinerServiceConfig | ModuleJoinerConfig)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1c7ca2a5f404d330d42107320d72a3fb30422d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->