### PR TITLE
feat(product): allow assigned-ids to be used

### DIFF
--- a/.changeset/solid-singers-smash.md
+++ b/.changeset/solid-singers-smash.md
@@ -1,0 +1,8 @@
+---
+"@medusajs/product": patch
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+"@medusajs/workflow-engine-redis": patch
+---
+
+add assignable id support to products

--- a/.changeset/solid-singers-smash.md
+++ b/.changeset/solid-singers-smash.md
@@ -2,7 +2,6 @@
 "@medusajs/product": patch
 "@medusajs/types": patch
 "@medusajs/medusa": patch
-"@medusajs/workflow-engine-redis": patch
 ---
 
 add assignable id support to products

--- a/packages/core/types/src/http/product-category/admin/payloads.ts
+++ b/packages/core/types/src/http/product-category/admin/payloads.ts
@@ -1,4 +1,10 @@
 export interface AdminCreateProductCategory {
+  
+  /**
+   * Optionally pass an ID when creating a product category.
+   */
+  id?: string;
+
   /**
    * The product category's name.
    */

--- a/packages/core/types/src/http/product/admin/payloads.ts
+++ b/packages/core/types/src/http/product/admin/payloads.ts
@@ -72,6 +72,7 @@ export interface AdminCreateProductVariantInventoryKit {
 }
 
 export interface AdminCreateProductVariant {
+  id?: string
   /**
    * The variant's title.
    */
@@ -157,6 +158,11 @@ export interface AdminCreateProductVariant {
 }
 
 export interface AdminCreateProduct {
+  /**
+   * Optionally pass an ID when creating a product.
+   */
+  id?: string
+  
   /**
    * The product's title.
    */

--- a/packages/core/types/src/product/common.ts
+++ b/packages/core/types/src/product/common.ts
@@ -357,6 +357,11 @@ export interface ProductCategoryDTO {
  */
 export interface CreateProductCategoryDTO {
   /**
+   * The ID of the product category. This is optional to set. If not provided, a unique ID will be generated. 
+   */
+  id?: string
+
+  /**
    * The product category's name.
    */
   name: string
@@ -1286,6 +1291,10 @@ export interface CreateProductVariantInventoryKit {
  * A product variant to create.
  */
 export interface CreateProductVariantDTO {
+  /**
+   * Optionally pass an ID when creating a product variant.
+   */
+  id?: string,
   /**
    * The id of the product
    */

--- a/packages/medusa/src/api/admin/product-categories/validators.ts
+++ b/packages/medusa/src/api/admin/product-categories/validators.ts
@@ -47,6 +47,7 @@ export const AdminProductCategoriesParams = createFindParams({
 
 export const CreateProductCategory = z
   .object({
+    id: z.string().optional(),
     name: z.string(),
     description: z.string().optional(),
     handle: z.string().optional(),

--- a/packages/medusa/src/api/admin/products/validators.ts
+++ b/packages/medusa/src/api/admin/products/validators.ts
@@ -125,6 +125,7 @@ export const AdminCreateProductType = z.object({
 export type AdminCreateProductVariantType = z.infer<typeof CreateProductVariant>
 export const CreateProductVariant = z
   .object({
+    id: z.string().optional(),
     title: z.string(),
     sku: z.string().nullish(),
     ean: z.string().nullish(),
@@ -201,6 +202,7 @@ export const IdAssociation = z.object({
 export type AdminCreateProductType = z.infer<typeof CreateProduct>
 export const CreateProduct = z
   .object({
+    id: z.string().optional(),
     title: z.string(),
     subtitle: z.string().nullish(),
     description: z.string().nullish(),

--- a/packages/modules/product/integration-tests/__fixtures__/product/data/create-product.ts
+++ b/packages/modules/product/integration-tests/__fixtures__/product/data/create-product.ts
@@ -39,6 +39,7 @@ export const buildProductOnlyData = ({
 }
 
 export const buildProductAndRelationsData = ({
+  id,
   title,
   description,
   subtitle,
@@ -57,6 +58,7 @@ export const buildProductAndRelationsData = ({
   const defaultOptionValue = "test-value"
 
   return {
+    id: id ?? undefined,
     title: title ?? faker.commerce.productName(),
     description: description ?? faker.commerce.productName(),
     subtitle: subtitle ?? faker.commerce.productName(),

--- a/packages/modules/product/integration-tests/__tests__/product-category.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-category.spec.ts
@@ -920,10 +920,11 @@ moduleIntegrationTestRunner<Service>({
           )
         })
 
-        it("should create a category with user provided id successfully", async () => {
+        it("should create a category with assigned id", async () => {
+          const assignedId = 'assigned-category-id-' + Date.now();
           await service.create([
             {
-              id: "custom-id-123",
+              id: assignedId,
               name: "New Category",
               handle: "new-category",
               parent_category_id: null,
@@ -931,23 +932,10 @@ moduleIntegrationTestRunner<Service>({
           ])
 
 
-          const [productCategory] = await service.list(
-            {
-              name: "New Category",
-            },
-            {
-              select: ["name", "rank", "id"],
-            }
-          )
+          const productCategory = await service.retrieve(assignedId);
 
 
-          expect(JSON.parse(JSON.stringify(productCategory))).toEqual(
-            expect.objectContaining({
-              id: "custom-id-123",
-              name: "New Category",
-              rank: 0,
-            })
-          )
+          expect(productCategory.id).toEqual(assignedId);
         })
 
 

--- a/packages/modules/product/integration-tests/__tests__/product-category.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-category.spec.ts
@@ -920,6 +920,38 @@ moduleIntegrationTestRunner<Service>({
           )
         })
 
+        it("should create a category with user provided id successfully", async () => {
+          await service.create([
+            {
+              id: "custom-id-123",
+              name: "New Category",
+              handle: "new-category",
+              parent_category_id: null,
+            },
+          ])
+
+
+          const [productCategory] = await service.list(
+            {
+              name: "New Category",
+            },
+            {
+              select: ["name", "rank", "id"],
+            }
+          )
+
+
+          expect(JSON.parse(JSON.stringify(productCategory))).toEqual(
+            expect.objectContaining({
+              id: "custom-id-123",
+              name: "New Category",
+              rank: 0,
+            })
+          )
+        })
+
+
+
         it("should append rank from an existing category depending on parent", async () => {
           await service.create([
             {

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/product-categories.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/product-categories.spec.ts
@@ -398,9 +398,10 @@ moduleIntegrationTestRunner<IProductModuleService>({
         })
 
 
-        it("should create a category with self-selected id successfully", async () => {
+        it("should create a category with assigned id", async () => {
+          const assignedId = 'assigned-category-id-' + Date.now();
           await service.createProductCategories({
-            id: "new-category-id",
+            id: assignedId,
             name: "New Category",
             parent_category_id: productCategoryOne.id,
           })
@@ -416,7 +417,7 @@ moduleIntegrationTestRunner<IProductModuleService>({
 
           expect(productCategory).toEqual(
             expect.objectContaining({
-              id: "new-category-id",
+              id: assignedId,
               name: "New Category",
               rank: 0,
             })

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/product-categories.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/product-categories.spec.ts
@@ -398,6 +398,33 @@ moduleIntegrationTestRunner<IProductModuleService>({
         })
 
 
+        it("should create a category with self-selected id successfully", async () => {
+          await service.createProductCategories({
+            id: "new-category-id",
+            name: "New Category",
+            parent_category_id: productCategoryOne.id,
+          })
+
+          const [productCategory] = await service.listProductCategories(
+            {
+              name: "New Category",
+            },
+            {
+              select: ["name", "rank", "id"],
+            }
+          )
+
+          expect(productCategory).toEqual(
+            expect.objectContaining({
+              id: "new-category-id",
+              name: "New Category",
+              rank: 0,
+            })
+          )
+        })
+
+
+
         it("should append rank from an existing category depending on parent", async () => {
           await service.createProductCategories({
             name: "New Category",

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/product-variants.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/product-variants.spec.ts
@@ -444,6 +444,19 @@ moduleIntegrationTestRunner<IProductModuleService>({
           expect(productVariant.title).toEqual("new test")
         })
 
+        it('should allow upserting a variant with an assigned-id', async () => {
+          const assignedId =  'assigned-variant-id-' + Date.now();
+          const upsertedVariant = (await service.upsertProductVariants([
+             {
+              id: assignedId,
+              product_id: productOne.id,
+              title: "new test",
+            },
+          ])) as ProductVariantDTO[];
+
+          expect(upsertedVariant[0].id).toEqual(assignedId);
+        });
+ 
         it("should do a partial update on the options of a variant successfully", async () => {
           await service.updateProductVariants(variantOne.id, {
             options: { size: "small", color: "red" },
@@ -510,6 +523,24 @@ moduleIntegrationTestRunner<IProductModuleService>({
             })
           )
         })
+
+        it("should create a variant with assigned id", async () => {
+          jest.clearAllMocks();
+
+          const assignedId = 'assigned-variant-id-' + Date.now();
+
+          const data: CreateProductVariantDTO = {
+            id: assignedId,
+            title: "variant 3",
+            product_id: productOne.id,
+            options: { size: "small", color: "blue" },
+          }
+
+          const variant = await service.createProductVariants(data)
+
+          expect(variant.id).toEqual(assignedId);
+        })
+
 
         it("should correctly associate variants with own product options", async () => {
           jest.clearAllMocks()

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
@@ -1222,23 +1222,25 @@ moduleIntegrationTestRunner<IProductModuleService>({
         })
 
         it('can create a product with an assigned id', async () => {
+          const assignedId = 'custom-product-id-' + Date.now(); 
           const data = buildProductAndRelationsData({
-            id: 'custom-product-id',
+            id: assignedId,
             images,
             thumbnail: images[0].url,
           })
           
           const productsCreated = await service.createProducts([data])
-          expect(productsCreated[0].id).toBe('custom-product-id')
+          expect(productsCreated[0].id).toBe(assignedId)
         });
 
         it ('can create a product variant with an assigned id', async () => {
+          const assignedVariantId = 'custom-variant-id-' + Date.now();
           const data = buildProductAndRelationsData({
             images,
             thumbnail: images[0].url,
             variants: [
               {
-                id: 'custom-variant-id',
+                id: assignedVariantId,
                 title: 'Custom Variant',
                 options: { size: 'M' }, 
               },
@@ -1249,7 +1251,7 @@ moduleIntegrationTestRunner<IProductModuleService>({
           }); 
           
           const productsCreated = await service.createProducts([data])
-          expect(productsCreated[0].variants[0].id).toBe('custom-variant-id')
+          expect(productsCreated[0].variants[0].id).toBe(assignedVariantId)
         });
 
         it("should throw because variant doesn't have all options set", async () => {

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
@@ -346,6 +346,22 @@ moduleIntegrationTestRunner<IProductModuleService>({
           expect(products[1].title).toEqual("updated title 2")
         })
 
+        it.only('should create products with assigned id, for upsert scenarios', async () => {
+          const assignedId = 'new-product-' + Date.now();
+          await service.upsertProducts([
+            { id: assignedId, title: "assigned title" },
+            { id: productTwo.id, title: "updated title 2" },
+          ])
+
+          const products = await service.listProducts(
+            { id: [assignedId, productTwo.id] },
+          )
+
+          expect(products).toHaveLength(2)
+          expect(products[0].title).toEqual("assigned title")
+          expect(products[1].title).toEqual("updated title 2")
+        });
+
         it("should update a product and upsert relations that are not created yet", async () => {
           const tags = await service.createProductTags([{ value: "tag-1" }])
           const data = buildProductAndRelationsData({
@@ -1204,6 +1220,37 @@ moduleIntegrationTestRunner<IProductModuleService>({
             })
           )
         })
+
+        it('can create a product with an assigned id', async () => {
+          const data = buildProductAndRelationsData({
+            id: 'custom-product-id',
+            images,
+            thumbnail: images[0].url,
+          })
+          
+          const productsCreated = await service.createProducts([data])
+          expect(productsCreated[0].id).toBe('custom-product-id')
+        });
+
+        it ('can create a product variant with an assigned id', async () => {
+          const data = buildProductAndRelationsData({
+            images,
+            thumbnail: images[0].url,
+            variants: [
+              {
+                id: 'custom-variant-id',
+                title: 'Custom Variant',
+                options: { size: 'M' }, 
+              },
+            ],
+            options: [
+              { title: 'size', values: ['S', 'M', 'L'] },
+            ],
+          }); 
+          
+          const productsCreated = await service.createProducts([data])
+          expect(productsCreated[0].variants[0].id).toBe('custom-variant-id')
+        });
 
         it("should throw because variant doesn't have all options set", async () => {
           const error = await service

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/products.spec.ts
@@ -346,7 +346,7 @@ moduleIntegrationTestRunner<IProductModuleService>({
           expect(products[1].title).toEqual("updated title 2")
         })
 
-        it.only('should create products with assigned id, for upsert scenarios', async () => {
+        it('should create products with assigned id, for upsert scenarios', async () => {
           const assignedId = 'new-product-' + Date.now();
           await service.upsertProducts([
             { id: assignedId, title: "assigned title" },

--- a/packages/modules/product/integration-tests/__tests__/product.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product.spec.ts
@@ -246,7 +246,22 @@ moduleIntegrationTestRunner<Service>({
             })
           )
         })
+        it('create with assigned id', async  ()  => {
+          const id = 'assigned-product-id-' + Date.now();
+          const data = buildProductOnlyData()
+          const products = await service.create([
+            {
+              id,
+              ...data
+            }
+          ])
+
+          const product = await service.retrieve(id);
+          expect(product.id).toEqual(id);
+        })
+
       })
+
 
       describe("update", function () {
         beforeEach(async () => {

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -436,18 +436,39 @@ export default class ProductModuleService
       (variant): variant is UpdateProductVariantInput => !!variant.id
     )
     const forCreate = input.filter(
-      (variant): variant is ProductTypes.CreateProductVariantDTO => !variant.id
+      (variant): variant is ProductTypes.CreateProductVariantDTO => !variant.id 
     )
 
     let created: ProductTypes.ProductVariantDTO[] = []
     let updated: InferEntityType<typeof ProductVariant>[] = []
 
+
+   // since the id is now possible to set from external sources, we need to change the logic here a bit
+    const idsInUpdate = new Set(forUpdate.map((variant) => variant.id));
+    const existingIdResponse = await this.productVariantService_.list(
+      {
+        id: Array.from(idsInUpdate),
+      },
+      {},
+      sharedContext
+    );
+    const existingIds = new Set(existingIdResponse.map((variant) => variant.id));
+    
+    // Split the forUpdate array into actual updates and creates based on existing IDs
+    const actualForUpdate = forUpdate.filter(variant => existingIds.has(variant.id));
+    const movedToCreate = forUpdate.filter(variant => !existingIds.has(variant.id));
+    forCreate.push(...(movedToCreate as ProductTypes.CreateProductVariantDTO[]));
+
+
     if (forCreate.length) {
       created = await this.createProductVariants(forCreate, sharedContext)
     }
-    if (forUpdate.length) {
-      updated = await this.updateVariants_(forUpdate, sharedContext)
+    if (actualForUpdate.length) {
+      updated = await this.updateVariants_(actualForUpdate, sharedContext)
     }
+
+    
+
 
     const result = [...created, ...updated]
     const allVariants = await this.baseRepository_.serialize<

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -1398,9 +1398,13 @@ export default class ProductModuleService
 
     // since the id is now possible to set from external sources, we need to change the logic here a bit
     const idsInUpdate = new Set(forUpdate.map((category) => category.id));
-    const existingIdResponse = await this.productCategoryService_.list({
-      id: Array.from(idsInUpdate),
-    });
+    const existingIdResponse = await this.productCategoryService_.list(
+      {
+        id: Array.from(idsInUpdate),
+      },
+      {},
+      sharedContext
+    );
     const existingIds = new Set(existingIdResponse.map((category) => category.id));
     
     // Split the forUpdate array into actual updates and creates based on existing IDs
@@ -1580,9 +1584,13 @@ export default class ProductModuleService
 
     // since the id is now possible to set from external sources, we need to change the logic here a bit
     const idsInUpdate = new Set(forUpdate.map((product) => product.id));
-    const existingIdResponse =  await this.productService_.list({
-      id: Array.from(idsInUpdate),
-    });
+    const existingIdResponse =  await this.productService_.list(
+      {
+        id: Array.from(idsInUpdate),
+      },
+      {},
+      sharedContext
+    );
     const existingIds = new Set(existingIdResponse.map((product) => product.id));
     
     // Split the forUpdate array into actual updates and creates based on existing IDs

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -432,7 +432,7 @@ export default class ProductModuleService
     ProductTypes.ProductVariantDTO[] | ProductTypes.ProductVariantDTO
   > {
     const input = Array.isArray(data) ? data : [data]
-    const forUpdate = input.filter(
+    let forUpdate = input.filter(
       (variant): variant is UpdateProductVariantInput => !!variant.id
     )
     const forCreate = input.filter(
@@ -442,29 +442,32 @@ export default class ProductModuleService
     let created: ProductTypes.ProductVariantDTO[] = []
     let updated: InferEntityType<typeof ProductVariant>[] = []
 
+    if (forUpdate.length > 0) {
+    // since the id is now possible to set from external sources, we need to change the logic here a bit
+      const idsInUpdate = new Set(forUpdate.map((variant) => variant.id));
+      const existingIdResponse = await this.productVariantService_.list(
+        {
+          id: Array.from(idsInUpdate),
+        },
+        {},
+        sharedContext
+      );
+      const existingIds = new Set(existingIdResponse.map((variant) => variant.id));
+      
+      // Split the forUpdate array into actual updates and creates based on existing IDs
+      const actualForUpdate = forUpdate.filter(variant => existingIds.has(variant.id));
+      const movedToCreate = forUpdate.filter(variant => !existingIds.has(variant.id));
 
-   // since the id is now possible to set from external sources, we need to change the logic here a bit
-    const idsInUpdate = new Set(forUpdate.map((variant) => variant.id));
-    const existingIdResponse = await this.productVariantService_.list(
-      {
-        id: Array.from(idsInUpdate),
-      },
-      {},
-      sharedContext
-    );
-    const existingIds = new Set(existingIdResponse.map((variant) => variant.id));
-    
-    // Split the forUpdate array into actual updates and creates based on existing IDs
-    const actualForUpdate = forUpdate.filter(variant => existingIds.has(variant.id));
-    const movedToCreate = forUpdate.filter(variant => !existingIds.has(variant.id));
-    forCreate.push(...(movedToCreate as ProductTypes.CreateProductVariantDTO[]));
+      forUpdate = actualForUpdate;
+      forCreate.push(...(movedToCreate as ProductTypes.CreateProductVariantDTO[]));
+    }
 
 
     if (forCreate.length) {
       created = await this.createProductVariants(forCreate, sharedContext)
     }
-    if (actualForUpdate.length) {
-      updated = await this.updateVariants_(actualForUpdate, sharedContext)
+    if (forUpdate.length) {
+      updated = await this.updateVariants_(forUpdate, sharedContext)
     }
 
     
@@ -1408,7 +1411,7 @@ export default class ProductModuleService
     @MedusaContext() sharedContext: Context = {}
   ): Promise<InferEntityType<typeof ProductCategory>[]> {
     const input = Array.isArray(data) ? data : [data]
-    const forUpdate = input.filter(
+    let forUpdate = input.filter(
       (category): category is UpdateCategoryInput => !!category.id
     )
     let forCreate = input.filter(
@@ -1419,21 +1422,25 @@ export default class ProductModuleService
     let created: InferEntityType<typeof ProductCategory>[] = []
     let updated: InferEntityType<typeof ProductCategory>[] = []
 
-    // since the id is now possible to set from external sources, we need to change the logic here a bit
-    const idsInUpdate = new Set(forUpdate.map((category) => category.id));
-    const existingIdResponse = await this.productCategoryService_.list(
-      {
-        id: Array.from(idsInUpdate),
-      },
-      {},
-      sharedContext
-    );
-    const existingIds = new Set(existingIdResponse.map((category) => category.id));
-    
-    // Split the forUpdate array into actual updates and creates based on existing IDs
-    const actualForUpdate = forUpdate.filter(category => existingIds.has(category.id));
-    const movedToCreate = forUpdate.filter(category => !existingIds.has(category.id));
-    forCreate.push(...(movedToCreate as ProductTypes.CreateProductCategoryDTO[]));
+    if (forUpdate.length > 0) {
+      // since the id is now possible to set from external sources, we need to change the logic here a bit
+      const idsInUpdate = new Set(forUpdate.map((category) => category.id));
+      const existingIdResponse = await this.productCategoryService_.list(
+        {
+          id: Array.from(idsInUpdate),
+        },
+        {},
+        sharedContext
+      );
+      const existingIds = new Set(existingIdResponse.map((category) => category.id));
+      
+      // Split the forUpdate array into actual updates and creates based on existing IDs
+      const actualForUpdate = forUpdate.filter(category => existingIds.has(category.id));
+      const movedToCreate = forUpdate.filter(category => !existingIds.has(category.id));
+
+      forUpdate = actualForUpdate;
+      forCreate.push(...(movedToCreate as ProductTypes.CreateProductCategoryDTO[]));
+    }
 
 
     if (forCreate.length) {
@@ -1449,9 +1456,9 @@ export default class ProductModuleService
         sharedContext
       )
     }
-    if (actualForUpdate.length) {
+    if (forUpdate.length) {
       updated = await this.productCategoryService_.update(
-        actualForUpdate,
+        forUpdate,
         sharedContext
       )
     }
@@ -1599,29 +1606,32 @@ export default class ProductModuleService
     @MedusaContext() sharedContext: Context = {}
   ): Promise<ProductTypes.ProductDTO[] | ProductTypes.ProductDTO> {
     const input = Array.isArray(data) ? data : [data]
-    const forUpdate = input.filter(
+    let forUpdate = input.filter(
       (product): product is UpdateProductInput => !!product.id
     )
     const forCreate = input.filter(
       (product): product is ProductTypes.CreateProductDTO => !product.id
     )
 
-
-    // since the id is now possible to set from external sources, we need to change the logic here a bit
-    const idsInUpdate = new Set(forUpdate.map((product) => product.id));
-    const existingIdResponse =  await this.productService_.list(
-      {
-        id: Array.from(idsInUpdate),
-      },
-      {},
-      sharedContext
-    );
-    const existingIds = new Set(existingIdResponse.map((product) => product.id));
-    
-    // Split the forUpdate array into actual updates and creates based on existing IDs
-    const actualForUpdate = forUpdate.filter(product => existingIds.has(product.id));
-    const movedToCreate = forUpdate.filter(product => !existingIds.has(product.id));
-    forCreate.push(...(movedToCreate as ProductTypes.CreateProductDTO[]));
+    if (forUpdate.length > 0) {
+      // since the id is now possible to set from external sources, we need to change the logic here a bit
+      const idsInUpdate = new Set(forUpdate.map((product) => product.id));
+      const existingIdResponse =  await this.productService_.list(
+        {
+          id: Array.from(idsInUpdate),
+        },
+        {},
+        sharedContext
+      );
+      const existingIds = new Set(existingIdResponse.map((product) => product.id));
+      
+      // Split the forUpdate array into actual updates and creates based on existing IDs
+      const actualForUpdate = forUpdate.filter(product => existingIds.has(product.id));
+      const movedToCreate = forUpdate.filter(product => !existingIds.has(product.id));
+      
+      forUpdate = actualForUpdate;
+      forCreate.push(...(movedToCreate as ProductTypes.CreateProductDTO[]));
+    }
 
     let created: ProductTypes.ProductDTO[] = []
     let updated: InferEntityType<typeof Product>[] = []
@@ -1629,8 +1639,8 @@ export default class ProductModuleService
     if (forCreate.length) {
       created = await this.createProducts(forCreate, sharedContext)
     }
-    if (actualForUpdate.length) {
-      updated = await this.updateProducts_(actualForUpdate, sharedContext)
+    if (forUpdate.length) {
+      updated = await this.updateProducts_(forUpdate, sharedContext)
     }
 
     const result = [...created, ...updated]

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -1347,7 +1347,9 @@ export default class ProductModuleService
   > {
     const input = (Array.isArray(data) ? data : [data]).map(
       (productCategory) => {
-        productCategory.handle ??= kebabCase(productCategory.name)
+        if (!productCategory.handle && productCategory.name) {
+          productCategory.handle = kebabCase(productCategory.name)
+        }
         return productCategory
       }
     )
@@ -1436,7 +1438,9 @@ export default class ProductModuleService
 
     if (forCreate.length) {
       forCreate = forCreate.map((productCategory) => {
-        productCategory.handle ??= kebabCase(productCategory.name)
+        if (!productCategory.handle && productCategory.name) {
+          productCategory.handle = kebabCase(productCategory.name)
+        } 
         return productCategory
       })
 

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -1396,6 +1396,19 @@ export default class ProductModuleService
     let created: InferEntityType<typeof ProductCategory>[] = []
     let updated: InferEntityType<typeof ProductCategory>[] = []
 
+    // since the id is now possible to set from external sources, we need to change the logic here a bit
+    const idsInUpdate = new Set(forUpdate.map((category) => category.id));
+    const existingIdResponse = await this.productCategoryService_.list({
+      id: Array.from(idsInUpdate),
+    });
+    const existingIds = new Set(existingIdResponse.map((category) => category.id));
+    
+    // Split the forUpdate array into actual updates and creates based on existing IDs
+    const actualForUpdate = forUpdate.filter(category => existingIds.has(category.id));
+    const movedToCreate = forUpdate.filter(category => !existingIds.has(category.id));
+    forCreate.push(...(movedToCreate as ProductTypes.CreateProductCategoryDTO[]));
+
+
     if (forCreate.length) {
       forCreate = forCreate.map((productCategory) => {
         productCategory.handle ??= kebabCase(productCategory.name)
@@ -1407,9 +1420,9 @@ export default class ProductModuleService
         sharedContext
       )
     }
-    if (forUpdate.length) {
+    if (actualForUpdate.length) {
       updated = await this.productCategoryService_.update(
-        forUpdate,
+        actualForUpdate,
         sharedContext
       )
     }
@@ -1564,14 +1577,27 @@ export default class ProductModuleService
       (product): product is ProductTypes.CreateProductDTO => !product.id
     )
 
+
+    // since the id is now possible to set from external sources, we need to change the logic here a bit
+    const idsInUpdate = new Set(forUpdate.map((product) => product.id));
+    const existingIdResponse =  await this.productService_.list({
+      id: Array.from(idsInUpdate),
+    });
+    const existingIds = new Set(existingIdResponse.map((product) => product.id));
+    
+    // Split the forUpdate array into actual updates and creates based on existing IDs
+    const actualForUpdate = forUpdate.filter(product => existingIds.has(product.id));
+    const movedToCreate = forUpdate.filter(product => !existingIds.has(product.id));
+    forCreate.push(...(movedToCreate as ProductTypes.CreateProductDTO[]));
+
     let created: ProductTypes.ProductDTO[] = []
     let updated: InferEntityType<typeof Product>[] = []
 
     if (forCreate.length) {
       created = await this.createProducts(forCreate, sharedContext)
     }
-    if (forUpdate.length) {
-      updated = await this.updateProducts_(forUpdate, sharedContext)
+    if (actualForUpdate.length) {
+      updated = await this.updateProducts_(actualForUpdate, sharedContext)
     }
 
     const result = [...created, ...updated]


### PR DESCRIPTION
This commit allows integration flows to assign an ID for categories, products and variants. This makes it easier  in scenarios where existing services already have assigned a globally known (external) id to the entity.

Example: you are adding medusa to a stack that has an existing recommendation engine in place, that has been using the PIM partnumber as key for a long time. As the PIM is the MDM master, reusing its key, makes it easier for all other systems in the stack to coordinate based on this.

External_id is not searchable or filteriable by default, so it does not serve same function.

## Summary

**What** — What changes are introduced in this PR?

API endpoints and SDK structures for creating Products, Variants and Categories now accept an optional id, that if set, will be used in lieu of the normal ID assignment.


**Why** — Why are these changes relevant or necessary?  

To make it easier for Medusa to be used in a Composable Context where these entities already exist in other systems using an established ID set.

https://github.com/medusajs/medusa/discussions/14256

**How** — How have these changes been implemented?

By adding the optional ID to the input types. 

The BaseEntity already had provisions for allowing the setting of an ID during create, it was just never used.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Unittests for Create and Upsert have been provided for the relevant entities.
Otherwise, manual test would be to call the endpoint to create a product using postman, and provide an `id` field, then observe that the category is `retrieve`able by this ID later.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
      response = await sdk.admin.productCategory.create({
        id: rootCategory.id,
        name: rootCategory.name,
        description: rootCategory.longDescription,
...

```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core upsert decision logic for products/variants/categories, which could affect update vs create behavior and uniqueness/collision scenarios when clients supply IDs.
> 
> **Overview**
> Adds optional `id` support across admin HTTP payload/types and zod validators for creating products, product variants, and product categories.
> 
> Updates `ProductModuleService` upsert flows (`upsertProducts`, `upsertProductVariants`, `upsertProductCategories_`) to *no longer assume* “has `id` == update”; it now pre-checks which IDs exist and routes non-existent IDs into the create path, enabling create/upsert with externally assigned IDs. Also tweaks category handle defaulting logic to avoid nullish assignment patterns.
> 
> Extends product module integration tests and fixtures to cover creating and upserting entities with assigned IDs (including nested variant IDs on product create).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b9543dbbbe2e2afdd8bae33f67906b091a3fc19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->