### PR TITLE
fix(types,medusa): use HTTP types in request type parameters of product options routes

### DIFF
--- a/packages/core/types/src/http/product/admin/payloads.ts
+++ b/packages/core/types/src/http/product/admin/payloads.ts
@@ -563,6 +563,10 @@ export interface AdminUpdateProductOption {
    * Whether the option is exclusive or global.
    */
   is_exclusive?: boolean
+  /**
+   * Key-value pairs of custom data.
+   */
+  metadata?: Record<string, unknown> | null
 }
 
 /**

--- a/packages/medusa/src/api/admin/product-options/[id]/route.ts
+++ b/packages/medusa/src/api/admin/product-options/[id]/route.ts
@@ -7,15 +7,11 @@ import {
   MedusaResponse,
 } from "@medusajs/framework/http"
 
-import {
-  AdminGetProductOptionParamsType,
-  AdminUpdateProductOptionType,
-} from "../validators"
 import { HttpTypes } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 export const GET = async (
-  req: AuthenticatedMedusaRequest<AdminGetProductOptionParamsType>,
+  req: AuthenticatedMedusaRequest<{}, HttpTypes.SelectParams>,
   res: MedusaResponse<HttpTypes.AdminProductOptionResponse>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
@@ -31,7 +27,7 @@ export const GET = async (
 }
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest<AdminUpdateProductOptionType>,
+  req: AuthenticatedMedusaRequest<HttpTypes.AdminUpdateProductOption>,
   res: MedusaResponse<HttpTypes.AdminProductOptionResponse>
 ) => {
   const { result } = await updateProductOptionsWorkflow(req.scope).run({

--- a/packages/medusa/src/api/store/product-options/[id]/route.ts
+++ b/packages/medusa/src/api/store/product-options/[id]/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@medusajs/framework/http"
 
 export const GET = async (
-  req: AuthenticatedMedusaRequest<HttpTypes.SelectParams>,
+  req: AuthenticatedMedusaRequest<{}, HttpTypes.SelectParams>,
   res: MedusaResponse<HttpTypes.StoreProductOptionResponse>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)

--- a/packages/medusa/src/api/store/product-options/[id]/route.ts
+++ b/packages/medusa/src/api/store/product-options/[id]/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@medusajs/framework/http"
 
 export const GET = async (
-  req: AuthenticatedMedusaRequest<HttpTypes.StoreProductOptionParams>,
+  req: AuthenticatedMedusaRequest<HttpTypes.SelectParams>,
   res: MedusaResponse<HttpTypes.StoreProductOptionResponse>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)


### PR DESCRIPTION
- Use HTTP types instead of validators in request type arguments of product option routes
- Add missing `metadata` property to HTTP type