### PR TITLE
docs: fix styling of code elements in headers

### DIFF
--- a/www/packages/docs-ui/src/components/Heading/H1/index.tsx
+++ b/www/packages/docs-ui/src/components/Heading/H1/index.tsx
@@ -10,7 +10,7 @@ export const H1 = ({ className, ...props }: H1Props) => {
     <div className="flex items-start justify-between gap-2 h1-wrapper">
       <h1
         className={clsx(
-          "text-h1 [&_code]:!text-h1 [&_code]:!font-mono mb-docs_1 text-medusa-fg-base",
+          "text-h1 [&>code]:!text-h1 [&>code]:!font-mono mb-docs_1 text-medusa-fg-base",
           props.id && "scroll-m-docs_7",
           className
         )}

--- a/www/packages/docs-ui/src/components/Heading/H2/index.tsx
+++ b/www/packages/docs-ui/src/components/Heading/H2/index.tsx
@@ -21,7 +21,7 @@ export const H2 = ({ className, children, passRef, ...props }: H2Props) => {
   return (
     <h2
       className={clsx(
-        "text-h2 [&_code]:!text-h2 [&_code]:!font-mono mb-docs_1 mt-docs_2 text-medusa-fg-base",
+        "text-h2 [&>code]:!text-h2 [&>code]:!font-mono mb-docs_1 mt-docs_2 text-medusa-fg-base",
         props.id && [
           "group/h2",
           showCollapsedNavbar && "scroll-m-docs_7",

--- a/www/packages/docs-ui/src/components/Heading/H3/index.tsx
+++ b/www/packages/docs-ui/src/components/Heading/H3/index.tsx
@@ -17,7 +17,7 @@ export const H3 = ({ className, children, ...props }: H3Props) => {
   return (
     <h3
       className={clsx(
-        "text-h3 [&_code]:!text-h3 [&_code]:!font-mono my-docs_1 text-medusa-fg-base",
+        "text-h3 [&>code]:!text-h3 [&>code]:!font-mono my-docs_1 text-medusa-fg-base",
         props.id && [
           "group/h3",
           showCollapsedNavbar && "scroll-m-docs_7",


### PR DESCRIPTION
Fixes styling of `code` elements in header components, specifically those in tooltips.

For example:

<img width="392" height="174" alt="CleanShot 2026-01-05 at 11 19 16" src="https://github.com/user-attachments/assets/9af96734-aded-4306-8d4d-515d11b3e64c" />
