### PR TITLE
fix(types,translations): fix types for translation and locale updates

### DIFF
--- a/.changeset/chubby-jobs-shout.md
+++ b/.changeset/chubby-jobs-shout.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/core-flows": patch
+"@medusajs/types": patch
+---
+
+fix(types,translations): fix types for translation and locale updates

--- a/packages/core/core-flows/src/translation/steps/update-translations.ts
+++ b/packages/core/core-flows/src/translation/steps/update-translations.ts
@@ -1,6 +1,7 @@
 import {
   FilterableTranslationProps,
   ITranslationModuleService,
+  UpdateTranslationDataDTO,
   UpdateTranslationDTO,
 } from "@medusajs/framework/types"
 import {
@@ -22,7 +23,7 @@ export type UpdateTranslationsStepInput =
       /**
        * The data to update in the translations.
        */
-      update: UpdateTranslationDTO
+      update: UpdateTranslationDataDTO
     }
   | {
       translations: UpdateTranslationDTO[]

--- a/packages/core/core-flows/src/translation/steps/validate-translations.ts
+++ b/packages/core/core-flows/src/translation/steps/validate-translations.ts
@@ -4,7 +4,7 @@ import {
   MedusaErrorTypes,
 } from "@medusajs/framework/utils"
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
-import { CreateTranslationDTO, UpdateTranslationDTO } from "@medusajs/types"
+import { CreateTranslationDTO, UpdateTranslationDataDTO, UpdateTranslationDTO } from "@medusajs/types"
 
 export const validateTranslationsStepId = "validate-translations"
 
@@ -13,6 +13,8 @@ export type ValidateTranslationsStepInput =
   | CreateTranslationDTO
   | UpdateTranslationDTO[]
   | UpdateTranslationDTO
+  | UpdateTranslationDataDTO
+  | UpdateTranslationDataDTO[]
 
 // TODO: Do we want to validate anything else here?
 export const validateTranslationsStep = createStep(

--- a/packages/core/core-flows/src/translation/steps/validate-translations.ts
+++ b/packages/core/core-flows/src/translation/steps/validate-translations.ts
@@ -14,7 +14,6 @@ export type ValidateTranslationsStepInput =
   | UpdateTranslationDTO[]
   | UpdateTranslationDTO
   | UpdateTranslationDataDTO
-  | UpdateTranslationDataDTO[]
 
 // TODO: Do we want to validate anything else here?
 export const validateTranslationsStep = createStep(

--- a/packages/core/types/src/translation/mutations.ts
+++ b/packages/core/types/src/translation/mutations.ts
@@ -19,14 +19,9 @@ export interface CreateLocaleDTO {
 }
 
 /**
- * The attributes to update in the locale.
+ * The data to update in the locale.
  */
-export interface UpdateLocaleDTO {
-  /**
-   * The ID of the locale to update.
-   */
-  id: string
-
+export interface UpdateLocaleDataDTO {
   /**
    * The BCP 47 language tag code of the locale.
    */
@@ -36,6 +31,16 @@ export interface UpdateLocaleDTO {
    * The human-readable name of the locale.
    */
   name?: string
+}
+
+/**
+ * The attributes to update in the locale.
+ */
+export interface UpdateLocaleDTO extends UpdateLocaleDataDTO {
+  /**
+   * The ID of the locale to update.
+   */
+  id: string
 }
 
 /**
@@ -84,14 +89,9 @@ export interface CreateTranslationDTO {
 }
 
 /**
- * The attributes to update in the translation.
+ * The attributes to update in translations matching a selector.
  */
-export interface UpdateTranslationDTO {
-  /**
-   * The ID of the translation to update.
-   */
-  id: string
-
+export interface UpdateTranslationDataDTO {
   /**
    * The ID of the entity being translated.
    */
@@ -111,6 +111,16 @@ export interface UpdateTranslationDTO {
    * The translated fields as key-value pairs.
    */
   translations?: Record<string, unknown>
+}
+
+/**
+ * The attributes to update in the translation.
+ */
+export interface UpdateTranslationDTO extends UpdateTranslationDataDTO {
+  /**
+   * The ID of the translation to update.
+   */
+  id: string
 }
 
 /**

--- a/packages/core/types/src/translation/service.ts
+++ b/packages/core/types/src/translation/service.ts
@@ -12,7 +12,9 @@ import {
   CreateLocaleDTO,
   CreateTranslationDTO,
   UpdateLocaleDTO,
+  UpdateLocaleDataDTO,
   UpdateTranslationDTO,
+  UpdateTranslationDataDTO,
 } from "./mutations"
 
 /**
@@ -110,7 +112,7 @@ export interface ITranslationModuleService extends IModuleService {
       | UpdateLocaleDTO[]
       | {
           selector: Record<string, any>
-          data: UpdateLocaleDTO | UpdateLocaleDTO[]
+          data: UpdateLocaleDataDTO | UpdateLocaleDataDTO[]
         },
     sharedContext?: Context
   ): Promise<LocaleDTO[]>
@@ -245,7 +247,7 @@ export interface ITranslationModuleService extends IModuleService {
       | UpdateTranslationDTO[]
       | {
           selector: Record<string, any>
-          data: UpdateTranslationDTO | UpdateTranslationDTO[]
+          data: UpdateTranslationDataDTO | UpdateTranslationDataDTO[]
         },
     sharedContext?: Context
   ): Promise<TranslationDTO[]>


### PR DESCRIPTION
Service methods and workflows that allow updating translations and locales by a selector use incorrect typing because the type is the same as update by ID, which requires an ID present (defeats the purpose of the selector)

This PR fixes the issue by separating the types to update a translation / locale by a selector and ID