### PR TITLE
fix(medusa): fix type of product variant request param

### DIFF
--- a/.changeset/strong-memes-tease.md
+++ b/.changeset/strong-memes-tease.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): fix type of product variant request param

--- a/packages/medusa/src/api/store/product-variants/route.ts
+++ b/packages/medusa/src/api/store/product-variants/route.ts
@@ -12,9 +12,9 @@ import { wrapVariantsWithInventoryQuantityForSalesChannel } from "../../utils/mi
 import { StoreRequestWithContext } from "../types"
 import { wrapVariantsWithTaxPrices } from "./helpers"
 
-type StoreVariantListRequest =
-  StoreRequestWithContext<HttpTypes.StoreProductVariantParams> &
-    AuthenticatedMedusaRequest<HttpTypes.StoreProductVariantParams>
+type StoreVariantListRequest<T = HttpTypes.StoreProductVariantParams> =
+  StoreRequestWithContext<T> &
+    AuthenticatedMedusaRequest<T>
 
 /**
  * @since 2.11.2


### PR DESCRIPTION
Fix type argument for requests which is necessary for generating OpenAPI specs

## Why

The `StoreVariantListRequest` type used in the `/store/product-variants` route doesn't match the convention of other routes since it doesn't accept a type parameter for the query (or body, but here that's not necessary). This makes it difficult for us to infer the query parameter type of the request.

This change would adapt the `StoreVariantListRequest` to match other conventions in our API routes so that we can generate correct OAS for docs