### PR TITLE
fix(translation): prevent duplicate locale error on server restart

### DIFF
--- a/.changeset/frank-days-start.md
+++ b/.changeset/frank-days-start.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/translation": patch
+---
+
+fix(translation): prevent duplicate locale error on server restart


### PR DESCRIPTION
The translation module's defaults loader throws a warning on every server restart after the first run because the upsert method uses `id` as the unique key, but defaultLocales only contains `code` and `name`.

This causes the upsert to always attempt creation, which fails on the unique `code` constraint with: "Locale with code: en-US, already exists."

Fix: Fetch existing locales first and map their IDs into defaultLocales so upsert can properly identify existing records and update them.

## Summary

**What** — What changes are introduced in this PR?

Modified the translation module's `defaults.ts` loader to fetch existing locales and map their IDs before calling upsert, ensuring the upsert method can properly identify existing records.

**Why** — Why are these changes relevant or necessary?

The current implementation throws a warning on every server restart after the first run: `"Locale with code: en-US, already exists."` This occurs because the `upsert` method uses `id` as the unique key, but `defaultLocales` only contains `code` and `name`. Without IDs, upsert always attempts creation, which fails on the unique `code` constraint.

**How** — How have these changes been implemented?

1. Before upserting, fetch existing locales with their `id` and `code` fields
2. Create a Map of `code -> id` for quick lookups
3. Map `defaultLocales` to include IDs for any locales that already exist in the database
4. Call upsert with the enhanced data so existing records are updated (via ID match) and new records are created

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

1. Enable the translation feature flag
2. Run `medusa develop` — all 48 default locales are created
3. Restart the server — no warning, upsert correctly identifies existing records
4. Verify locales exist via `GET /admin/locales`

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Before: Always tries to create, fails on restart
await localeService_.upsert(defaultLocales)

// After: Maps IDs for existing locales so upsert works correctly
const existingLocales = await localeService_.list({}, { select: ["id", "code"] })
const existingByCode = new Map(existingLocales.map((l) => [l.code, l.id]))

const localesToUpsert = defaultLocales.map((locale) => {
  const normalizedCode = normalizeLocale(locale.code)
  const existingId = existingByCode.get(normalizedCode)
  return existingId ? { ...locale, id: existingId } : locale
})

await localeService_.upsert(localesToUpsert)
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure locale upsert maps existing IDs (with normalized codes) to avoid duplicate code errors on server restarts.
> 
> - **Translation module**:
>   - **Loader `packages/modules/translation/src/loaders/defaults.ts`**:
>     - Fetch existing locales via `localeService_.list` (selecting `id`, `code`) and map by code.
>     - Normalize codes with `normalizeLocale` and include matching `id` in default locales.
>     - Upsert using the ID-mapped data to update existing locales and create missing ones, preventing duplicate `code` conflicts.
>     - Adds `normalizeLocale` import.
> - **Changeset**: adds patch entry for `@medusajs/translation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 105d27e1e86d4f06f055dada2266e33311505e8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->