### PR TITLE
fix(js-sdk,types,medusa): add HTTP types for update order change API route

### DIFF
--- a/.changeset/pink-sites-visit.md
+++ b/.changeset/pink-sites-visit.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/js-sdk": patch
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+fix(js-sdk,types,medusa): add HTTP types for update order change API route

--- a/packages/core/js-sdk/src/admin/order.ts
+++ b/packages/core/js-sdk/src/admin/order.ts
@@ -638,6 +638,8 @@ export class Order {
    * This method updates an order change. It sends a request to the
    * [Update Order Change](https://docs.medusajs.com/api/admin#order-changes_postorder-changesid)
    * API route.
+   * 
+   * @since v2.11.4
    *
    * @param id - The order change's ID.
    * @param body - The update details.
@@ -658,8 +660,8 @@ export class Order {
    */
   async updateOrderChange(
     id: string,
-    body: { carry_over_promotions: boolean },
-    query?: SelectParams,
+    body: HttpTypes.AdminUpdateOrderChange,
+    query?: HttpTypes.AdminOrderChangesFilters,
     headers?: ClientHeaders
   ) {
     return await this.client.fetch<HttpTypes.AdminOrderChangeResponse>(

--- a/packages/core/types/src/http/order/admin/payload.ts
+++ b/packages/core/types/src/http/order/admin/payload.ts
@@ -189,3 +189,10 @@ export interface AdminCreateOrderCreditLine {
    */
   metadata?: Record<string, unknown> | null
 }
+
+export interface AdminUpdateOrderChange {
+  /**
+   * Whether to carry over promotions to outbound exchange items.
+   */
+  carry_over_promotions?: boolean
+}

--- a/packages/medusa/src/api/admin/order-changes/[id]/route.ts
+++ b/packages/medusa/src/api/admin/order-changes/[id]/route.ts
@@ -4,11 +4,16 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { AdminPostOrderChangesReqSchemaType } from "../validators"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
+/**
+ * @since v2.11.4
+ */
 export const POST = async (
-  req: AuthenticatedMedusaRequest<AdminPostOrderChangesReqSchemaType>,
+  req: AuthenticatedMedusaRequest<
+    HttpTypes.AdminUpdateOrderChange,
+    HttpTypes.AdminOrderChangesFilters
+  >,
   res: MedusaResponse<HttpTypes.AdminOrderChangeResponse>
 ) => {
   const { id } = req.params


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

- Add HTTP type for update order API route payload + use it in the JS SDK and API route
- other: add `since` tag

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
