### PR TITLE
Fix not in promotion rule empty value validation

### DIFF
--- a/.changeset/thick-shrimps-peel.md
+++ b/.changeset/thick-shrimps-peel.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/promotion": patch
+---
+
+Fix not in promotion rule empty value validation

--- a/packages/modules/promotion/integration-tests/__tests__/services/promotion-module/evaluate-rule-value-condition.spec.ts
+++ b/packages/modules/promotion/integration-tests/__tests__/services/promotion-module/evaluate-rule-value-condition.spec.ts
@@ -35,6 +35,7 @@ moduleIntegrationTestRunner({
           expect(testFunc(["2"], operator, [2])).toEqual(false)
           expect(testFunc(["2"], operator, ["2"])).toEqual(false)
           expect(testFunc(["2"], operator, ["22"])).toEqual(true)
+          expect(testFunc(["2"], operator, [])).toEqual(true)
         })
       })
 

--- a/packages/modules/promotion/src/utils/validations/promotion-rule.ts
+++ b/packages/modules/promotion/src/utils/validations/promotion-rule.ts
@@ -118,7 +118,12 @@ export function evaluateRuleValueCondition(
     : [ruleValuesToCheck]
 
   if (!valuesToCheck.length) {
-    return false
+    switch (operator) {
+      case "ne":
+        return true
+      default:
+        return false
+    }
   }
 
   switch (operator) {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix for the not in operator on promotions. Also see issue: https://github.com/medusajs/medusa/issues/14168

**Why** — Why are these changes relevant or necessary?  

Otherwise the promotion rule will not apply properly.

**How** — How have these changes been implemented?

Extended the early return in the `evaluateRuleValueCondition`, when the operator `ne` is used.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Extended the existing test with th use-case where `ruleValuesToCheck` are empty.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

1. Create a promotion rule with a condition: customer group not in GroupX.
2. Then log in as customer that has no customer groups assigned
3. Try to applye the promotion
4. Throws error and promotion is not being applied.

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `evaluateRuleValueCondition` to return true for `ne` when `valuesToCheck` is empty, and adds a corresponding test.
> 
> - **Promotion rule evaluation**:
>   - Adjust `evaluateRuleValueCondition` in `packages/modules/promotion/src/utils/validations/promotion-rule.ts` to return `true` for operator `ne` when `valuesToCheck` is empty; fallback remains `false` for others.
> - **Tests**:
>   - Extend `ne` test in `packages/modules/promotion/integration-tests/__tests__/services/promotion-module/evaluate-rule-value-condition.spec.ts` to cover empty `ruleValuesToCheck` case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 168b586cc7739f1001c88dd5361678d13bb1b37c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->