### PR TITLE
escape non-ascii characters in filenames in s3 file provider

### DIFF
--- a/.changeset/shiny-hounds-learn.md
+++ b/.changeset/shiny-hounds-learn.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/file-s3": patch
+---
+
+URL-encode S3 object metadata and returned URL

--- a/packages/modules/providers/file-s3/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/file-s3/integration-tests/__tests__/services.spec.ts
@@ -1,5 +1,5 @@
-import fs from "fs/promises"
 import axios from "axios"
+import fs from "fs/promises"
 import { S3FileService } from "../../src/services/s3-file"
 jest.setTimeout(100000)
 
@@ -79,6 +79,23 @@ describe.skip("S3 File Plugin", () => {
         .catch((e) => e)
 
       expect(response.status).toEqual(404)
+    })
+  })
+
+  it("uploads a file with non-ascii characters in the name", async () => {
+    const fileContent = await fs.readFile(fixtureImagePath)
+    const fixtureAsBinary = fileContent.toString("base64")
+
+    const resp = await s3Service.upload({
+      filename: "catphoto-か.jpg",
+      mimeType: "image/jpeg",
+      content: fixtureAsBinary,
+      access: "private",
+    })
+
+    expect(resp).toEqual({
+      key: expect.stringMatching(/tests\/catphoto-か.*\.jpg/),
+      url: expect.stringMatching(/https:\/\/.*\/catphoto-%E3%81%8B.*\.jpg/),
     })
   })
 

--- a/packages/modules/providers/file-s3/src/services/s3-file.ts
+++ b/packages/modules/providers/file-s3/src/services/s3-file.ts
@@ -148,7 +148,7 @@ export class S3FileService extends AbstractFileProviderService {
       // Note: We could potentially set the content disposition when uploading,
       // but storing the original filename as metadata should suffice.
       Metadata: {
-        "x-amz-meta-original-filename": file.filename,
+        "original-filename": encodeURIComponent(file.filename),
       },
     })
 
@@ -160,7 +160,7 @@ export class S3FileService extends AbstractFileProviderService {
     }
 
     return {
-      url: `${this.config_.fileUrl}/${fileKey}`,
+      url: encodeURI(`${this.config_.fileUrl}/${fileKey}`),
       key: fileKey,
     }
   }

--- a/packages/modules/providers/file-s3/src/services/s3-file.ts
+++ b/packages/modules/providers/file-s3/src/services/s3-file.ts
@@ -160,7 +160,7 @@ export class S3FileService extends AbstractFileProviderService {
     }
 
     return {
-      url: encodeURI(`${this.config_.fileUrl}/${fileKey}`),
+      url: `${this.config_.fileUrl}/${encodeURI(fileKey)}`,
       key: fileKey,
     }
   }


### PR DESCRIPTION
## Summary

**What**
URL-encode non-ascii characters in S3 metadata and returned url

**Why**
S3 uploads with non-ascii characters are currently failing with the cryptic `The request signature we calculated does not match the signature you provided`. Also, for some ascii characters that need URL encoding (e.g. `?`) the upload succeeds, but the files are not displayed in the admin because of the non-encoded URL.

**How**
Just URL-encoding the metadata and the returned URL. On top of that, the metadata key was changed from `x-amz-meta-original-filename` to `original-filename`, cause the `x-amz-meta-` is added by the SDK. Right now the created objects had `x-amz-meta-x-amz-meta-original-filename`.

**Testing**
Added an integration test
## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable
