### PR TITLE
docs: add vite configuration to docker guide

### DIFF
--- a/www/apps/book/app/learn/installation/docker/page.mdx
+++ b/www/apps/book/app/learn/installation/docker/page.mdx
@@ -97,6 +97,7 @@ services:
       - redis
     ports:
       - "9000:9000"
+      - "5173:5173"
     environment:
       - NODE_ENV=development
       - DATABASE_URL=postgres://postgres:postgres@postgres:5432/medusa-store
@@ -139,6 +140,7 @@ If this isn't the first Medusa project you're setting up with Docker on your mac
     - Use `"5433:5432"` for PostgreSQL.
     - Use `"6380:6379"` for Redis.
     - Use `"9001:9000"` for the Medusa server.
+    - Use `"5174:5173"` for the Medusa Admin dashboard.
 - Update the `DATABASE_URL` and `REDIS_URL` environment variables accordingly.
 
 ---
@@ -333,6 +335,8 @@ Where:
 
 ## 7. Update Medusa Configuration
 
+### Disable SSL for PostgreSQL Connection
+
 If you try to run the Medusa application now with Docker, you'll encounter an SSL error as the server tries to connect to the PostgreSQL database.
 
 To resolve the error, add the following configurations in `medusa-config.ts`:
@@ -354,6 +358,43 @@ module.exports = defineConfig({
 ```
 
 You add the [projectConfig.databaseDriverOptions](../../configurations/medusa-config/page.mdx#databasedriveroptions) to disable SSL for the PostgreSQL database connection.
+
+### Add Vite Configuration for Medusa Admin
+
+To ensure that the Medusa Admin dashboard works correctly when running inside Docker, connects to the Medusa server, and reloads properly with Hot Module Replacement (HMR), add the following Vite configuration in `medusa-config.ts`:
+
+```ts title="medusa-config.ts"
+module.exports = defineConfig({
+  // ...
+  admin: {
+    vite: (config) => {
+      return {
+        ...config,
+        server: {
+          ...config.server,
+          host: "0.0.0.0",
+          // Allow all hosts when running in Docker (development mode)
+          // In production, this should be more restrictive
+          allowedHosts: [
+            "localhost",
+            ".localhost",
+            "127.0.0.1",
+          ],
+          hmr: {
+            ...config.server?.hmr,
+            // HMR websocket port inside container
+            port: 5173, 
+            // Port browser connects to (exposed in docker-compose.yml)
+            clientPort: 5173,
+          },
+        },
+      }
+    },
+  },
+})
+```
+
+You configure the Vite development server to listen on all network interfaces (`0.0.0.0`) and set up HMR to work correctly within the Docker environment.
 
 ---
 

--- a/www/apps/book/generated/edit-dates.mjs
+++ b/www/apps/book/generated/edit-dates.mjs
@@ -123,7 +123,7 @@ export const generatedEditDates = {
   "app/learn/fundamentals/module-links/index/page.mdx": "2025-05-23T07:57:58.958Z",
   "app/learn/fundamentals/module-links/index-module/page.mdx": "2025-11-26T11:20:25.961Z",
   "app/learn/introduction/build-with-llms-ai/page.mdx": "2025-12-09T14:17:13.295Z",
-  "app/learn/installation/docker/page.mdx": "2025-10-24T08:53:46.445Z",
+  "app/learn/installation/docker/page.mdx": "2025-12-18T11:18:25.856Z",
   "app/learn/fundamentals/generated-types/page.mdx": "2025-07-25T13:17:35.319Z",
   "app/learn/introduction/from-v1-to-v2/page.mdx": "2025-10-29T11:55:11.531Z",
   "app/learn/debugging-and-testing/debug-workflows/page.mdx": "2025-07-30T13:45:14.117Z",


### PR DESCRIPTION
Fix the docker guide by including vite configurations section. We need to set the HMR port specifically and expose it in `docker-compose.yml`

Closes #14347
Closes DX-2387

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Docker installation guide to configure Medusa Admin Vite/HMR and expose port 5173; regenerates docs index with new translation, locale, and order export references.
> 
> - **Installation Docs (Docker)**:
>   - Expose Admin Vite port `5173` in `docker-compose.yml` and add port-collision guidance (`"5174:5173"`).
>   - Add Vite config in `medusa-config.ts` for Admin (`server.host=0.0.0.0`, `allowedHosts`, HMR `port/clientPort=5173`).
>   - Clarify PostgreSQL SSL section with explicit heading.
> - **Generated Content**:
>   - Update edit date for `app/learn/installation/docker/page.mdx`.
>   - Refresh aggregated docs index `public/llms-full.txt` with:
>     - Docker guide changes mirroring the above.
>     - New references for translations (workflows, steps, events, admin/store APIs, JS SDK methods).
>     - Order export workflow/step and Admin API endpoint; Price List prices endpoint; Locale APIs and SDK entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9aa1710704b3db676ada23e5a87682a3c7d80b25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->