### PR TITLE
Fix to make sure payment status checks on very small diffs

### DIFF
--- a/.changeset/six-emus-pump.md
+++ b/.changeset/six-emus-pump.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/core-flows": patch
+"@medusajs/utils": patch
+---
+
+Fix to make sure payment status checks on very small diffs

--- a/.changeset/six-emus-pump.md
+++ b/.changeset/six-emus-pump.md
@@ -1,6 +1,5 @@
 ---
 "@medusajs/core-flows": patch
-"@medusajs/utils": patch
 ---
 
 Fix to make sure payment status checks on very small diffs

--- a/packages/core/core-flows/src/order/utils/aggregate-status.ts
+++ b/packages/core/core-flows/src/order/utils/aggregate-status.ts
@@ -1,6 +1,5 @@
 import type { OrderDetailDTO } from "@medusajs/framework/types"
-import { isDefined, MathBN } from "@medusajs/framework/utils"
-import { BigNumber } from "@medusajs/utils/src"
+import { isDefined, MathBN, BigNumber } from "@medusajs/framework/utils"
 
 const MEDUSA_PAYMENTS_EPSILON = new BigNumber(
   process.env.MEDUSA_PAYMENTS_EPSILON || "0.01"

--- a/packages/core/core-flows/src/order/utils/aggregate-status.ts
+++ b/packages/core/core-flows/src/order/utils/aggregate-status.ts
@@ -1,5 +1,5 @@
 import type { OrderDetailDTO } from "@medusajs/framework/types"
-import { isDefined, MathBN, BigNumber } from "@medusajs/framework/utils"
+import { BigNumber, isDefined, MathBN } from "@medusajs/framework/utils"
 
 const MEDUSA_PAYMENTS_EPSILON = new BigNumber(
   process.env.MEDUSA_PAYMENTS_EPSILON || "0.01"
@@ -7,7 +7,7 @@ const MEDUSA_PAYMENTS_EPSILON = new BigNumber(
 
 export const getLastPaymentStatus = (order: OrderDetailDTO) => {
   const PaymentStatus = {
-    NOT_PAID: "not_paid",
+    NOT_PAID: "not_paid",ø
     AWAITING: "awaiting",
     CAPTURED: "captured",
     PARTIALLY_CAPTURED: "partially_captured",

--- a/packages/core/core-flows/src/order/utils/aggregate-status.ts
+++ b/packages/core/core-flows/src/order/utils/aggregate-status.ts
@@ -1,5 +1,10 @@
 import type { OrderDetailDTO } from "@medusajs/framework/types"
-import { isDefined, MathBN, MEDUSA_PAYMENTS_EPSILON } from "@medusajs/framework/utils"
+import { isDefined, MathBN } from "@medusajs/framework/utils"
+import { BigNumber } from "@medusajs/utils/src"
+
+const MEDUSA_PAYMENTS_EPSILON = new BigNumber(
+  process.env.MEDUSA_PAYMENTS_EPSILON || "0.01"
+)
 
 export const getLastPaymentStatus = (order: OrderDetailDTO) => {
   const PaymentStatus = {

--- a/packages/core/core-flows/src/order/utils/aggregate-status.ts
+++ b/packages/core/core-flows/src/order/utils/aggregate-status.ts
@@ -7,7 +7,7 @@ const MEDUSA_PAYMENTS_EPSILON = new BigNumber(
 
 export const getLastPaymentStatus = (order: OrderDetailDTO) => {
   const PaymentStatus = {
-    NOT_PAID: "not_paid",ø
+    NOT_PAID: "not_paid",
     AWAITING: "awaiting",
     CAPTURED: "captured",
     PARTIALLY_CAPTURED: "partially_captured",

--- a/packages/core/core-flows/src/order/utils/aggregate-status.ts
+++ b/packages/core/core-flows/src/order/utils/aggregate-status.ts
@@ -1,5 +1,5 @@
 import type { OrderDetailDTO } from "@medusajs/framework/types"
-import { isDefined, MathBN, MEDUSA_EPSILON } from "@medusajs/framework/utils"
+import { isDefined, MathBN, MEDUSA_PAYMENTS_EPSILON } from "@medusajs/framework/utils"
 
 export const getLastPaymentStatus = (order: OrderDetailDTO) => {
   const PaymentStatus = {
@@ -31,7 +31,7 @@ export const getLastPaymentStatus = (order: OrderDetailDTO) => {
           paymentCollection.amount,
           paymentCollection.captured_amount as number
         ),
-        MEDUSA_EPSILON
+        MEDUSA_PAYMENTS_EPSILON
       )
       paymentStatus[PaymentStatus.CAPTURED] += isGte ? 1 : 0.5
     }
@@ -42,7 +42,7 @@ export const getLastPaymentStatus = (order: OrderDetailDTO) => {
           paymentCollection.amount,
           paymentCollection.refunded_amount as number
         ),
-        MEDUSA_EPSILON
+        MEDUSA_PAYMENTS_EPSILON
       )
       paymentStatus[PaymentStatus.REFUNDED] += isGte ? 1 : 0.5
     }

--- a/packages/core/utils/src/totals/big-number.ts
+++ b/packages/core/utils/src/totals/big-number.ts
@@ -150,3 +150,7 @@ export class BigNumber implements IBigNumber {
 export const MEDUSA_EPSILON = new BigNumber(
   process.env.MEDUSA_EPSILON || "0.0001"
 )
+
+export const MEDUSA_PAYMENTS_EPSILON = new BigNumber(
+  process.env.MEDUSA_PAYMENTS_EPSILON || "0.01"
+)

--- a/packages/core/utils/src/totals/big-number.ts
+++ b/packages/core/utils/src/totals/big-number.ts
@@ -150,7 +150,3 @@ export class BigNumber implements IBigNumber {
 export const MEDUSA_EPSILON = new BigNumber(
   process.env.MEDUSA_EPSILON || "0.0001"
 )
-
-export const MEDUSA_PAYMENTS_EPSILON = new BigNumber(
-  process.env.MEDUSA_PAYMENTS_EPSILON || "0.01"
-)


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Introduced an additional epsilon value which is used in the payment status check.

**Why** — Why are these changes relevant or necessary?  

Currently the core epsilon is 0.0001, which can cause issues when you have a payment collection amount that has >2 decimals & a payment provider that accepts only 2 decimals. Then the difference between the two will cause the status to be partially captured, which is not correct. Also see: https://github.com/medusajs/medusa/issues/13971

**How** — How have these changes been implemented?

Added an additional `MEDUSA_PAYMENT_EPSILON` with a lower default value of 0.01 then used this new variable in the getLastPaymentStatus utility.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Create an order with more than 2 decimals, try to pay with any payment provider that only uses 2 decimals (which are most)

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

It is a small fix, maybe it should be covered more extensive in the core, i.e. that this check would depend on the payment provider and/or currency on how specific the decimal check should be. However for 99% of the use-cases this will suffice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a configurable payments epsilon (default 0.01) in payment status calculations to handle very small diffs.
> 
> - **Core Flows**:
>   - **Payments epsilon**: Introduce `MEDUSA_PAYMENTS_EPSILON` (env-configurable, default `0.01`) via `BigNumber`.
>   - **Payment status**: Update `getLastPaymentStatus` in `packages/core/core-flows/src/order/utils/aggregate-status.ts` to use `MEDUSA_PAYMENTS_EPSILON` for captured/refunded comparisons instead of `MEDUSA_EPSILON`.
> - **Release**:
>   - Add changeset for `@medusajs/core-flows` patch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab6c77b65571bbb6cd8f3fc27796b0013c120ba8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->