### PR TITLE
fix(dashboard): Add payment_collections to default fields in customer orders section

### DIFF
--- a/.changeset/neat-pears-smash.md
+++ b/.changeset/neat-pears-smash.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): Add payment_collections to default fields in customer orders

--- a/packages/admin/dashboard/src/hooks/table/columns/use-order-table-columns.tsx
+++ b/packages/admin/dashboard/src/hooks/table/columns/use-order-table-columns.tsx
@@ -121,7 +121,7 @@ export const useOrderTableColumns = (props: UseOrderTableColumnsProps) => {
       columnHelper.display({
         id: "actions",
         cell: ({ row }) => {
-          const country = row.original.shipping_address?.country
+          const country = row.original.shipping_address?.country_code
 
           return <CountryCell country={country} />
         },

--- a/packages/admin/dashboard/src/hooks/table/columns/use-order-table-columns.tsx
+++ b/packages/admin/dashboard/src/hooks/table/columns/use-order-table-columns.tsx
@@ -121,7 +121,7 @@ export const useOrderTableColumns = (props: UseOrderTableColumnsProps) => {
       columnHelper.display({
         id: "actions",
         cell: ({ row }) => {
-          const country = row.original.shipping_address?.country_code
+          const country = row.original.shipping_address?.country
 
           return <CountryCell country={country} />
         },

--- a/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
+++ b/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
@@ -21,7 +21,7 @@ const PREFIX = "cusord"
 const PAGE_SIZE = 10
 const DEFAULT_RELATIONS = "*customer,*items,*sales_channel"
 const DEFAULT_FIELDS =
-  "id,status,display_id,created_at,email,fulfillment_status,payment_status,total,currency_code,payment_collections"
+  "id,status,display_id,created_at,email,fulfillment_status,payment_status,total,currency_code,payment_collections,shipping_address.country_code"
 
 export const CustomerOrderSection = ({
   customer,

--- a/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
+++ b/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
@@ -19,9 +19,9 @@ type CustomerGeneralSectionProps = {
 
 const PREFIX = "cusord"
 const PAGE_SIZE = 10
-const DEFAULT_RELATIONS = "*customer,*items,*sales_channel"
+const DEFAULT_RELATIONS = "*customer,*items,*sales_channel,*payment_collections"
 const DEFAULT_FIELDS =
-  "id,status,display_id,created_at,email,fulfillment_status,payment_status,total,currency_code,payment_collections"
+  "id,status,display_id,created_at,email,fulfillment_status,payment_status,total,currency_code"
 
 export const CustomerOrderSection = ({
   customer,

--- a/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
+++ b/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
@@ -21,7 +21,7 @@ const PREFIX = "cusord"
 const PAGE_SIZE = 10
 const DEFAULT_RELATIONS = "*customer,*items,*sales_channel"
 const DEFAULT_FIELDS =
-  "id,status,display_id,created_at,email,fulfillment_status,payment_status,total,currency_code,payment_collections,shipping_address.country_code"
+  "id,status,display_id,created_at,email,fulfillment_status,payment_status,total,currency_code,payment_collections"
 
 export const CustomerOrderSection = ({
   customer,

--- a/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
+++ b/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
@@ -21,7 +21,7 @@ const PREFIX = "cusord"
 const PAGE_SIZE = 10
 const DEFAULT_RELATIONS = "*customer,*items,*sales_channel"
 const DEFAULT_FIELDS =
-  "id,status,display_id,created_at,email,fulfillment_status,payment_status,total,currency_code"
+  "id,status,display_id,created_at,email,fulfillment_status,payment_status,total,currency_code,payment_collections"
 
 export const CustomerOrderSection = ({
   customer,


### PR DESCRIPTION
I added payment_collections to the default fields in customer orders because if line https://github.com/medusajs/medusa/blob/0277062fecc278e630bf2110761a545339f6b9fe/packages/admin/dashboard/src/hooks/table/columns/use-order-table-columns.tsx#L101-L104 is triggered, we need payment_collections; otherwise, the page crashes and the customer page cannot be displayed. This is a very minor change.

<img width="807" height="59" alt="image" src="https://github.com/user-attachments/assets/70bdf171-d874-4233-afd1-5ae5eb69d605" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `*payment_collections` to the default relations for customer orders to ensure required data is fetched.
> 
> - **Dashboard (Customer Orders)**:
>   - Update `DEFAULT_RELATIONS` in `packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx` to include `*payment_collections` when fetching orders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a44b7f738ead93b99ab811fb12f2d1e9604e068a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->