### PR TITLE
add automatic cloud login route

### DIFF
--- a/.changeset/vast-corners-see.md
+++ b/.changeset/vast-corners-see.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+add automatic cloud login endpoint

--- a/packages/admin/dashboard/src/dashboard-app/routes/get-route.map.tsx
+++ b/packages/admin/dashboard/src/dashboard-app/routes/get-route.map.tsx
@@ -1879,6 +1879,10 @@ export function getRouteMap({
               lazy: () => import("../../routes/login"),
             },
             {
+              path: "/cloud/login",
+              lazy: () => import("../../routes/cloud/login"),
+            },
+            {
               path: "/reset-password",
               lazy: () => import("../../routes/reset-password"),
             },

--- a/packages/admin/dashboard/src/routes/cloud/login/hooks/use-auth-callback.tsx
+++ b/packages/admin/dashboard/src/routes/cloud/login/hooks/use-auth-callback.tsx
@@ -1,0 +1,57 @@
+import { toast } from "@medusajs/ui"
+import { useMutation } from "@tanstack/react-query"
+import { useTranslation } from "react-i18next"
+import { decodeToken } from "react-jwt"
+import { useNavigate } from "react-router-dom"
+import { CLOUD_AUTH_PROVIDER } from ".."
+import { useCreateCloudAuthUser } from "../../../../hooks/api/cloud"
+import { sdk } from "../../../../lib/client"
+
+export const useCloudAuthCallback = (searchParams: URLSearchParams) => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { mutateAsync: createCloudAuthUser } = useCreateCloudAuthUser()
+
+  const { mutateAsync: handleCallback, isPending: isCallbackPending } =
+    useMutation({
+      mutationFn: async () => {
+        let token: string
+        try {
+          const query = Object.fromEntries(searchParams)
+          delete query.auth_provider // BE doesn't need this
+
+          token = await sdk.auth.callback("user", CLOUD_AUTH_PROVIDER, query)
+        } catch (error) {
+          throw new Error("Authentication callback failed")
+        }
+
+        const decodedToken = decodeToken(token) as {
+          actor_id: string
+          user_metadata: Record<string, unknown>
+        }
+
+        // If user doesn't exist, create it
+        if (!decodedToken?.actor_id) {
+          await createCloudAuthUser()
+
+          // Refresh token to get the updated token with actor_id
+          const refreshedToken = await sdk.auth.refresh({
+            Authorization: `Bearer ${token}`, // passing it manually in case the auth type is session
+          })
+          if (!refreshedToken) {
+            throw new Error("Failed to refresh token after user creation")
+          }
+        }
+
+        return true
+      },
+      onSuccess: () => {
+        navigate("/")
+      },
+      onError: () => {
+        toast.error(t("auth.login.authenticationFailed"))
+      },
+    })
+
+  return { handleCallback, isCallbackPending }
+}

--- a/packages/admin/dashboard/src/routes/cloud/login/hooks/use-auth-login.tsx
+++ b/packages/admin/dashboard/src/routes/cloud/login/hooks/use-auth-login.tsx
@@ -1,0 +1,30 @@
+import { toast } from "@medusajs/ui"
+import { useCallback } from "react"
+import { useTranslation } from "react-i18next"
+import { CLOUD_AUTH_PROVIDER } from ".."
+import { sdk } from "../../../../lib/client"
+
+export const useCloudLogin = () => {
+  const { t } = useTranslation()
+
+  const handleLogin = useCallback(async () => {
+    try {
+      const result = await sdk.auth.login("user", CLOUD_AUTH_PROVIDER, {
+        // in case the admin is on a different domain, or the backend URL is set to just "/" which won't work for the callback
+        callback_url: `${window.location.origin}${window.location.pathname}?auth_provider=${CLOUD_AUTH_PROVIDER}`,
+      })
+
+      if (typeof result === "object" && result.location) {
+        // Redirect to Medusa Cloud for authentication
+        window.location.href = result.location
+        return
+      }
+
+      throw new Error("Unexpected login response")
+    } catch {
+      toast.error(t("auth.login.authenticationFailed"))
+    }
+  }, [t])
+
+  return { handleLogin }
+}

--- a/packages/admin/dashboard/src/routes/cloud/login/index.ts
+++ b/packages/admin/dashboard/src/routes/cloud/login/index.ts
@@ -1,0 +1,3 @@
+export { CloudLogin as Component } from "./login"
+
+export const CLOUD_AUTH_PROVIDER = "cloud"

