### PR TITLE
fix(dashboard): pass prefix to useDataTable to fix product list not paginating

### DIFF
--- a/.changeset/stale-coats-shave.md
+++ b/.changeset/stale-coats-shave.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): pass prefix to useDataTable to fix product list not paginating

--- a/packages/admin/dashboard/src/routes/price-lists/price-list-create/components/price-list-create-form/price-list-products-form.tsx
+++ b/packages/admin/dashboard/src/routes/price-lists/price-list-create/components/price-list-create-form/price-list-products-form.tsx
@@ -109,6 +109,7 @@ export const PriceListProductsForm = ({ form }: PriceListProductsFormProps) => {
       updater,
     },
     pageSize: PAGE_SIZE,
+    prefix: PREFIX,
   })
 
   if (isError) {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Pass correct prefix to `useDataTable` hook on create price list product list form.

**Why** — Why are these changes relevant or necessary?  

Without this, any action taken in the product list form component, that writes to search params, would be disconnected from what the query expects to handle.

**How** — How have these changes been implemented?

Pass correct prefix to `useDataTable` hook.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Validated pagination works after the change.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #14231 
