### PR TITLE
chore: Create publishable API key as part of the defaults

### DIFF
--- a/.changeset/tiny-carrots-bathe.md
+++ b/.changeset/tiny-carrots-bathe.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+chore: Create publishable API key in defaults

--- a/integration-tests/http/__tests__/api-key/admin/api-key.spec.ts
+++ b/integration-tests/http/__tests__/api-key/admin/api-key.spec.ts
@@ -1,5 +1,5 @@
-import { ApiKeyType } from "@medusajs/utils"
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { ApiKeyType } from "@medusajs/utils"
 import {
   adminHeaders,
   createAdminUser,
@@ -74,7 +74,7 @@ medusaIntegrationTestRunner({
         const listedApiKeys = await api.get(`/admin/api-keys`, adminHeaders)
 
         expect(deleted.status).toEqual(200)
-        expect(listedApiKeys.data.api_keys).toHaveLength(0)
+        expect(listedApiKeys.data.api_keys).toHaveLength(1) // we still have the default publishable api key
       })
 
       it("should allow searching for api keys", async () => {
@@ -108,9 +108,16 @@ medusaIntegrationTestRunner({
         expect(listedSecretKeys.data.api_keys[0].title).toEqual(
           "Test Secret Key"
         )
-        expect(listedPublishableKeys.data.api_keys).toHaveLength(1)
-        expect(listedPublishableKeys.data.api_keys[0].title).toEqual(
-          "Test Publishable Key"
+        expect(listedPublishableKeys.data.api_keys).toHaveLength(2)
+        expect(listedPublishableKeys.data.api_keys).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              title: "Test Publishable Key",
+            }),
+            expect.objectContaining({
+              title: "Default Publishable API Key",
+            }),
+          ])
         )
       })
 

