### PR TITLE
chore: fix TSDocs of total fields to be accurate

### DIFF
--- a/packages/core/types/src/http/cart/common.ts
+++ b/packages/core/types/src/http/cart/common.ts
@@ -91,72 +91,72 @@ export interface BaseCart {
   updated_at?: string | Date
 
   /**
-   * The original item total of the cart.
+   * The sum of all line items' original totals before discounts, including taxes.
    */
   original_item_total: number
 
   /**
-   * The original item subtotal of the cart.
+   * The sum of all line items' original subtotals before discounts, excluding taxes.
    */
   original_item_subtotal: number
 
   /**
-   * The original item tax total of the cart.
+   * The sum of all line items' original tax totals before discounts.
    */
   original_item_tax_total: number
 
   /**
-   * The item total of the cart.
+   * The sum of all line items' totals after discounts, including taxes.
    */
   item_total: number
 
   /**
-   * The item subtotal of the cart.
+   * The sum of all line items' subtotals before discounts, excluding taxes.
    */
   item_subtotal: number
 
   /**
-   * The item tax total of the cart.
+   * The sum of all line items' tax totals after discounts.
    */
   item_tax_total: number
 
   /**
-   * The original total of the cart.
+   * The cart's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
    */
   original_total: number
 
   /**
-   * The original subtotal of the cart.
+   * The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
    */
   original_subtotal: number
 
   /**
-   * The original tax total of the cart.
+   * The cart's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
    */
   original_tax_total: number
 
   /**
-   * The total of the cart.
+   * The cart's final total after discounts and credit lines, including taxes.
    */
   total: number
 
   /**
-   * The subtotal of the cart. (Excluding taxes)
+   * The cart's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
    */
   subtotal: number
 
   /**
-   * The tax total of the cart.
+   * The cart's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
    */
   tax_total: number
 
   /**
-   * The discount total of the cart.
+   * The total amount of discounts applied to the cart, including the tax portion of discounts.
    */
   discount_total: number
 
   /**
-   * The discount tax total of the cart.
+   * The total amount of discounts applied to the cart's tax. Represents the tax portion of discounts.
    */
   discount_tax_total: number
 
@@ -171,32 +171,32 @@ export interface BaseCart {
   gift_card_tax_total: number
 
   /**
-   * The shipping total of the cart.
+   * The sum of all shipping methods' totals after discounts, including taxes.
    */
   shipping_total: number
 
   /**
-   * The shipping subtotal of the cart.
+   * The sum of all shipping methods' subtotals before discounts, excluding taxes.
    */
   shipping_subtotal: number
 
   /**
-   * The shipping tax total of the cart.
+   * The sum of all shipping methods' tax totals after discounts.
    */
   shipping_tax_total: number
 
   /**
-   * The original shipping total of the cart.
+   * The sum of all shipping methods' original totals before discounts, including taxes.
    */
   original_shipping_total: number
 
   /**
-   * The original shipping subtotal of the cart.
+   * The sum of all shipping methods' original subtotals before discounts, excluding taxes.
    */
   original_shipping_subtotal: number
 
   /**
-   * The original shipping tax total of the cart.
+   * The sum of all shipping methods' original tax totals before discounts.
    */
   original_shipping_tax_total: number
 }
@@ -352,56 +352,56 @@ export interface BaseCartShippingMethod {
   updated_at: Date | string
 
   /**
-   * The original total of the cart shipping method.
+   * The shipping method's original total before discounts, including taxes.
    * This field is only available if you expand the `shipping_methods.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
    */
   original_total?: number
 
   /**
-   * The original subtotal of the cart shipping method.
+   * The shipping method's original subtotal before discounts, excluding taxes.
    * This field is only available if you expand the `shipping_methods.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
    */
   original_subtotal?: number
 
   /**
-   * The original tax total of the cart shipping method.
+   * The shipping method's original tax total before discounts.
    * This field is only available if you expand the `shipping_methods.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
    */
   original_tax_total?: number
 
   /**
-   * The total of the cart shipping method.
+   * The shipping method's total after discounts, including taxes.
    * This field is only available if you expand the `shipping_methods.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
    */
   total?: number
 
   /**
-   * The subtotal of the cart shipping method.
+   * The shipping method's subtotal before discounts, excluding taxes.
    * This field is only available if you expand the `shipping_methods.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
    */
   subtotal?: number
 
   /**
-   * The tax total of the cart shipping method.
+   * The shipping method's tax total after discounts.
    * This field is only available if you expand the `shipping_methods.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
    */
   tax_total?: number
 
   /**
-   * The discount total of the cart shipping method.
+   * The total amount of discounts applied to the shipping method, including the tax portion of discounts.
    * This field is only available if you expand the `shipping_methods.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
    */
   discount_total?: number
 
   /**
-   * The discount tax total of the cart shipping method.
+   * The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts.
    * This field is only available if you expand the `shipping_methods.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-shipping-method-totals) guide.
    */
@@ -588,77 +588,77 @@ export interface BaseCartLineItem extends BaseCartLineItemTotals {
  */
 export interface BaseCartLineItemTotals {
   /**
-   * The original total of the cart line item.
+   * The line item's original total before discounts, including taxes.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   original_total?: number
 
   /**
-   * The original subtotal of the cart line item.
+   * The line item's original subtotal before discounts, excluding taxes.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   original_subtotal?: number
 
   /**
-   * The original tax total of the cart line item.
+   * The line item's original tax total before discounts.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   original_tax_total?: number
 
   /**
-   * The item total of the cart line item.
+   * The line item's total after discounts, including taxes.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   item_total?: number
 
   /**
-   * The item subtotal of the cart line item.
+   * The line item's subtotal before discounts, excluding taxes.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   item_subtotal?: number
 
   /**
-   * The item tax total of the cart line item.
+   * The line item's tax total after discounts.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   item_tax_total?: number
 
   /**
-   * The total of the cart line item.
+   * The line item's total after discounts, including taxes.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   total?: number
 
   /**
-   * The subtotal of the cart line item.
+   * The line item's subtotal before discounts, excluding taxes.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   subtotal?: number
 
   /**
-   * The tax total of the cart line item.
+   * The line item's tax total after discounts.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   tax_total?: number
 
   /**
-   * The discount total of the cart line item.
+   * The total amount of discounts applied to the line item, including the tax portion of discounts.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */
   discount_total?: number
 
   /**
-   * The discount tax total of the cart line item.
+   * The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
    * This field is only available if you expand the `items.*` relation. Learn more in the
    * [Cart Totals](https://docs.medusajs.com/resources/storefront-development/cart/totals#retrieve-and-show-cart-item-totals) guide.
    */

--- a/packages/core/types/src/http/order/common.ts
+++ b/packages/core/types/src/http/order/common.ts
@@ -265,19 +265,19 @@ export interface BaseOrderShippingMethod {
    */
   adjustments?: BaseOrderShippingMethodAdjustment[]
   /**
-   * The total of the shipping method including taxes, excluding promotions.
+   * The shipping method's original total before discounts, including taxes.
    */
   original_total: number
   /**
-   * The total of the shipping method excluding taxes, including promotions.
+   * The shipping method's original subtotal before discounts, excluding taxes.
    */
   original_subtotal: number
   /**
-   * The tax total of the shipping method excluding promotions.
+   * The shipping method's original tax total before discounts.
    */
   original_tax_total: number
   /**
-   * The total of the shipping method including taxes and promotions.
+   * The shipping method's total after discounts, including taxes.
    */
   total: number
   /**
@@ -285,19 +285,19 @@ export interface BaseOrderShippingMethod {
    */
   detail?: BaseOrderShippingDetail
   /**
-   * The total of the shipping method excluding taxes, including promotions.
+   * The shipping method's subtotal before discounts, excluding taxes.
    */
   subtotal: number
   /**
-   * The tax total of the shipping method including promotions.
+   * The shipping method's tax total after discounts.
    */
   tax_total: number
   /**
-   * The total discounted amount.
+   * The total amount of discounts applied to the shipping method, including the tax portion of discounts.
    */
   discount_total: number
   /**
-   * The tax total of the shipping method's discounted amount.
+   * The total amount of discounts applied to the shipping method's tax. Represents the tax portion of discounts.
    */
   discount_tax_total: number
   /**
@@ -436,47 +436,47 @@ export interface BaseOrderLineItem {
    */
   metadata: Record<string, unknown> | null
   /**
-   * The total of the item including taxes, excluding promotions.
+   * The line item's original total before discounts, including taxes.
    */
   original_total: number
   /**
-   * The total of the item excluding taxes, including promotions.
+   * The line item's original subtotal before discounts, excluding taxes.
    */
   original_subtotal: number
   /**
-   * The total taxes applied on the item, excluding promotions.
+   * The line item's original tax total before discounts.
    */
   original_tax_total: number
   /**
-   * The total of a single quantity of the the item including taxes and promotions.
+   * The line item's total after discounts, including taxes.
    */
   item_total: number
   /**
-   * The total of a single quantity of the the item excluding taxes, including promotions.
+   * The line item's subtotal before discounts, excluding taxes.
    */
   item_subtotal: number
   /**
-   * The total taxes applied on a single quantity of the item, including promotions.
+   * The line item's tax total after discounts.
    */
   item_tax_total: number
   /**
-   * The total of the item including taxes and promotions.
+   * The line item's total after discounts, including taxes.
    */
   total: number
   /**
-   * The total of the item excluding taxes, including promotions.
+   * The line item's subtotal before discounts, excluding taxes.
    */
   subtotal: number
   /**
-   * The total taxes of the item, including promotions.
+   * The line item's tax total after discounts.
    */
   tax_total: number
   /**
-   * The total discount applied on the item.
+   * The total amount of discounts applied to the line item, including the tax portion of discounts.
    */
   discount_total: number
   /**
-   * The total taxes applied on the discounted amount.
+   * The total amount of discounts applied to the line item's tax. Represents the tax portion of discounts.
    */
   discount_tax_total: number
   /**
@@ -801,63 +801,63 @@ export interface BaseOrder {
    */
   updated_at: string | Date
   /**
-   * The total of the order's items including taxes, excluding promotions.
+   * The sum of all line items' original totals before discounts, including taxes.
    */
   original_item_total: number
   /**
-   * The total of the order's items excluding taxes, including promotions.
+   * The sum of all line items' original subtotals before discounts, excluding taxes.
    */
   original_item_subtotal: number
   /**
-   * The tax total applied on the order's items, excluding promotions.
+   * The sum of all line items' original tax totals before discounts.
    */
   original_item_tax_total: number
   /**
-   * The total of the order's items including taxes and promotions.
+   * The sum of all line items' totals after discounts, including taxes.
    */
   item_total: number
   /**
-   * The total of the order's items excluding taxes, including promotions.
+   * The sum of all line items' subtotals before discounts, excluding taxes.
    */
   item_subtotal: number
   /**
-   * The tax total applied on the order's items, including promotions.
+   * The sum of all line items' tax totals after discounts.
    */
   item_tax_total: number
   /**
-   * The promotion total applied on the order's items.
+   * The sum of all discounts applied to line items, including the tax portion of discounts.
    */
   item_discount_total: number
   /**
-   * The total of the order including taxes, excluding promotions.
+   * The order's total before discounts, including taxes. Calculated as the sum of `original_item_total` and `original_shipping_total`.
    */
   original_total: number
   /**
-   * The total of the order excluding taxes, including promotions.
+   * The order's subtotal before discounts, excluding taxes. Calculated as the sum of `original_item_subtotal` and `original_shipping_subtotal`.
    */
   original_subtotal: number
   /**
-   * The tax total applied on the order's items, excluding promotions.
+   * The order's tax total before discounts. Calculated as the sum of `original_item_tax_total` and `original_shipping_tax_total`.
    */
   original_tax_total: number
   /**
-   * The total of the order including taxes and promotions.
+   * The order's final total after discounts and credit lines, including taxes.
    */
   total: number
   /**
-   * The total of the order excluding taxes and promotions.
+   * The order's subtotal before discounts, excluding taxes. Calculated as the sum of `item_subtotal` and `shipping_subtotal`.
    */
   subtotal: number
   /**
-   * The tax total applied on the order's items, including promotions.
+   * The order's tax total after discounts. Calculated as the sum of `item_tax_total` and `shipping_tax_total`.
    */
   tax_total: number
   /**
-   * The total amount discounted.
+   * The total amount of discounts applied to the order, including the tax portion of discounts.
    */
   discount_total: number
   /**
-   * The tax total applied on the order's discounted amount.
+   * The total amount of discounts applied to the order's tax. Represents the tax portion of discounts.
    */
   discount_tax_total: number
   /**
@@ -869,35 +869,35 @@ export interface BaseOrder {
    */
   gift_card_tax_total: number
   /**
-   * The total of the order's shipping methods including taxes and promotions.
+   * The sum of all shipping methods' totals after discounts, including taxes.
    */
   shipping_total: number
   /**
-   * The total of the order's shipping methods excluding taxes, including promotions.
+   * The sum of all shipping methods' subtotals before discounts, excluding taxes.
    */
   shipping_subtotal: number
   /**
-   * The tax total applied on the order's shipping methods, including promotions.
+   * The sum of all shipping methods' tax totals after discounts.
    */
   shipping_tax_total: number
   /**
-   * The promotion total applied on the order's shipping methods.
+   * The sum of all discounts applied to shipping methods, including the tax portion of discounts.
    */
   shipping_discount_total: number
   /**
-   * The total of the order's shipping methods including taxes, excluding promotions.
+   * The sum of all shipping methods' original totals before discounts, including taxes.
    */
   original_shipping_total: number
   /**
-   * The total of the order's shipping methods excluding taxes, including promotions.
+   * The sum of all shipping methods' original subtotals before discounts, excluding taxes.
    */
   original_shipping_subtotal: number
   /**
-   * The tax total applied on the order's shipping methods, excluding promotions.
+   * The sum of all shipping methods' original tax totals before discounts.
    */
   original_shipping_tax_total: number
   /**
-   * The total of the order's credit lines.
+   * The total amount of credit lines applied to the order, including taxes. Subtracted from the final total.
    */
   credit_line_total: number
 }


### PR DESCRIPTION
Fix the TSDocs of total fields for cart and order to ensure they're correct and accurate

Related to #14366

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines TSDoc for cart/order totals to explicitly state before/after discounts, tax inclusion, and calculation relationships across items and shipping.
> 
> - **Types (cart)**:
>   - Clarify `BaseCart` totals (`original_*`, `item_*`, `shipping_*`, `total`, `subtotal`, `tax_total`, `discount_*`) with explicit before/after discount semantics, tax inclusion/exclusion, and sum formulas across items/shipping.
>   - Update `BaseCartShippingMethod` totals docs (`original_*`, `total`, `subtotal`, `tax_total`, `discount_*`).
>   - Update `BaseCartLineItemTotals` docs (`original_*`, `item_*`, `total`, `subtotal`, `tax_total`, `discount_*`).
> - **Types (order)**:
>   - Clarify `BaseOrder` totals (`original_*`, `item_*`, `shipping_*`, `total`, `subtotal`, `tax_total`, `discount_*`, `item_discount_total`, `credit_line_total`) with precise before/after discount semantics, tax handling, and aggregation formulas.
>   - Update `BaseOrderShippingMethod` totals docs (`original_*`, `total`, `subtotal`, `tax_total`, `discount_*`).
>   - Update `BaseOrderLineItem` totals docs (`original_*`, `item_*`, `total`, `subtotal`, `tax_total`, `discount_*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd34f403ec9e287e4521a9b6cf5685eebaf5b238. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->