### PR TITLE
fix(core-flows): Access orderItem.variant safely inside convertDraftOrderWorkflow when containing custom items

### DIFF
--- a/.changeset/three-dodos-admire.md
+++ b/.changeset/three-dodos-admire.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): Access orderItem.variant safely inside convertDraftOrderWorkflow when containing custom items

--- a/integration-tests/http/__tests__/draft-order/admin/draft-order.spec.ts
+++ b/integration-tests/http/__tests__/draft-order/admin/draft-order.spec.ts
@@ -240,7 +240,7 @@ medusaIntegrationTestRunner({
       })
     })
 
-    describe("POST /draft-orders/:id/convert-to-order", () => {
+    describe.only("POST /draft-orders/:id/convert-to-order", () => {
       let product
       let inventoryItemLarge
       let inventoryItemMedium
@@ -408,6 +408,102 @@ medusaIntegrationTestRunner({
             }),
             expect.objectContaining({
               inventory_item_id: inventoryItemMedium.id,
+              quantity: 1,
+            }),
+          ])
+        )
+
+        expect(response.status).toBe(200)
+        expect(response.data.order.status).toBe("pending")
+      })
+
+      it("should convert a draft order with a custom item (without variant_id) to an order", async () => {
+        await api.post(
+          `/admin/draft-orders/${testDraftOrder.id}/edit`,
+          {},
+          adminHeaders
+        )
+
+        await api.post(
+          `/admin/draft-orders/${testDraftOrder.id}/edit/items`,
+          {
+            items: [
+              {
+                title: "Custom Item",
+                quantity: 2,
+                unit_price: 1500,
+              },
+            ],
+          },
+          adminHeaders
+        )
+
+        await api.post(
+          `/admin/draft-orders/${testDraftOrder.id}/edit/confirm`,
+          {},
+          adminHeaders
+        )
+
+        const response = await api.post(
+          `/admin/draft-orders/${testDraftOrder.id}/convert-to-order`,
+          {},
+          adminHeaders
+        )
+
+        expect(response.status).toBe(200)
+        expect(response.data.order.status).toBe("pending")
+      })
+
+      it("should convert a draft order with both variant items and custom items to an order", async () => {
+        await api.post(
+          `/admin/draft-orders/${testDraftOrder.id}/edit`,
+          {},
+          adminHeaders
+        )
+
+        await api.post(
+          `/admin/draft-orders/${testDraftOrder.id}/edit/items`,
+          {
+            items: [
+              {
+                variant_id: product.variants.find((v) => v.title === "L shirt")
+                  .id,
+                quantity: 1,
+              },
+              {
+                title: "Custom Item",
+                quantity: 1,
+                unit_price: 2000,
+              },
+            ],
+          },
+          adminHeaders
+        )
+
+        await api.post(
+          `/admin/draft-orders/${testDraftOrder.id}/edit/confirm`,
+          {},
+          adminHeaders
+        )
+
+        let reservations = (await api.get(`/admin/reservations`, adminHeaders))
+          .data.reservations
+
+        expect(reservations.length).toBe(0)
+
+        const response = await api.post(
+          `/admin/draft-orders/${testDraftOrder.id}/convert-to-order`,
+          {},
+          adminHeaders
+        )
+
+        reservations = (await api.get(`/admin/reservations`, adminHeaders)).data
+          .reservations
+
+        expect(reservations).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              inventory_item_id: inventoryItemLarge.id,
               quantity: 1,
             }),
           ])

--- a/integration-tests/http/__tests__/draft-order/admin/draft-order.spec.ts
+++ b/integration-tests/http/__tests__/draft-order/admin/draft-order.spec.ts
@@ -240,7 +240,7 @@ medusaIntegrationTestRunner({
       })
     })
 
-    describe.only("POST /draft-orders/:id/convert-to-order", () => {
+    describe("POST /draft-orders/:id/convert-to-order", () => {
       let product
       let inventoryItemLarge
       let inventoryItemMedium

--- a/packages/core/core-flows/src/draft-order/workflows/convert-draft-order.ts
+++ b/packages/core/core-flows/src/draft-order/workflows/convert-draft-order.ts
@@ -143,11 +143,13 @@ export const convertDraftOrderWorkflow = createWorkflow(
 
       for (const orderItem of orderItems.items ?? []) {
         items.push({
-          variant_id: orderItem.variant.id,
+          variant_id: orderItem.variant?.id,
           quantity: orderItem.quantity,
           id: orderItem.id,
         })
-        variants.push(orderItem.variant)
+        if (orderItem.variant) {
+          variants.push(orderItem.variant)
+        }
       }
 
       return {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Access `orderItem.variant` for order items inside `convertDraftOrderWorkflow` safely.

**Why** — Why are these changes relevant or necessary?  

A darft order can contain custom items (not linked to a variant) and so, it is incorrect to assume the relation will always be present.

**How** — How have these changes been implemented?

Access the `variant` relation safely inside the workflow.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #14219 
