### PR TITLE
feat(): Add support for locale to the js sdk

### DIFF
--- a/.changeset/great-icons-thank.md
+++ b/.changeset/great-icons-thank.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/js-sdk": patch
+---
+
+feat(): Add support for locale to the js sdk

--- a/packages/core/js-sdk/src/index.ts
+++ b/packages/core/js-sdk/src/index.ts
@@ -18,6 +18,14 @@ class Medusa {
     this.store = new Store(this.client)
     this.auth = new Auth(this.client, config)
   }
+
+  setLocale(locale: string) {
+    this.client.setLocale(locale)
+  }
+
+  getLocale() {
+    return this.client.locale
+  }
 }
 
 export default Medusa


### PR DESCRIPTION
### overview

Add support for locale to the js-sdk:
- set locale will store in the object and locale store under `medusa_locale`
- getting locale will return it from the local storage if available and fallback to the local object property