### PR TITLE
fix(medusa): use customer query config on delete address route

### DIFF
--- a/.changeset/vast-cats-hug.md
+++ b/.changeset/vast-cats-hug.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): use customer query config on delete address route

--- a/packages/medusa/src/api/store/customers/middlewares.ts
+++ b/packages/medusa/src/api/store/customers/middlewares.ts
@@ -106,7 +106,7 @@ export const storeCustomerRoutesMiddlewares: MiddlewareRoute[] = [
     middlewares: [
       validateAndTransformQuery(
         StoreGetCustomerAddressParams,
-        QueryConfig.retrieveAddressTransformQueryConfig
+        QueryConfig.retrieveTransformQueryConfig
       ),
     ],
   },


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Use customer query config on delete address endpoint.

**Why** — Why are these changes relevant or necessary?  

We end up passing `fields` incorrectly expecting `customer_address` entrypoint when `customer` entrypoint is the actual one.

**How** — How have these changes been implemented?

Use the customer query config on delete address route.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #14091 
