### PR TITLE
fix(utils,core-flows): add events constant for translations and use it in workflows

### DIFF
--- a/.changeset/fruity-eyes-glow.md
+++ b/.changeset/fruity-eyes-glow.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/core-flows": patch
+"@medusajs/utils": patch
+---
+
+fix(utils,core-flows): add events constant for translations and use it in workflows

--- a/packages/core/core-flows/src/translation/workflows/create-translations.ts
+++ b/packages/core/core-flows/src/translation/workflows/create-translations.ts
@@ -8,6 +8,7 @@ import {
 import { emitEventStep } from "../../common/steps/emit-event"
 import { createTranslationsStep } from "../steps"
 import { validateTranslationsStep } from "../steps"
+import { TranslationWorkflowEvents } from "@medusajs/framework/utils"
 
 export type CreateTranslationsWorkflowInput = {
   translations: CreateTranslationDTO[]
@@ -57,7 +58,7 @@ export const createTranslationsWorkflow = createWorkflow(
     )
 
     emitEventStep({
-      eventName: "translation.created",
+      eventName: TranslationWorkflowEvents.CREATED,
       data: translationIdEvents,
     })
 

--- a/packages/core/core-flows/src/translation/workflows/delete-translations.ts
+++ b/packages/core/core-flows/src/translation/workflows/delete-translations.ts
@@ -5,6 +5,7 @@ import {
 } from "@medusajs/framework/workflows-sdk"
 import { emitEventStep } from "../../common/steps/emit-event"
 import { deleteTranslationsStep } from "../steps"
+import { TranslationWorkflowEvents } from "@medusajs/framework/utils"
 
 export type DeleteTranslationsWorkflowInput = { ids: string[] }
 
@@ -41,7 +42,7 @@ export const deleteTranslationsWorkflow = createWorkflow(
     })
 
     emitEventStep({
-      eventName: "translation.deleted",
+      eventName: TranslationWorkflowEvents.DELETED,
       data: translationIdEvents,
     })
   }

--- a/packages/core/core-flows/src/translation/workflows/update-translations.ts
+++ b/packages/core/core-flows/src/translation/workflows/update-translations.ts
@@ -8,6 +8,7 @@ import {
 import { emitEventStep } from "../../common/steps/emit-event"
 import { updateTranslationsStep, UpdateTranslationsStepInput } from "../steps"
 import { validateTranslationsStep } from "../steps"
+import { TranslationWorkflowEvents } from "@medusajs/framework/utils"
 
 export type UpdateTranslationsWorkflowInput = UpdateTranslationsStepInput
 
@@ -58,7 +59,7 @@ export const updateTranslationsWorkflow = createWorkflow(
     )
 
     emitEventStep({
-      eventName: "translation.updated",
+      eventName: TranslationWorkflowEvents.UPDATED,
       data: translationIdEvents,
     })
 

--- a/packages/core/utils/src/core-flows/events.ts
+++ b/packages/core/utils/src/core-flows/events.ts
@@ -889,3 +889,49 @@ export const PaymentEvents = {
    */
   REFUNDED: "payment.refunded",
 }
+
+/**
+ * @category Translation
+ * @customNamespace Translation
+ */
+export const TranslationWorkflowEvents = {
+  /**
+   * Emitted when translations are created.
+   * 
+   * @since 2.13.0
+   * @featureFlag translation
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the translation
+   * }
+   * ```
+   */
+  CREATED: "translation.created",
+  /**
+   * Emitted when translations are updated.
+   *
+   * @since 2.13.0
+   * @featureFlag translation
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the translation
+   * }
+   * ```
+   */
+  UPDATED: "translation.updated",
+  /**
+   * Emitted when translations are deleted.
+   *
+   * @since 2.13.0
+   * @featureFlag translation
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the translation
+   * }
+   * ```
+   */
+  DELETED: "translation.deleted",
+}


### PR DESCRIPTION
Use an event constant for translations, following existing conventions for events