### PR TITLE
fix(utils): handle undefined __meta in mikroOrmBaseRepositoryFactory

### DIFF
--- a/packages/core/utils/src/dal/mikro-orm/mikro-orm-repository.ts
+++ b/packages/core/utils/src/dal/mikro-orm/mikro-orm-repository.ts
@@ -18,6 +18,7 @@ import {
   EntityProperty,
   EntitySchema,
   LoadStrategy,
+  MetadataStorage,
   FilterQuery as MikroFilterQuery,
   FindOptions as MikroOptions,
   ReferenceKind,
@@ -295,7 +296,8 @@ export function mikroOrmBaseRepositoryFactory<const T extends object>(
     entity = mikroOrmEntity
     tableName = (
       (mikroOrmEntity as unknown as EntitySchema).meta ??
-      (mikroOrmEntity as EntityClass<any>).prototype.__meta
+      (mikroOrmEntity as EntityClass<any>).prototype?.__meta ??
+      MetadataStorage.getMetadataFromDecorator(mikroOrmEntity)
     ).collection
 
     // @ts-ignore


### PR DESCRIPTION
## What
Fix a bug where `mikroOrmBaseRepositoryFactory` crashes with:
```
TypeError: Cannot read properties of undefined (reading 'collection')
```

## Why
When repository classes are instantiated during DI (via Awilix), MikroORM may not have completed initialization. The `__meta` property is only set after `MikroORM.init()`, but `MetadataStorage.getMetadataFromDecorator()` has the data immediately.

## How
Added `MetadataStorage.getMetadataFromDecorator()` as fallback:
```typescript
tableName = (
  (mikroOrmEntity as unknown as EntitySchema).meta ??
  (mikroOrmEntity as EntityClass<any>).prototype?.__meta ??
  MetadataStorage.getMetadataFromDecorator(mikroOrmEntity)
).collection
```

## Testing
Tested on Medusa 2.12.4 project - server starts successfully after fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures repository initialization succeeds even before MikroORM is fully initialized by making table metadata resolution more robust.
> 
> - Uses `prototype?.__meta` and falls back to `MetadataStorage.getMetadataFromDecorator(mikroOrmEntity)` when computing `tableName` in `mikro-orm-repository.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96c8cb226f10bf6f8508614c0a310d2ca35eaaf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->