### PR TITLE
feat: added ka-GE to the default list of locales

### DIFF
--- a/.changeset/red-donkeys-prove.md
+++ b/.changeset/red-donkeys-prove.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/translation": patch
+---
+
+feat: added ka-GE to the default list of locales

--- a/packages/modules/translation/src/loaders/defaults.ts
+++ b/packages/modules/translation/src/loaders/defaults.ts
@@ -64,6 +64,7 @@ const defaultLocales = [
   { code: "zh-HK", name: "Chinese Traditional (Hong Kong)" },
   { code: "ja-JP", name: "Japanese (Japan)" },
   { code: "ko-KR", name: "Korean (South Korea)" },
+  { code: "ka-GE", name: "Georgian (Georgia)" },
 ]
 
 export default async ({ container }: LoaderOptions): Promise<void> => {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

I've added support for Georgian (ka-GE) locale.

**Why** — Why are these changes relevant or necessary?  

This change is necessary to expand list of supported locales (which is somewhat short).

**How** — How have these changes been implemented?

Georgian locale was directly added to the default list of locales.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

It should allow admins to select Georgian locale in Settings > Store > Locales

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Georgian (ka-GE) to the translation module’s default locales list.
> 
> - **Translation Module**:
>   - Extend `defaultLocales` in `packages/modules/translation/src/loaders/defaults.ts` with `ka-GE` (Georgian).
> - **Changeset**:
>   - Add patch changeset for `@medusajs/translation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afc6d7bfbbe2e5c5080c56222312a5d77880bd10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->