--- a/packages/admin/dashboard/src/routes/cloud/login/login.tsx
+++ b/packages/admin/dashboard/src/routes/cloud/login/login.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react"
+import { useSearchParams } from "react-router-dom"
+import { CLOUD_AUTH_PROVIDER } from "."
+import { useCloudAuthCallback } from "./hooks/use-auth-callback"
+import { useCloudLogin } from "./hooks/use-auth-login"
+
+export const CloudLogin = () => {
+  const [searchParams] = useSearchParams()
+
+  const { handleLogin } = useCloudLogin()
+  const { handleCallback } = useCloudAuthCallback(searchParams)
+
+  // Check if we're returning from the OAuth callback
+  const hasCallbackParams =
+    searchParams.get("auth_provider") === CLOUD_AUTH_PROVIDER &&
+    searchParams.has("code") &&
+    searchParams.has("state")
+
+  const callbackInitiated = useRef(false) // ref to prevent duplicate calls in React strict mode and other unmounting+mounting scenarios
+  useEffect(() => {
+    if (!hasCallbackParams) {
+      handleLogin()
+    } else if (!callbackInitiated.current) {
+      callbackInitiated.current = true
+      handleCallback()
+    }
+  }, [hasCallbackParams, handleCallback, handleLogin])
+
+  return <div className="bg-ui-bg-subtle min-h-dvh w-dvw" />
+}

--- a/packages/admin/dashboard/src/routes/cloud/login/login.tsx
+++ b/packages/admin/dashboard/src/routes/cloud/login/login.tsx
@@ -1,30 +1,37 @@
+import { toast } from "@medusajs/ui"
 import { useEffect, useRef } from "react"
+import { useTranslation } from "react-i18next"
 import { useSearchParams } from "react-router-dom"
 import { CLOUD_AUTH_PROVIDER } from "."
 import { useCloudAuthCallback } from "./hooks/use-auth-callback"
 import { useCloudLogin } from "./hooks/use-auth-login"
 
 export const CloudLogin = () => {
+  const { t } = useTranslation()
   const [searchParams] = useSearchParams()
 
   const { handleLogin } = useCloudLogin()
   const { handleCallback } = useCloudAuthCallback(searchParams)
 
-  // Check if we're returning from the OAuth callback
-  const hasCallbackParams =
-    searchParams.get("auth_provider") === CLOUD_AUTH_PROVIDER &&
-    searchParams.has("code") &&
-    searchParams.has("state")
-
   const callbackInitiated = useRef(false) // ref to prevent duplicate calls in React strict mode and other unmounting+mounting scenarios
   useEffect(() => {
-    if (!hasCallbackParams) {
-      handleLogin()
-    } else if (!callbackInitiated.current) {
+    const isSuccessfulCallback =
+      searchParams.get("auth_provider") === CLOUD_AUTH_PROVIDER &&
+      searchParams.has("code") &&
+      searchParams.has("state")
+    const isErrorCallback =
+      searchParams.get("auth_provider") === CLOUD_AUTH_PROVIDER &&
+      searchParams.has("error")
+
+    if (isSuccessfulCallback && !callbackInitiated.current) {
       callbackInitiated.current = true
       handleCallback()
+    } else if (isErrorCallback) {
+      toast.error(t("auth.login.authenticationFailed"))
+    } else {
+      handleLogin()
     }
-  }, [hasCallbackParams, handleCallback, handleLogin])
+  }, [searchParams, t, handleCallback, handleLogin])
 
   return <div className="bg-ui-bg-subtle min-h-dvh w-dvw" />
 }

--- a/packages/admin/dashboard/src/routes/login/components/cloud-auth-login.tsx
+++ b/packages/admin/dashboard/src/routes/login/components/cloud-auth-login.tsx
@@ -1,19 +1,17 @@
-import { Button, toast } from "@medusajs/ui"
-import { useMutation } from "@tanstack/react-query"
+import { Button } from "@medusajs/ui"
 import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
-import { decodeToken } from "react-jwt"
-import { useNavigate, useSearchParams } from "react-router-dom"
-import { useCreateCloudAuthUser } from "../../../hooks/api/cloud"
-import { sdk } from "../../../lib/client"
-
-const CLOUD_AUTH_PROVIDER = "cloud"
+import { useSearchParams } from "react-router-dom"
+import { CLOUD_AUTH_PROVIDER } from "../../cloud/login"
+import { useCloudAuthCallback } from "../../cloud/login/hooks/use-auth-callback"
+import { useCloudLogin } from "../../cloud/login/hooks/use-auth-login"
 
 export const CloudAuthLogin = () => {
   const { t } = useTranslation()
   const [searchParams] = useSearchParams()
 
-  const { handleCallback, isCallbackPending } = useAuthCallback(searchParams)
+  const { handleCallback, isCallbackPending } =
+    useCloudAuthCallback(searchParams)
 
   // Check if we're returning from the OAuth callback
   const hasCallbackParams =
@@ -29,31 +27,14 @@ export const CloudAuthLogin = () => {
     }
   }, [hasCallbackParams, handleCallback])
 
