### PR TITLE
fix(core-flows): fix type of getTranslatedLineItemsStep

### DIFF
--- a/.changeset/fiery-horses-hug.md
+++ b/.changeset/fiery-horses-hug.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): fix type of getTranslatedLineItemsStep

--- a/packages/core/core-flows/src/common/steps/get-translated-line-items.ts
+++ b/packages/core/core-flows/src/common/steps/get-translated-line-items.ts
@@ -43,4 +43,6 @@ const step = createStep(
  */
 export const getTranslatedLineItemsStep = <T>(
   data: GetTranslatedLineItemsStepInput<T>
-): ReturnType<StepFunction<any, T[]>> => step(data)
+): ReturnType<StepFunction<any, T[]>> => step(data) as unknown as ReturnType<
+  StepFunction<any, T[]>
+>


### PR DESCRIPTION
Fix the return type of the `getTranslatedLineItemsStep`, otherwise our reference generator can't pick up the step's typing correctly