### PR TITLE
feat(js-sdk,types,medusa): add list locales store method to JS SDK

### DIFF
--- a/.changeset/happy-jobs-hear.md
+++ b/.changeset/happy-jobs-hear.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/js-sdk": patch
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+feat(js-sdk,types,medusa): add list locales store method to JS SDK

--- a/packages/core/js-sdk/src/store/index.ts
+++ b/packages/core/js-sdk/src/store/index.ts
@@ -1654,4 +1654,33 @@ export class Store {
       )
     },
   }
+
+  /**
+   * @tags locale
+   */
+  public locale = {
+    /**
+     * This method retrieves the list of supported locales in the store. It sends a request to the
+     * [List Locales](https://docs.medusajs.com/api/store#locales_getlocales) API route.
+     * 
+     * @param headers - Headers to pass in the request.
+     * @returns The list of supported locales.
+     * 
+     * @example
+     * sdk.store.locale.list()
+     * .then(({ locales }) => {
+     *   console.log(locales)
+     * })
+     */
+    list: async (
+      headers?: ClientHeaders
+    ) => {
+      return this.client.fetch<HttpTypes.StoreLocaleListResponse>(
+        `/store/locales`,
+        {
+          headers,
+        }
+      )
+    },
+  }
 }

--- a/packages/core/types/src/http/locale/index.ts
+++ b/packages/core/types/src/http/locale/index.ts
@@ -1,2 +1,3 @@
 export * from "./admin"
+export * from "./store"
 export * from "./common"

--- a/packages/core/types/src/http/locale/store/entities.ts
+++ b/packages/core/types/src/http/locale/store/entities.ts
@@ -1,0 +1,3 @@
+import { BaseLocale } from "../common";
+
+export interface StoreLocale extends Pick<BaseLocale, "code" | "name"> {}

--- a/packages/core/types/src/http/locale/store/index.ts
+++ b/packages/core/types/src/http/locale/store/index.ts
@@ -1,0 +1,2 @@
+export * from "./entities"
+export * from "./responses"

--- a/packages/core/types/src/http/locale/store/responses.ts
+++ b/packages/core/types/src/http/locale/store/responses.ts
@@ -1,0 +1,5 @@
+import { StoreLocale } from "./entities";
+
+export interface StoreLocaleListResponse {
+  locales: StoreLocale[]
+}

--- a/packages/core/types/src/http/order/admin/payload.ts
+++ b/packages/core/types/src/http/order/admin/payload.ts
@@ -12,6 +12,12 @@ export interface AdminUpdateOrder {
    */
   billing_address?: OrderAddress
   /**
+   * The order's locale code. Items in the 
+   * order will be translated to the given locale,
+   * if translations are available.
+   */
+  locale?: string | null
+  /**
    * The order's metadata.
    */
   metadata?: Record<string, unknown> | null

--- a/packages/medusa/src/api/store/locales/route.ts
+++ b/packages/medusa/src/api/store/locales/route.ts
@@ -1,7 +1,11 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { HttpTypes } from "@medusajs/framework/types"
 
-export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+export const GET = async (
+  req: MedusaRequest, 
+  res: MedusaResponse<HttpTypes.StoreLocaleListResponse>
+) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
   const {


### PR DESCRIPTION
- Add a `sdk.store.locale.list` method to retrieve the supported locales in a store
- Add HTTP types for store locale types
- Use response type in list locales API route
- Other: Add missing locale parameter for the update order HTTP payload type