-  const handleCloudLogin = async () => {
-    try {
-      const result = await sdk.auth.login("user", CLOUD_AUTH_PROVIDER, {
-        // in case the admin is on a different domain, or the backend URL is set to just "/" which won't work for the callback
-        callback_url: `${window.location.origin}${window.location.pathname}?auth_provider=${CLOUD_AUTH_PROVIDER}`,
-      })
-
-      if (typeof result === "object" && result.location) {
-        // Redirect to Medusa Cloud for authentication
-        window.location.href = result.location
-        return
-      }
-
-      throw new Error("Unexpected login response")
-    } catch {
-      toast.error(t("auth.login.authenticationFailed"))
-    }
-  }
+  const { handleLogin } = useCloudLogin()
 
   return (
     <>
       <hr className="bg-ui-border-base my-4" />
       <Button
         variant="secondary"
-        onClick={handleCloudLogin}
+        onClick={handleLogin}
         className="w-full"
         disabled={isCallbackPending}
         isLoading={isCallbackPending}
@@ -62,53 +43,4 @@ export const CloudAuthLogin = () => {
       </Button>
     </>
   )
-}
-
-const useAuthCallback = (searchParams: URLSearchParams) => {
-  const { t } = useTranslation()
-  const navigate = useNavigate()
-  const { mutateAsync: createCloudAuthUser } = useCreateCloudAuthUser()
-
-  const { mutateAsync: handleCallback, isPending: isCallbackPending } =
-    useMutation({
-      mutationFn: async () => {
-        let token: string
-        try {
-          const query = Object.fromEntries(searchParams)
-          delete query.auth_provider // BE doesn't need this
-
-          token = await sdk.auth.callback("user", CLOUD_AUTH_PROVIDER, query)
-        } catch (error) {
-          throw new Error("Authentication callback failed")
-        }
-
-        const decodedToken = decodeToken(token) as {
-          actor_id: string
-          user_metadata: Record<string, unknown>
-        }
-
-        // If user doesn't exist, create it
-        if (!decodedToken?.actor_id) {
-          await createCloudAuthUser()
-
-          // Refresh token to get the updated token with actor_id
-          const refreshedToken = await sdk.auth.refresh({
-            Authorization: `Bearer ${token}`, // passing it manually in case the auth type is session
-          })
-          if (!refreshedToken) {
-            throw new Error("Failed to refresh token after user creation")
-          }
-        }
-
-        return true
-      },
-      onSuccess: () => {
-        navigate("/")
-      },
-      onError: () => {
-        toast.error(t("auth.login.authenticationFailed"))
-      },
-    })
-
-  return { handleCallback, isCallbackPending }
 }

--- a/packages/admin/dashboard/src/routes/login/components/cloud-auth-login.tsx
+++ b/packages/admin/dashboard/src/routes/login/components/cloud-auth-login.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@medusajs/ui"
+import { Button, toast } from "@medusajs/ui"
 import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { useSearchParams } from "react-router-dom"
@@ -13,19 +13,23 @@ export const CloudAuthLogin = () => {
   const { handleCallback, isCallbackPending } =
     useCloudAuthCallback(searchParams)
 
-  // Check if we're returning from the OAuth callback
-  const hasCallbackParams =
-    searchParams.get("auth_provider") === CLOUD_AUTH_PROVIDER &&
-    searchParams.has("code") &&
-    searchParams.has("state")
-
   const callbackInitiated = useRef(false) // ref to prevent duplicate calls in React strict mode and other unmounting+mounting scenarios
   useEffect(() => {
-    if (hasCallbackParams && !callbackInitiated.current) {
+    const isSuccessfulCallback =
+      searchParams.get("auth_provider") === CLOUD_AUTH_PROVIDER &&
+      searchParams.has("code") &&
+      searchParams.has("state")
+    const isErrorCallback =
+      searchParams.get("auth_provider") === CLOUD_AUTH_PROVIDER &&
+      searchParams.has("error")
+
+    if (isErrorCallback) {
+      toast.error(t("auth.login.authenticationFailed"))
+    } else if (isSuccessfulCallback && !callbackInitiated.current) {
       callbackInitiated.current = true
       handleCallback()
     }
-  }, [hasCallbackParams, handleCallback])
+  }, [searchParams, t, handleCallback])
 
   const { handleLogin } = useCloudLogin()
 

--- a/packages/core/utils/src/common/define-config.ts
+++ b/packages/core/utils/src/common/define-config.ts
@@ -456,7 +456,6 @@ function normalizeProjectConfig(
   } satisfies ConfigModule["projectConfig"]
 
   if (
-    isCloud &&
     !mergedCloudOptions.oauthDisabled &&
     mergedCloudOptions.oauthAuthorizeEndpoint &&
     mergedCloudOptions.oauthTokenEndpoint


### PR DESCRIPTION
## Summary

**What** —

Added a new admin dashboard route to automatically initiate Cloud login

**Why** —

To simplify login process in Cloud

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automatic Cloud OAuth login flow and supporting refactor.
> 
> - Adds public route `'/cloud/login'` that auto-initiates Cloud OAuth, handles callback/refresh, navigates on success, and toasts on error
> - Extracts reusable auth hooks: `useCloudLogin` and `useCloudAuthCallback`; updates `CloudAuthLogin` to consume them
> - Config tweak in `define-config.ts`: automatically appends `"cloud"` to `http.authMethodsPerActor.user` when OAuth endpoints are configured (regardless of execution context)
> - Adds changeset for `@medusajs/dashboard`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7324d9941963e2d30158bbab12306f53a519bea3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->