### PR TITLE
fix(medusa): allow passing null to cart API routes

### DIFF
--- a/.changeset/early-dingos-repeat.md
+++ b/.changeset/early-dingos-repeat.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): allow passing null to cart API routes

--- a/packages/medusa/src/api/store/carts/validators.ts
+++ b/packages/medusa/src/api/store/carts/validators.ts
@@ -23,7 +23,7 @@ export const CreateCart = z
     sales_channel_id: z.string().nullish(),
     promo_codes: z.array(z.string()).optional(),
     metadata: z.record(z.unknown()).nullish(),
-    locale: z.string().optional(),
+    locale: z.string().nullish(),
   })
   .strict()
 export const StoreCreateCart = WithAdditionalData(CreateCart)
@@ -58,7 +58,7 @@ export const UpdateCart = z
     sales_channel_id: z.string().nullish(),
     metadata: z.record(z.unknown()).nullish(),
     promo_codes: z.array(z.string()).optional(),
-    locale: z.string().optional(),
+    locale: z.string().nullish(),
   })
   .strict()
 export const StoreUpdateCart = WithAdditionalData(UpdateCart)


### PR DESCRIPTION
Allow passing `null` as the locale for cart API route, as `optional` only allow passing `undefined`.