### PR TITLE
fix(dashboard): fix customer details page crashing when their order is refunded

### DIFF
--- a/.changeset/slimy-schools-help.md
+++ b/.changeset/slimy-schools-help.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): fix customer details page crashing when their order is refunded

--- a/packages/admin/dashboard/src/components/table/table-cells/order/country-cell/country-cell.tsx
+++ b/packages/admin/dashboard/src/components/table/table-cells/order/country-cell/country-cell.tsx
@@ -3,10 +3,14 @@ import ReactCountryFlag from "react-country-flag"
 import { PlaceholderCell } from "../../common/placeholder-cell"
 import { HttpTypes } from "@medusajs/types"
 
+type Country = Omit<HttpTypes.AdminRegionCountry, "id"> & {
+  id?: string
+}
+
 export const CountryCell = ({
   country,
 }: {
-  country?: HttpTypes.AdminRegionCountry | null
+  country?: Country | null
 }) => {
   if (!country) {
     return <PlaceholderCell />

--- a/packages/admin/dashboard/src/hooks/table/columns/use-order-table-columns.tsx
+++ b/packages/admin/dashboard/src/hooks/table/columns/use-order-table-columns.tsx
@@ -9,6 +9,7 @@ import {
   DateCell,
   DateHeader,
 } from "../../../components/table/table-cells/common/date-cell"
+import { countries } from "../../../lib/data/countries"
 import { CountryCell } from "../../../components/table/table-cells/order/country-cell"
 import {
   CustomerCell,
@@ -101,10 +102,10 @@ export const useOrderTableColumns = (props: UseOrderTableColumnsProps) => {
             const isFullyRefunded = row.original.payment_status === "refunded"
             const total = !isFullyRefunded
               ? getValue()
-              : row.original.payment_collections.reduce(
+              : row.original.payment_collections?.reduce(
                   (acc, payCol) => acc + (payCol.refunded_amount ?? 0),
                   0
-                )
+                ) || 0
             const currencyCode = row.original.currency_code
 
             return (
@@ -121,7 +122,8 @@ export const useOrderTableColumns = (props: UseOrderTableColumnsProps) => {
       columnHelper.display({
         id: "actions",
         cell: ({ row }) => {
-          const country = row.original.shipping_address?.country
+          const countryCode = row.original.shipping_address?.country_code
+          const country = countries.find((c) => c.iso_2 === countryCode)
 
           return <CountryCell country={country} />
         },

--- a/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
+++ b/packages/admin/dashboard/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
@@ -19,7 +19,7 @@ type CustomerGeneralSectionProps = {
 
 const PREFIX = "cusord"
 const PAGE_SIZE = 10
-const DEFAULT_RELATIONS = "*customer,*items,*sales_channel"
+const DEFAULT_RELATIONS = "*customer,*items,*sales_channel,payment_collections.refunded_amount,+shipping_address.country_code"
 const DEFAULT_FIELDS =
   "id,status,display_id,created_at,email,fulfillment_status,payment_status,total,currency_code"
 


### PR DESCRIPTION
1. Fix the customer details page crashing when a customer's order is fully refunded. The error was originating from the payment collections of the order not being retrieved, since they're being used to calculate the refunded total.
2. Other: fix country not showing as well due to incorrectly trying to retrieving and access the shipping address's country

Closes #14409