### PR TITLE
fix(create-medusa-app): fix version option not working with Next.js storefront

### DIFF
--- a/.changeset/fifty-parrots-appear.md
+++ b/.changeset/fifty-parrots-appear.md
@@ -1,0 +1,5 @@
+---
+"create-medusa-app": patch
+---
+
+fix(create-medusa-app): fix version option not working with Next.js storefront

--- a/packages/cli/create-medusa-app/src/utils/log-message.ts
+++ b/packages/cli/create-medusa-app/src/utils/log-message.ts
@@ -5,9 +5,10 @@ import { logger } from "./logger.js"
 type LogOptions = {
   message: string
   type?: "error" | "success" | "info" | "warn" | "verbose"
+  stack?: string
 }
 
-export default ({ message, type = "info" }: LogOptions) => {
+export default ({ message, type = "info", stack }: LogOptions) => {
   switch (type) {
     case "info":
       logger.info(chalk.white(message))
@@ -22,6 +23,6 @@ export default ({ message, type = "info" }: LogOptions) => {
       logger.info(`${chalk.bgYellowBright("VERBOSE LOG:")} ${message}`)
       break
     case "error":
-      program.error(chalk.bold.red(message))
+      program.error(chalk.bold.red(message.trim() + stack))
   }
 }

--- a/packages/cli/create-medusa-app/src/utils/log-message.ts
+++ b/packages/cli/create-medusa-app/src/utils/log-message.ts
@@ -23,6 +23,6 @@ export default ({ message, type = "info", stack }: LogOptions) => {
       logger.info(`${chalk.bgYellowBright("VERBOSE LOG:")} ${message}`)
       break
     case "error":
-      program.error(chalk.bold.red(message.trim() + stack))
+      program.error(chalk.bold.red(message.trim() + (stack || "")))
   }
 }

--- a/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
+++ b/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
@@ -204,15 +204,18 @@ export class MedusaProjectCreator
     })
   }
 
-  private handleError(e: any): void {
+  private handleError(e: Error): void {
     if (isAbortError(e)) {
       process.exit()
     }
+
+    const showStack = e.message.includes("npm") || e.message.includes("yarn")
 
     this.spinner.stop()
     logMessage({
       message: `An error occurred: ${e}`,
       type: "error",
+      stack: showStack ? e.stack?.replace(e.toString(), "") : "",
     })
   }
 

--- a/packages/cli/create-medusa-app/src/utils/update-package-versions.ts
+++ b/packages/cli/create-medusa-app/src/utils/update-package-versions.ts
@@ -12,14 +12,14 @@ export function updatePackageVersions(
 
   if (packageJson.dependencies) {
     for (const dependency of Object.keys(packageJson.dependencies)) {
-      if (dependency.startsWith("@medusajs/")) {
+      if (shouldUpdateVersion(dependency)) {
         packageJson.dependencies[dependency] = version
       }
     }
   }
   if (packageJson.devDependencies) {
     for (const dependency of Object.keys(packageJson.devDependencies)) {
-      if (dependency.startsWith("@medusajs/")) {
+      if (shouldUpdateVersion(dependency)) {
         packageJson.devDependencies[dependency] = version
       }
     }
@@ -28,4 +28,10 @@ export function updatePackageVersions(
   if (applyChanges && typeof packageJsonOrPath === "string") {
     writeFileSync(packageJsonOrPath, JSON.stringify(packageJson, null, 2))
   }
+}
+
+function shouldUpdateVersion(dependency: string): boolean {
+  // UI package follows different versioning, so we can't update it following
+  // the same logic as other Medusa packages
+  return dependency.startsWith("@medusajs/") && dependency !== "@medusajs/ui"
 }


### PR DESCRIPTION
1. Fix error when passing `--version` and installing Next.js storefront. The error is because the UI package doesn't follow the same versioning as other Medusa packages, so this will skip updating the version of the UI package.
2. Other: added error logging for installation errors