### PR TITLE
chore: Update medusa exec worker mode

### DIFF
--- a/.changeset/cuddly-numbers-camp.md
+++ b/.changeset/cuddly-numbers-camp.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+chore: Update medusa exec worker mode

--- a/packages/medusa/src/commands/exec.ts
+++ b/packages/medusa/src/commands/exec.ts
@@ -41,7 +41,6 @@ export default async function exec({ file, args }: Options) {
       throw new Error(`File doesn't default export a function to execute.`)
     }
 
-    // set worker mode
     process.env.MEDUSA_WORKER_MODE = "server"
 
     const { container } = await loaders({

--- a/packages/medusa/src/commands/exec.ts
+++ b/packages/medusa/src/commands/exec.ts
@@ -1,5 +1,9 @@
 import { ExecArgs } from "@medusajs/framework/types"
-import { ContainerRegistrationKeys, dynamicImport, isFileSkipped, } from "@medusajs/framework/utils"
+import {
+  ContainerRegistrationKeys,
+  dynamicImport,
+  isFileSkipped,
+} from "@medusajs/framework/utils"
 import express from "express"
 import { existsSync } from "fs"
 import path from "path"
@@ -38,7 +42,7 @@ export default async function exec({ file, args }: Options) {
     }
 
     // set worker mode
-    process.env.MEDUSA_WORKER_MODE = "worker"
+    process.env.MEDUSA_WORKER_MODE = "server"
 
     const { container } = await loaders({
       directory,


### PR DESCRIPTION
RESOLVES CORE-1292
**What**

Currently, using `medusa exec` start the application in worker mode, which sometimes leads to unexpected behaviour in the sense that potential events get emitted and the worker might start to pull them but then get killed once the script is done, this can lead to partially handled event and do not allow for recovery of such