--- a/integration-tests/http/__tests__/api-key/admin/publishable-key.spec.ts
+++ b/integration-tests/http/__tests__/api-key/admin/publishable-key.spec.ts
@@ -61,7 +61,7 @@ medusaIntegrationTestRunner({
             adminHeaders
           )
 
-          expect(response.data.count).toBe(2)
+          expect(response.data.count).toBe(3) // two created keys and the default publishable api key
           expect(response.data.limit).toBe(2)
           expect(response.data.offset).toBe(0)
           expect(response.data.api_keys).toHaveLength(2)

--- a/integration-tests/modules/__tests__/defaults/defaults.spec.ts
+++ b/integration-tests/modules/__tests__/defaults/defaults.spec.ts
@@ -1,0 +1,91 @@
+import { createDefaultsWorkflow } from "@medusajs/core-flows"
+import { Query } from "@medusajs/modules-sdk"
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+
+jest.setTimeout(50000)
+
+const env = {}
+
+medusaIntegrationTestRunner({
+  env,
+  testSuite: ({ getContainer }) => {
+    describe("Defaults", () => {
+      let appContainer
+      let query: Query
+
+      beforeAll(async () => {
+        appContainer = getContainer()
+        query = appContainer.resolve("query")
+      })
+
+      it("should successfully create default data on first run", async () => {
+        const {
+          data: [store],
+        } = await query.graph({
+          entity: "store",
+          fields: ["id", "name", "default_sales_channel_id"],
+        })
+        const {
+          data: [salesChannel],
+        } = await query.graph({
+          entity: "sales_channel",
+          fields: ["id", "name"],
+        })
+        const {
+          data: [publishableApiKey],
+        } = await query.graph({
+          entity: "api_key",
+          fields: ["id", "type", "title"],
+          filters: {
+            type: "publishable",
+          },
+        })
+
+        expect(store).toEqual(
+          expect.objectContaining({
+            id: expect.any(String),
+            name: "Medusa Store",
+            default_sales_channel_id: salesChannel.id,
+          })
+        )
+        expect(salesChannel).toEqual(
+          expect.objectContaining({
+            id: expect.any(String),
+            name: "Default Sales Channel",
+          })
+        )
+        expect(publishableApiKey).toEqual(
+          expect.objectContaining({
+            id: expect.any(String),
+            title: "Default Publishable API Key",
+            type: "publishable",
+          })
+        )
+      })
+
+      it("should skip creating default data on n+1 runs", async () => {
+        await createDefaultsWorkflow(appContainer).run()
+
+        const { data: stores } = await query.graph({
+          entity: "store",
+          fields: ["id"],
+        })
+        const { data: salesChannels } = await query.graph({
+          entity: "sales_channel",
+          fields: ["id"],
+        })
+        const { data: publishableApiKeys } = await query.graph({
+          entity: "api_key",
+          fields: ["id", "type"],
+          filters: {
+            type: "publishable",
+          },
+        })
+
+        expect(stores.length).toEqual(1)
+        expect(salesChannels.length).toEqual(1)
+        expect(publishableApiKeys.length).toEqual(1)
+      })
+    })
+  },
+})

--- a/packages/core/core-flows/src/defaults/workflows/create-defaults.ts
+++ b/packages/core/core-flows/src/defaults/workflows/create-defaults.ts
@@ -1,7 +1,14 @@
 import {
   createWorkflow,
+  transform,
+  when,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
+import {
+  createApiKeysStep,
+  linkSalesChannelsToApiKeyWorkflow,
+} from "../../api-key"
+import { useQueryGraphStep } from "../../common"
 import { createDefaultSalesChannelStep } from "../../sales-channel"
 import { createDefaultStoreStep } from "../steps/create-default-store"
 
@@ -10,16 +17,16 @@ export const createDefaultsWorkflowID = "create-defaults"
  * This workflow creates default data for a Medusa application, including
  * a default sales channel and store. The Medusa application uses this workflow
  * to create the default data, if not existing, when the application is first started.
- * 
+ *
  * You can use this workflow within your customizations or your own custom workflows, allowing you to
  * create default data within your custom flows, such as seed scripts.
- * 
+ *
  * @example
  * const { result } = await createDefaultsWorkflow(container)
  * .run()
- * 
+ *
  * @summary
- * 
+ *
  * Create default data for a Medusa application.
  */
 export const createDefaultsWorkflow = createWorkflow(
@@ -35,6 +42,46 @@ export const createDefaultsWorkflow = createWorkflow(
       store: {
         default_sales_channel_id: salesChannel.id,
       },
+    })
+
+    const publishableApiKey = useQueryGraphStep({
+      entity: "api_key",
+      fields: ["id", "type"],
+      filters: {
+        type: "publishable",
+      },
+      options: {
+        isList: false,
+      },
+    })
+
+    when(
+      { publishableApiKey },
+      ({ publishableApiKey }) => !publishableApiKey?.data
+    ).then(() => {
+      const createResult = createApiKeysStep({
+        api_keys: [
+          {
+            title: "Default Publishable API Key",
+            type: "publishable",
+            created_by: "",
+          },
+        ],
+      })
+
+      const publishableApiKey = transform(
+        { createResult },
+        ({ createResult }) => {
+          return createResult[0]
+        }
+      )
+
+      linkSalesChannelsToApiKeyWorkflow.runAsStep({
+        input: {
+          id: publishableApiKey.id,
+          add: [salesChannel.id],
+        },
+      })
     })
 
     return new WorkflowResponse(store)


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Create a publishable API key in the defaults workflow

**Why** — Why are these changes relevant or necessary?  

To create a smooth first deployment of backend + storefront on Cloud, applications need to have a publishable API key, because it hits the Store API as part of its deployment process. Right now, this requires us to do some nasty custom SQL in Cloud, which we would like to avoid.

Aside from creating a friction-less experience in Cloud, one could also make the argument that because the Store API is effectively useless without an API key, creating it as part of the default is sensible.

**How** — How have these changes been implemented?

Add it to the `createDefaultsWorkflow`

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Add integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Create a default publishable API key during defaults setup and link it to the default sales channel; update tests to reflect the new default key.
> 
> - **Core Flows**:
>   - Update `create-defaults` workflow:
>     - Query for existing `api_key` of type `publishable`; if absent, create `"Default Publishable API Key"`.
>     - Link the created key to the default `sales_channel` via `linkSalesChannelsToApiKeyWorkflow`.
> - **Tests**:
>   - Adjust admin API key specs to account for the persistent default publishable key (counts/search expectations).
>   - Add defaults integration tests to verify creation of default `store`, `sales_channel`, and publishable `api_key`, and ensure idempotency on subsequent runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c54d54721f17ecad5cfa21d73fc766c0503f96de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->