### PR TITLE
feat(dashboard): Add first and last name inputs to update order shipping and billing address forms

### DIFF
--- a/.changeset/empty-rockets-sink.md
+++ b/.changeset/empty-rockets-sink.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+feat(dashboard): Add first and last name inputs to update order shipping and billing address forms

--- a/packages/admin/dashboard/src/routes/orders/order-edit-billing-address/components/edit-order-billing-address-form/edit-order-billing-address-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-edit-billing-address/components/edit-order-billing-address-form/edit-order-billing-address-form.tsx
@@ -16,6 +16,8 @@ type EditOrderBillingAddressFormProps = {
 }
 
 const EditOrderBillingAddressSchema = zod.object({
+  first_name: zod.string().optional(),
+  last_name: zod.string().optional(),
   address_1: zod.string().min(1),
   address_2: zod.string().optional(),
   country_code: zod.string().min(2).max(2),
@@ -34,6 +36,8 @@ export function EditOrderBillingAddressForm({
 
   const form = useForm<zod.infer<typeof EditOrderBillingAddressSchema>>({
     defaultValues: {
+      first_name: order.billing_address?.first_name || "",
+      last_name: order.billing_address?.last_name || "",
       address_1: order.billing_address?.address_1 || "",
       address_2: order.billing_address?.address_2 || "",
       city: order.billing_address?.city || "",
@@ -150,6 +154,36 @@ export function EditOrderBillingAddressForm({
                 return (
                   <Form.Item>
                     <Form.Label optional>{t("fields.state")}</Form.Label>
+                    <Form.Control>
+                      <Input size="small" {...field} />
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )
+              }}
+            />
+            <Form.Field
+              control={form.control}
+              name="first_name"
+              render={({ field }) => {
+                return (
+                  <Form.Item>
+                    <Form.Label>{t("fields.firstName")}</Form.Label>
+                    <Form.Control>
+                      <Input size="small" {...field} />
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )
+              }}
+            />
+            <Form.Field
+              control={form.control}
+              name="last_name"
+              render={({ field }) => {
+                return (
+                  <Form.Item>
+                    <Form.Label>{t("fields.lastName")}</Form.Label>
                     <Form.Control>
                       <Input size="small" {...field} />
                     </Form.Control>

--- a/packages/admin/dashboard/src/routes/orders/order-edit-shipping-address/components/edit-order-shipping-address-form/edit-order-shipping-address-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-edit-shipping-address/components/edit-order-shipping-address-form/edit-order-shipping-address-form.tsx
@@ -16,6 +16,8 @@ type EditOrderShippingAddressFormProps = {
 }
 
 const EditOrderShippingAddressSchema = zod.object({
+  first_name: zod.string().optional(),
+  last_name: zod.string().optional(),
   address_1: zod.string().min(1),
   address_2: zod.string().optional(),
   country_code: zod.string().min(2).max(2),
@@ -34,6 +36,8 @@ export function EditOrderShippingAddressForm({
 
   const form = useForm<zod.infer<typeof EditOrderShippingAddressSchema>>({
     defaultValues: {
+      first_name: order.shipping_address?.first_name || "",
+      last_name: order.shipping_address?.last_name || "",
       address_1: order.shipping_address?.address_1 || "",
       address_2: order.shipping_address?.address_2 || "",
       city: order.shipping_address?.city || "",
@@ -154,6 +158,34 @@ export function EditOrderShippingAddressForm({
                       <Input size="small" {...field} />
                     </Form.Control>
                     <Form.ErrorMessage />
+                  </Form.Item>
+                )
+              }}
+            />
+            <Form.Field
+              control={form.control}
+              name="first_name"
+              render={({ field }) => {
+                return (
+                  <Form.Item>
+                    <Form.Label>{t("fields.firstName")}</Form.Label>
+                    <Form.Control>
+                      <Input size="small" {...field} />
+                    </Form.Control>
+                  </Form.Item>
+                )
+              }}
+            />
+            <Form.Field
+              control={form.control}
+              name="last_name"
+              render={({ field }) => {
+                return (
+                  <Form.Item>
+                    <Form.Label>{t("fields.lastName")}</Form.Label>
+                    <Form.Control>
+                      <Input size="small" {...field} />
+                    </Form.Control>
                   </Form.Item>
                 )
               }}


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Include first and last name inputs on the update order shipping and billing address forms.

<img width="706" height="937" alt="image" src="https://github.com/user-attachments/assets/fd7a2fd9-9f6a-4b2a-b456-90c46294b19a" />

**Why** — Why are these changes relevant or necessary?  

Not currently possible to update first and last name for an order addresses from the Admin UI.

**How** — How have these changes been implemented?

Included two new inputs for the fields in both the billing and shipping address forms in the order detail page.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Validated i can update the fields correctly from within the UI.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes CORE-1343
