### PR TITLE
feat(core-flows,utils): Shipping options workflow events emission

### DIFF
--- a/.changeset/eleven-news-hug.md
+++ b/.changeset/eleven-news-hug.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/core-flows": patch
+"@medusajs/utils": patch
+---
+
+feat(core-flows,utils): Shipping options workflow events emission

--- a/packages/core/utils/src/core-flows/events.ts
+++ b/packages/core/utils/src/core-flows/events.ts
@@ -862,6 +862,46 @@ export const ShippingOptionTypeWorkflowEvents = {
 }
 
 /**
+ * @category Shipping Option
+ * @customNamespace Fulfillment
+ */
+export const ShippingOptionWorkflowEvents = {
+  /**
+   * Emitted when shipping options are created.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the shipping option
+   * }
+   * ```
+   */
+  CREATED: "shipping-option.created",
+  /**
+   * Emitted when shipping options are updated.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the shipping option
+   * }
+   * ```
+   */
+  UPDATED: "shipping-option.updated",
+  /**
+   * Emitted when shipping options are deleted.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the shipping option
+   * }
+   * ```
+   */
+  DELETED: "shipping-option.deleted",
+}
+
+/**
  * @category Payment
  * @customNamespace Payment
  */


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Add shipping options event emissions on create/update/delete workflows.

**Why** — Why are these changes relevant or necessary?  

It wasn't possible to create subscribers that react to create/update/delete operations on shipping options.

**How** — How have these changes been implemented?

Added new shipping options workflow event type and emitted accordinglyn in create/update/delete workflows.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes CORE-1344
