### PR TITLE
fix(core-flows): conditionally create customer on order email update if unset

### DIFF
--- a/.changeset/quick-candles-leave.md
+++ b/.changeset/quick-candles-leave.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): conditionally create customer on order email update if unset

--- a/integration-tests/http/__tests__/fixtures/order.ts
+++ b/integration-tests/http/__tests__/fixtures/order.ts
@@ -6,7 +6,11 @@ import {
   AdminStockLocation,
   MedusaContainer,
 } from "@medusajs/types"
-import { ContainerRegistrationKeys, Modules, ProductStatus } from "@medusajs/utils"
+import {
+  ContainerRegistrationKeys,
+  Modules,
+  ProductStatus,
+} from "@medusajs/utils"
 import {
   adminHeaders,
   generatePublishableKey,

--- a/packages/core/core-flows/src/order/workflows/update-order.ts
+++ b/packages/core/core-flows/src/order/workflows/update-order.ts
@@ -10,6 +10,7 @@ import {
   createStep,
   createWorkflow,
   transform,
+  when,
 } from "@medusajs/framework/workflows-sdk"
 import {
   OrderPreviewDTO,
@@ -24,6 +25,7 @@ import {
   updateOrdersStep,
 } from "../steps"
 import { throwIfOrderIsCancelled } from "../utils/order-validation"
+import { findOrCreateCustomerStep } from "../../cart"
 
 /**
  * The data to validate the order update.
@@ -143,30 +145,43 @@ export const updateOrderWorkflow = createWorkflow(
 
     updateOrderValidationStep({ order, input })
 
-    const updateInput = transform({ input, order }, ({ input, order }) => {
-      const update: UpdateOrderDTO = {}
-
-      if (input.shipping_address) {
-        const address = {
-          // we want to create a new address
-          ...order.shipping_address,
-          ...input.shipping_address,
-        }
-        delete address.id
-        update.shipping_address = address
-      }
-
-      if (input.billing_address) {
-        const address = {
-          ...order.billing_address,
-          ...input.billing_address,
-        }
-        delete address.id
-        update.billing_address = address
-      }
-
-      return { ...input, ...update }
+    const customerData = when({ input, order }, ({ input, order }) => {
+      return !order.email && !!input.email
+    }).then(() => {
+      return findOrCreateCustomerStep({ email: input.email })
     })
+
+    const updateInput = transform(
+      { input, order, customerData },
+      ({ input, order, customerData }) => {
+        const update: UpdateOrderDTO = {}
+
+        if (input.shipping_address) {
+          const address = {
+            // we want to create a new address
+            ...order.shipping_address,
+            ...input.shipping_address,
+          }
+          delete address.id
+          update.shipping_address = address
+        }
+
+        if (input.billing_address) {
+          const address = {
+            ...order.billing_address,
+            ...input.billing_address,
+          }
+          delete address.id
+          update.billing_address = address
+        }
+
+        if (!!customerData?.customer) {
+          update.customer_id = customerData.customer.id
+        }
+
+        return { ...input, ...update }
+      }
+    )
 
     const updatedOrders = updateOrdersStep({
       selector: { id: input.id },


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Conditionally find or create a customer when an order's email is updated and this was previously unset. This allows to cover more flows, like for example, if an order is created from a sync to an external system that doesn't provide customer information and this should be filled manually afterwards, we now make it possible to implement said flow.

If the email is already set, we don't create nor link a customer to the order. This flow is already possible using the transfer order workflow.

**Why** — Why are these changes relevant or necessary?  

If an order doesn't have an email set, calling the update order endpoint and passing the email only updates the field, but the customer linked to the order is still `null`. This will cause issues in the Admin UI when clicking on the customer email to navigate to the customer detail, since no customer exists. It also makes it impossible to transfer the order, as source is `null`

**How** — How have these changes been implemented?

Take the same approach as cart flows where we find or create a customer when one is not linked to the cart but we have an email. In the `updateOrderWorkflow` we check if the update input contains an `email` and the `order.email` is unset and in this case, we find or create a customer matching the input email and link it to the order.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes CORE-1308
