### PR TITLE
fix(order): Add composite unique index on order_item version:item_id

### DIFF
--- a/.changeset/upset-mangos-stare.md
+++ b/.changeset/upset-mangos-stare.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/order": minor
+---
+
+fix(order): Add composite unique index on order_item version:item_id

--- a/packages/modules/order/src/migrations/.snapshot-medusa-order.json
+++ b/packages/modules/order/src/migrations/.snapshot-medusa-order.json
@@ -2006,6 +2006,15 @@
           "expression": "CREATE INDEX IF NOT EXISTS \"IDX_order_item_deleted_at\" ON \"order_item\" (\"deleted_at\") WHERE deleted_at IS NOT NULL"
         },
         {
+          "keyName": "IDX_unique_order_item_version_item_id",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE UNIQUE INDEX IF NOT EXISTS \"IDX_unique_order_item_version_item_id\" ON \"order_item\" (\"version\", \"item_id\") WHERE deleted_at IS NULL"
+        },
+        {
           "keyName": "order_item_pkey",
           "columnNames": [
             "id"

--- a/packages/modules/order/src/migrations/Migration20251130184633.ts
+++ b/packages/modules/order/src/migrations/Migration20251130184633.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20251130184633 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_unique_order_item_version_item_id" ON "order_item" ("version", "item_id") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "IDX_unique_order_item_version_item_id";`);
+  }
+
+}

--- a/packages/modules/order/src/models/order-item.ts
+++ b/packages/modules/order/src/models/order-item.ts
@@ -51,6 +51,12 @@ const _OrderItem = model
       unique: false,
       where: "deleted_at IS NOT NULL",
     },
+    {
+      name: "IDX_unique_order_item_version_item_id",
+      on: ["version", "item_id"],
+      unique: true,
+      where: "deleted_at IS NULL",
+    },
   ])
 
 export const OrderItem = _OrderItem


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Adds a unique constraint to `order_item` table to prevent a given `order_line_item` from having duplicates for a given `version`.

**Why** — Why are these changes relevant or necessary?  

There is no constraint at the DB level to enforce this atm.

**How** — How have these changes been implemented?

Added a composite unique index for `order_item` table on `version:item_id` fields.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Run migrations successfully.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

We already prevented generating this situation when executing `markOrderFulfillmentAsDeliveredWorkflow` with [this PR](https://github.com/medusajs/medusa/pull/14111). The intention here is to now also enforce this at the DB level, relevant to custom workflows and any other workflow impacting the `order_item` table.

Closes CORE-1297
