### PR TITLE
fix(medusa): use process.execPath in execFile for cross-platform plugin:develop compatibility

### DIFF
--- a/.changeset/crisp-clouds-add.md
+++ b/.changeset/crisp-clouds-add.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": major
+---
+
+Added process.execPath to always have the correct node executable path, so that npx medusa plugin:develop does not fail ensuring cross-platform compatibility.

--- a/packages/medusa/src/commands/plugin/develop.ts
+++ b/packages/medusa/src/commands/plugin/develop.ts
@@ -42,8 +42,8 @@ export default async function developPlugin({
      * flaky.
      */
     execFile(
-      yalcBin,
-      ["publish", "--push", "--no-scripts"],
+      process.execPath,
+      [yalcBin, "publish", "--push", "--no-scripts"],
       {
         cwd: directory,
       },


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Added `process.execPath` as first argument to execFile for cross-platform compatibility.

Basically now: `process.execPath, [yalcBin, "publish", "--push", "--no-scripts"],`

Translates to: `node path/to/yalcBin/ publish --push --no-scripts` which should be cross-platform compatible.

Same as: `execFile(process.execPath, [scriptPath, ...args])` the actual executable should be `node` not `yalc.js`, `yalc` is the script that `node` should run.

**Why** — Why are these changes relevant or necessary?  

`npx medusa plugin:develop` breaks on Windows, since it fails to run the yalc.js directly and needs the correct `node` path.

It breaks the moment the watcher detects a file change with:

```bash
info:    src\modules\storyblok\service.ts updated: Republishing changes
Error: spawn EFTYPE
    at ChildProcess.spawn (node:internal/child_process:420:11)
    at spawn (node:child_process:786:9)
    at execFile (node:child_process:349:17)
    at publishChanges (C:\...\medusajs-plugins\medusa-storyblok\node_modules\@medusajs\medusa\src\commands\plugin\develop.ts:44:13)
    at FSWatcher.<anonymous> (C:\...\medusajs-plugins\medusa-storyblok\node_modules\@medusajs\framework\src\build-tools\compiler.ts:525:21) {
  errno: -4028,
  code: 'EFTYPE',
  syscall: 'spawn'
}
```

**How** — How have these changes been implemented?

Added `process.execPath` to first argument of `execFile` in the `develop` command file handler.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Published the modified Medusa locally:

```bash
cd C:\medusa-src\medusa\packages\medusa
npx yalc publish --push --private
```

Then installed the modified Medusa into a plugin project:

```bash
npx yalc add @medusajs/medusa
yarn install
```

Ran

```bash
npx medusa plugin:develop
```

Modified and saved a file:

```bash
info:    src\modules\storyblok\service.ts updated: Republishing changes
@alphabite/medusa-storyblok@0.2.8 published in store.
Pushing @alphabite/medusa-storyblok@0.2.8 in C:\...\inara-medusa
Package @alphabite/medusa-storyblok@0.2.8 added ==> C:\...\inara-medusa\node_modules\@alphabite\medusa-storyblok
```

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
npx medusa plugin:develop
```

---

## Checklist

Please ensure the following before requesting a review:

- [X] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [X] I have verified the code works as intended locally
- [X] I have linked the related issue(s) if applicable

Fixes #14416

---

## Additional Context

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `plugin:develop` publishes via Node for cross-platform stability.
> 
> - In `packages/medusa/src/commands/plugin/develop.ts`, change `execFile` to use `process.execPath` and pass `yalc.js` with args (`publish --push --no-scripts`), fixing spawn issues (e.g., Windows) when running `npx medusa plugin:develop`.
> - Add changeset marking `@medusajs/medusa` as major with note about using `process.execPath`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 997576e9b53e0377cb2ec45e9d7d3f0765f14fc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->