### PR TITLE
Fix typo in returns and exchanges section

### DIFF
--- a/www/apps/resources/app/recipes/oms/page.mdx
+++ b/www/apps/resources/app/recipes/oms/page.mdx
@@ -169,7 +169,7 @@ Once the item is fulfilled, the reserved quantity is deducted from the item's in
 
 ## Handle Returns, Exchanges, and Changes
 
-Customers can return or exchaneg items in an order. A merchant can also edit an order to add, update, or delete items.
+Customers can return or exchange items in an order. A merchant can also edit an order to add, update, or delete items.
 
 When changes are made to an order by any of the mentioned actions, the changes are reflected on the order's totals and associated inventory. The integrated fulfillment and payment module providers are used if fulfillment or payment actions are required, such as fulfilling exchanged items.
 


### PR DESCRIPTION
## Summary

Small typo in the OMS recipe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a misspelling (“exchaneg” → “exchange”) in the OMS recipe’s returns/exchanges section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e35fa4842602ec49c697582b1b65305120ee90b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->