### PR TITLE
fix(dashboard): Initialize complete price structure for variants in price list edit

### DIFF
--- a/.changeset/quiet-flowers-tease.md
+++ b/.changeset/quiet-flowers-tease.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): Initialize complete price structure for variants in price list edit

--- a/packages/admin/dashboard/src/routes/price-lists/price-list-prices-edit/components/price-list-prices-edit-form/price-list-prices-edit-form.tsx
+++ b/packages/admin/dashboard/src/routes/price-lists/price-list-prices-edit/components/price-list-prices-edit-form/price-list-prices-edit-form.tsx
@@ -162,8 +162,10 @@ function initRecord(
       variants:
         product.variants?.reduce((variants, variant) => {
           const prices = variantPrices[variant.id] || {}
-          variants[variant.id] = prices
-
+          variants[variant.id] = {
+            currency_prices: prices.currency_prices || {},
+            region_prices: prices.region_prices || {},
+          }
           return variants
         }, {} as PriceListUpdateProductVariantsSchema) || {},
     }


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Initialize empty currency_prices and region_prices objects for all product variants in the price list edit form, regardless of whether they have existing prices.

**Why** — Why are these changes relevant or necessary?  

When editing a price list with many products/variants, the DataGrid uses virtualization to only render visible rows. The form uses Controller from react-hook-form which only registers fields when the component is rendered.
Previously, variants without existing prices were initialized with an empty object {} instead of the expected structure { currency_prices: {}, region_prices: {} }. This caused Zod validation to fail on unrendered (virtualized) rows because the schema requires both currency_prices and region_prices properties to exist.
As a result, users had to scroll through the entire DataGrid to render all cells before being able to submit the form.


**How** — How have these changes been implemented?

Modified the initRecord function in price-list-prices-edit-form.tsx to always initialize variants with the complete structure containing empty currency_prices and region_prices objects, matching the pattern already used in the price list add form.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

1. Create a price list with many products (enough to trigger virtualization)
2. Ensure some variants have no existing prices
3. Open the price list edit form
4. Try to submit without scrolling to the end
5. Verify the form submits successfully without validation errors

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

[ ] I have added a changeset for this PR
Every non-breaking change should be marked as a patch
To add a changeset, run yarn changeset and follow the prompts
[ ] The changes are covered by relevant tests
[x] I have verified the code works as intended locally
[ ] I have linked the related issue(s) if applicable

---

## Additional Context

This fix aligns the price list edit form with the existing implementation in the price list add form (price-list-prices-add-prices-form.tsx), which already initializes variants with the complete structure.

before : 

https://github.com/user-attachments/assets/8a2a457b-4609-4bc6-a7f4-8b032e23128a



after : 


https://github.com/user-attachments/assets/e1480af5-f71e-437f-941c-4a92f5258042



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always initialize each variant with `{ currency_prices: {}, region_prices: {} }` in the price list edit form to ensure schema-compliant defaults.
> 
> - **Price List Edit Form (`price-list-prices-edit-form.tsx`)**:
>   - Ensure each variant in `initRecord` is initialized with `{ currency_prices: {}, region_prices: {} }`.
>   - Prevents empty `{}` variant entries by defaulting missing `currency_prices` and `region_prices` to empty objects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85fba66ba40696c301e658fd060737f29f5cefb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->