### PR TITLE
feat: add non-sortable fields to entity mappings

### DIFF
--- a/.changeset/wet-bags-arrive.md
+++ b/.changeset/wet-bags-arrive.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+Added `nonSortableFields` on the entity mappings for the view_configuration ff to disable sortable fields on computed columns

--- a/packages/medusa/src/api/admin/views/[entity]/columns/entity-mappings.ts
+++ b/packages/medusa/src/api/admin/views/[entity]/columns/entity-mappings.ts
@@ -20,6 +20,8 @@ export const ENTITY_MAPPINGS = {
       // Specific field names to exclude
       excludeFields: ["order_change"],
     },
+    // Fields that cannot be sorted (virtual/computed fields)
+    nonSortableFields: ["total", "payment_status", "fulfillment_status"],
     computedColumns: {
       customer_display: {
         name: "Customer",
@@ -84,32 +86,26 @@ export const ENTITY_MAPPINGS = {
       excludePrefixes: ["raw_"],
       excludeFields: [],
     },
+    nonSortableFields: [] as string[],
     computedColumns: {
       product_display: {
         name: "Product",
         render_type: "product_info",
-        required_fields: [
-          "title",
-          "thumbnail",
-        ],
+        required_fields: ["title", "thumbnail"],
         optional_fields: ["handle"],
         default_visible: true,
       },
       variants_count: {
         name: "Variants",
         render_type: "count",
-        required_fields: [
-          "variants",
-        ],
+        required_fields: ["variants"],
         optional_fields: [],
         default_visible: true,
       },
       sales_channels_display: {
         name: "Sales Channels",
         render_type: "sales_channels_list",
-        required_fields: [
-          "sales_channels",
-        ],
+        required_fields: ["sales_channels"],
         optional_fields: [],
         default_visible: true,
       },
@@ -130,6 +126,7 @@ export const ENTITY_MAPPINGS = {
       excludePrefixes: ["raw_"],
       excludeFields: [],
     },
+    nonSortableFields: [] as string[],
     computedColumns: {},
   },
   users: {
@@ -147,6 +144,7 @@ export const ENTITY_MAPPINGS = {
       excludePrefixes: ["raw_"],
       excludeFields: [],
     },
+    nonSortableFields: [] as string[],
     computedColumns: {},
   },
   regions: {
@@ -158,6 +156,7 @@ export const ENTITY_MAPPINGS = {
       excludePrefixes: ["raw_"],
       excludeFields: [],
     },
+    nonSortableFields: [] as string[],
     computedColumns: {},
   },
   "sales-channels": {
@@ -175,6 +174,7 @@ export const ENTITY_MAPPINGS = {
       excludePrefixes: ["raw_"],
       excludeFields: [],
     },
+    nonSortableFields: [] as string[],
     computedColumns: {},
   },
 }

--- a/packages/medusa/src/api/admin/views/[entity]/columns/helpers.ts
+++ b/packages/medusa/src/api/admin/views/[entity]/columns/helpers.ts
@@ -472,8 +472,13 @@ export const generateEntityColumns = (
       ? getTypeInfoFromGraphQLType(fieldDef.type, fieldName)
       : getTypeInfoFromGraphQLType(null, fieldName)
 
+    const nonSortableFields = (entityMapping.nonSortableFields ??
+      []) as string[]
+    const isNonSortable = nonSortableFields.includes(fieldName)
     const sortable =
-      !fieldName.includes("metadata") && typeInfo.data_type !== "object"
+      !isNonSortable &&
+      !fieldName.includes("metadata") &&
+      typeInfo.data_type !== "object"
 
     const isDefaultField =
       entityMapping.defaultVisibleFields.includes(fieldName)


### PR DESCRIPTION

## Summary

**What** — What changes are introduced in this PR?

- Introduced `nonSortableFields` to the entity mappings to specify fields that cannot be sorted, enhancing the data handling capabilities.
- Updated the `generateEntityColumns` function to respect the new `nonSortableFields` logic, ensuring proper sorting behavior across entities.

```ts
export const ENTITY_MAPPINGS = {
  orders: {
    serviceName: "order",
    graphqlType: "Order",
    defaultVisibleFields: [
      "display_id",
      "created_at",
      "payment_status",
      "fulfillment_status",
      "total",
      "customer_display",
      "country",
      "sales_channel.name",
    ],
    // Here the non sortable fields by default as they will throw a 500 error
    nonSortableFields: ["total", "payment_status", "fulfillment_status"], 
```

**Why** — Why are these changes relevant or necessary?  

If you use the view configurations FF it will show that the total, fulfillment status or payment status can be sorted ASC or DESC, which is impossible as it is and will throw a 500 error on the server (virtual field)

**How** — How have these changes been implemented?

This add a new key to the entity mapping `nonSortableFields` that will be used in the helper to determine the `sortable` bool

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

https://github.com/user-attachments/assets/0937b7d0-98b2-448b-9250-3d0cd4ceed7b

**Fix on orders with nonSortableFields**


https://github.com/user-attachments/assets/8b35193d-763f-465f-93f3-83e64ab42bd9


---

## Checklist

Please ensure the following before requesting a review:

- [X] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [X] I have verified the code works as intended locally
- [X] I have linked the related issue(s) if applicable

---

## Additional Context

We can't inject the total, fulfillment status and payment status on the computedColumns from what I've understood, so I just kept it that way and added that logic on top of it, tell me if that's not the way 🙌 
