### PR TITLE
chore(): revert route loading parallelization

### DIFF
--- a/.changeset/dull-pots-dream.md
+++ b/.changeset/dull-pots-dream.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/framework": patch
+---
+
+chore(): revert route loading parallelization

--- a/packages/core/framework/src/http/router.ts
+++ b/packages/core/framework/src/http/router.ts
@@ -1,4 +1,8 @@
-import { ContainerRegistrationKeys, parseCorsOrigins, promiseAll } from "@medusajs/utils"
+import {
+  ContainerRegistrationKeys,
+  parseCorsOrigins,
+  promiseAll,
+} from "@medusajs/utils"
 import cors, { CorsOptions } from "cors"
 import type { ErrorRequestHandler, Express, RequestHandler } from "express"
 import type {
@@ -85,12 +89,10 @@ export class ApiLoader {
     const routesLoader = new RoutesLoader()
     const middlewareLoader = new MiddlewareFileLoader()
 
-    await promiseAll(
-      this.#sourceDirs.flatMap(dir => [
-        routesLoader.scanDir(dir),
-        middlewareLoader.scanDir(dir)
-      ])
-    )
+    for (const dir of this.#sourceDirs) {
+      await routesLoader.scanDir(dir)
+      await middlewareLoader.scanDir(dir)
+    }
 
     return {
       routes: routesLoader.getRoutes(),

--- a/packages/core/framework/src/http/router.ts
+++ b/packages/core/framework/src/http/router.ts
@@ -1,8 +1,4 @@
-import {
-  ContainerRegistrationKeys,
-  parseCorsOrigins,
-  promiseAll,
-} from "@medusajs/utils"
+import { ContainerRegistrationKeys, parseCorsOrigins } from "@medusajs/utils"
 import cors, { CorsOptions } from "cors"
 import type { ErrorRequestHandler, Express, RequestHandler } from "express"
 import type {


### PR DESCRIPTION
**What**
To prevent undeterministic route loading, remove route loading concurrency