### PR TITLE
docs: auth in cloud + restructure deployment guides

### DIFF
--- a/www/apps/cloud/app/deployments/access/page.mdx
+++ b/www/apps/cloud/app/deployments/access/page.mdx
@@ -1,0 +1,83 @@
+export const metadata = {
+  title: `Access Deployment`,
+}
+
+# {metadata.title}
+
+In this guide, you'll learn how to access your Medusa Cloud [deployment](../page.mdx) for an environment.
+
+## Access Live Deployment
+
+You can only access a deployment of an [environment](../../environments/page.mdx) once its status is "Live". A live deployment means that your Medusa application is successfully built and is publicly accessible. You can't access previous deployments or deployments that are still in the "Building" or "Failed" status.
+
+You can access the live deployment's Medusa Admin and send requests to its API routes using the deployment's environment URL.
+
+---
+
+## Find Environment's URL
+
+<Note>
+
+For preview environments, refer to the [Preview Environments](../../environments/preview/page.mdx#access-deployed-preview-environment) guide to find the URL of the preview environment.
+
+</Note>
+
+An environment's URL is in the format `<subdomain>.medusajs.app`, where `<subdomain>` is the subdomain you set either when [creating its project](../../projects/page.mdx#create-a-project) or when [creating the environment](../../environments/long-lived/page.mdx#create-a-long-lived-environment).
+
+You can also find the URL of a deployment's environment through the Cloud dashboard:
+
+1. Select a project from the [organization's dashboard](../../organizations/page.mdx#organization-dashboard).
+2. In the project's dashboard, find the URL in the environment's card under its name. For example, find the production URL in the Production environment card. You can copy the URL by clicking the copy icon next to it.
+
+<Note title="Why are there two URLs?">
+
+Aside from the subdomain you set when [creating the environment](../../environments/long-lived/page.mdx#create-a-long-lived-environment), Medusa also provides a unique, randomly generated URL for each environment. Both of these URLs point to the same deployment.
+
+</Note>
+
+![URL of environment in its card under the environment's name](https://res.cloudinary.com/dza7lstvk/image/upload/v1750157464/Cloud/CleanShot_2025-06-17_at_13.50.38_2x_nfxy1t.png)
+
+3. You can also click on the environment's name to open its dashboard, where you'll find the URL under the environment's name.
+
+![URL of environment in its dashboard under the environment's name](https://res.cloudinary.com/dza7lstvk/image/upload/v1750081257/Cloud/CleanShot_2025-06-16_at_16.40.37_2x_vxupew.png)
+
+---
+
+## Access the Deployment's Medusa Admin
+
+To access the Medusa Admin of a live deployment, click on [the environment's URL](#find-environments-url), or navigate to `<environment-url>/app`. For example, if your environment's URL is `my-project.medusajs.app`, navigate to `my-project.medusajs.app/app`.
+
+You can then log in either using:
+
+1. The email and password set either [during project creation](../../projects/page.mdx#create-a-project).
+2. Your existing Medusa Cloud account by clicking the "Log in with Medusa Cloud" button. A user will be created in the Medusa application with the same email as your Medusa Cloud account.
+
+<Note>
+
+Your Medusa application must be using Medusa [v2.12.4](https://github.com/medusajs/medusa/releases/tag/v2.12.4) or later to have the "Log in with Medusa Cloud" option.
+
+</Note>
+
+![Log in form of Medusa Admin](https://res.cloudinary.com/dza7lstvk/image/upload/v1767696461/Medusa%20Resources/CleanShot_2026-01-06_at_12.47.11_2x_q18pca.png)
+
+---
+
+## Send Requests to the Deployment
+
+You can send requests to a live deployment's API routes using the deployment's [environment URL](#find-environments-url).
+
+For example, to check the health of the live deployment, you can send a `GET` request to the `/health` endpoint:
+
+```bash
+curl https://my-project.medusajs.app/health
+```
+
+Where `https://my-project.medusajs.app` is the environment URL of the deployment.
+
+---
+
+## Access Deployment's Server through SSH
+
+Medusa doesn't support SSH access to the server instance of a deployment. However, you can still access the server's [runtime and build logs](../../logs/page.mdx) to debug issues in your application.
+
+If this isn't sufficient for your use case, you can contact support to discuss alternatives.

--- a/www/apps/cloud/app/deployments/access/page.mdx
+++ b/www/apps/cloud/app/deployments/access/page.mdx
@@ -52,13 +52,14 @@ You can then log in either using:
 1. The email and password set either [during project creation](../../projects/page.mdx#create-a-project).
 2. Your existing Medusa Cloud account by clicking the "Log in with Medusa Cloud" button. A user will be created in the Medusa application with the same email as your Medusa Cloud account.
 
-<Note>
-
-Your Medusa application must be using Medusa [v2.12.4](https://github.com/medusajs/medusa/releases/tag/v2.12.4) or later to have the "Log in with Medusa Cloud" option.
-
-</Note>
-
 ![Log in form of Medusa Admin](https://res.cloudinary.com/dza7lstvk/image/upload/v1767696461/Medusa%20Resources/CleanShot_2026-01-06_at_12.47.11_2x_q18pca.png)
+
+### Can't Find the Log in With Medusa Cloud Button?
+
+If you don't see the "Log in with Medusa Cloud" button on the Medusa Admin log in page, make sure that:
+
+1. Your Medusa application's version is using [Medusa v2.12.4 or later](https://github.com/medusajs/medusa/releases/tag/v2.12.4).
+2. If your deployed project was created before Medusa v2.12.4, set the [environment variable](../../environments/environment-variables/page.mdx) `MEDUSA_CLOUD_OAUTH_DISABLED` to `false` in the environment's settings, then redeploy the environment.
 
 ---
 

--- a/www/apps/cloud/app/deployments/access/page.mdx
+++ b/www/apps/cloud/app/deployments/access/page.mdx
@@ -4,7 +4,7 @@ export const metadata = {
 
 # {metadata.title}
 
-In this guide, you'll learn how to access your Medusa Cloud [deployment](../page.mdx) for an environment.
+In this guide, you'll learn how to access your Cloud [deployment](../page.mdx) for an environment.
 
 ## Access Live Deployment
 
@@ -50,11 +50,11 @@ To access the Medusa Admin of a live deployment, click on [the environment's URL
 You can then log in either using:
 
 1. The email and password set either [during project creation](../../projects/page.mdx#create-a-project).
-2. Your existing Medusa Cloud account by clicking the "Log in with Medusa Cloud" button. A user will be created in the Medusa application with the same email as your Medusa Cloud account.
+2. Your existing Cloud account by clicking the "Log in with Medusa Cloud" button. A user will be created in the Medusa application with the same email as your Cloud account.
 
 ![Log in form of Medusa Admin](https://res.cloudinary.com/dza7lstvk/image/upload/v1767696461/Medusa%20Resources/CleanShot_2026-01-06_at_12.47.11_2x_q18pca.png)
 
-### Can't Find the Log in With Medusa Cloud Button?
+### Can't Find the Log in with Medusa Cloud Button?
 
 If you don't see the "Log in with Medusa Cloud" button on the Medusa Admin log in page, make sure that:
 

--- a/www/apps/cloud/app/deployments/page.mdx
+++ b/www/apps/cloud/app/deployments/page.mdx
@@ -11,7 +11,7 @@ In this guide, you'll learn about deployments in Cloud, how they're created, and
 
 ## Deployments Overview
 
-Each [environment](../environments/page.mdx) has at least one deployment, which is publicly accessible at the [environment's URL](#find-environments-url).
+Each [environment](../environments/page.mdx) has at least one deployment, which is publicly accessible at the [environment's URL](./access/page.mdx#find-environments-url).
 
 A deployment is created from the latest source code of an [environment](../environments/page.mdx)'s branch. An environment can have only one live deployment at a time.
 
@@ -87,7 +87,6 @@ You'll find all deployments for the project's environments in the "Deployments" 
 
 ---
 
-
 ## Find Environment Deployments
 
 You can find the deployments for an environment in the project and environment dashboards.
@@ -145,63 +144,6 @@ To switch to a different deployment:
 ![Deployment switcher at the top of the deployment details page](https://res.cloudinary.com/dza7lstvk/image/upload/v1750148493/Cloud/CleanShot_2025-06-17_at_11.20.16_2x_jegncv.png)
 
 This will change the view to the selected deployment and you'll see its details and logs.
-
----
-
-## Access Live Deployment
-
-You can only access a deployment once its status is "Live". You can access it through its environment's URL.
-
-### Find Environment's URL
-
-<Note>
-
-For preview environments, refer to the [Preview Environments](../environments/preview/page.mdx#access-deployed-preview-environment) guide to find the URL of the preview environment.
-
-</Note>
-
-An environment's URL is in the format `<subdomain>.medusajs.app`, where `<subdomain>` is the subdomain you set either when [creating its project](../projects/page.mdx#create-a-project) or when [creating the environment](../environments/long-lived/page.mdx#create-a-long-lived-environment).
-
-You can also find the URL of a deployment's environment through the Cloud dashboard:
-
-1. Select a project from the [organization's dashboard](../organizations/page.mdx#organization-dashboard).
-2. In the project's dashboard, find the URL in the environment's card under its name. For example, find the production URL in the Production environment card.
-
-<Note title="Why are there two URLs?">
-
-Aside from the subdomain you set when [creating the environment](../environments/long-lived/page.mdx#create-a-long-lived-environment), Medusa also provides a unique, randomly generated URL for each environment. Both of these URLs point to the same deployment.
-
-</Note>
-
-![URL of environment in its card under the environment's name](https://res.cloudinary.com/dza7lstvk/image/upload/v1750157464/Cloud/CleanShot_2025-06-17_at_13.50.38_2x_nfxy1t.png)
-
-3. You can also click on the environment's name to open its dashboard, where you'll find the URL under the environment's name.
-
-![URL of environment in its dashboard under the environment's name](https://res.cloudinary.com/dza7lstvk/image/upload/v1750081257/Cloud/CleanShot_2025-06-16_at_16.40.37_2x_vxupew.png)
-
-### Access the Deployment's Medusa Admin
-
-To access the Medusa Admin of a live deployment, click on [the environment's URL](#find-environments-url).
-
-You can then log in using the email and password set either [during project creation](../projects/page.mdx#create-a-project) or [in the environment's variables](../environments/long-lived/page.mdx#create-medusa-admin-user-in-environment).
-
-### Send Requests to the Deployment
-
-You can send requests to a live deployment's API routes using its URL.
-
-For example, to check the health of the live deployment, you can send a `GET` request to the `/health` endpoint:
-
-```bash
-curl https://my-project.medusajs.app/health
-```
-
-Where `my-project` is the subdomain you set either when [creating the project](../projects/page.mdx#create-a-project) or when [creating the environment](../environments/long-lived/page.mdx#create-a-long-lived-environment).
-
-### Access Deployment's Server through SSH
-
-Medusa doesn't support SSH access to the server instance of a deployment. However, you can still access the server's [runtime and build logs](../logs/page.mdx) to debug issues in your application.
-
-If this isn't sufficient for your use case, you can contact support to discuss alternatives.
 
 ---
 
@@ -297,6 +239,14 @@ If a deployment is stuck at a status like "Building" or "Deploying" for a long t
 </Note>
 
 ![Diagram showcasing the lifecycle of a deployment](https://res.cloudinary.com/dza7lstvk/image/upload/v1750150491/Cloud/deployment-lifecycle_y85gdl.jpg)
+
+---
+
+## Access Live Deployment
+
+Once a deployment's status is "Live", you can access its Medusa Admin and send requests to its API routes.
+
+Learn more in the [Access Live Deployment](./access/page.mdx) guide.
 
 ---
 

--- a/www/apps/cloud/app/environments/long-lived/page.mdx
+++ b/www/apps/cloud/app/environments/long-lived/page.mdx
@@ -74,9 +74,20 @@ After that, Medusa will automatically deploy the environment whenever you push a
 
 ### Create Medusa Admin User in Environment
 
-After the environment is deployed, you need to set the email and password for the environment's Medusa Admin user.
+After the environment is deployed, you can log in either with:
 
-To set the email and password for the admin user:
+1. Your Medusa Cloud account by clicking the "Log in with Medusa Cloud" button. A user will be created in the Medusa application with the same email as your Medusa Cloud account.
+2. The email and password you set using environment variables.
+
+<Note>
+
+Your Medusa application must be using Medusa [v2.12.4](https://github.com/medusajs/medusa/releases/tag/v2.12.4) or later to have the "Log in with Medusa Cloud" option.
+
+</Note>
+
+You can set the initial admin user's email and password only once if they aren't already set in the environment. Updating these environment variables later won't change the existing admin user's credentials.
+
+To set the initial admin user's email and password:
 
 1. In the [project's dashboard](../../projects/page.mdx#open-project-dashboard), click on the environment you just created.
 2. In the environment's dashboard, click on the "Settings" tab.
@@ -97,9 +108,9 @@ Make sure to replace the values with your desired email and password.
 
 4. Click the "Save" button to save the environment variables.
 
-### Redeploy Environment
+#### Redeploy Environment
 
-After adding the environment variables, you need to redeploy the environment for the changes to take effect:
+If you added the initial admin user's email and password environment variables, you need to redeploy the environment for the changes to take effect:
 
 1. Go back to the environment's dashboard by clicking the "Overview" tab.
 2. Click on the "Redeploy" button to redeploy the environment with the new environment variables.
@@ -116,7 +127,7 @@ Then, wait for the deployment to finish. You can check its status in the "Deploy
 
 Once an environment is deployed, you can access it through its URL.
 
-Learn more about how to access an environment's deployment in the [Deployments](../../deployments/page.mdx#access-live-deployment) guide.
+Learn more about how to access an environment's deployment in the [Access Deployment](../../deployments/access/page.mdx) guide.
 
 ---
 

--- a/www/apps/cloud/app/environments/long-lived/page.mdx
+++ b/www/apps/cloud/app/environments/long-lived/page.mdx
@@ -79,9 +79,9 @@ After the environment is deployed, you can log in either with:
 1. Your Medusa Cloud account by clicking the "Log in with Medusa Cloud" button. A user will be created in the Medusa application with the same email as your Medusa Cloud account.
 2. The email and password you set using environment variables.
 
-<Note>
+<Note title="Can't find the Log in With Medusa Cloud Button?">
 
-Your Medusa application must be using Medusa [v2.12.4](https://github.com/medusajs/medusa/releases/tag/v2.12.4) or later to have the "Log in with Medusa Cloud" option.
+Refer to the [Access Deployment](../../deployments/access/page.mdx#cant-find-the-log-in-with-medusa-cloud-button) guide for troubleshooting steps.
 
 </Note>
 

--- a/www/apps/cloud/app/environments/long-lived/page.mdx
+++ b/www/apps/cloud/app/environments/long-lived/page.mdx
@@ -76,7 +76,7 @@ After that, Medusa will automatically deploy the environment whenever you push a
 
 After the environment is deployed, you can log in either with:
 
-1. Your Medusa Cloud account by clicking the "Log in with Medusa Cloud" button. A user will be created in the Medusa application with the same email as your Medusa Cloud account.
+1. Your Cloud account by clicking the "Log in with Medusa Cloud" button. A user will be created in the Medusa application with the same email as your Cloud account.
 2. The email and password you set using environment variables.
 
 <Note title="Can't find the Log in With Medusa Cloud Button?">

--- a/www/apps/cloud/app/projects/page.mdx
+++ b/www/apps/cloud/app/projects/page.mdx
@@ -179,7 +179,7 @@ All your project's deployments will be in the selected region. For better perfor
 
 To access the deployed project, you can navigate to the URL of its Production environment.
 
-Learn more in the [Deployments](../deployments/page.mdx#access-live-deployment) guide.
+Learn more in the [Access Deployment](../deployments/access/page.mdx) guide.
 
 ---
 

--- a/www/apps/cloud/app/update-medusa/page.mdx
+++ b/www/apps/cloud/app/update-medusa/page.mdx
@@ -62,7 +62,7 @@ To update your Medusa application deployed on Cloud:
     - If you're using a long-lived environment, Medusa will automatically deploy the changes to the branch's environment.
     - If you're using a new branch to create a pull request, open the pull request to the production branch. This will create a preview environment that you can use to test the update before merging it into the production branch.
 
-Then, you can access the environment's [live deployment](../deployments/page.mdx#access-live-deployment) to test the update. You can also use the [build](../logs/page.mdx#view-build-logs) and [runtime](../logs/page.mdx#view-runtime-logs) logs of the environment to debug any issues that occur during the update process or testing.
+Then, you can access the environment's [live deployment](../deployments/access/page.mdx) to test the update. You can also use the [build](../logs/page.mdx#view-build-logs) and [runtime](../logs/page.mdx#view-runtime-logs) logs of the environment to debug any issues that occur during the update process or testing.
 
 ### Push Update to Production
 

--- a/www/apps/cloud/generated/edit-dates.mjs
+++ b/www/apps/cloud/generated/edit-dates.mjs
@@ -1,9 +1,9 @@
 export const generatedEditDates = {
   "app/page.mdx": "2025-10-13T10:56:37.352Z",
   "app/organization/page.mdx": "2025-06-12T14:43:20.772Z",
-  "app/projects/page.mdx": "2025-11-20T09:48:32.899Z",
+  "app/projects/page.mdx": "2026-01-06T10:52:09.224Z",
   "app/environments/page.mdx": "2025-10-15T15:25:09.940Z",
-  "app/deployments/page.mdx": "2025-10-17T14:40:07.793Z",
+  "app/deployments/page.mdx": "2026-01-06T10:50:49.029Z",
   "app/organizations/page.mdx": "2025-12-17T11:56:48.669Z",
   "app/notifications/page.mdx": "2025-10-15T15:25:33.672Z",
   "app/database/page.mdx": "2025-10-20T15:47:46.364Z",
@@ -11,10 +11,10 @@ export const generatedEditDates = {
   "app/s3/page.mdx": "2025-10-15T15:23:02.835Z",
   "app/loyalty-plugin/page.mdx": "2025-10-15T15:27:40.303Z",
   "app/logs/page.mdx": "2025-10-15T15:24:53.277Z",
-  "app/update-medusa/page.mdx": "2025-06-25T07:57:30.170Z",
+  "app/update-medusa/page.mdx": "2026-01-06T10:52:20.587Z",
   "app/connect-storefront/page.mdx": "2025-06-25T07:47:00.499Z",
   "app/environments/environment-variables/page.mdx": "2025-11-12T15:42:19.187Z",
-  "app/environments/long-lived/page.mdx": "2025-10-15T15:27:08.743Z",
+  "app/environments/long-lived/page.mdx": "2026-01-06T10:56:18.660Z",
   "app/environments/preview/page.mdx": "2025-11-03T12:50:29.841Z",
   "app/faq/page.mdx": "2025-10-08T14:43:21.930Z",
   "app/billing/page.mdx": "2025-12-17T12:39:37.397Z",
@@ -28,5 +28,6 @@ export const generatedEditDates = {
   "app/deployments/troubleshooting/page.mdx": "2025-10-17T14:44:22.894Z",
   "app/emails/page.mdx": "2025-11-26T11:07:58.083Z",
   "app/emails/react-email/page.mdx": "2025-11-12T15:41:56.365Z",
-  "app/user/page.mdx": "2025-12-17T12:03:18.968Z"
+  "app/user/page.mdx": "2025-12-17T12:03:18.968Z",
+  "app/deployments/access/page.mdx": "2026-01-06T10:56:01.868Z"
 }

--- a/www/apps/cloud/generated/sidebar.mjs
+++ b/www/apps/cloud/generated/sidebar.mjs
@@ -111,6 +111,14 @@ export const generatedSidebars = [
                 "loaded": true,
                 "isPathHref": true,
                 "type": "link",
+                "title": "Access Deployment",
+                "path": "/deployments/access",
+                "children": []
+              },
+              {
+                "loaded": true,
+                "isPathHref": true,
+                "type": "link",
                 "title": "Troubleshooting",
                 "path": "/deployments/troubleshooting",
                 "children": []

--- a/www/apps/cloud/sidebar.mjs
+++ b/www/apps/cloud/sidebar.mjs
@@ -75,6 +75,11 @@ export const sidebar = [
             children: [
               {
                 type: "link",
+                title: "Access Deployment",
+                path: "/deployments/access",
+              },
+              {
+                type: "link",
                 title: "Troubleshooting",
                 path: "/deployments/troubleshooting",
               },

--- a/www/vale/styles/docs/Tooling.yml
+++ b/www/vale/styles/docs/Tooling.yml
@@ -20,7 +20,7 @@ swap:
   "Next.js starter storefront": "Next.js Starter Storefront"
   "Next.js storefront": "Next.js Starter Storefront"
   "Next.js Storefront": "Next.js Starter Storefront"
-  "Medusa Cloud": "Cloud"
+  '(?:[\w\d\s'']+) Medusa Cloud': "$1 Cloud"
   " cloud ": " Cloud "
   "flex usage": "Flex Usage"
 exceptions:
@@ -38,3 +38,4 @@ exceptions:
   - 'Frontend''s Framework'
   - 'Frontend''s framework'
   - 'your framework'
+  - 'Log in with Medusa Cloud'


### PR DESCRIPTION
1. Move existing access deployment section to its own document for easy access and reference
2. Add details on logging in with Cloud