### PR TITLE
docs: fix total descriptions across docs

### DIFF
--- a/www/apps/api-reference/specs/admin/components/schemas/BaseCart.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseCart.yaml
@@ -89,59 +89,77 @@ properties:
   original_item_total:
     type: number
     title: original_item_total
-    description: The cart's original item total.
+    description: >-
+      The sum of all line items' original totals before discounts, including
+      taxes.
   original_item_subtotal:
     type: number
     title: original_item_subtotal
-    description: The cart's original item subtotal.
+    description: >-
+      The sum of all line items' original subtotals before discounts, excluding
+      taxes.
   original_item_tax_total:
     type: number
     title: original_item_tax_total
-    description: The cart's original item tax total.
+    description: The sum of all line items' original tax totals before discounts.
   item_total:
     type: number
     title: item_total
-    description: The cart's item total.
+    description: The sum of all line items' totals after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The cart's item subtotal.
+    description: The sum of all line items' subtotals before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The cart's item tax total.
+    description: The sum of all line items' tax totals after discounts.
   original_total:
     type: number
     title: original_total
-    description: The cart's original total.
+    description: >-
+      The cart's total before discounts, including taxes. Calculated as the sum
+      of `original_item_total` and `original_shipping_total`.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The cart's original subtotal.
+    description: >-
+      The cart's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `original_item_subtotal` and `original_shipping_subtotal`.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The cart's original tax total.
+    description: >-
+      The cart's tax total before discounts. Calculated as the sum of
+      `original_item_tax_total` and `original_shipping_tax_total`.
   total:
     type: number
     title: total
-    description: The cart's total.
+    description: The cart's final total after discounts and credit lines, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The cart's subtotal.
+    description: >-
+      The cart's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `item_subtotal` and `shipping_subtotal`.
   tax_total:
     type: number
     title: tax_total
-    description: The cart's tax total.
+    description: >-
+      The cart's tax total after discounts. Calculated as the sum of
+      `item_tax_total` and `shipping_tax_total`.
   discount_total:
     type: number
     title: discount_total
-    description: The cart's discount total.
+    description: >-
+      The total amount of discounts applied to the cart, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The cart's discount tax total.
+    description: >-
+      The total amount of discounts applied to the cart's tax. Represents the
+      tax portion of discounts.
   gift_card_total:
     type: number
     title: gift_card_total
@@ -153,24 +171,30 @@ properties:
   shipping_total:
     type: number
     title: shipping_total
-    description: The cart's shipping total.
+    description: The sum of all shipping methods' totals after discounts, including taxes.
   shipping_subtotal:
     type: number
     title: shipping_subtotal
-    description: The cart's shipping subtotal.
+    description: >-
+      The sum of all shipping methods' subtotals before discounts, excluding
+      taxes.
   shipping_tax_total:
     type: number
     title: shipping_tax_total
-    description: The cart's shipping tax total.
+    description: The sum of all shipping methods' tax totals after discounts.
   original_shipping_total:
     type: number
     title: original_shipping_total
-    description: The cart's original shipping total.
+    description: >-
+      The sum of all shipping methods' original totals before discounts,
+      including taxes.
   original_shipping_subtotal:
     type: number
     title: original_shipping_subtotal
-    description: The cart's original shipping subtotal.
+    description: >-
+      The sum of all shipping methods' original subtotals before discounts,
+      excluding taxes.
   original_shipping_tax_total:
     type: number
     title: original_shipping_tax_total
-    description: The cart's original shipping tax total.
+    description: The sum of all shipping methods' original tax totals before discounts.

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseCartLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseCartLineItem.yaml
@@ -143,44 +143,48 @@ properties:
   original_total:
     type: number
     title: original_total
-    description: The item's original total.
+    description: The line item's original total before discounts, including taxes.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The item's original subtotal.
+    description: The line item's original subtotal before discounts, excluding taxes.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The item's original tax total.
+    description: The line item's original tax total before discounts.
   item_total:
     type: number
     title: item_total
-    description: The item's item total.
+    description: The line item's total after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The item's item subtotal.
+    description: The line item's subtotal before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The item's item tax total.
+    description: The line item's tax total after discounts.
   total:
     type: number
     title: total
-    description: The item's total.
+    description: The line item's total after discounts, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The item's subtotal.
+    description: The line item's subtotal before discounts, excluding taxes.
   tax_total:
     type: number
     title: tax_total
-    description: The item's tax total.
+    description: The line item's tax total after discounts.
   discount_total:
     type: number
     title: discount_total
-    description: The item's discount total.
+    description: >-
+      The total amount of discounts applied to the line item, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The item's discount tax total.
+    description: >-
+      The total amount of discounts applied to the line item's tax. Represents
+      the tax portion of discounts.

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseCartShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseCartShippingMethod.yaml
@@ -75,36 +75,36 @@ properties:
   original_total:
     type: number
     title: original_total
-    description: The shipping method's total including taxes, excluding promotions.
+    description: The shipping method's original total before discounts, including taxes.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The shipping method's total excluding taxes, including promotions.
+    description: The shipping method's original subtotal before discounts, excluding taxes.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: >-
-      The total taxes applied on the shipping method's amount including
-      promotions.
+    description: The shipping method's original tax total before discounts.
   total:
     type: number
     title: total
-    description: The shipping method's total amount including taxes and promotions.
+    description: The shipping method's total after discounts, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The shipping method's total amount excluding taxes, including promotions.
+    description: The shipping method's subtotal before discounts, excluding taxes.
   tax_total:
     type: number
     title: tax_total
-    description: >-
-      The total taxes applied on the shipping method's amount including
-      promotions.
+    description: The shipping method's tax total after discounts.
   discount_total:
     type: number
     title: discount_total
-    description: The total amount discounted.
+    description: >-
+      The total amount of discounts applied to the shipping method, including
+      the tax portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The taxes applied on the discounted amount.
+    description: >-
+      The total amount of discounts applied to the shipping method's tax.
+      Represents the tax portion of discounts.

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseOrder.yaml
@@ -152,59 +152,77 @@ properties:
   original_item_total:
     type: number
     title: original_item_total
-    description: The total of the order's items including taxes, excluding promotions.
+    description: >-
+      The sum of all line items' original totals before discounts, including
+      taxes.
   original_item_subtotal:
     type: number
     title: original_item_subtotal
-    description: The total of the order's items excluding taxes, including promotions.
+    description: >-
+      The sum of all line items' original subtotals before discounts, excluding
+      taxes.
   original_item_tax_total:
     type: number
     title: original_item_tax_total
-    description: The tax total of the order's items excluding promotions.
+    description: The sum of all line items' original tax totals before discounts.
   item_total:
     type: number
     title: item_total
-    description: The total of the order's items including taxes and promotions.
+    description: The sum of all line items' totals after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The total of the order's items excluding taxes, including promotions.
+    description: The sum of all line items' subtotals before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The tax total of the order's items including promotions.
+    description: The sum of all line items' tax totals after discounts.
   original_total:
     type: number
     title: original_total
-    description: The order's total excluding promotions, including taxes.
+    description: >-
+      The order's total before discounts, including taxes. Calculated as the sum
+      of `original_item_total` and `original_shipping_total`.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The order's total excluding taxes, including promotions.
+    description: >-
+      The order's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `original_item_subtotal` and `original_shipping_subtotal`.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The order's tax total, excluding promotions.
+    description: >-
+      The order's tax total before discounts. Calculated as the sum of
+      `original_item_tax_total` and `original_shipping_tax_total`.
   total:
     type: number
     title: total
-    description: The order's total including taxes and promotions.
+    description: The order's final total after discounts and credit lines, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The order's total excluding taxes, including promotions.
+    description: >-
+      The order's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `item_subtotal` and `shipping_subtotal`.
   tax_total:
     type: number
     title: tax_total
-    description: The order's tax total including promotions.
+    description: >-
+      The order's tax total after discounts. Calculated as the sum of
+      `item_tax_total` and `shipping_tax_total`.
   discount_total:
     type: number
     title: discount_total
-    description: The order's discount or promotions total.
+    description: >-
+      The total amount of discounts applied to the order, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The tax total of order's discount or promotion.
+    description: >-
+      The total amount of discounts applied to the order's tax. Represents the
+      tax portion of discounts.
   gift_card_total:
     type: number
     title: gift_card_total
@@ -216,27 +234,33 @@ properties:
   shipping_total:
     type: number
     title: shipping_total
-    description: The order's shipping total including taxes and promotions.
+    description: The sum of all shipping methods' totals after discounts, including taxes.
   shipping_subtotal:
     type: number
     title: shipping_subtotal
-    description: The order's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' subtotals before discounts, excluding
+      taxes.
   shipping_tax_total:
     type: number
     title: shipping_tax_total
-    description: The tax total of the order's shipping.
+    description: The sum of all shipping methods' tax totals after discounts.
   original_shipping_total:
     type: number
     title: original_shipping_total
-    description: The order's shipping total including taxes, excluding promotions.
+    description: >-
+      The sum of all shipping methods' original totals before discounts,
+      including taxes.
   original_shipping_subtotal:
     type: number
     title: original_shipping_subtotal
-    description: The order's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' original subtotals before discounts,
+      excluding taxes.
   original_shipping_tax_total:
     type: number
     title: original_shipping_tax_total
-    description: The tax total of the order's shipping excluding promotions.
+    description: The sum of all shipping methods' original tax totals before discounts.
   status:
     type: string
     title: status
@@ -244,15 +268,21 @@ properties:
   credit_line_total:
     type: number
     title: credit_line_total
-    description: The order's credit line total.
+    description: >-
+      The total amount of credit lines applied to the order, including taxes.
+      Subtracted from the final total.
   item_discount_total:
     type: number
     title: item_discount_total
-    description: The total discount amount applied on the order's items.
+    description: >-
+      The sum of all discounts applied to line items, including the tax portion
+      of discounts.
   shipping_discount_total:
     type: number
     title: shipping_discount_total
-    description: The total discount amount applied on the order's shipping.
+    description: >-
+      The sum of all discounts applied to shipping methods, including the tax
+      portion of discounts.
   custom_display_id:
     type: string
     title: custom_display_id

--- a/www/apps/api-reference/specs/admin/components/schemas/BaseOrderLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/BaseOrderLineItem.yaml
@@ -166,47 +166,51 @@ properties:
   original_total:
     type: number
     title: original_total
-    description: The item's total including taxes, excluding promotions.
+    description: The line item's original total before discounts, including taxes.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The item's total excluding taxes, including promotions.
+    description: The line item's original subtotal before discounts, excluding taxes.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The total taxes of the item, excluding promotions.
+    description: The line item's original tax total before discounts.
   item_total:
     type: number
     title: item_total
-    description: The total taxes of the item, including promotions.
+    description: The line item's total after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The item's total excluding taxes, including promotions.
+    description: The line item's subtotal before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The total taxes of the item, including promotions.
+    description: The line item's tax total after discounts.
   total:
     type: number
     title: total
-    description: The item's total, including taxes and promotions.
+    description: The line item's total after discounts, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The item's subtotal excluding taxes, including promotions.
+    description: The line item's subtotal before discounts, excluding taxes.
   tax_total:
     type: number
     title: tax_total
-    description: The tax total of the item including promotions.
+    description: The line item's tax total after discounts.
   discount_total:
     type: number
     title: discount_total
-    description: The total discount amount of the item.
+    description: >-
+      The total amount of discounts applied to the line item, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The total taxes applied on the discounted amount.
+    description: >-
+      The total amount of discounts applied to the line item's tax. Represents
+      the tax portion of discounts.
   refundable_total:
     type: number
     title: refundable_total

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCart.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCart.yaml
@@ -94,59 +94,77 @@ properties:
   original_item_total:
     type: number
     title: original_item_total
-    description: The cart items' total including taxes, excluding promotions.
+    description: >-
+      The sum of all line items' original totals before discounts, including
+      taxes.
   original_item_subtotal:
     type: number
     title: original_item_subtotal
-    description: The cart items' total excluding taxes, including promotions.
+    description: >-
+      The sum of all line items' original subtotals before discounts, excluding
+      taxes.
   original_item_tax_total:
     type: number
     title: original_item_tax_total
-    description: The cart items' tax total excluding promotions.
+    description: The sum of all line items' original tax totals before discounts.
   item_total:
     type: number
     title: item_total
-    description: The cart items' total including taxes and promotions.
+    description: The sum of all line items' totals after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The cart items' total excluding taxes, including promotions.
+    description: The sum of all line items' subtotals before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The cart items' tax total including promotions.
+    description: The sum of all line items' tax totals after discounts.
   original_total:
     type: number
     title: original_total
-    description: The cart's total including taxes, excluding promotions.
+    description: >-
+      The cart's total before discounts, including taxes. Calculated as the sum
+      of `original_item_total` and `original_shipping_total`.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The cart's total excluding taxes, including promotions.
+    description: >-
+      The cart's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `original_item_subtotal` and `original_shipping_subtotal`.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The cart's tax total excluding promotions.
+    description: >-
+      The cart's tax total before discounts. Calculated as the sum of
+      `original_item_tax_total` and `original_shipping_tax_total`.
   total:
     type: number
     title: total
-    description: The cart's total including taxes and promotions.
+    description: The cart's final total after discounts and credit lines, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The cart's total excluding taxes, including promotions.
+    description: >-
+      The cart's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `item_subtotal` and `shipping_subtotal`.
   tax_total:
     type: number
     title: tax_total
-    description: The cart's tax total including promotions.
+    description: >-
+      The cart's tax total after discounts. Calculated as the sum of
+      `item_tax_total` and `shipping_tax_total`.
   discount_total:
     type: number
     title: discount_total
-    description: The cart's discount total.
+    description: >-
+      The total amount of discounts applied to the cart, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The tax total applied on the discounted amount.
+    description: >-
+      The total amount of discounts applied to the cart's tax. Represents the
+      tax portion of discounts.
   gift_card_total:
     type: number
     title: gift_card_total
@@ -158,27 +176,33 @@ properties:
   shipping_total:
     type: number
     title: shipping_total
-    description: The cart's shipping total including taxes and promotions.
+    description: The sum of all shipping methods' totals after discounts, including taxes.
   shipping_subtotal:
     type: number
     title: shipping_subtotal
-    description: The cart's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' subtotals before discounts, excluding
+      taxes.
   shipping_tax_total:
     type: number
     title: shipping_tax_total
-    description: The total taxes applied on the cart's shipping amount.
+    description: The sum of all shipping methods' tax totals after discounts.
   original_shipping_total:
     type: number
     title: original_shipping_total
-    description: The cart's shipping total including taxes, excluding promotions.
+    description: >-
+      The sum of all shipping methods' original totals before discounts,
+      including taxes.
   original_shipping_subtotal:
     type: number
     title: original_shipping_subtotal
-    description: The cart's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' original subtotals before discounts,
+      excluding taxes.
   original_shipping_tax_total:
     type: number
     title: original_shipping_tax_total
-    description: The total taxes applied on the cart's shipping amount.
+    description: The sum of all shipping methods' original tax totals before discounts.
   promotions:
     type: array
     description: The cart's promotions.

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCartLineItem.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCartLineItem.yaml
@@ -288,31 +288,33 @@ properties:
     type: number
     title: original_total
     description: >-
-      The item's total including taxes, excluding promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's original total before discounts, including taxes. This
+      field is only available if you expand the `items.*` relation. Learn more
+      in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   original_subtotal:
     type: number
     title: original_subtotal
     description: >-
-      The item's total excluding taxes, including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's original subtotal before discounts, excluding taxes. This
+      field is only available if you expand the `items.*` relation. Learn more
+      in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   original_tax_total:
     type: number
     title: original_tax_total
     description: >-
-      The total taxes of the item excluding promotions. This field is only
+      The line item's original tax total before discounts. This field is only
       available if you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   item_total:
     type: number
-    title: original_tax_total
+    title: item_total
     description: >-
-      The item's total including taxes and promotions. This field is only
+      The line item's total after discounts, including taxes. This field is only
       available if you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
@@ -320,23 +322,24 @@ properties:
     type: number
     title: item_subtotal
     description: >-
