### PR TITLE
fix(medusa,framework): HMR file watch

### DIFF
--- a/.changeset/mighty-apples-cover.md
+++ b/.changeset/mighty-apples-cover.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/framework": patch
+"@medusajs/medusa": patch
+---
+
+fix(medusa,framework): hmr file watch

--- a/packages/core/framework/package.json
+++ b/packages/core/framework/package.json
@@ -79,7 +79,7 @@
     "@medusajs/utils": "2.12.3",
     "@medusajs/workflows-sdk": "2.12.3",
     "@types/express": "^4.17.21",
-    "chokidar": "^3.5.3",
+    "chokidar": "^4.0.3",
     "compression": "^1.8.1",
     "connect-redis": "5.2.0",
     "cookie-parser": "^1.4.6",

--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -37,10 +37,10 @@ export class Compiler {
     this.#adminOnlyDistFolder = path.join(this.#projectRoot, ".medusa/admin")
     this.#pluginsDistFolder = path.join(this.#projectRoot, ".medusa/server")
     this.#backendIgnoreFiles = [
-      "/integration-tests/",
-      "/test/",
-      "/unit-tests/",
-      "/src/admin/",
+      "integration-tests",
+      "test",
+      "unit-tests",
+      "src/admin",
     ]
   }
 
@@ -495,7 +495,7 @@ export class Compiler {
         "dist",
         "static",
         "private",
-        ".medusa/**/*",
+        ".medusa",
         ...this.#backendIgnoreFiles,
       ],
     })

--- a/packages/medusa/src/commands/develop.ts
+++ b/packages/medusa/src/commands/develop.ts
@@ -182,8 +182,8 @@ export default async function ({ types, directory }) {
           "dist",
           "static",
           "private",
-          "src/admin/**/*",
-          ".medusa/**/*",
+          "src/admin",
+          ".medusa",
         ],
       })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,7 +3631,7 @@ __metadata:
     "@medusajs/utils": 2.12.3
     "@medusajs/workflows-sdk": 2.12.3
     "@types/express": ^4.17.21
-    chokidar: ^3.5.3
+    chokidar: ^4.0.3
     compression: ^1.8.1
     connect-redis: 5.2.0
     cookie-parser: ^1.4.6


### PR DESCRIPTION
**What**

In Chokidar v4+, support for glob patterns in the ignored option was removed.

- `@medusajs/medusa` is using v4, this PR also update chokidar to v4 on the `@medusajs/framework`, for plugin development.

