### PR TITLE
chore: Add locks to order edit flows

### DIFF
--- a/.changeset/little-panthers-hide.md
+++ b/.changeset/little-panthers-hide.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+chore: Add locks to order edit flows

--- a/packages/core/core-flows/src/order/workflows/order-edit/cancel-begin-order-edit.ts
+++ b/packages/core/core-flows/src/order/workflows/order-edit/cancel-begin-order-edit.ts
@@ -12,6 +12,7 @@ import {
   transform,
 } from "@medusajs/framework/workflows-sdk"
 import { emitEventStep, useQueryGraphStep } from "../../../common"
+import { acquireLockStep, releaseLockStep } from "../../../locking"
 import { deleteOrderChangesStep, deleteOrderShippingMethods } from "../../steps"
 import {
   throwIfIsCancelled,
@@ -102,6 +103,12 @@ export const cancelBeginOrderEditWorkflow = createWorkflow(
   function (
     input: WorkflowData<CancelBeginOrderEditWorkflowInput>
   ): WorkflowData<void> {
+    acquireLockStep({
+      key: input.order_id,
+      timeout: 2,
+      ttl: 10,
+    })
+
     const orderResult = useQueryGraphStep({
       entity: "order",
       fields: fieldsToRefreshOrderEdit,
@@ -160,5 +167,9 @@ export const cancelBeginOrderEditWorkflow = createWorkflow(
         data: eventData,
       })
     )
+
+    releaseLockStep({
+      key: input.order_id,
+    })
   }
 )

--- a/packages/core/core-flows/src/order/workflows/order-edit/remove-order-edit-item-action.ts
+++ b/packages/core/core-flows/src/order/workflows/order-edit/remove-order-edit-item-action.ts
@@ -14,6 +14,7 @@ import {
   transform,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep } from "../../../common"
+import { acquireLockStep, releaseLockStep } from "../../../locking"
 import {
   deleteOrderChangeActionsStep,
   previewOrderChangeStep,
@@ -128,6 +129,12 @@ export const removeItemOrderEditActionWorkflow = createWorkflow(
   function (
     input: WorkflowData<OrderWorkflow.DeleteOrderEditItemActionWorkflowInput>
   ): WorkflowResponse<OrderPreviewDTO> {
+    acquireLockStep({
+      key: input.order_id,
+      timeout: 2,
+      ttl: 10,
+    })
+
     const orderResult = useQueryGraphStep({
       entity: "order",
       fields: fieldsToRefreshOrderEdit,
@@ -172,6 +179,12 @@ export const removeItemOrderEditActionWorkflow = createWorkflow(
       },
     })
 
-    return new WorkflowResponse(previewOrderChangeStep(order.id))
+    const previewOrderChange = previewOrderChangeStep(order.id) as OrderPreviewDTO
+
+    releaseLockStep({
+      key: input.order_id,
+    })
+
+    return new WorkflowResponse(previewOrderChange)
   }
 )

--- a/packages/core/core-flows/src/order/workflows/order-edit/request-order-edit.ts
+++ b/packages/core/core-flows/src/order/workflows/order-edit/request-order-edit.ts
@@ -14,6 +14,7 @@ import {
   transform,
 } from "@medusajs/framework/workflows-sdk"
 import { emitEventStep, useQueryGraphStep } from "../../../common"
+import { acquireLockStep, releaseLockStep } from "../../../locking"
 import { previewOrderChangeStep } from "../../steps"
 import { updateOrderChangesStep } from "../../steps/update-order-changes"
 import {
@@ -128,6 +129,12 @@ export const requestOrderEditRequestWorkflow = createWorkflow(
   function (
     input: OrderEditRequestWorkflowInput
   ): WorkflowResponse<OrderPreviewDTO> {
+    acquireLockStep({
+      key: input.order_id,
+      timeout: 2,
+      ttl: 10,
+    })
+
     const orderResult = useQueryGraphStep({
       entity: "order",
       fields: fieldsToRefreshOrderEdit,
@@ -180,6 +187,12 @@ export const requestOrderEditRequestWorkflow = createWorkflow(
       data: eventData,
     })
 
-    return new WorkflowResponse(previewOrderChangeStep(order.id))
+    const previewOrderChange = previewOrderChangeStep(order.id) as OrderPreviewDTO
+
+    releaseLockStep({
+      key: input.order_id,
+    })
+
+    return new WorkflowResponse(previewOrderChange)
   }
 )

--- a/packages/core/core-flows/src/order/workflows/order-edit/update-order-edit-item-quantity.ts
+++ b/packages/core/core-flows/src/order/workflows/order-edit/update-order-edit-item-quantity.ts
@@ -14,6 +14,7 @@ import {
   transform,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep } from "../../../common"
+import { acquireLockStep, releaseLockStep } from "../../../locking"
 import {
   previewOrderChangeStep,
   updateOrderChangeActionsStep,
@@ -134,6 +135,12 @@ export const updateOrderEditItemQuantityWorkflow = createWorkflow(
   function (
     input: WorkflowData<OrderWorkflow.UpdateOrderEditItemQuantityWorkflowInput>
   ): WorkflowResponse<OrderPreviewDTO> {
+    acquireLockStep({
+      key: input.order_id,
+      timeout: 2,
+      ttl: 10,
+    })
+
     const orderResult = useQueryGraphStep({
       entity: "order",
       fields: fieldsToRefreshOrderEdit,
@@ -196,6 +203,12 @@ export const updateOrderEditItemQuantityWorkflow = createWorkflow(
       },
     })
 
-    return new WorkflowResponse(previewOrderChangeStep(order.id))
+    const previewOrderChange = previewOrderChangeStep(order.id) as OrderPreviewDTO
+
+    releaseLockStep({
+      key: input.order_id,
+    })
+
+    return new WorkflowResponse(previewOrderChange)
   }
 )


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Add locks to order edit flows

**Why** — Why are these changes relevant or necessary?  

To ensure concurrent requests don't lead to data inconsistencies

**How** — How have these changes been implemented?

Use acquire and release lock steps

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds acquire/release locking around order edit workflows to serialize concurrent operations and avoid conflicts.
> 
> - **Backend – Order Edit Workflows**
>   - **Locking**: Add `acquireLockStep`/`releaseLockStep` around critical sections in:
>     - `begin-order-edit`, `cancel-begin-order-edit`, `confirm-order-edit-request`
>     - `create-order-edit-shipping-method`, `remove-order-edit-shipping-method`, `update-order-edit-shipping-method`
>     - `order-edit-add-new-item`, `order-edit-update-item-quantity`
>     - `remove-order-edit-item-action`, `update-order-edit-add-item`, `update-order-edit-item-quantity`, `request-order-edit`
>   - **Refactor**: Compute `previewOrderChange` before returning and release lock explicitly prior to response in affected workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce19cf385915774b9399394fbd633c7d94b39a16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->