-      The item's total excluding taxes, including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's subtotal before discounts, excluding taxes. This field is
+      only available if you expand the `items.*` relation. Learn more in the
+      [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   item_tax_total:
     type: number
     title: item_tax_total
     description: >-
-      The total taxes of the item including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's tax total after discounts. This field is only available if
+      you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   total:
     type: number
     title: total
     description: >-
-      The item's total including taxes and promotions. This field is only
+      The line item's total after discounts, including taxes. This field is only
       available if you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
@@ -344,31 +347,34 @@ properties:
     type: number
     title: subtotal
     description: >-
-      The item's total excluding taxes, including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's subtotal before discounts, excluding taxes. This field is
+      only available if you expand the `items.*` relation. Learn more in the
+      [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   tax_total:
     type: number
     title: tax_total
     description: >-
-      The total taxes of the item including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's tax total after discounts. This field is only available if
+      you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   discount_total:
     type: number
     title: discount_total
     description: >-
-      The total discount of the item. This field is only available if you expand
-      the `items.*` relation. Learn more in the [Cart
+      The total amount of discounts applied to the line item, including the tax
+      portion of discounts. This field is only available if you expand the
+      `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   discount_tax_total:
     type: number
     title: discount_tax_total
     description: >-
-      The total taxes applied on the discounted amount. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The total amount of discounts applied to the line item's tax. Represents
+      the tax portion of discounts. This field is only available if you expand
+      the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreCartShippingMethod.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreCartShippingMethod.yaml
@@ -214,61 +214,62 @@ properties:
     type: number
     title: original_total
     description: >-
-      The shipping method's total including taxes, excluding promotions. This
-      field is only available if you expand the `shipping_methods.*` relation.
-      Learn more in the [Cart
+      The shipping method's original total before discounts, including taxes.
+      This field is only available if you expand the `shipping_methods.*`
+      relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   original_subtotal:
     type: number
     title: original_subtotal
     description: >-
-      The shipping method's total excluding taxes, including promotions. This
-      field is only available if you expand the `shipping_methods.*` relation.
-      Learn more in the [Cart
+      The shipping method's original subtotal before discounts, excluding taxes.
+      This field is only available if you expand the `shipping_methods.*`
+      relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   original_tax_total:
     type: number
     title: original_tax_total
     description: >-
-      The total taxes applied on the shipping method's amount including
-      promotions. This field is only available if you expand the
-      `shipping_methods.*` relation. Learn more in the [Cart
+      The shipping method's original tax total before discounts. This field is
+      only available if you expand the `shipping_methods.*` relation. Learn more
+      in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   total:
     type: number
     title: total
     description: >-
-      The shipping method's total amount including taxes and promotions. This
-      field is only available if you expand the `shipping_methods.*` relation.
-      Learn more in the [Cart
+      The shipping method's total after discounts, including taxes. This field
+      is only available if you expand the `shipping_methods.*` relation. Learn
+      more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   subtotal:
     type: number
     title: subtotal
     description: >-
-      The shipping method's total amount excluding taxes, including promotions.
-      This field is only available if you expand the `shipping_methods.*`
-      relation. Learn more in the [Cart
+      The shipping method's subtotal before discounts, excluding taxes. This
+      field is only available if you expand the `shipping_methods.*` relation.
+      Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   tax_total:
     type: number
     title: tax_total
     description: >-
-      The total taxes applied on the shipping method's amount including
-      promotions. This field is only available if you expand the
-      `shipping_methods.*` relation. Learn more in the [Cart
+      The shipping method's tax total after discounts. This field is only
+      available if you expand the `shipping_methods.*` relation. Learn more in
+      the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   discount_total:
     type: number
     title: discount_total
     description: >-
-      The total amount discounted. This field is only available if you expand
+      The total amount of discounts applied to the shipping method, including
+      the tax portion of discounts. This field is only available if you expand
       the `shipping_methods.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
@@ -276,7 +277,8 @@ properties:
     type: number
     title: discount_tax_total
     description: >-
-      The taxes applied on the discounted amount. This field is only available
-      if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+      The total amount of discounts applied to the shipping method's tax.
+      Represents the tax portion of discounts. This field is only available if
+      you expand the `shipping_methods.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.

--- a/www/apps/api-reference/specs/admin/components/schemas/StoreOrder.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreOrder.yaml
@@ -143,59 +143,77 @@ properties:
   original_item_total:
     type: number
     title: original_item_total
-    description: The order items' total including taxes, excluding promotions.
+    description: >-
+      The sum of all line items' original totals before discounts, including
+      taxes.
   original_item_subtotal:
     type: number
     title: original_item_subtotal
-    description: The order items' total excluding taxes, including promotions.
+    description: >-
+      The sum of all line items' original subtotals before discounts, excluding
+      taxes.
   original_item_tax_total:
     type: number
     title: original_item_tax_total
-    description: The total taxes applied on the order items, excluding promotions.
+    description: The sum of all line items' original tax totals before discounts.
   item_total:
     type: number
     title: item_total
-    description: The order items' total including taxes and promotions.
+    description: The sum of all line items' totals after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The order items' total excluding taxes, including promotions.
+    description: The sum of all line items' subtotals before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The total taxes applied on the order's items, including promotions.
+    description: The sum of all line items' tax totals after discounts.
   original_total:
     type: number
     title: original_total
-    description: The order's total including taxes, excluding promotions.
+    description: >-
+      The order's total before discounts, including taxes. Calculated as the sum
+      of `original_item_total` and `original_shipping_total`.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The order's total excluding taxes, including promotions.
+    description: >-
+      The order's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `original_item_subtotal` and `original_shipping_subtotal`.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The total taxes of the order excluding promotions.
+    description: >-
+      The order's tax total before discounts. Calculated as the sum of
+      `original_item_tax_total` and `original_shipping_tax_total`.
   total:
     type: number
     title: total
-    description: The order's total including taxes and promotions.
+    description: The order's final total after discounts and credit lines, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The order's total excluding taxes, including promotions.
+    description: >-
+      The order's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `item_subtotal` and `shipping_subtotal`.
   tax_total:
     type: number
     title: tax_total
-    description: The tax totals of the order including promotions.
+    description: >-
+      The order's tax total after discounts. Calculated as the sum of
+      `item_tax_total` and `shipping_tax_total`.
   discount_total:
     type: number
     title: discount_total
-    description: The order's discount total.
+    description: >-
+      The total amount of discounts applied to the order, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The total taxes applied on the discounted amount.
+    description: >-
+      The total amount of discounts applied to the order's tax. Represents the
+      tax portion of discounts.
   gift_card_total:
     type: number
     title: gift_card_total
@@ -207,27 +225,33 @@ properties:
   shipping_total:
     type: number
     title: shipping_total
-    description: The order's shipping total including taxes and promotions.
+    description: The sum of all shipping methods' totals after discounts, including taxes.
   shipping_subtotal:
     type: number
     title: shipping_subtotal
-    description: The order's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' subtotals before discounts, excluding
+      taxes.
   shipping_tax_total:
     type: number
     title: shipping_tax_total
-    description: The total taxes of the order's shipping including promotions.
+    description: The sum of all shipping methods' tax totals after discounts.
   original_shipping_total:
     type: number
     title: original_shipping_total
-    description: The order's shipping total including taxes, excluding promotions.
+    description: >-
+      The sum of all shipping methods' original totals before discounts,
+      including taxes.
   original_shipping_subtotal:
     type: number
     title: original_shipping_subtotal
-    description: The order's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' original subtotals before discounts,
+      excluding taxes.
   original_shipping_tax_total:
     type: number
     title: original_shipping_tax_total
-    description: The total taxes of the order's shipping excluding promotions.
+    description: The sum of all shipping methods' original tax totals before discounts.
   customer:
     $ref: ./StoreCustomer.yaml
   transactions:
@@ -242,15 +266,21 @@ properties:
   credit_line_total:
     type: number
     title: credit_line_total
-    description: The order's credit line total.
+    description: >-
+      The total amount of credit lines applied to the order, including taxes.
+      Subtracted from the final total.
   item_discount_total:
     type: number
     title: item_discount_total
-    description: The total discount amount applied on the order's items.
+    description: >-
+      The sum of all discounts applied to line items, including the tax portion
+      of discounts.
   shipping_discount_total:
     type: number
     title: shipping_discount_total
-    description: The total discount amount applied on the order's shipping.
+    description: >-
+      The sum of all discounts applied to shipping methods, including the tax
+      portion of discounts.
   custom_display_id:
     type: string
     title: custom_display_id

--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -83900,59 +83900,59 @@ components:
         original_item_total:
           type: number
           title: original_item_total
-          description: The cart's original item total.
+          description: The sum of all line items' original totals before discounts, including taxes.
         original_item_subtotal:
           type: number
           title: original_item_subtotal
-          description: The cart's original item subtotal.
+          description: The sum of all line items' original subtotals before discounts, excluding taxes.
         original_item_tax_total:
           type: number
           title: original_item_tax_total
-          description: The cart's original item tax total.
+          description: The sum of all line items' original tax totals before discounts.
         item_total:
           type: number
           title: item_total
-          description: The cart's item total.
+          description: The sum of all line items' totals after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The cart's item subtotal.
+          description: The sum of all line items' subtotals before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The cart's item tax total.
+          description: The sum of all line items' tax totals after discounts.
         original_total:
           type: number
           title: original_total
-          description: The cart's original total.
+          description: The cart's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The cart's original subtotal.
+          description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The cart's original tax total.
+          description: The cart's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
         total:
           type: number
           title: total
-          description: The cart's total.
+          description: The cart's final total after discounts and credit lines, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The cart's subtotal.
+          description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
         tax_total:
           type: number
           title: tax_total
-          description: The cart's tax total.
+          description: The cart's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
         discount_total:
           type: number
           title: discount_total
-          description: The cart's discount total.
+          description: The total amount of discounts applied to the cart, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The cart's discount tax total.
+          description: The total amount of discounts applied to the cart's tax. Represents the tax portion of discounts.
         gift_card_total:
           type: number
           title: gift_card_total
@@ -83964,27 +83964,27 @@ components:
         shipping_total:
           type: number
           title: shipping_total
-          description: The cart's shipping total.
+          description: The sum of all shipping methods' totals after discounts, including taxes.
         shipping_subtotal:
           type: number
           title: shipping_subtotal
-          description: The cart's shipping subtotal.
+          description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
         shipping_tax_total:
           type: number
           title: shipping_tax_total
-          description: The cart's shipping tax total.
+          description: The sum of all shipping methods' tax totals after discounts.
         original_shipping_total:
           type: number
           title: original_shipping_total
-          description: The cart's original shipping total.
+          description: The sum of all shipping methods' original totals before discounts, including taxes.
         original_shipping_subtotal:
           type: number
           title: original_shipping_subtotal
-          description: The cart's original shipping subtotal.
+          description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
         original_shipping_tax_total:
           type: number
           title: original_shipping_tax_total
-          description: The cart's original shipping tax total.
+          description: The sum of all shipping methods' original tax totals before discounts.
     BaseCartAddress:
       type: object
       description: The cart's shipping address.
@@ -84135,47 +84135,47 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The item's original total.
+          description: The line item's original total before discounts, including taxes.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The item's original subtotal.
+          description: The line item's original subtotal before discounts, excluding taxes.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The item's original tax total.
+          description: The line item's original tax total before discounts.
         item_total:
           type: number
           title: item_total
-          description: The item's item total.
+          description: The line item's total after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The item's item subtotal.
+          description: The line item's subtotal before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The item's item tax total.
+          description: The line item's tax total after discounts.
         total:
           type: number
           title: total
-          description: The item's total.
+          description: The line item's total after discounts, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The item's subtotal.
+          description: The line item's subtotal before discounts, excluding taxes.
         tax_total:
           type: number
           title: tax_total
-          description: The item's tax total.
+          description: The line item's tax total after discounts.
         discount_total:
           type: number
           title: discount_total
-          description: The item's discount total.
+          description: The total amount of discounts applied to the line item, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The item's discount tax total.
+          description: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
     BaseCartShippingMethod:
       type: object
       description: A cart's shipping method.
@@ -84251,35 +84251,35 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The shipping method's total including taxes, excluding promotions.
+          description: The shipping method's original total before discounts, including taxes.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The shipping method's total excluding taxes, including promotions.
+          description: The shipping method's original subtotal before discounts, excluding taxes.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes applied on the shipping method's amount including promotions.
+          description: The shipping method's original tax total before discounts.
         total:
           type: number
           title: total
-          description: The shipping method's total amount including taxes and promotions.
+          description: The shipping method's total after discounts, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The shipping method's total amount excluding taxes, including promotions.
+          description: The shipping method's subtotal before discounts, excluding taxes.
         tax_total:
           type: number
           title: tax_total
-          description: The total taxes applied on the shipping method's amount including promotions.
+          description: The shipping method's tax total after discounts.
         discount_total:
           type: number
           title: discount_total
-          description: The total amount discounted.
+          description: The total amount of discounts applied to the shipping method, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The taxes applied on the discounted amount.
+          description: The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts.
     BaseClaimItem:
       type: object
       description: The claim item's details.
@@ -84742,59 +84742,59 @@ components:
         original_item_total:
           type: number
           title: original_item_total
-          description: The total of the order's items including taxes, excluding promotions.
+          description: The sum of all line items' original totals before discounts, including taxes.
         original_item_subtotal:
           type: number
           title: original_item_subtotal
-          description: The total of the order's items excluding taxes, including promotions.
+          description: The sum of all line items' original subtotals before discounts, excluding taxes.
         original_item_tax_total:
           type: number
           title: original_item_tax_total
-          description: The tax total of the order's items excluding promotions.
+          description: The sum of all line items' original tax totals before discounts.
         item_total:
           type: number
           title: item_total
-          description: The total of the order's items including taxes and promotions.
+          description: The sum of all line items' totals after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The total of the order's items excluding taxes, including promotions.
+          description: The sum of all line items' subtotals before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The tax total of the order's items including promotions.
+          description: The sum of all line items' tax totals after discounts.
         original_total:
           type: number
           title: original_total
-          description: The order's total excluding promotions, including taxes.
+          description: The order's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The order's total excluding taxes, including promotions.
+          description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The order's tax total, excluding promotions.
+          description: The order's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
         total:
           type: number
           title: total
-          description: The order's total including taxes and promotions.
+          description: The order's final total after discounts and credit lines, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The order's total excluding taxes, including promotions.
+          description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
         tax_total:
           type: number
           title: tax_total
-          description: The order's tax total including promotions.
+          description: The order's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
         discount_total:
           type: number
           title: discount_total
-          description: The order's discount or promotions total.
+          description: The total amount of discounts applied to the order, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The tax total of order's discount or promotion.
+          description: The total amount of discounts applied to the order's tax. Represents the tax portion of discounts.
         gift_card_total:
           type: number
           title: gift_card_total
@@ -84806,27 +84806,27 @@ components:
         shipping_total:
           type: number
           title: shipping_total
-          description: The order's shipping total including taxes and promotions.
+          description: The sum of all shipping methods' totals after discounts, including taxes.
         shipping_subtotal:
           type: number
           title: shipping_subtotal
-          description: The order's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
         shipping_tax_total:
           type: number
           title: shipping_tax_total
-          description: The tax total of the order's shipping.
+          description: The sum of all shipping methods' tax totals after discounts.
         original_shipping_total:
           type: number
           title: original_shipping_total
-          description: The order's shipping total including taxes, excluding promotions.
+          description: The sum of all shipping methods' original totals before discounts, including taxes.
         original_shipping_subtotal:
           type: number
           title: original_shipping_subtotal
-          description: The order's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
         original_shipping_tax_total:
           type: number
           title: original_shipping_tax_total
-          description: The tax total of the order's shipping excluding promotions.
+          description: The sum of all shipping methods' original tax totals before discounts.
         status:
           type: string
           title: status
@@ -84834,15 +84834,15 @@ components:
         credit_line_total:
           type: number
           title: credit_line_total
-          description: The order's credit line total.
+          description: The total amount of credit lines applied to the order, including taxes. Subtracted from the final total.
         item_discount_total:
           type: number
           title: item_discount_total
-          description: The total discount amount applied on the order's items.
+          description: The sum of all discounts applied to line items, including the tax portion of discounts.
         shipping_discount_total:
           type: number
           title: shipping_discount_total
-          description: The total discount amount applied on the order's shipping.
+          description: The sum of all discounts applied to shipping methods, including the tax portion of discounts.
         custom_display_id:
           type: string
           title: custom_display_id
@@ -85253,47 +85253,47 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The item's total including taxes, excluding promotions.
+          description: The line item's original total before discounts, including taxes.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The item's total excluding taxes, including promotions.
+          description: The line item's original subtotal before discounts, excluding taxes.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes of the item, excluding promotions.
+          description: The line item's original tax total before discounts.
         item_total:
           type: number
           title: item_total
-          description: The total taxes of the item, including promotions.
+          description: The line item's total after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The item's total excluding taxes, including promotions.
+          description: The line item's subtotal before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The total taxes of the item, including promotions.
+          description: The line item's tax total after discounts.
         total:
           type: number
           title: total
-          description: The item's total, including taxes and promotions.
+          description: The line item's total after discounts, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The item's subtotal excluding taxes, including promotions.
+          description: The line item's subtotal before discounts, excluding taxes.
         tax_total:
           type: number
           title: tax_total
-          description: The tax total of the item including promotions.
+          description: The line item's tax total after discounts.
         discount_total:
           type: number
           title: discount_total
-          description: The total discount amount of the item.
+          description: The total amount of discounts applied to the line item, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The total taxes applied on the discounted amount.
+          description: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
         refundable_total:
           type: number
           title: refundable_total
@@ -89691,59 +89691,59 @@ components:
         original_item_total:
           type: number
           title: original_item_total
-          description: The cart items' total including taxes, excluding promotions.
+          description: The sum of all line items' original totals before discounts, including taxes.
         original_item_subtotal:
           type: number
           title: original_item_subtotal
-          description: The cart items' total excluding taxes, including promotions.
+          description: The sum of all line items' original subtotals before discounts, excluding taxes.
         original_item_tax_total:
           type: number
           title: original_item_tax_total
-          description: The cart items' tax total excluding promotions.
+          description: The sum of all line items' original tax totals before discounts.
         item_total:
           type: number
           title: item_total
-          description: The cart items' total including taxes and promotions.
+          description: The sum of all line items' totals after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The cart items' total excluding taxes, including promotions.
+          description: The sum of all line items' subtotals before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The cart items' tax total including promotions.
+          description: The sum of all line items' tax totals after discounts.
         original_total:
           type: number
           title: original_total
-          description: The cart's total including taxes, excluding promotions.
+          description: The cart's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The cart's total excluding taxes, including promotions.
+          description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The cart's tax total excluding promotions.
+          description: The cart's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
         total:
           type: number
           title: total
-          description: The cart's total including taxes and promotions.
+          description: The cart's final total after discounts and credit lines, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The cart's total excluding taxes, including promotions.
+          description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
         tax_total:
           type: number
           title: tax_total
-          description: The cart's tax total including promotions.
+          description: The cart's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
         discount_total:
           type: number
           title: discount_total
-          description: The cart's discount total.
+          description: The total amount of discounts applied to the cart, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The tax total applied on the discounted amount.
+          description: The total amount of discounts applied to the cart's tax. Represents the tax portion of discounts.
         gift_card_total:
           type: number
           title: gift_card_total
@@ -89755,27 +89755,27 @@ components:
         shipping_total:
           type: number
           title: shipping_total
-          description: The cart's shipping total including taxes and promotions.
+          description: The sum of all shipping methods' totals after discounts, including taxes.
         shipping_subtotal:
           type: number
           title: shipping_subtotal
-          description: The cart's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
         shipping_tax_total:
           type: number
           title: shipping_tax_total
-          description: The total taxes applied on the cart's shipping amount.
+          description: The sum of all shipping methods' tax totals after discounts.
         original_shipping_total:
           type: number
           title: original_shipping_total
-          description: The cart's shipping total including taxes, excluding promotions.
+          description: The sum of all shipping methods' original totals before discounts, including taxes.
         original_shipping_subtotal:
           type: number
           title: original_shipping_subtotal
-          description: The cart's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
         original_shipping_tax_total:
           type: number
           title: original_shipping_tax_total
-          description: The total taxes applied on the cart's shipping amount.
+          description: The sum of all shipping methods' original tax totals before discounts.
         promotions:
           type: array
           description: The cart's promotions.
@@ -90163,47 +90163,47 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The item's total including taxes, excluding promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's original total before discounts, including taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The item's total excluding taxes, including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's original subtotal before discounts, excluding taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes of the item excluding promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's original tax total before discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         item_total:
           type: number
-          title: original_tax_total
-          description: The item's total including taxes and promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          title: item_total
+          description: The line item's total after discounts, including taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The item's total excluding taxes, including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's subtotal before discounts, excluding taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The total taxes of the item including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's tax total after discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         total:
           type: number
           title: total
-          description: The item's total including taxes and promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's total after discounts, including taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         subtotal:
           type: number
           title: subtotal
-          description: The item's total excluding taxes, including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's subtotal before discounts, excluding taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         tax_total:
           type: number
           title: tax_total
-          description: The total taxes of the item including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's tax total after discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         discount_total:
           type: number
           title: discount_total
-          description: The total discount of the item. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The total amount of discounts applied to the line item, including the tax portion of discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The total taxes applied on the discounted amount. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
     StoreCartPromotion:
       type: object
       description: The promotion's promotions.
@@ -90481,35 +90481,35 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The shipping method's total including taxes, excluding promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's original total before discounts, including taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The shipping method's total excluding taxes, including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's original subtotal before discounts, excluding taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes applied on the shipping method's amount including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's original tax total before discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         total:
           type: number
           title: total
-          description: The shipping method's total amount including taxes and promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's total after discounts, including taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         subtotal:
           type: number
           title: subtotal
-          description: The shipping method's total amount excluding taxes, including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's subtotal before discounts, excluding taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         tax_total:
           type: number
           title: tax_total
-          description: The total taxes applied on the shipping method's amount including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's tax total after discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         discount_total:
           type: number
           title: discount_total
-          description: The total amount discounted. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The total amount of discounts applied to the shipping method, including the tax portion of discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The taxes applied on the discounted amount. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
     StoreCartShippingOption:
       type: object
       description: The shipping option's details.
@@ -91509,59 +91509,59 @@ components:
         original_item_total:
           type: number
           title: original_item_total
-          description: The order items' total including taxes, excluding promotions.
+          description: The sum of all line items' original totals before discounts, including taxes.
         original_item_subtotal:
           type: number
           title: original_item_subtotal
-          description: The order items' total excluding taxes, including promotions.
+          description: The sum of all line items' original subtotals before discounts, excluding taxes.
         original_item_tax_total:
           type: number
           title: original_item_tax_total
-          description: The total taxes applied on the order items, excluding promotions.
+          description: The sum of all line items' original tax totals before discounts.
         item_total:
           type: number
           title: item_total
-          description: The order items' total including taxes and promotions.
+          description: The sum of all line items' totals after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The order items' total excluding taxes, including promotions.
+          description: The sum of all line items' subtotals before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The total taxes applied on the order's items, including promotions.
+          description: The sum of all line items' tax totals after discounts.
         original_total:
           type: number
           title: original_total
-          description: The order's total including taxes, excluding promotions.
+          description: The order's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The order's total excluding taxes, including promotions.
+          description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes of the order excluding promotions.
+          description: The order's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
         total:
           type: number
           title: total
-          description: The order's total including taxes and promotions.
+          description: The order's final total after discounts and credit lines, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The order's total excluding taxes, including promotions.
+          description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
         tax_total:
           type: number
           title: tax_total
-          description: The tax totals of the order including promotions.
+          description: The order's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
         discount_total:
           type: number
           title: discount_total
-          description: The order's discount total.
+          description: The total amount of discounts applied to the order, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The total taxes applied on the discounted amount.
+          description: The total amount of discounts applied to the order's tax. Represents the tax portion of discounts.
         gift_card_total:
           type: number
           title: gift_card_total
@@ -91573,27 +91573,27 @@ components:
         shipping_total:
           type: number
           title: shipping_total
-          description: The order's shipping total including taxes and promotions.
+          description: The sum of all shipping methods' totals after discounts, including taxes.
         shipping_subtotal:
           type: number
           title: shipping_subtotal
-          description: The order's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
         shipping_tax_total:
           type: number
           title: shipping_tax_total
-          description: The total taxes of the order's shipping including promotions.
+          description: The sum of all shipping methods' tax totals after discounts.
         original_shipping_total:
           type: number
           title: original_shipping_total
-          description: The order's shipping total including taxes, excluding promotions.
+          description: The sum of all shipping methods' original totals before discounts, including taxes.
         original_shipping_subtotal:
           type: number
           title: original_shipping_subtotal
-          description: The order's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
         original_shipping_tax_total:
           type: number
           title: original_shipping_tax_total
-          description: The total taxes of the order's shipping excluding promotions.
+          description: The sum of all shipping methods' original tax totals before discounts.
         customer:
           $ref: '#/components/schemas/StoreCustomer'
         transactions:
@@ -91608,15 +91608,15 @@ components:
         credit_line_total:
           type: number
           title: credit_line_total
-          description: The order's credit line total.
+          description: The total amount of credit lines applied to the order, including taxes. Subtracted from the final total.
         item_discount_total:
           type: number
           title: item_discount_total
-          description: The total discount amount applied on the order's items.
+          description: The sum of all discounts applied to line items, including the tax portion of discounts.
         shipping_discount_total:
           type: number
           title: shipping_discount_total
-          description: The total discount amount applied on the order's shipping.
+          description: The sum of all discounts applied to shipping methods, including the tax portion of discounts.
         custom_display_id:
           type: string
           title: custom_display_id

--- a/www/apps/api-reference/specs/store/components/schemas/BaseCart.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseCart.yaml
@@ -89,59 +89,77 @@ properties:
   original_item_total:
     type: number
     title: original_item_total
-    description: The cart's original item total.
+    description: >-
+      The sum of all line items' original totals before discounts, including
+      taxes.
   original_item_subtotal:
     type: number
     title: original_item_subtotal
-    description: The cart's original item subtotal.
+    description: >-
+      The sum of all line items' original subtotals before discounts, excluding
+      taxes.
   original_item_tax_total:
     type: number
     title: original_item_tax_total
-    description: The cart's original item tax total.
+    description: The sum of all line items' original tax totals before discounts.
   item_total:
     type: number
     title: item_total
-    description: The cart's item total.
+    description: The sum of all line items' totals after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The cart's item subtotal.
+    description: The sum of all line items' subtotals before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The cart's item tax total.
+    description: The sum of all line items' tax totals after discounts.
   original_total:
     type: number
     title: original_total
-    description: The cart's original total.
+    description: >-
+      The cart's total before discounts, including taxes. Calculated as the sum
+      of `original_item_total` and `original_shipping_total`.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The cart's original subtotal.
+    description: >-
+      The cart's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `original_item_subtotal` and `original_shipping_subtotal`.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The cart's original tax total.
+    description: >-
+      The cart's tax total before discounts. Calculated as the sum of
+      `original_item_tax_total` and `original_shipping_tax_total`.
   total:
     type: number
     title: total
-    description: The cart's total.
+    description: The cart's final total after discounts and credit lines, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The cart's subtotal.
+    description: >-
+      The cart's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `item_subtotal` and `shipping_subtotal`.
   tax_total:
     type: number
     title: tax_total
-    description: The cart's tax total.
+    description: >-
+      The cart's tax total after discounts. Calculated as the sum of
+      `item_tax_total` and `shipping_tax_total`.
   discount_total:
     type: number
     title: discount_total
-    description: The cart's discount total.
+    description: >-
+      The total amount of discounts applied to the cart, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The cart's discount tax total.
+    description: >-
+      The total amount of discounts applied to the cart's tax. Represents the
+      tax portion of discounts.
   gift_card_total:
     type: number
     title: gift_card_total
@@ -153,24 +171,30 @@ properties:
   shipping_total:
     type: number
     title: shipping_total
-    description: The cart's shipping total.
+    description: The sum of all shipping methods' totals after discounts, including taxes.
   shipping_subtotal:
     type: number
     title: shipping_subtotal
-    description: The cart's shipping subtotal.
+    description: >-
+      The sum of all shipping methods' subtotals before discounts, excluding
+      taxes.
   shipping_tax_total:
     type: number
     title: shipping_tax_total
-    description: The cart's shipping tax total.
+    description: The sum of all shipping methods' tax totals after discounts.
   original_shipping_total:
     type: number
     title: original_shipping_total
-    description: The cart's original shipping total.
+    description: >-
+      The sum of all shipping methods' original totals before discounts,
+      including taxes.
   original_shipping_subtotal:
     type: number
     title: original_shipping_subtotal
-    description: The cart's original shipping subtotal.
+    description: >-
+      The sum of all shipping methods' original subtotals before discounts,
+      excluding taxes.
   original_shipping_tax_total:
     type: number
     title: original_shipping_tax_total
-    description: The cart's original shipping tax total.
+    description: The sum of all shipping methods' original tax totals before discounts.

--- a/www/apps/api-reference/specs/store/components/schemas/BaseCartLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseCartLineItem.yaml
@@ -143,44 +143,48 @@ properties:
   original_total:
     type: number
     title: original_total
-    description: The item's original total.
+    description: The line item's original total before discounts, including taxes.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The item's original subtotal.
+    description: The line item's original subtotal before discounts, excluding taxes.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The item's original tax total.
+    description: The line item's original tax total before discounts.
   item_total:
     type: number
     title: item_total
-    description: The item's item total.
+    description: The line item's total after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The item's item subtotal.
+    description: The line item's subtotal before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The item's item tax total.
+    description: The line item's tax total after discounts.
   total:
     type: number
     title: total
-    description: The item's total.
+    description: The line item's total after discounts, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The item's subtotal.
+    description: The line item's subtotal before discounts, excluding taxes.
   tax_total:
     type: number
     title: tax_total
-    description: The item's tax total.
+    description: The line item's tax total after discounts.
   discount_total:
     type: number
     title: discount_total
-    description: The item's discount total.
+    description: >-
+      The total amount of discounts applied to the line item, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The item's discount tax total.
+    description: >-
+      The total amount of discounts applied to the line item's tax. Represents
+      the tax portion of discounts.

--- a/www/apps/api-reference/specs/store/components/schemas/BaseCartShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseCartShippingMethod.yaml
@@ -75,36 +75,36 @@ properties:
   original_total:
     type: number
     title: original_total
-    description: The shipping method's total including taxes, excluding promotions.
+    description: The shipping method's original total before discounts, including taxes.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The shipping method's total excluding taxes, including promotions.
+    description: The shipping method's original subtotal before discounts, excluding taxes.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: >-
-      The total taxes applied on the shipping method's amount including
-      promotions.
+    description: The shipping method's original tax total before discounts.
   total:
     type: number
     title: total
-    description: The shipping method's total amount including taxes and promotions.
+    description: The shipping method's total after discounts, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The shipping method's total amount excluding taxes, including promotions.
+    description: The shipping method's subtotal before discounts, excluding taxes.
   tax_total:
     type: number
     title: tax_total
-    description: >-
-      The total taxes applied on the shipping method's amount including
-      promotions.
+    description: The shipping method's tax total after discounts.
   discount_total:
     type: number
     title: discount_total
-    description: The total amount discounted.
+    description: >-
+      The total amount of discounts applied to the shipping method, including
+      the tax portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The taxes applied on the discounted amount.
+    description: >-
+      The total amount of discounts applied to the shipping method's tax.
+      Represents the tax portion of discounts.

--- a/www/apps/api-reference/specs/store/components/schemas/BaseOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseOrder.yaml
@@ -152,59 +152,77 @@ properties:
   original_item_total:
     type: number
     title: original_item_total
-    description: The total of the order's items including taxes, excluding promotions.
+    description: >-
+      The sum of all line items' original totals before discounts, including
+      taxes.
   original_item_subtotal:
     type: number
     title: original_item_subtotal
-    description: The total of the order's items excluding taxes, including promotions.
+    description: >-
+      The sum of all line items' original subtotals before discounts, excluding
+      taxes.
   original_item_tax_total:
     type: number
     title: original_item_tax_total
-    description: The tax total of the order's items excluding promotions.
+    description: The sum of all line items' original tax totals before discounts.
   item_total:
     type: number
     title: item_total
-    description: The total of the order's items including taxes and promotions.
+    description: The sum of all line items' totals after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The total of the order's items excluding taxes, including promotions.
+    description: The sum of all line items' subtotals before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The tax total of the order's items including promotions.
+    description: The sum of all line items' tax totals after discounts.
   original_total:
     type: number
     title: original_total
-    description: The order's total excluding promotions, including taxes.
+    description: >-
+      The order's total before discounts, including taxes. Calculated as the sum
+      of `original_item_total` and `original_shipping_total`.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The order's total excluding taxes, including promotions.
+    description: >-
+      The order's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `original_item_subtotal` and `original_shipping_subtotal`.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The order's tax total, excluding promotions.
+    description: >-
+      The order's tax total before discounts. Calculated as the sum of
+      `original_item_tax_total` and `original_shipping_tax_total`.
   total:
     type: number
     title: total
-    description: The order's total including taxes and promotions.
+    description: The order's final total after discounts and credit lines, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The order's total excluding taxes, including promotions.
+    description: >-
+      The order's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `item_subtotal` and `shipping_subtotal`.
   tax_total:
     type: number
     title: tax_total
-    description: The order's tax total including promotions.
+    description: >-
+      The order's tax total after discounts. Calculated as the sum of
+      `item_tax_total` and `shipping_tax_total`.
   discount_total:
     type: number
     title: discount_total
-    description: The order's discount or promotions total.
+    description: >-
+      The total amount of discounts applied to the order, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The tax total of order's discount or promotion.
+    description: >-
+      The total amount of discounts applied to the order's tax. Represents the
+      tax portion of discounts.
   gift_card_total:
     type: number
     title: gift_card_total
@@ -216,27 +234,33 @@ properties:
   shipping_total:
     type: number
     title: shipping_total
-    description: The order's shipping total including taxes and promotions.
+    description: The sum of all shipping methods' totals after discounts, including taxes.
   shipping_subtotal:
     type: number
     title: shipping_subtotal
-    description: The order's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' subtotals before discounts, excluding
+      taxes.
   shipping_tax_total:
     type: number
     title: shipping_tax_total
-    description: The tax total of the order's shipping.
+    description: The sum of all shipping methods' tax totals after discounts.
   original_shipping_total:
     type: number
     title: original_shipping_total
-    description: The order's shipping total including taxes, excluding promotions.
+    description: >-
+      The sum of all shipping methods' original totals before discounts,
+      including taxes.
   original_shipping_subtotal:
     type: number
     title: original_shipping_subtotal
-    description: The order's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' original subtotals before discounts,
+      excluding taxes.
   original_shipping_tax_total:
     type: number
     title: original_shipping_tax_total
-    description: The tax total of the order's shipping excluding promotions.
+    description: The sum of all shipping methods' original tax totals before discounts.
   status:
     type: string
     title: status
@@ -244,15 +268,21 @@ properties:
   credit_line_total:
     type: number
     title: credit_line_total
-    description: The order's credit line total.
+    description: >-
+      The total amount of credit lines applied to the order, including taxes.
+      Subtracted from the final total.
   item_discount_total:
     type: number
     title: item_discount_total
-    description: The total discount amount applied on the order's items.
+    description: >-
+      The sum of all discounts applied to line items, including the tax portion
+      of discounts.
   shipping_discount_total:
     type: number
     title: shipping_discount_total
-    description: The total discount amount applied on the order's shipping.
+    description: >-
+      The sum of all discounts applied to shipping methods, including the tax
+      portion of discounts.
   custom_display_id:
     type: string
     title: custom_display_id

--- a/www/apps/api-reference/specs/store/components/schemas/BaseOrderLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/BaseOrderLineItem.yaml
@@ -166,47 +166,51 @@ properties:
   original_total:
     type: number
     title: original_total
-    description: The item's total including taxes, excluding promotions.
+    description: The line item's original total before discounts, including taxes.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The item's total excluding taxes, including promotions.
+    description: The line item's original subtotal before discounts, excluding taxes.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The total taxes of the item, excluding promotions.
+    description: The line item's original tax total before discounts.
   item_total:
     type: number
     title: item_total
-    description: The total taxes of the item, including promotions.
+    description: The line item's total after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The item's total excluding taxes, including promotions.
+    description: The line item's subtotal before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The total taxes of the item, including promotions.
+    description: The line item's tax total after discounts.
   total:
     type: number
     title: total
-    description: The item's total, including taxes and promotions.
+    description: The line item's total after discounts, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The item's subtotal excluding taxes, including promotions.
+    description: The line item's subtotal before discounts, excluding taxes.
   tax_total:
     type: number
     title: tax_total
-    description: The tax total of the item including promotions.
+    description: The line item's tax total after discounts.
   discount_total:
     type: number
     title: discount_total
-    description: The total discount amount of the item.
+    description: >-
+      The total amount of discounts applied to the line item, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The total taxes applied on the discounted amount.
+    description: >-
+      The total amount of discounts applied to the line item's tax. Represents
+      the tax portion of discounts.
   refundable_total:
     type: number
     title: refundable_total

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCart.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCart.yaml
@@ -94,59 +94,77 @@ properties:
   original_item_total:
     type: number
     title: original_item_total
-    description: The cart items' total including taxes, excluding promotions.
+    description: >-
+      The sum of all line items' original totals before discounts, including
+      taxes.
   original_item_subtotal:
     type: number
     title: original_item_subtotal
-    description: The cart items' total excluding taxes, including promotions.
+    description: >-
+      The sum of all line items' original subtotals before discounts, excluding
+      taxes.
   original_item_tax_total:
     type: number
     title: original_item_tax_total
-    description: The cart items' tax total excluding promotions.
+    description: The sum of all line items' original tax totals before discounts.
   item_total:
     type: number
     title: item_total
-    description: The cart items' total including taxes and promotions.
+    description: The sum of all line items' totals after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The cart items' total excluding taxes, including promotions.
+    description: The sum of all line items' subtotals before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The cart items' tax total including promotions.
+    description: The sum of all line items' tax totals after discounts.
   original_total:
     type: number
     title: original_total
-    description: The cart's total including taxes, excluding promotions.
+    description: >-
+      The cart's total before discounts, including taxes. Calculated as the sum
+      of `original_item_total` and `original_shipping_total`.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The cart's total excluding taxes, including promotions.
+    description: >-
+      The cart's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `original_item_subtotal` and `original_shipping_subtotal`.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The cart's tax total excluding promotions.
+    description: >-
+      The cart's tax total before discounts. Calculated as the sum of
+      `original_item_tax_total` and `original_shipping_tax_total`.
   total:
     type: number
     title: total
-    description: The cart's total including taxes and promotions.
+    description: The cart's final total after discounts and credit lines, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The cart's total excluding taxes, including promotions.
+    description: >-
+      The cart's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `item_subtotal` and `shipping_subtotal`.
   tax_total:
     type: number
     title: tax_total
-    description: The cart's tax total including promotions.
+    description: >-
+      The cart's tax total after discounts. Calculated as the sum of
+      `item_tax_total` and `shipping_tax_total`.
   discount_total:
     type: number
     title: discount_total
-    description: The cart's discount total.
+    description: >-
+      The total amount of discounts applied to the cart, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The tax total applied on the discounted amount.
+    description: >-
+      The total amount of discounts applied to the cart's tax. Represents the
+      tax portion of discounts.
   gift_card_total:
     type: number
     title: gift_card_total
@@ -158,27 +176,33 @@ properties:
   shipping_total:
     type: number
     title: shipping_total
-    description: The cart's shipping total including taxes and promotions.
+    description: The sum of all shipping methods' totals after discounts, including taxes.
   shipping_subtotal:
     type: number
     title: shipping_subtotal
-    description: The cart's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' subtotals before discounts, excluding
+      taxes.
   shipping_tax_total:
     type: number
     title: shipping_tax_total
-    description: The total taxes applied on the cart's shipping amount.
+    description: The sum of all shipping methods' tax totals after discounts.
   original_shipping_total:
     type: number
     title: original_shipping_total
-    description: The cart's shipping total including taxes, excluding promotions.
+    description: >-
+      The sum of all shipping methods' original totals before discounts,
+      including taxes.
   original_shipping_subtotal:
     type: number
     title: original_shipping_subtotal
-    description: The cart's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' original subtotals before discounts,
+      excluding taxes.
   original_shipping_tax_total:
     type: number
     title: original_shipping_tax_total
-    description: The total taxes applied on the cart's shipping amount.
+    description: The sum of all shipping methods' original tax totals before discounts.
   promotions:
     type: array
     description: The cart's promotions.

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCartLineItem.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCartLineItem.yaml
@@ -288,31 +288,33 @@ properties:
     type: number
     title: original_total
     description: >-
-      The item's total including taxes, excluding promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's original total before discounts, including taxes. This
+      field is only available if you expand the `items.*` relation. Learn more
+      in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   original_subtotal:
     type: number
     title: original_subtotal
     description: >-
-      The item's total excluding taxes, including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's original subtotal before discounts, excluding taxes. This
+      field is only available if you expand the `items.*` relation. Learn more
+      in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   original_tax_total:
     type: number
     title: original_tax_total
     description: >-
-      The total taxes of the item excluding promotions. This field is only
+      The line item's original tax total before discounts. This field is only
       available if you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   item_total:
     type: number
-    title: original_tax_total
+    title: item_total
     description: >-
-      The item's total including taxes and promotions. This field is only
+      The line item's total after discounts, including taxes. This field is only
       available if you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
@@ -320,23 +322,24 @@ properties:
     type: number
     title: item_subtotal
     description: >-
-      The item's total excluding taxes, including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's subtotal before discounts, excluding taxes. This field is
+      only available if you expand the `items.*` relation. Learn more in the
+      [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   item_tax_total:
     type: number
     title: item_tax_total
     description: >-
-      The total taxes of the item including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's tax total after discounts. This field is only available if
+      you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   total:
     type: number
     title: total
     description: >-
-      The item's total including taxes and promotions. This field is only
+      The line item's total after discounts, including taxes. This field is only
       available if you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
@@ -344,31 +347,34 @@ properties:
     type: number
     title: subtotal
     description: >-
-      The item's total excluding taxes, including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's subtotal before discounts, excluding taxes. This field is
+      only available if you expand the `items.*` relation. Learn more in the
+      [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   tax_total:
     type: number
     title: tax_total
     description: >-
-      The total taxes of the item including promotions. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The line item's tax total after discounts. This field is only available if
+      you expand the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   discount_total:
     type: number
     title: discount_total
     description: >-
-      The total discount of the item. This field is only available if you expand
-      the `items.*` relation. Learn more in the [Cart
+      The total amount of discounts applied to the line item, including the tax
+      portion of discounts. This field is only available if you expand the
+      `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.
   discount_tax_total:
     type: number
     title: discount_tax_total
     description: >-
-      The total taxes applied on the discounted amount. This field is only
-      available if you expand the `items.*` relation. Learn more in the [Cart
+      The total amount of discounts applied to the line item's tax. Represents
+      the tax portion of discounts. This field is only available if you expand
+      the `items.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals)
       guide.

--- a/www/apps/api-reference/specs/store/components/schemas/StoreCartShippingMethod.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreCartShippingMethod.yaml
@@ -214,61 +214,62 @@ properties:
     type: number
     title: original_total
     description: >-
-      The shipping method's total including taxes, excluding promotions. This
-      field is only available if you expand the `shipping_methods.*` relation.
-      Learn more in the [Cart
+      The shipping method's original total before discounts, including taxes.
+      This field is only available if you expand the `shipping_methods.*`
+      relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   original_subtotal:
     type: number
     title: original_subtotal
     description: >-
-      The shipping method's total excluding taxes, including promotions. This
-      field is only available if you expand the `shipping_methods.*` relation.
-      Learn more in the [Cart
+      The shipping method's original subtotal before discounts, excluding taxes.
+      This field is only available if you expand the `shipping_methods.*`
+      relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   original_tax_total:
     type: number
     title: original_tax_total
     description: >-
-      The total taxes applied on the shipping method's amount including
-      promotions. This field is only available if you expand the
-      `shipping_methods.*` relation. Learn more in the [Cart
+      The shipping method's original tax total before discounts. This field is
+      only available if you expand the `shipping_methods.*` relation. Learn more
+      in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   total:
     type: number
     title: total
     description: >-
-      The shipping method's total amount including taxes and promotions. This
-      field is only available if you expand the `shipping_methods.*` relation.
-      Learn more in the [Cart
+      The shipping method's total after discounts, including taxes. This field
+      is only available if you expand the `shipping_methods.*` relation. Learn
+      more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   subtotal:
     type: number
     title: subtotal
     description: >-
-      The shipping method's total amount excluding taxes, including promotions.
-      This field is only available if you expand the `shipping_methods.*`
-      relation. Learn more in the [Cart
+      The shipping method's subtotal before discounts, excluding taxes. This
+      field is only available if you expand the `shipping_methods.*` relation.
+      Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   tax_total:
     type: number
     title: tax_total
     description: >-
-      The total taxes applied on the shipping method's amount including
-      promotions. This field is only available if you expand the
-      `shipping_methods.*` relation. Learn more in the [Cart
+      The shipping method's tax total after discounts. This field is only
+      available if you expand the `shipping_methods.*` relation. Learn more in
+      the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
   discount_total:
     type: number
     title: discount_total
     description: >-
-      The total amount discounted. This field is only available if you expand
+      The total amount of discounts applied to the shipping method, including
+      the tax portion of discounts. This field is only available if you expand
       the `shipping_methods.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.
@@ -276,7 +277,8 @@ properties:
     type: number
     title: discount_tax_total
     description: >-
-      The taxes applied on the discounted amount. This field is only available
-      if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+      The total amount of discounts applied to the shipping method's tax.
+      Represents the tax portion of discounts. This field is only available if
+      you expand the `shipping_methods.*` relation. Learn more in the [Cart
       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals)
       guide.

--- a/www/apps/api-reference/specs/store/components/schemas/StoreOrder.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreOrder.yaml
@@ -143,59 +143,77 @@ properties:
   original_item_total:
     type: number
     title: original_item_total
-    description: The order items' total including taxes, excluding promotions.
+    description: >-
+      The sum of all line items' original totals before discounts, including
+      taxes.
   original_item_subtotal:
     type: number
     title: original_item_subtotal
-    description: The order items' total excluding taxes, including promotions.
+    description: >-
+      The sum of all line items' original subtotals before discounts, excluding
+      taxes.
   original_item_tax_total:
     type: number
     title: original_item_tax_total
-    description: The total taxes applied on the order items, excluding promotions.
+    description: The sum of all line items' original tax totals before discounts.
   item_total:
     type: number
     title: item_total
-    description: The order items' total including taxes and promotions.
+    description: The sum of all line items' totals after discounts, including taxes.
   item_subtotal:
     type: number
     title: item_subtotal
-    description: The order items' total excluding taxes, including promotions.
+    description: The sum of all line items' subtotals before discounts, excluding taxes.
   item_tax_total:
     type: number
     title: item_tax_total
-    description: The total taxes applied on the order's items, including promotions.
+    description: The sum of all line items' tax totals after discounts.
   original_total:
     type: number
     title: original_total
-    description: The order's total including taxes, excluding promotions.
+    description: >-
+      The order's total before discounts, including taxes. Calculated as the sum
+      of `original_item_total` and `original_shipping_total`.
   original_subtotal:
     type: number
     title: original_subtotal
-    description: The order's total excluding taxes, including promotions.
+    description: >-
+      The order's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `original_item_subtotal` and `original_shipping_subtotal`.
   original_tax_total:
     type: number
     title: original_tax_total
-    description: The total taxes of the order excluding promotions.
+    description: >-
+      The order's tax total before discounts. Calculated as the sum of
+      `original_item_tax_total` and `original_shipping_tax_total`.
   total:
     type: number
     title: total
-    description: The order's total including taxes and promotions.
+    description: The order's final total after discounts and credit lines, including taxes.
   subtotal:
     type: number
     title: subtotal
-    description: The order's total excluding taxes, including promotions.
+    description: >-
+      The order's subtotal before discounts, excluding taxes. Calculated as the
+      sum of `item_subtotal` and `shipping_subtotal`.
   tax_total:
     type: number
     title: tax_total
-    description: The tax totals of the order including promotions.
+    description: >-
+      The order's tax total after discounts. Calculated as the sum of
+      `item_tax_total` and `shipping_tax_total`.
   discount_total:
     type: number
     title: discount_total
-    description: The order's discount total.
+    description: >-
+      The total amount of discounts applied to the order, including the tax
+      portion of discounts.
   discount_tax_total:
     type: number
     title: discount_tax_total
-    description: The total taxes applied on the discounted amount.
+    description: >-
+      The total amount of discounts applied to the order's tax. Represents the
+      tax portion of discounts.
   gift_card_total:
     type: number
     title: gift_card_total
@@ -207,27 +225,33 @@ properties:
   shipping_total:
     type: number
     title: shipping_total
-    description: The order's shipping total including taxes and promotions.
+    description: The sum of all shipping methods' totals after discounts, including taxes.
   shipping_subtotal:
     type: number
     title: shipping_subtotal
-    description: The order's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' subtotals before discounts, excluding
+      taxes.
   shipping_tax_total:
     type: number
     title: shipping_tax_total
-    description: The total taxes of the order's shipping including promotions.
+    description: The sum of all shipping methods' tax totals after discounts.
   original_shipping_total:
     type: number
     title: original_shipping_total
-    description: The order's shipping total including taxes, excluding promotions.
+    description: >-
+      The sum of all shipping methods' original totals before discounts,
+      including taxes.
   original_shipping_subtotal:
     type: number
     title: original_shipping_subtotal
-    description: The order's shipping total excluding taxes, including promotions.
+    description: >-
+      The sum of all shipping methods' original subtotals before discounts,
+      excluding taxes.
   original_shipping_tax_total:
     type: number
     title: original_shipping_tax_total
-    description: The total taxes of the order's shipping excluding promotions.
+    description: The sum of all shipping methods' original tax totals before discounts.
   customer:
     $ref: ./StoreCustomer.yaml
   transactions:
@@ -242,15 +266,21 @@ properties:
   credit_line_total:
     type: number
     title: credit_line_total
-    description: The order's credit line total.
+    description: >-
+      The total amount of credit lines applied to the order, including taxes.
+      Subtracted from the final total.
   item_discount_total:
     type: number
     title: item_discount_total
-    description: The total discount amount applied on the order's items.
+    description: >-
+      The sum of all discounts applied to line items, including the tax portion
+      of discounts.
   shipping_discount_total:
     type: number
     title: shipping_discount_total
-    description: The total discount amount applied on the order's shipping.
+    description: >-
+      The sum of all discounts applied to shipping methods, including the tax
+      portion of discounts.
   custom_display_id:
     type: string
     title: custom_display_id

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -26978,59 +26978,59 @@ components:
         original_item_total:
           type: number
           title: original_item_total
-          description: The cart's original item total.
+          description: The sum of all line items' original totals before discounts, including taxes.
         original_item_subtotal:
           type: number
           title: original_item_subtotal
-          description: The cart's original item subtotal.
+          description: The sum of all line items' original subtotals before discounts, excluding taxes.
         original_item_tax_total:
           type: number
           title: original_item_tax_total
-          description: The cart's original item tax total.
+          description: The sum of all line items' original tax totals before discounts.
         item_total:
           type: number
           title: item_total
-          description: The cart's item total.
+          description: The sum of all line items' totals after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The cart's item subtotal.
+          description: The sum of all line items' subtotals before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The cart's item tax total.
+          description: The sum of all line items' tax totals after discounts.
         original_total:
           type: number
           title: original_total
-          description: The cart's original total.
+          description: The cart's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The cart's original subtotal.
+          description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The cart's original tax total.
+          description: The cart's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
         total:
           type: number
           title: total
-          description: The cart's total.
+          description: The cart's final total after discounts and credit lines, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The cart's subtotal.
+          description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
         tax_total:
           type: number
           title: tax_total
-          description: The cart's tax total.
+          description: The cart's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
         discount_total:
           type: number
           title: discount_total
-          description: The cart's discount total.
+          description: The total amount of discounts applied to the cart, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The cart's discount tax total.
+          description: The total amount of discounts applied to the cart's tax. Represents the tax portion of discounts.
         gift_card_total:
           type: number
           title: gift_card_total
@@ -27042,27 +27042,27 @@ components:
         shipping_total:
           type: number
           title: shipping_total
-          description: The cart's shipping total.
+          description: The sum of all shipping methods' totals after discounts, including taxes.
         shipping_subtotal:
           type: number
           title: shipping_subtotal
-          description: The cart's shipping subtotal.
+          description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
         shipping_tax_total:
           type: number
           title: shipping_tax_total
-          description: The cart's shipping tax total.
+          description: The sum of all shipping methods' tax totals after discounts.
         original_shipping_total:
           type: number
           title: original_shipping_total
-          description: The cart's original shipping total.
+          description: The sum of all shipping methods' original totals before discounts, including taxes.
         original_shipping_subtotal:
           type: number
           title: original_shipping_subtotal
-          description: The cart's original shipping subtotal.
+          description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
         original_shipping_tax_total:
           type: number
           title: original_shipping_tax_total
-          description: The cart's original shipping tax total.
+          description: The sum of all shipping methods' original tax totals before discounts.
     BaseCartAddress:
       type: object
       description: The cart's shipping address.
@@ -27213,47 +27213,47 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The item's original total.
+          description: The line item's original total before discounts, including taxes.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The item's original subtotal.
+          description: The line item's original subtotal before discounts, excluding taxes.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The item's original tax total.
+          description: The line item's original tax total before discounts.
         item_total:
           type: number
           title: item_total
-          description: The item's item total.
+          description: The line item's total after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The item's item subtotal.
+          description: The line item's subtotal before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The item's item tax total.
+          description: The line item's tax total after discounts.
         total:
           type: number
           title: total
-          description: The item's total.
+          description: The line item's total after discounts, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The item's subtotal.
+          description: The line item's subtotal before discounts, excluding taxes.
         tax_total:
           type: number
           title: tax_total
-          description: The item's tax total.
+          description: The line item's tax total after discounts.
         discount_total:
           type: number
           title: discount_total
-          description: The item's discount total.
+          description: The total amount of discounts applied to the line item, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The item's discount tax total.
+          description: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
     BaseCartShippingMethod:
       type: object
       description: A cart's shipping method.
@@ -27329,35 +27329,35 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The shipping method's total including taxes, excluding promotions.
+          description: The shipping method's original total before discounts, including taxes.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The shipping method's total excluding taxes, including promotions.
+          description: The shipping method's original subtotal before discounts, excluding taxes.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes applied on the shipping method's amount including promotions.
+          description: The shipping method's original tax total before discounts.
         total:
           type: number
           title: total
-          description: The shipping method's total amount including taxes and promotions.
+          description: The shipping method's total after discounts, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The shipping method's total amount excluding taxes, including promotions.
+          description: The shipping method's subtotal before discounts, excluding taxes.
         tax_total:
           type: number
           title: tax_total
-          description: The total taxes applied on the shipping method's amount including promotions.
+          description: The shipping method's tax total after discounts.
         discount_total:
           type: number
           title: discount_total
-          description: The total amount discounted.
+          description: The total amount of discounts applied to the shipping method, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The taxes applied on the discounted amount.
+          description: The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts.
     BaseClaimItem:
       type: object
       description: The claim item's details.
@@ -27820,59 +27820,59 @@ components:
         original_item_total:
           type: number
           title: original_item_total
-          description: The total of the order's items including taxes, excluding promotions.
+          description: The sum of all line items' original totals before discounts, including taxes.
         original_item_subtotal:
           type: number
           title: original_item_subtotal
-          description: The total of the order's items excluding taxes, including promotions.
+          description: The sum of all line items' original subtotals before discounts, excluding taxes.
         original_item_tax_total:
           type: number
           title: original_item_tax_total
-          description: The tax total of the order's items excluding promotions.
+          description: The sum of all line items' original tax totals before discounts.
         item_total:
           type: number
           title: item_total
-          description: The total of the order's items including taxes and promotions.
+          description: The sum of all line items' totals after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The total of the order's items excluding taxes, including promotions.
+          description: The sum of all line items' subtotals before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The tax total of the order's items including promotions.
+          description: The sum of all line items' tax totals after discounts.
         original_total:
           type: number
           title: original_total
-          description: The order's total excluding promotions, including taxes.
+          description: The order's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The order's total excluding taxes, including promotions.
+          description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The order's tax total, excluding promotions.
+          description: The order's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
         total:
           type: number
           title: total
-          description: The order's total including taxes and promotions.
+          description: The order's final total after discounts and credit lines, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The order's total excluding taxes, including promotions.
+          description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
         tax_total:
           type: number
           title: tax_total
-          description: The order's tax total including promotions.
+          description: The order's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
         discount_total:
           type: number
           title: discount_total
-          description: The order's discount or promotions total.
+          description: The total amount of discounts applied to the order, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The tax total of order's discount or promotion.
+          description: The total amount of discounts applied to the order's tax. Represents the tax portion of discounts.
         gift_card_total:
           type: number
           title: gift_card_total
@@ -27884,27 +27884,27 @@ components:
         shipping_total:
           type: number
           title: shipping_total
-          description: The order's shipping total including taxes and promotions.
+          description: The sum of all shipping methods' totals after discounts, including taxes.
         shipping_subtotal:
           type: number
           title: shipping_subtotal
-          description: The order's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
         shipping_tax_total:
           type: number
           title: shipping_tax_total
-          description: The tax total of the order's shipping.
+          description: The sum of all shipping methods' tax totals after discounts.
         original_shipping_total:
           type: number
           title: original_shipping_total
-          description: The order's shipping total including taxes, excluding promotions.
+          description: The sum of all shipping methods' original totals before discounts, including taxes.
         original_shipping_subtotal:
           type: number
           title: original_shipping_subtotal
-          description: The order's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
         original_shipping_tax_total:
           type: number
           title: original_shipping_tax_total
-          description: The tax total of the order's shipping excluding promotions.
+          description: The sum of all shipping methods' original tax totals before discounts.
         status:
           type: string
           title: status
@@ -27912,15 +27912,15 @@ components:
         credit_line_total:
           type: number
           title: credit_line_total
-          description: The order's credit line total.
+          description: The total amount of credit lines applied to the order, including taxes. Subtracted from the final total.
         item_discount_total:
           type: number
           title: item_discount_total
-          description: The total discount amount applied on the order's items.
+          description: The sum of all discounts applied to line items, including the tax portion of discounts.
         shipping_discount_total:
           type: number
           title: shipping_discount_total
-          description: The total discount amount applied on the order's shipping.
+          description: The sum of all discounts applied to shipping methods, including the tax portion of discounts.
         custom_display_id:
           type: string
           title: custom_display_id
@@ -28331,47 +28331,47 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The item's total including taxes, excluding promotions.
+          description: The line item's original total before discounts, including taxes.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The item's total excluding taxes, including promotions.
+          description: The line item's original subtotal before discounts, excluding taxes.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes of the item, excluding promotions.
+          description: The line item's original tax total before discounts.
         item_total:
           type: number
           title: item_total
-          description: The total taxes of the item, including promotions.
+          description: The line item's total after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The item's total excluding taxes, including promotions.
+          description: The line item's subtotal before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The total taxes of the item, including promotions.
+          description: The line item's tax total after discounts.
         total:
           type: number
           title: total
-          description: The item's total, including taxes and promotions.
+          description: The line item's total after discounts, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The item's subtotal excluding taxes, including promotions.
+          description: The line item's subtotal before discounts, excluding taxes.
         tax_total:
           type: number
           title: tax_total
-          description: The tax total of the item including promotions.
+          description: The line item's tax total after discounts.
         discount_total:
           type: number
           title: discount_total
-          description: The total discount amount of the item.
+          description: The total amount of discounts applied to the line item, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The total taxes applied on the discounted amount.
+          description: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
         refundable_total:
           type: number
           title: refundable_total
@@ -32769,59 +32769,59 @@ components:
         original_item_total:
           type: number
           title: original_item_total
-          description: The cart items' total including taxes, excluding promotions.
+          description: The sum of all line items' original totals before discounts, including taxes.
         original_item_subtotal:
           type: number
           title: original_item_subtotal
-          description: The cart items' total excluding taxes, including promotions.
+          description: The sum of all line items' original subtotals before discounts, excluding taxes.
         original_item_tax_total:
           type: number
           title: original_item_tax_total
-          description: The cart items' tax total excluding promotions.
+          description: The sum of all line items' original tax totals before discounts.
         item_total:
           type: number
           title: item_total
-          description: The cart items' total including taxes and promotions.
+          description: The sum of all line items' totals after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The cart items' total excluding taxes, including promotions.
+          description: The sum of all line items' subtotals before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The cart items' tax total including promotions.
+          description: The sum of all line items' tax totals after discounts.
         original_total:
           type: number
           title: original_total
-          description: The cart's total including taxes, excluding promotions.
+          description: The cart's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The cart's total excluding taxes, including promotions.
+          description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The cart's tax total excluding promotions.
+          description: The cart's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
         total:
           type: number
           title: total
-          description: The cart's total including taxes and promotions.
+          description: The cart's final total after discounts and credit lines, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The cart's total excluding taxes, including promotions.
+          description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
         tax_total:
           type: number
           title: tax_total
-          description: The cart's tax total including promotions.
+          description: The cart's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
         discount_total:
           type: number
           title: discount_total
-          description: The cart's discount total.
+          description: The total amount of discounts applied to the cart, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The tax total applied on the discounted amount.
+          description: The total amount of discounts applied to the cart's tax. Represents the tax portion of discounts.
         gift_card_total:
           type: number
           title: gift_card_total
@@ -32833,27 +32833,27 @@ components:
         shipping_total:
           type: number
           title: shipping_total
-          description: The cart's shipping total including taxes and promotions.
+          description: The sum of all shipping methods' totals after discounts, including taxes.
         shipping_subtotal:
           type: number
           title: shipping_subtotal
-          description: The cart's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
         shipping_tax_total:
           type: number
           title: shipping_tax_total
-          description: The total taxes applied on the cart's shipping amount.
+          description: The sum of all shipping methods' tax totals after discounts.
         original_shipping_total:
           type: number
           title: original_shipping_total
-          description: The cart's shipping total including taxes, excluding promotions.
+          description: The sum of all shipping methods' original totals before discounts, including taxes.
         original_shipping_subtotal:
           type: number
           title: original_shipping_subtotal
-          description: The cart's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
         original_shipping_tax_total:
           type: number
           title: original_shipping_tax_total
-          description: The total taxes applied on the cart's shipping amount.
+          description: The sum of all shipping methods' original tax totals before discounts.
         promotions:
           type: array
           description: The cart's promotions.
@@ -33241,47 +33241,47 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The item's total including taxes, excluding promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's original total before discounts, including taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The item's total excluding taxes, including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's original subtotal before discounts, excluding taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes of the item excluding promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's original tax total before discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         item_total:
           type: number
-          title: original_tax_total
-          description: The item's total including taxes and promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          title: item_total
+          description: The line item's total after discounts, including taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The item's total excluding taxes, including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's subtotal before discounts, excluding taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The total taxes of the item including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's tax total after discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         total:
           type: number
           title: total
-          description: The item's total including taxes and promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's total after discounts, including taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         subtotal:
           type: number
           title: subtotal
-          description: The item's total excluding taxes, including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's subtotal before discounts, excluding taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         tax_total:
           type: number
           title: tax_total
-          description: The total taxes of the item including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The line item's tax total after discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         discount_total:
           type: number
           title: discount_total
-          description: The total discount of the item. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The total amount of discounts applied to the line item, including the tax portion of discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The total taxes applied on the discounted amount. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
+          description: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
     StoreCartPromotion:
       type: object
       description: The promotion's promotions.
@@ -33559,35 +33559,35 @@ components:
         original_total:
           type: number
           title: original_total
-          description: The shipping method's total including taxes, excluding promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's original total before discounts, including taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The shipping method's total excluding taxes, including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's original subtotal before discounts, excluding taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes applied on the shipping method's amount including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's original tax total before discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         total:
           type: number
           title: total
-          description: The shipping method's total amount including taxes and promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's total after discounts, including taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         subtotal:
           type: number
           title: subtotal
-          description: The shipping method's total amount excluding taxes, including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's subtotal before discounts, excluding taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         tax_total:
           type: number
           title: tax_total
-          description: The total taxes applied on the shipping method's amount including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The shipping method's tax total after discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         discount_total:
           type: number
           title: discount_total
-          description: The total amount discounted. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The total amount of discounts applied to the shipping method, including the tax portion of discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The taxes applied on the discounted amount. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
+          description: The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
     StoreCartShippingOption:
       type: object
       description: The shipping option's details.
@@ -34587,59 +34587,59 @@ components:
         original_item_total:
           type: number
           title: original_item_total
-          description: The order items' total including taxes, excluding promotions.
+          description: The sum of all line items' original totals before discounts, including taxes.
         original_item_subtotal:
           type: number
           title: original_item_subtotal
-          description: The order items' total excluding taxes, including promotions.
+          description: The sum of all line items' original subtotals before discounts, excluding taxes.
         original_item_tax_total:
           type: number
           title: original_item_tax_total
-          description: The total taxes applied on the order items, excluding promotions.
+          description: The sum of all line items' original tax totals before discounts.
         item_total:
           type: number
           title: item_total
-          description: The order items' total including taxes and promotions.
+          description: The sum of all line items' totals after discounts, including taxes.
         item_subtotal:
           type: number
           title: item_subtotal
-          description: The order items' total excluding taxes, including promotions.
+          description: The sum of all line items' subtotals before discounts, excluding taxes.
         item_tax_total:
           type: number
           title: item_tax_total
-          description: The total taxes applied on the order's items, including promotions.
+          description: The sum of all line items' tax totals after discounts.
         original_total:
           type: number
           title: original_total
-          description: The order's total including taxes, excluding promotions.
+          description: The order's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
         original_subtotal:
           type: number
           title: original_subtotal
-          description: The order's total excluding taxes, including promotions.
+          description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
         original_tax_total:
           type: number
           title: original_tax_total
-          description: The total taxes of the order excluding promotions.
+          description: The order's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
         total:
           type: number
           title: total
-          description: The order's total including taxes and promotions.
+          description: The order's final total after discounts and credit lines, including taxes.
         subtotal:
           type: number
           title: subtotal
-          description: The order's total excluding taxes, including promotions.
+          description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
         tax_total:
           type: number
           title: tax_total
-          description: The tax totals of the order including promotions.
+          description: The order's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
         discount_total:
           type: number
           title: discount_total
-          description: The order's discount total.
+          description: The total amount of discounts applied to the order, including the tax portion of discounts.
         discount_tax_total:
           type: number
           title: discount_tax_total
-          description: The total taxes applied on the discounted amount.
+          description: The total amount of discounts applied to the order's tax. Represents the tax portion of discounts.
         gift_card_total:
           type: number
           title: gift_card_total
@@ -34651,27 +34651,27 @@ components:
         shipping_total:
           type: number
           title: shipping_total
-          description: The order's shipping total including taxes and promotions.
+          description: The sum of all shipping methods' totals after discounts, including taxes.
         shipping_subtotal:
           type: number
           title: shipping_subtotal
-          description: The order's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
         shipping_tax_total:
           type: number
           title: shipping_tax_total
-          description: The total taxes of the order's shipping including promotions.
+          description: The sum of all shipping methods' tax totals after discounts.
         original_shipping_total:
           type: number
           title: original_shipping_total
-          description: The order's shipping total including taxes, excluding promotions.
+          description: The sum of all shipping methods' original totals before discounts, including taxes.
         original_shipping_subtotal:
           type: number
           title: original_shipping_subtotal
-          description: The order's shipping total excluding taxes, including promotions.
+          description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
         original_shipping_tax_total:
           type: number
           title: original_shipping_tax_total
-          description: The total taxes of the order's shipping excluding promotions.
+          description: The sum of all shipping methods' original tax totals before discounts.
         customer:
           $ref: '#/components/schemas/StoreCustomer'
         transactions:
@@ -34686,15 +34686,15 @@ components:
         credit_line_total:
           type: number
           title: credit_line_total
-          description: The order's credit line total.
+          description: The total amount of credit lines applied to the order, including taxes. Subtracted from the final total.
         item_discount_total:
           type: number
           title: item_discount_total
-          description: The total discount amount applied on the order's items.
+          description: The sum of all discounts applied to line items, including the tax portion of discounts.
         shipping_discount_total:
           type: number
           title: shipping_discount_total
-          description: The total discount amount applied on the order's shipping.
+          description: The sum of all discounts applied to shipping methods, including the tax portion of discounts.
         custom_display_id:
           type: string
           title: custom_display_id

--- a/www/apps/resources/app/commerce-modules/cart/cart-totals/page.mdx
+++ b/www/apps/resources/app/commerce-modules/cart/cart-totals/page.mdx
@@ -195,57 +195,57 @@ The returned `cart` object will look like this:
 
 The cart will include the following total fields:
 
-- `total`: The grand total of the cart, including all line items, shipping methods, taxes, and discounts.
-- `subtotal`: The cart's total excluding taxes, including promotions.
-- `tax_total`: The total tax amount applied to the cart.
-- `discount_total`: The total amount of discounts applied to the cart.
-- `discount_subtotal`: The total amount of discounts applied to the cart's subtotal.
-- `discount_tax_total`: The total amount of discounts applied to the cart's tax.
-- `original_total`: The cart's total including taxes, excluding promotions.
-- `original_tax_total`: The cart items' tax total including promotions.
-- `item_total`: The cart items' total including taxes and promotions.
-- `item_subtotal`: The cart items' total excluding taxes, including promotions.
-- `item_tax_total`: The cart items' tax total including promotions.
-- `original_item_total`: The cart items' total including taxes, excluding promotions.
-- `original_item_subtotal`: The cart items' total excluding taxes, including promotions.
-- `original_item_tax_total`: The cart items' tax total excluding promotions.
-- `shipping_total`: The cart's shipping total including taxes and promotions.
-- `shipping_subtotal`: The cart's shipping total excluding taxes, including promotions.
-- `shipping_tax_total`: The total taxes applied to the cart's shipping amount.
-- `original_shipping_tax_total`: The total taxes applied to the cart's shipping amount, excluding promotions.
-- `original_shipping_subtotal`: The cart's shipping total excluding taxes, including promotions.
-- `original_shipping_total`: The cart's shipping total including taxes, excluding promotions.
-- `credit_line_subtotal`: The subtotal of the credit line applied to the cart.
-- `credit_line_tax_total`: The total tax amount applied to the credit line.
-- `credit_line_total`: The total amount of the credit line applied to the cart.
+- `total`: The cart's final total after discounts and credit lines, including taxes.
+- `subtotal`: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
+- `tax_total`: The cart's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
+- `discount_total`: The total amount of discounts applied to the cart, including the tax portion of discounts.
+- `discount_subtotal`: The total amount of discounts applied to the cart's subtotal (excluding tax portion). Used in the final total calculation.
+- `discount_tax_total`: The total amount of discounts applied to the cart's tax. Represents the tax portion of discounts.
+- `original_total`: The cart's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
+- `original_tax_total`: The cart's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
+- `item_total`: The sum of all line items' totals after discounts, including taxes.
+- `item_subtotal`: The sum of all line items' subtotals before discounts, excluding taxes.
+- `item_tax_total`: The sum of all line items' tax totals after discounts.
+- `original_item_total`: The sum of all line items' original totals before discounts, including taxes.
+- `original_item_subtotal`: The sum of all line items' original subtotals before discounts, excluding taxes.
+- `original_item_tax_total`: The sum of all line items' original tax totals before discounts.
+- `shipping_total`: The sum of all shipping methods' totals after discounts, including taxes.
+- `shipping_subtotal`: The sum of all shipping methods' subtotals before discounts, excluding taxes.
+- `shipping_tax_total`: The sum of all shipping methods' tax totals after discounts.
+- `original_shipping_tax_total`: The sum of all shipping methods' original tax totals before discounts.
+- `original_shipping_subtotal`: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
+- `original_shipping_total`: The sum of all shipping methods' original totals before discounts, including taxes.
+- `credit_line_subtotal`: The subtotal of credit lines applied to the cart, excluding taxes.
+- `credit_line_tax_total`: The tax total of credit lines applied to the cart.
+- `credit_line_total`: The total amount of credit lines applied to the cart, including taxes. Subtracted from the final total.
 
 ### Cart Line Item Totals
 
 The `items` array in the `cart` object contains total fields for each line item:
 
 - `unit_price`: The price of a single unit of the line item. This field is not calculated and is stored in the database.
-- `subtotal`: The total price of the line item before any discounts or taxes.
-- `total`: The total price of the line item after applying discounts and taxes.
-- `original_total`: The total price of the line item before any discounts.
-- `discount_total`: The total amount of discounts applied to the line item.
-- `discount_subtotal`: The total amount of discounts applied to the line item's subtotal.
-- `discount_tax_total`: The total amount of discounts applied to the line item's tax.
-- `tax_total`: The total tax amount applied to the line item.
-- `original_tax_total`: The total tax amount applied to the line item before any discounts.
+- `subtotal`: The line item's subtotal before discounts, excluding taxes.
+- `total`: The line item's total after discounts, including taxes.
+- `original_total`: The line item's original total before discounts, including taxes.
+- `discount_total`: The total amount of discounts applied to the line item, including the tax portion of discounts.
+- `discount_subtotal`: The total amount of discounts applied to the line item's subtotal (excluding tax portion).
+- `discount_tax_total`: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
+- `tax_total`: The line item's tax total after discounts.
+- `original_tax_total`: The line item's original tax total before discounts.
 
 ### Cart Shipping Method Totals
 
 The `shipping_methods` array in the `cart` object contains total fields for each shipping method:
 
 - `amount`: The amount charged for the shipping method. This field is not calculated and is stored in the database.
-- `subtotal`: The total price of the shipping method before any discounts or taxes.
-- `total`: The total price of the shipping method after applying discounts and taxes.
-- `original_total`: The total price of the shipping method before any discounts.
-- `discount_total`: The total amount of discounts applied to the shipping method.
-- `discount_subtotal`: The total amount of discounts applied to the shipping method's subtotal.
-- `discount_tax_total`: The total amount of discounts applied to the shipping method's tax.
-- `tax_total`: The total tax amount applied to the shipping method.
-- `original_tax_total`: The total tax amount applied to the shipping method before any discounts.
+- `subtotal`: The shipping method's subtotal before discounts, excluding taxes.
+- `total`: The shipping method's total after discounts, including taxes.
+- `original_total`: The shipping method's original total before discounts, including taxes.
+- `discount_total`: The total amount of discounts applied to the shipping method, including the tax portion of discounts.
+- `discount_subtotal`: The total amount of discounts applied to the shipping method's subtotal (excluding tax portion).
+- `discount_tax_total`: The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts.
+- `tax_total`: The shipping method's tax total after discounts.
+- `original_tax_total`: The shipping method's original tax total before discounts.
 
 ---
 

--- a/www/apps/resources/app/commerce-modules/order/order-totals/page.mdx
+++ b/www/apps/resources/app/commerce-modules/order/order-totals/page.mdx
@@ -205,26 +205,26 @@ The returned `order` object will look like this:
 
 The order will include the following total fields:
 
-- `total`: The grand total of the order, including all line items, shipping methods, taxes, and discounts.
-- `subtotal`: The order's total excluding taxes, including promotions.
-- `tax_total`: The order's tax total including promotions.
-- `original_total`: The order's total including taxes, excluding promotions.
-- `original_subtotal`: The order's total excluding taxes, including promotions.
-- `original_tax_total`: The order's tax total excluding promotions.
-- `discount_total`: The order's discount or promotions total.
-- `discount_tax_total`: The tax total of the order's discount or promotion.
-- `shipping_total`: The order's shipping total including taxes and promotions.
-- `shipping_subtotal`: The order's shipping total excluding taxes, including promotions.
-- `shipping_tax_total`: The tax total of the order's shipping.
-- `original_shipping_total`: The order's shipping total including taxes, excluding promotions.
-- `original_shipping_subtotal`: The order's shipping total excluding taxes, including promotions.
-- `original_shipping_tax_total`: The tax total of the order's shipping excluding promotions.
-- `item_total`: The total of all line items in the order, including taxes and promotions.
-- `item_tax_total`: The tax total of all line items in the order, including promotions.
-- `item_subtotal`: The subtotal of all line items in the order, excluding taxes, including promotions.
-- `original_item_total`: The total of all line items in the order, including taxes, excluding promotions.
-- `original_item_tax_total`: The tax total of all line items in the order, excluding promotions.
-- `original_item_subtotal`: The subtotal of all line items in the order, excluding taxes, including promotions.
+- `total`: The order's final total after discounts and credit lines, including taxes.
+- `subtotal`: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
+- `tax_total`: The order's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
+- `original_total`: The order's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
+- `original_subtotal`: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
+- `original_tax_total`: The order's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
+- `discount_total`: The total amount of discounts applied to the order, including the tax portion of discounts.
+- `discount_tax_total`: The total amount of discounts applied to the order's tax. Represents the tax portion of discounts.
+- `shipping_total`: The sum of all shipping methods' totals after discounts, including taxes.
+- `shipping_subtotal`: The sum of all shipping methods' subtotals before discounts, excluding taxes.
+- `shipping_tax_total`: The sum of all shipping methods' tax totals after discounts.
+- `original_shipping_total`: The sum of all shipping methods' original totals before discounts, including taxes.
+- `original_shipping_subtotal`: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
+- `original_shipping_tax_total`: The sum of all shipping methods' original tax totals before discounts.
+- `item_total`: The sum of all line items' totals after discounts, including taxes.
+- `item_tax_total`: The sum of all line items' tax totals after discounts.
+- `item_subtotal`: The sum of all line items' subtotals before discounts, excluding taxes.
+- `original_item_total`: The sum of all line items' original totals before discounts, including taxes.
+- `original_item_tax_total`: The sum of all line items' original tax totals before discounts.
+- `original_item_subtotal`: The sum of all line items' original subtotals before discounts, excluding taxes.
 - `gift_card_total`: The total amount of gift cards applied to the order.
 - `gift_card_tax_total`: The tax total of the gift cards applied to the order.
 
@@ -233,14 +233,14 @@ The order will include the following total fields:
 The `items` array in the `order` object contains total fields for each line item:
 
 - `unit_price`: The price of a single unit of the line item. This field is not calculated and is stored in the database.
-- `subtotal`: The total price of the line item before any discounts or taxes.
-- `total`: The total price of the line item after applying discounts and taxes.
-- `original_total`: The total price of the line item before any discounts.
-- `discount_total`: The total amount of discounts applied to the line item.
-- `discount_subtotal`: The total amount of discounts applied to the line item's subtotal.
-- `discount_tax_total`: The total amount of discounts applied to the line item's tax.
-- `tax_total`: The total tax amount applied to the line item.
-- `original_tax_total`: The total tax amount applied to the line item before any discounts.
+- `subtotal`: The line item's subtotal before discounts, excluding taxes.
+- `total`: The line item's total after discounts, including taxes.
+- `original_total`: The line item's original total before discounts, including taxes.
+- `discount_total`: The total amount of discounts applied to the line item, including the tax portion of discounts.
+- `discount_subtotal`: The total amount of discounts applied to the line item's subtotal (excluding tax portion).
+- `discount_tax_total`: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
+- `tax_total`: The line item's tax total after discounts.
+- `original_tax_total`: The line item's original tax total before discounts.
 - `refundable_total_per_unit`: The total amount that can be refunded per unit of the line item.
 - `refundable_total`: The total amount that can be refunded for the line item.
 - `fulfilled_total`: The total amount of the line item that has been fulfilled.
@@ -257,14 +257,14 @@ The `items` array in the `order` object contains total fields for each line item
 The `shipping_methods` array in the `order` object contains total fields for each shipping method:
 
 - `amount`: The amount charged for the shipping method. This field is not calculated and is stored in the database.
-- `subtotal`: The total price of the shipping method before any discounts or taxes.
-- `total`: The total price of the shipping method after applying discounts and taxes.
-- `original_total`: The total price of the shipping method before any discounts.
-- `discount_total`: The total amount of discounts applied to the shipping method.
-- `discount_subtotal`: The total amount of discounts applied to the shipping method's subtotal.
-- `discount_tax_total`: The total amount of discounts applied to the shipping method's tax.
-- `tax_total`: The total tax amount applied to the shipping method.
-- `original_tax_total`: The total tax amount applied to the shipping method before any discounts.
+- `subtotal`: The shipping method's subtotal before discounts, excluding taxes.
+- `total`: The shipping method's total after discounts, including taxes.
+- `original_total`: The shipping method's original total before discounts, including taxes.
+- `discount_total`: The total amount of discounts applied to the shipping method, including the tax portion of discounts.
+- `discount_subtotal`: The total amount of discounts applied to the shipping method's subtotal (excluding tax portion).
+- `discount_tax_total`: The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts.
+- `tax_total`: The shipping method's tax total after discounts.
+- `original_tax_total`: The shipping method's original tax total before discounts.
 
 ### Order Summary Totals
 

--- a/www/apps/resources/app/storefront-development/cart/totals/page.mdx
+++ b/www/apps/resources/app/storefront-development/cart/totals/page.mdx
@@ -35,7 +35,7 @@ The fields that are most commonly used are:
         `subtotal`
       </Table.Cell>
       <Table.Cell>
-        The cart's subtotal excluding taxes and including items, shipping, and discounts.
+        The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
       </Table.Cell>
     </Table.Row>
     <Table.Row>
@@ -43,7 +43,7 @@ The fields that are most commonly used are:
       `discount_total`
       </Table.Cell>
       <Table.Cell>
-        The total discounts or promotions applied to the cart.
+        The total amount of discounts applied to the cart, including the tax portion of discounts.
       </Table.Cell>
     </Table.Row>
     <Table.Row>
@@ -51,7 +51,7 @@ The fields that are most commonly used are:
         `shipping_total`
       </Table.Cell>
       <Table.Cell>
-        The total shipping cost.
+        The sum of all shipping methods' totals after discounts, including taxes.
       </Table.Cell>
     </Table.Row>
     <Table.Row>
@@ -59,7 +59,7 @@ The fields that are most commonly used are:
         `tax_total`
       </Table.Cell>
       <Table.Cell>
-        The total tax amount.
+        The cart's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
       </Table.Cell>
     </Table.Row>
     <Table.Row>
@@ -67,7 +67,7 @@ The fields that are most commonly used are:
         `total`
       </Table.Cell>
       <Table.Cell>
-        The total amount of the cart including all taxes, shipping, and discounts.
+        The cart's final total after discounts and credit lines, including taxes.
       </Table.Cell>
     </Table.Row>
   </Table.Body>

--- a/www/apps/resources/app/storefront-development/checkout/order-confirmation/page.mdx
+++ b/www/apps/resources/app/storefront-development/checkout/order-confirmation/page.mdx
@@ -178,7 +178,7 @@ An order has various fields for the order totals, which you can check out in the
         `subtotal`
       </Table.Cell>
       <Table.Cell>
-        The order's subtotal excluding taxes, and including total of items, shipping, and discounts.
+        The order's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
       </Table.Cell>
     </Table.Row>
     <Table.Row>
@@ -186,7 +186,7 @@ An order has various fields for the order totals, which you can check out in the
       `discount_total`
       </Table.Cell>
       <Table.Cell>
-        The total discounts or promotions applied to the order.
+        The total amount of discounts applied to the order, including the tax portion of discounts.
       </Table.Cell>
     </Table.Row>
     <Table.Row>
@@ -194,7 +194,7 @@ An order has various fields for the order totals, which you can check out in the
         `shipping_total`
       </Table.Cell>
       <Table.Cell>
-        The total shipping cost.
+        The sum of all shipping methods' totals after discounts, including taxes.
       </Table.Cell>
     </Table.Row>
     <Table.Row>
@@ -202,7 +202,7 @@ An order has various fields for the order totals, which you can check out in the
         `tax_total`
       </Table.Cell>
       <Table.Cell>
-        The total tax amount.
+        The order's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
       </Table.Cell>
     </Table.Row>
     <Table.Row>
@@ -210,7 +210,7 @@ An order has various fields for the order totals, which you can check out in the
         `total`
       </Table.Cell>
       <Table.Cell>
-        The total amount of the order including all taxes, shipping, and discounts.
+        The order's final total after discounts and credit lines, including taxes.
       </Table.Cell>
     </Table.Row>
   </Table.Body>

--- a/www/utils/generated/oas-output/schemas/BaseCart.ts
+++ b/www/utils/generated/oas-output/schemas/BaseCart.ts
@@ -91,59 +91,59 @@
  *   original_item_total:
  *     type: number
  *     title: original_item_total
- *     description: The cart's original item total.
+ *     description: The sum of all line items' original totals before discounts, including taxes.
  *   original_item_subtotal:
  *     type: number
  *     title: original_item_subtotal
- *     description: The cart's original item subtotal.
+ *     description: The sum of all line items' original subtotals before discounts, excluding taxes.
  *   original_item_tax_total:
  *     type: number
  *     title: original_item_tax_total
- *     description: The cart's original item tax total.
+ *     description: The sum of all line items' original tax totals before discounts.
  *   item_total:
  *     type: number
  *     title: item_total
- *     description: The cart's item total.
+ *     description: The sum of all line items' totals after discounts, including taxes.
  *   item_subtotal:
  *     type: number
  *     title: item_subtotal
- *     description: The cart's item subtotal.
+ *     description: The sum of all line items' subtotals before discounts, excluding taxes.
  *   item_tax_total:
  *     type: number
  *     title: item_tax_total
- *     description: The cart's item tax total.
+ *     description: The sum of all line items' tax totals after discounts.
  *   original_total:
  *     type: number
  *     title: original_total
- *     description: The cart's original total.
+ *     description: The cart's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
  *   original_subtotal:
  *     type: number
  *     title: original_subtotal
- *     description: The cart's original subtotal.
+ *     description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
  *   original_tax_total:
  *     type: number
  *     title: original_tax_total
- *     description: The cart's original tax total.
+ *     description: The cart's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
  *   total:
  *     type: number
  *     title: total
- *     description: The cart's total.
+ *     description: The cart's final total after discounts and credit lines, including taxes.
  *   subtotal:
  *     type: number
  *     title: subtotal
- *     description: The cart's subtotal.
+ *     description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
  *   tax_total:
  *     type: number
  *     title: tax_total
- *     description: The cart's tax total.
+ *     description: The cart's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
  *   discount_total:
  *     type: number
  *     title: discount_total
- *     description: The cart's discount total.
+ *     description: The total amount of discounts applied to the cart, including the tax portion of discounts.
  *   discount_tax_total:
  *     type: number
  *     title: discount_tax_total
- *     description: The cart's discount tax total.
+ *     description: The total amount of discounts applied to the cart's tax. Represents the tax portion of discounts.
  *   gift_card_total:
  *     type: number
  *     title: gift_card_total
@@ -155,27 +155,27 @@
  *   shipping_total:
  *     type: number
  *     title: shipping_total
- *     description: The cart's shipping total.
+ *     description: The sum of all shipping methods' totals after discounts, including taxes.
  *   shipping_subtotal:
  *     type: number
  *     title: shipping_subtotal
- *     description: The cart's shipping subtotal.
+ *     description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
  *   shipping_tax_total:
  *     type: number
  *     title: shipping_tax_total
- *     description: The cart's shipping tax total.
+ *     description: The sum of all shipping methods' tax totals after discounts.
  *   original_shipping_total:
  *     type: number
  *     title: original_shipping_total
- *     description: The cart's original shipping total.
+ *     description: The sum of all shipping methods' original totals before discounts, including taxes.
  *   original_shipping_subtotal:
  *     type: number
  *     title: original_shipping_subtotal
- *     description: The cart's original shipping subtotal.
+ *     description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
  *   original_shipping_tax_total:
  *     type: number
  *     title: original_shipping_tax_total
- *     description: The cart's original shipping tax total.
+ *     description: The sum of all shipping methods' original tax totals before discounts.
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/BaseCartLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/BaseCartLineItem.ts
@@ -145,47 +145,47 @@
  *   original_total:
  *     type: number
  *     title: original_total
- *     description: The item's original total.
+ *     description: The line item's original total before discounts, including taxes.
  *   original_subtotal:
  *     type: number
  *     title: original_subtotal
- *     description: The item's original subtotal.
+ *     description: The line item's original subtotal before discounts, excluding taxes.
  *   original_tax_total:
  *     type: number
  *     title: original_tax_total
- *     description: The item's original tax total.
+ *     description: The line item's original tax total before discounts.
  *   item_total:
  *     type: number
  *     title: item_total
- *     description: The item's item total.
+ *     description: The line item's total after discounts, including taxes.
  *   item_subtotal:
  *     type: number
  *     title: item_subtotal
- *     description: The item's item subtotal.
+ *     description: The line item's subtotal before discounts, excluding taxes.
  *   item_tax_total:
  *     type: number
  *     title: item_tax_total
- *     description: The item's item tax total.
+ *     description: The line item's tax total after discounts.
  *   total:
  *     type: number
  *     title: total
- *     description: The item's total.
+ *     description: The line item's total after discounts, including taxes.
  *   subtotal:
  *     type: number
  *     title: subtotal
- *     description: The item's subtotal.
+ *     description: The line item's subtotal before discounts, excluding taxes.
  *   tax_total:
  *     type: number
  *     title: tax_total
- *     description: The item's tax total.
+ *     description: The line item's tax total after discounts.
  *   discount_total:
  *     type: number
  *     title: discount_total
- *     description: The item's discount total.
+ *     description: The total amount of discounts applied to the line item, including the tax portion of discounts.
  *   discount_tax_total:
  *     type: number
  *     title: discount_tax_total
- *     description: The item's discount tax total.
+ *     description: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/BaseCartShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/BaseCartShippingMethod.ts
@@ -74,35 +74,35 @@
  *   original_total:
  *     type: number
  *     title: original_total
- *     description: The shipping method's total including taxes, excluding promotions.
+ *     description: The shipping method's original total before discounts, including taxes.
  *   original_subtotal:
  *     type: number
  *     title: original_subtotal
- *     description: The shipping method's total excluding taxes, including promotions.
+ *     description: The shipping method's original subtotal before discounts, excluding taxes.
  *   original_tax_total:
  *     type: number
  *     title: original_tax_total
- *     description: The total taxes applied on the shipping method's amount including promotions.
+ *     description: The shipping method's original tax total before discounts.
  *   total:
  *     type: number
  *     title: total
- *     description: The shipping method's total amount including taxes and promotions.
+ *     description: The shipping method's total after discounts, including taxes.
  *   subtotal:
  *     type: number
  *     title: subtotal
- *     description: The shipping method's total amount excluding taxes, including promotions.
+ *     description: The shipping method's subtotal before discounts, excluding taxes.
  *   tax_total:
  *     type: number
  *     title: tax_total
- *     description: The total taxes applied on the shipping method's amount including promotions.
+ *     description: The shipping method's tax total after discounts.
  *   discount_total:
  *     type: number
  *     title: discount_total
- *     description: The total amount discounted.
+ *     description: The total amount of discounts applied to the shipping method, including the tax portion of discounts.
  *   discount_tax_total:
  *     type: number
  *     title: discount_tax_total
- *     description: The taxes applied on the discounted amount.
+ *     description: The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts.
  * 
 */
 

--- a/www/utils/generated/oas-output/schemas/BaseOrder.ts
+++ b/www/utils/generated/oas-output/schemas/BaseOrder.ts
@@ -154,59 +154,59 @@
  *   original_item_total:
  *     type: number
  *     title: original_item_total
- *     description: The total of the order's items including taxes, excluding promotions.
+ *     description: The sum of all line items' original totals before discounts, including taxes.
  *   original_item_subtotal:
  *     type: number
  *     title: original_item_subtotal
- *     description: The total of the order's items excluding taxes, including promotions.
+ *     description: The sum of all line items' original subtotals before discounts, excluding taxes.
  *   original_item_tax_total:
  *     type: number
  *     title: original_item_tax_total
- *     description: The tax total of the order's items excluding promotions.
+ *     description: The sum of all line items' original tax totals before discounts.
  *   item_total:
  *     type: number
  *     title: item_total
- *     description: The total of the order's items including taxes and promotions.
+ *     description: The sum of all line items' totals after discounts, including taxes.
  *   item_subtotal:
  *     type: number
  *     title: item_subtotal
- *     description: The total of the order's items excluding taxes, including promotions.
+ *     description: The sum of all line items' subtotals before discounts, excluding taxes.
  *   item_tax_total:
  *     type: number
  *     title: item_tax_total
- *     description: The tax total of the order's items including promotions.
+ *     description: The sum of all line items' tax totals after discounts.
  *   original_total:
  *     type: number
  *     title: original_total
- *     description: The order's total excluding promotions, including taxes.
+ *     description: The order's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
  *   original_subtotal:
  *     type: number
  *     title: original_subtotal
- *     description: The order's total excluding taxes, including promotions.
+ *     description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
  *   original_tax_total:
  *     type: number
  *     title: original_tax_total
- *     description: The order's tax total, excluding promotions.
+ *     description: The order's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
  *   total:
  *     type: number
  *     title: total
- *     description: The order's total including taxes and promotions.
+ *     description: The order's final total after discounts and credit lines, including taxes.
  *   subtotal:
  *     type: number
  *     title: subtotal
- *     description: The order's total excluding taxes, including promotions.
+ *     description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
  *   tax_total:
  *     type: number
  *     title: tax_total
- *     description: The order's tax total including promotions.
+ *     description: The order's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
  *   discount_total:
  *     type: number
  *     title: discount_total
- *     description: The order's discount or promotions total.
+ *     description: The total amount of discounts applied to the order, including the tax portion of discounts.
  *   discount_tax_total:
  *     type: number
  *     title: discount_tax_total
- *     description: The tax total of order's discount or promotion.
+ *     description: The total amount of discounts applied to the order's tax. Represents the tax portion of discounts.
  *   gift_card_total:
  *     type: number
  *     title: gift_card_total
@@ -218,27 +218,27 @@
  *   shipping_total:
  *     type: number
  *     title: shipping_total
- *     description: The order's shipping total including taxes and promotions.
+ *     description: The sum of all shipping methods' totals after discounts, including taxes.
  *   shipping_subtotal:
  *     type: number
  *     title: shipping_subtotal
- *     description: The order's shipping total excluding taxes, including promotions.
+ *     description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
  *   shipping_tax_total:
  *     type: number
  *     title: shipping_tax_total
- *     description: The tax total of the order's shipping.
+ *     description: The sum of all shipping methods' tax totals after discounts.
  *   original_shipping_total:
  *     type: number
  *     title: original_shipping_total
- *     description: The order's shipping total including taxes, excluding promotions.
+ *     description: The sum of all shipping methods' original totals before discounts, including taxes.
  *   original_shipping_subtotal:
  *     type: number
  *     title: original_shipping_subtotal
- *     description: The order's shipping total excluding taxes, including promotions.
+ *     description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
  *   original_shipping_tax_total:
  *     type: number
  *     title: original_shipping_tax_total
- *     description: The tax total of the order's shipping excluding promotions.
+ *     description: The sum of all shipping methods' original tax totals before discounts.
  *   status:
  *     type: string
  *     title: status
@@ -246,15 +246,15 @@
  *   credit_line_total:
  *     type: number
  *     title: credit_line_total
- *     description: The order's credit line total.
+ *     description: The total amount of credit lines applied to the order, including taxes. Subtracted from the final total.
  *   item_discount_total:
  *     type: number
  *     title: item_discount_total
- *     description: The total discount amount applied on the order's items.
+ *     description: The sum of all discounts applied to line items, including the tax portion of discounts.
  *   shipping_discount_total:
  *     type: number
  *     title: shipping_discount_total
- *     description: The total discount amount applied on the order's shipping.
+ *     description: The sum of all discounts applied to shipping methods, including the tax portion of discounts.
  *   custom_display_id:
  *     type: string
  *     title: custom_display_id

--- a/www/utils/generated/oas-output/schemas/BaseOrderLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/BaseOrderLineItem.ts
@@ -168,47 +168,47 @@
  *   original_total:
  *     type: number
  *     title: original_total
- *     description: The item's total including taxes, excluding promotions.
+ *     description: The line item's original total before discounts, including taxes.
  *   original_subtotal:
  *     type: number
  *     title: original_subtotal
- *     description: The item's total excluding taxes, including promotions.
+ *     description: The line item's original subtotal before discounts, excluding taxes.
  *   original_tax_total:
  *     type: number
  *     title: original_tax_total
- *     description: The total taxes of the item, excluding promotions.
+ *     description: The line item's original tax total before discounts.
  *   item_total:
  *     type: number
  *     title: item_total
- *     description: The total taxes of the item, including promotions.
+ *     description: The line item's total after discounts, including taxes.
  *   item_subtotal:
  *     type: number
  *     title: item_subtotal
- *     description: The item's total excluding taxes, including promotions.
+ *     description: The line item's subtotal before discounts, excluding taxes.
  *   item_tax_total:
  *     type: number
  *     title: item_tax_total
- *     description: The total taxes of the item, including promotions.
+ *     description: The line item's tax total after discounts.
  *   total:
  *     type: number
  *     title: total
- *     description: The item's total, including taxes and promotions.
+ *     description: The line item's total after discounts, including taxes.
  *   subtotal:
  *     type: number
  *     title: subtotal
- *     description: The item's subtotal excluding taxes, including promotions.
+ *     description: The line item's subtotal before discounts, excluding taxes.
  *   tax_total:
  *     type: number
  *     title: tax_total
- *     description: The tax total of the item including promotions.
+ *     description: The line item's tax total after discounts.
  *   discount_total:
  *     type: number
  *     title: discount_total
- *     description: The total discount amount of the item.
+ *     description: The total amount of discounts applied to the line item, including the tax portion of discounts.
  *   discount_tax_total:
  *     type: number
  *     title: discount_tax_total
- *     description: The total taxes applied on the discounted amount.
+ *     description: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
  *   refundable_total:
  *     type: number
  *     title: refundable_total

--- a/www/utils/generated/oas-output/schemas/StoreCart.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCart.ts
@@ -93,59 +93,59 @@
  *   original_item_total:
  *     type: number
  *     title: original_item_total
- *     description: The cart items' total including taxes, excluding promotions.
+ *     description: The sum of all line items' original totals before discounts, including taxes.
  *   original_item_subtotal:
  *     type: number
  *     title: original_item_subtotal
- *     description: The cart items' total excluding taxes, including promotions.
+ *     description: The sum of all line items' original subtotals before discounts, excluding taxes.
  *   original_item_tax_total:
  *     type: number
  *     title: original_item_tax_total
- *     description: The cart items' tax total excluding promotions.
+ *     description: The sum of all line items' original tax totals before discounts.
  *   item_total:
  *     type: number
  *     title: item_total
- *     description: The cart items' total including taxes and promotions.
+ *     description: The sum of all line items' totals after discounts, including taxes.
  *   item_subtotal:
  *     type: number
  *     title: item_subtotal
- *     description: The cart items' total excluding taxes, including promotions.
+ *     description: The sum of all line items' subtotals before discounts, excluding taxes.
  *   item_tax_total:
  *     type: number
  *     title: item_tax_total
- *     description: The cart items' tax total including promotions.
+ *     description: The sum of all line items' tax totals after discounts.
  *   original_total:
  *     type: number
  *     title: original_total
- *     description: The cart's total including taxes, excluding promotions.
+ *     description: The cart's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
  *   original_subtotal:
  *     type: number
  *     title: original_subtotal
- *     description: The cart's total excluding taxes, including promotions.
+ *     description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
  *   original_tax_total:
  *     type: number
  *     title: original_tax_total
- *     description: The cart's tax total excluding promotions.
+ *     description: The cart's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
  *   total:
  *     type: number
  *     title: total
- *     description: The cart's total including taxes and promotions.
+ *     description: The cart's final total after discounts and credit lines, including taxes.
  *   subtotal:
  *     type: number
  *     title: subtotal
- *     description: The cart's total excluding taxes, including promotions.
+ *     description: The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
  *   tax_total:
  *     type: number
  *     title: tax_total
- *     description: The cart's tax total including promotions.
+ *     description: The cart's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
  *   discount_total:
  *     type: number
  *     title: discount_total
- *     description: The cart's discount total.
+ *     description: The total amount of discounts applied to the cart, including the tax portion of discounts.
  *   discount_tax_total:
  *     type: number
  *     title: discount_tax_total
- *     description: The tax total applied on the discounted amount.
+ *     description: The total amount of discounts applied to the cart's tax. Represents the tax portion of discounts.
  *   gift_card_total:
  *     type: number
  *     title: gift_card_total
@@ -157,27 +157,27 @@
  *   shipping_total:
  *     type: number
  *     title: shipping_total
- *     description: The cart's shipping total including taxes and promotions.
+ *     description: The sum of all shipping methods' totals after discounts, including taxes.
  *   shipping_subtotal:
  *     type: number
  *     title: shipping_subtotal
- *     description: The cart's shipping total excluding taxes, including promotions.
+ *     description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
  *   shipping_tax_total:
  *     type: number
  *     title: shipping_tax_total
- *     description: The total taxes applied on the cart's shipping amount.
+ *     description: The sum of all shipping methods' tax totals after discounts.
  *   original_shipping_total:
  *     type: number
  *     title: original_shipping_total
- *     description: The cart's shipping total including taxes, excluding promotions.
+ *     description: The sum of all shipping methods' original totals before discounts, including taxes.
  *   original_shipping_subtotal:
  *     type: number
  *     title: original_shipping_subtotal
- *     description: The cart's shipping total excluding taxes, including promotions.
+ *     description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
  *   original_shipping_tax_total:
  *     type: number
  *     title: original_shipping_tax_total
- *     description: The total taxes applied on the cart's shipping amount.
+ *     description: The sum of all shipping methods' original tax totals before discounts.
  *   promotions:
  *     type: array
  *     description: The cart's promotions.

--- a/www/utils/generated/oas-output/schemas/StoreCartLineItem.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCartLineItem.ts
@@ -289,57 +289,57 @@
  *   original_total:
  *     type: number
  *     title: original_total
- *     description: The item's total including taxes, excluding promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The line item's original total before discounts, including taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   original_subtotal:
  *     type: number
  *     title: original_subtotal
- *     description: The item's total excluding taxes, including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The line item's original subtotal before discounts, excluding taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   original_tax_total:
  *     type: number
  *     title: original_tax_total
- *     description: The total taxes of the item excluding promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The line item's original tax total before discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   item_total:
  *     type: number
- *     title: original_tax_total
- *     description: The item's total including taxes and promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     title: item_total
+ *     description: The line item's total after discounts, including taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   item_subtotal:
  *     type: number
  *     title: item_subtotal
- *     description: The item's total excluding taxes, including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The line item's subtotal before discounts, excluding taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   item_tax_total:
  *     type: number
  *     title: item_tax_total
- *     description: The total taxes of the item including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The line item's tax total after discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   total:
  *     type: number
  *     title: total
- *     description: The item's total including taxes and promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The line item's total after discounts, including taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   subtotal:
  *     type: number
  *     title: subtotal
- *     description: The item's total excluding taxes, including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The line item's subtotal before discounts, excluding taxes. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   tax_total:
  *     type: number
  *     title: tax_total
- *     description: The total taxes of the item including promotions. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The line item's tax total after discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   discount_total:
  *     type: number
  *     title: discount_total
- *     description: The total discount of the item. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The total amount of discounts applied to the line item, including the tax portion of discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  *   discount_tax_total:
  *     type: number
  *     title: discount_tax_total
- *     description: The total taxes applied on the discounted amount. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
+ *     description: The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts. This field is only available if you expand the `items.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
  * 
 */

--- a/www/utils/generated/oas-output/schemas/StoreCartShippingMethod.ts
+++ b/www/utils/generated/oas-output/schemas/StoreCartShippingMethod.ts
@@ -212,42 +212,42 @@
  *   original_total:
  *     type: number
  *     title: original_total
- *     description: The shipping method's total including taxes, excluding promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+ *     description: The shipping method's original total before discounts, including taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
  *   original_subtotal:
  *     type: number
  *     title: original_subtotal
- *     description: The shipping method's total excluding taxes, including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+ *     description: The shipping method's original subtotal before discounts, excluding taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
  *   original_tax_total:
  *     type: number
  *     title: original_tax_total
- *     description: The total taxes applied on the shipping method's amount including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+ *     description: The shipping method's original tax total before discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
  *   total:
  *     type: number
  *     title: total
- *     description: The shipping method's total amount including taxes and promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+ *     description: The shipping method's total after discounts, including taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
  *   subtotal:
  *     type: number
  *     title: subtotal
- *     description: The shipping method's total amount excluding taxes, including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+ *     description: The shipping method's subtotal before discounts, excluding taxes. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
  *   tax_total:
  *     type: number
  *     title: tax_total
- *     description: The total taxes applied on the shipping method's amount including promotions. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+ *     description: The shipping method's tax total after discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
  *   discount_total:
  *     type: number
  *     title: discount_total
- *     description: The total amount discounted. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+ *     description: The total amount of discounts applied to the shipping method, including the tax portion of discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
  *   discount_tax_total:
  *     type: number
  *     title: discount_tax_total
- *     description: The taxes applied on the discounted amount. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
+ *     description: The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts. This field is only available if you expand the `shipping_methods.*` relation. Learn more in the [Cart
  *       Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
  * 
 */

--- a/www/utils/generated/oas-output/schemas/StoreOrder.ts
+++ b/www/utils/generated/oas-output/schemas/StoreOrder.ts
@@ -145,59 +145,59 @@
  *   original_item_total:
  *     type: number
  *     title: original_item_total
- *     description: The order items' total including taxes, excluding promotions.
+ *     description: The sum of all line items' original totals before discounts, including taxes.
  *   original_item_subtotal:
  *     type: number
  *     title: original_item_subtotal
- *     description: The order items' total excluding taxes, including promotions.
+ *     description: The sum of all line items' original subtotals before discounts, excluding taxes.
  *   original_item_tax_total:
  *     type: number
  *     title: original_item_tax_total
- *     description: The total taxes applied on the order items, excluding promotions.
+ *     description: The sum of all line items' original tax totals before discounts.
  *   item_total:
  *     type: number
  *     title: item_total
- *     description: The order items' total including taxes and promotions.
+ *     description: The sum of all line items' totals after discounts, including taxes.
  *   item_subtotal:
  *     type: number
  *     title: item_subtotal
- *     description: The order items' total excluding taxes, including promotions.
+ *     description: The sum of all line items' subtotals before discounts, excluding taxes.
  *   item_tax_total:
  *     type: number
  *     title: item_tax_total
- *     description: The total taxes applied on the order's items, including promotions.
+ *     description: The sum of all line items' tax totals after discounts.
  *   original_total:
  *     type: number
  *     title: original_total
- *     description: The order's total including taxes, excluding promotions.
+ *     description: The order's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
  *   original_subtotal:
  *     type: number
  *     title: original_subtotal
- *     description: The order's total excluding taxes, including promotions.
+ *     description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
  *   original_tax_total:
  *     type: number
  *     title: original_tax_total
- *     description: The total taxes of the order excluding promotions.
+ *     description: The order's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
  *   total:
  *     type: number
  *     title: total
- *     description: The order's total including taxes and promotions.
+ *     description: The order's final total after discounts and credit lines, including taxes.
  *   subtotal:
  *     type: number
  *     title: subtotal
- *     description: The order's total excluding taxes, including promotions.
+ *     description: The order's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
  *   tax_total:
  *     type: number
  *     title: tax_total
- *     description: The tax totals of the order including promotions.
+ *     description: The order's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
  *   discount_total:
  *     type: number
  *     title: discount_total
- *     description: The order's discount total.
+ *     description: The total amount of discounts applied to the order, including the tax portion of discounts.
  *   discount_tax_total:
  *     type: number
  *     title: discount_tax_total
- *     description: The total taxes applied on the discounted amount.
+ *     description: The total amount of discounts applied to the order's tax. Represents the tax portion of discounts.
  *   gift_card_total:
  *     type: number
  *     title: gift_card_total
@@ -209,27 +209,27 @@
  *   shipping_total:
  *     type: number
  *     title: shipping_total
- *     description: The order's shipping total including taxes and promotions.
+ *     description: The sum of all shipping methods' totals after discounts, including taxes.
  *   shipping_subtotal:
  *     type: number
  *     title: shipping_subtotal
- *     description: The order's shipping total excluding taxes, including promotions.
+ *     description: The sum of all shipping methods' subtotals before discounts, excluding taxes.
  *   shipping_tax_total:
  *     type: number
  *     title: shipping_tax_total
- *     description: The total taxes of the order's shipping including promotions.
+ *     description: The sum of all shipping methods' tax totals after discounts.
  *   original_shipping_total:
  *     type: number
  *     title: original_shipping_total
- *     description: The order's shipping total including taxes, excluding promotions.
+ *     description: The sum of all shipping methods' original totals before discounts, including taxes.
  *   original_shipping_subtotal:
  *     type: number
  *     title: original_shipping_subtotal
- *     description: The order's shipping total excluding taxes, including promotions.
+ *     description: The sum of all shipping methods' original subtotals before discounts, excluding taxes.
  *   original_shipping_tax_total:
  *     type: number
  *     title: original_shipping_tax_total
- *     description: The total taxes of the order's shipping excluding promotions.
+ *     description: The sum of all shipping methods' original tax totals before discounts.
  *   customer:
  *     $ref: "#/components/schemas/StoreCustomer"
  *   transactions:
@@ -244,15 +244,15 @@
  *   credit_line_total:
  *     type: number
  *     title: credit_line_total
- *     description: The order's credit line total.
+ *     description: The total amount of credit lines applied to the order, including taxes. Subtracted from the final total.
  *   item_discount_total:
  *     type: number
  *     title: item_discount_total
- *     description: The total discount amount applied on the order's items.
+ *     description: The sum of all discounts applied to line items, including the tax portion of discounts.
  *   shipping_discount_total:
  *     type: number
  *     title: shipping_discount_total
- *     description: The total discount amount applied on the order's shipping.
+ *     description: The sum of all discounts applied to shipping methods, including the tax portion of discounts.
  *   custom_display_id:
  *     type: string
  *     title: custom_display_id


### PR DESCRIPTION
Fixed cart and order total descriptions across OAS, references, and guides.

Closes DX-2325

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes and clarifies cart/order total field descriptions across admin/store schemas, generated OAS, and docs, specifying pre/post-discount semantics, tax inclusion, and aggregation formulas.
> 
> - **API Schemas (Admin/Store)**:
>   - Refine descriptions for totals in `BaseCart`, `BaseOrder`, line items, and shipping methods (e.g., `total`, `subtotal`, `tax_total`, `original_*`, `item_*`, `shipping_*`).
>   - Specify pre/post-discount semantics, tax inclusion/exclusion, and explicit aggregation formulas (e.g., sums of item/shipping components); clarify discount and discount tax fields.
> - **OpenAPI (full) + Generated Types**:
>   - Sync updated descriptions in `openapi.full.yaml` and generated `oas-output` TypeScript schema docs.
> - **Guides/Resources**:
>   - Update cart and order totals guides and storefront tables to the new definitions; add clarifications for `discount_subtotal` and credit line totals and how subtotals/totals are computed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7e4a676e0035a523ce438dae87df8bdb6eceab1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->