### PR TITLE
RFC - feat: add event emission for product category updates in `batchLinkProductsToCategoryWorkflow`

### DIFF
--- a/.changeset/beige-gifts-grow.md
+++ b/.changeset/beige-gifts-grow.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+Emit the `product-category.updated` event when batch adding products to a category

--- a/packages/core/core-flows/src/product/workflows/batch-products-in-category.ts
+++ b/packages/core/core-flows/src/product/workflows/batch-products-in-category.ts
@@ -1,6 +1,10 @@
 import type { ProductCategoryWorkflow } from "@medusajs/framework/types"
-import { WorkflowData, createWorkflow } from "@medusajs/framework/workflows-sdk"
+import {
+  WorkflowData, createWorkflow
+} from "@medusajs/framework/workflows-sdk"
 import { batchLinkProductsToCategoryStep } from "../steps/batch-link-products-in-category"
+import { emitEventStep } from "../../common"
+import { ProductCategoryWorkflowEvents } from "@medusajs/framework/utils"
 
 export const batchLinkProductsToCategoryWorkflowId =
   "batch-link-products-to-category"
@@ -30,6 +34,10 @@ export const batchLinkProductsToCategoryWorkflow = createWorkflow(
     // eslint-disable-next-line max-len
     input: WorkflowData<ProductCategoryWorkflow.BatchUpdateProductsOnCategoryWorkflowInput>
   ): WorkflowData<void> => {
-    return batchLinkProductsToCategoryStep(input)
+    batchLinkProductsToCategoryStep(input)
+    emitEventStep({
+      eventName: ProductCategoryWorkflowEvents.UPDATED,
+      data: [{ id: input.id }],
+    })
   }
 )


### PR DESCRIPTION
## Summary
Emit the `product-category.updated` event when we add products in batch to a category

**What** — What changes are introduced in this PR?
Added a new step `emitEventStep` in the `batchLinkProductsToCategoryWorkflow`

**Why** — Why are these changes relevant or necessary?  
This will allow devs to listen to a product category update, allowing to revalidate storefront cached products for example

**How** — How have these changes been implemented?
Added the `emitEventStep` with the `ProductCategoryWorkflowEvents.UPDATED` event name

**Testing** — How have these changes been tested, or how can the reviewer test the feature?
Locally with a dev server :

```
http:    POST /admin/product-categories/pcat_01KBD9410TDE304R6F4APZYS7F/products ← http://localhost:9000/app/categories/pcat_01KBD9410TDE304R6F4APZYS7F/products (200) - 54.302 ms
info:    Processing product-category.updated which has 0 subscribers
```

<img width="1622" height="262" alt="CleanShot 2025-12-05 at 09 51 54" src="https://github.com/user-attachments/assets/dbdc9c04-9db1-4326-b4c2-4080fbfe4973" />


---

## Examples

- Add product(s) to category

---

## Checklist

Please ensure the following before requesting a review:

- [X] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [X] The changes are covered by relevant **tests**
- [X] I have verified the code works as intended locally
- [] I have linked the related issue(s) if applicable

---

## Additional Context

Related to RFC
https://github.com/medusajs/medusa/discussions/14223