### PR TITLE
feat(): Add support for store locales end point

### DIFF
--- a/.changeset/wicked-candles-mate.md
+++ b/.changeset/wicked-candles-mate.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/medusa": patch
+"@medusajs/link-modules": patch
+---
+
+feat(): Add support for store locales end point

--- a/integration-tests/http/__tests__/store/store/locale.spec.ts
+++ b/integration-tests/http/__tests__/store/store/locale.spec.ts
@@ -53,27 +53,18 @@ medusaIntegrationTestRunner({
           expect(response.data.locales).toHaveLength(3)
           expect(response.data.locales).toEqual(
             expect.arrayContaining([
-              expect.objectContaining({
-                locale_code: "en-US",
-                locale: expect.objectContaining({
-                  code: "en-US",
-                  name: expect.any(String),
-                }),
-              }),
-              expect.objectContaining({
-                locale_code: "fr-FR",
-                locale: expect.objectContaining({
-                  code: "fr-FR",
-                  name: expect.any(String),
-                }),
-              }),
-              expect.objectContaining({
-                locale_code: "de-DE",
-                locale: expect.objectContaining({
-                  code: "de-DE",
-                  name: expect.any(String),
-                }),
-              }),
+              {
+                code: "en-US",
+                name: expect.any(String),
+              },
+              {
+                code: "fr-FR",
+                name: expect.any(String),
+              },
+              {
+                code: "de-DE",
+                name: expect.any(String),
+              },
             ])
           )
         })

--- a/integration-tests/http/__tests__/store/store/locale.spec.ts
+++ b/integration-tests/http/__tests__/store/store/locale.spec.ts
@@ -1,0 +1,102 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/types"
+import { Modules } from "@medusajs/utils"
+import {
+  generatePublishableKey,
+  generateStoreHeaders,
+} from "../../../../helpers/create-admin-user"
+
+jest.setTimeout(30000)
+
+process.env.MEDUSA_FF_TRANSLATION = "true"
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api }) => {
+    describe("Store Locales API", () => {
+      let appContainer: MedusaContainer
+      let storeHeaders
+
+      beforeAll(async () => {
+        appContainer = getContainer()
+      })
+
+      beforeEach(async () => {
+        const publishableKey = await generatePublishableKey(appContainer)
+        storeHeaders = generateStoreHeaders({ publishableKey })
+
+        const storeModule = appContainer.resolve(Modules.STORE)
+        const [defaultStore] = await storeModule.listStores(
+          {},
+          {
+            select: ["id"],
+            take: 1,
+          }
+        )
+        await storeModule.updateStores(defaultStore.id, {
+          supported_locales: [
+            { locale_code: "en-US" },
+            { locale_code: "fr-FR" },
+            { locale_code: "de-DE" },
+          ],
+        })
+      })
+
+      afterAll(async () => {
+        delete process.env.MEDUSA_FF_TRANSLATION
+      })
+
+      describe("GET /store/locales", () => {
+        it("should return store supported locales", async () => {
+          const response = await api.get("/store/locales", storeHeaders)
+
+          expect(response.status).toEqual(200)
+          expect(response.data.locales).toHaveLength(3)
+          expect(response.data.locales).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                locale_code: "en-US",
+                locale: expect.objectContaining({
+                  code: "en-US",
+                  name: expect.any(String),
+                }),
+              }),
+              expect.objectContaining({
+                locale_code: "fr-FR",
+                locale: expect.objectContaining({
+                  code: "fr-FR",
+                  name: expect.any(String),
+                }),
+              }),
+              expect.objectContaining({
+                locale_code: "de-DE",
+                locale: expect.objectContaining({
+                  code: "de-DE",
+                  name: expect.any(String),
+                }),
+              }),
+            ])
+          )
+        })
+
+        it("should return empty array when no locales configured", async () => {
+          const storeModule = appContainer.resolve(Modules.STORE)
+          const [defaultStore] = await storeModule.listStores(
+            {},
+            {
+              select: ["id"],
+              take: 1,
+            }
+          )
+          await storeModule.updateStores(defaultStore.id, {
+            supported_locales: [],
+          })
+
+          const response = await api.get("/store/locales", storeHeaders)
+
+          expect(response.status).toEqual(200)
+          expect(response.data.locales).toEqual([])
+        })
+      })
+    })
+  },
+})

--- a/integration-tests/http/medusa-config.js
+++ b/integration-tests/http/medusa-config.js
@@ -85,6 +85,7 @@ module.exports = defineConfig({
   },
   featureFlags: {
     index_engine: process.env.ENABLE_INDEX_MODULE === "true",
+    translation: process.env.MEDUSA_FF_TRANSLATION === "true",
   },
   modules,
 })

--- a/packages/medusa/src/api/store/locales/middlewares.ts
+++ b/packages/medusa/src/api/store/locales/middlewares.ts
@@ -1,0 +1,9 @@
+import { MiddlewareRoute } from "@medusajs/framework/http"
+
+export const storeLocalesRoutesMiddlewares: MiddlewareRoute[] = [
+  {
+    method: ["GET"],
+    matcher: "/store/locales",
+    middlewares: [],
+  },
+]

--- a/packages/medusa/src/api/store/locales/route.ts
+++ b/packages/medusa/src/api/store/locales/route.ts
@@ -14,7 +14,15 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     },
   })
 
+  const locales = store?.supported_locales.reduce((acc, locale) => {
+    acc.push({
+      code: locale.locale_code,
+      name: locale.locale.name,
+    })
+    return acc
+  }, [])
+
   res.json({
-    locales: store?.supported_locales ?? [],
+    locales,
   })
 }

--- a/packages/medusa/src/api/store/locales/route.ts
+++ b/packages/medusa/src/api/store/locales/route.ts
@@ -1,0 +1,20 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const {
+    data: [store],
+  } = await query.graph({
+    entity: "store",
+    fields: ["supported_locales.*", "supported_locales.locale.*"],
+    pagination: {
+      take: 1,
+    },
+  })
+
+  res.json({
+    locales: store?.supported_locales ?? [],
+  })
+}

--- a/packages/medusa/src/api/store/middlewares.ts
+++ b/packages/medusa/src/api/store/middlewares.ts
@@ -1,6 +1,8 @@
 import { MiddlewareRoute } from "@medusajs/framework/http"
+import { storeLocalesRoutesMiddlewares } from "./locales/middlewares"
 import { storeReturnsRoutesMiddlewares } from "./returns/middlewares"
 
 export const storeRoutesMiddlewares: MiddlewareRoute[] = [
+  ...storeLocalesRoutesMiddlewares,
   ...storeReturnsRoutesMiddlewares,
 ]

--- a/packages/modules/link-modules/src/definitions/readonly/store-locale.ts
+++ b/packages/modules/link-modules/src/definitions/readonly/store-locale.ts
@@ -1,12 +1,8 @@
 import { ModuleJoinerConfig } from "@medusajs/framework/types"
-import {
-  FeatureFlag,
-  MEDUSA_SKIP_FILE,
-  Modules,
-} from "@medusajs/framework/utils"
+import { MEDUSA_SKIP_FILE, Modules } from "@medusajs/framework/utils"
 
 export const StoreLocales: ModuleJoinerConfig = {
-  [MEDUSA_SKIP_FILE]: !FeatureFlag.isFeatureEnabled("translation"),
+  [MEDUSA_SKIP_FILE]: process.env.MEDUSA_FF_TRANSLATION !== "true",
   isLink: true,
   isReadOnlyLink: true,
   extends: [


### PR DESCRIPTION
**What**
Add support for `store/locales` which return the configured supported locales