### PR TITLE
fix(translation): add index file for models

### DIFF
--- a/packages/modules/translation/src/models/index.ts
+++ b/packages/modules/translation/src/models/index.ts
@@ -1,0 +1,2 @@
+export { default as Translation } from "./translation"
+export { default as Locale } from "./locale"


### PR DESCRIPTION
Add an index file to the Translation Module that exports the data models. This follows existing conventions and is necessary for how we generate the data model references in the docs