### PR TITLE
fix(utils): fix error when generating migrations for a module with existing snapshot

### DIFF
--- a/.changeset/icy-vans-kneel.md
+++ b/.changeset/icy-vans-kneel.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+fix(utils): fix error when generating migrations for a module with existing snapshot

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -210,7 +210,7 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
     )
 
     if (snapshotFile) {
-      const absoluteName = join(snapshotFile.path, snapshotFile.name)
+      const absoluteName = join(snapshotFile.parentPath, snapshotFile.name)
       if (absoluteName !== snapshotPath) {
         await rename(absoluteName, snapshotPath)
       }


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix error that occurs when generating migrations for a module with an existing snapshot.

Closes #14152

**Why** — Why are these changes relevant or necessary?  

On Node.js v24+, when you:

1. Create a custom module.
2. Generate migrations.
3. Make changes to a data model.
4. Generate migrations again

The following error occurs:

```
error:   Failed with error The "path" argument must be of type string. Received undefined
error:   The "path" argument must be of type string. Received undefined
TypeError: The "path" argument must be of type string. Received undefined
```

**How** — How have these changes been implemented?

Upon investigation, the `path` property of Node.js's `Dirent` is deprecated in Node v20 and v22 (LTS), and has been removed from Node v24. Instead, we should be using the `parentPath` property.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

1. Ensure you're using Node v24 (LTS)
2. Create a module with data model.
3. Generate migrations
4. Make changes to data model
5. Generate migrations
6. See error

After adding the changes in this PR, you shouldn't see an error

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
