### PR TITLE
fix(core-flows): Pass shipping_methods to computeActions context

### DIFF
--- a/.changeset/sixty-eagles-melt.md
+++ b/.changeset/sixty-eagles-melt.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): Pass shipping_methods to computeActions context

--- a/integration-tests/http/__tests__/order-edits/order-edits.spec.ts
+++ b/integration-tests/http/__tests__/order-edits/order-edits.spec.ts
@@ -2492,6 +2492,186 @@ medusaIntegrationTestRunner({
         expect(orderResult2.total).toEqual(20)
         expect(orderResult2.original_total).toEqual(20)
       })
+
+      it("should maintain shipping method adjustments when adding a new item with promotion targeting shipping methods", async () => {
+        // Create a promotion that targets shipping methods
+        const shippingPromotion = await promotionModule.createPromotions({
+          code: "SHIPPING_PROMO",
+          type: PromotionType.STANDARD,
+          status: PromotionStatus.ACTIVE,
+          application_method: {
+            type: "fixed",
+            target_type: "shipping_methods",
+            allocation: "each",
+            value: 2,
+            max_quantity: 1,
+            currency_code: "usd",
+            target_rules: [
+              {
+                attribute: "name",
+                operator: "in",
+                values: ["Test shipping method"],
+              },
+            ],
+          },
+        })
+
+        // Create an order with shipping method
+        // @ts-ignore
+        const orderWithShipping = await orderModule.createOrders({
+          email: "foo@bar.com",
+          region_id: region.id,
+          sales_channel_id: salesChannel.id,
+          items: [
+            {
+              // @ts-ignore
+              id: "item-shipping-1",
+              title: "Custom Item",
+              quantity: 1,
+              unit_price: 10,
+            },
+          ],
+          shipping_address: {
+            first_name: "Test",
+            last_name: "Test",
+            address_1: "Test",
+            city: "Test",
+            country_code: "US",
+            postal_code: "12345",
+            phone: "12345",
+          },
+          billing_address: {
+            first_name: "Test",
+            last_name: "Test",
+            address_1: "Test",
+            city: "Test",
+            country_code: "US",
+            postal_code: "12345",
+          },
+          shipping_methods: [
+            {
+              name: "Test shipping method",
+              amount: 5,
+            },
+          ],
+          currency_code: "usd",
+        })
+
+        // Create shipping method adjustment for the promotion
+        if (orderWithShipping.shipping_methods?.[0]) {
+          await orderModule.createOrderShippingMethodAdjustments(
+            orderWithShipping.id,
+            [
+              {
+                shipping_method_id: orderWithShipping.shipping_methods[0].id,
+                code: shippingPromotion.code!,
+                amount: 2,
+              },
+            ]
+          )
+        }
+
+        // Link promotion to order
+        await remoteLink.create({
+          [Modules.ORDER]: { order_id: orderWithShipping.id },
+          [Modules.PROMOTION]: { promotion_id: shippingPromotion.id },
+        })
+
+        // Create order edit
+        let result = await api.post(
+          "/admin/order-edits",
+          {
+            order_id: orderWithShipping.id,
+            description: "Test shipping promotion",
+          },
+          adminHeaders
+        )
+
+        const orderChangeId = result.data.order_change.id
+        const orderId = result.data.order_change.order_id
+
+        // Enable carry over promotions
+        await api.post(
+          `/admin/order-changes/${orderChangeId}`,
+          {
+            carry_over_promotions: true,
+          },
+          adminHeaders
+        )
+
+        result = (await api.get(`/admin/orders/${orderId}`, adminHeaders)).data
+          .order
+
+        // Original order: $10 item + $5 shipping - $2 shipping discount = $13
+        expect(result.total).toEqual(13)
+        expect(result.shipping_methods[0].adjustments).toEqual([
+          expect.objectContaining({
+            code: shippingPromotion.code!,
+            amount: 2,
+          }),
+        ])
+
+        // Add item with price $12
+        result = (
+          await api.post(
+            `/admin/order-edits/${orderId}/items`,
+            {
+              items: [
+                {
+                  variant_id: productExtra.variants[0].id,
+                  quantity: 1,
+                },
+              ],
+            },
+            adminHeaders
+          )
+        ).data.order_preview
+
+        // After adding item: $22 items + $5 shipping - $2 shipping discount + $1.2 tax = $26.2
+        expect(result.total).toEqual(26.2)
+        expect(result.original_total).toEqual(28.2) // +$2 shipping discount
+
+        // Shipping method adjustment should still be present
+        expect(result.shipping_methods[0].adjustments).toEqual([
+          expect.objectContaining({
+            code: shippingPromotion.code!,
+            amount: 2,
+          }),
+        ])
+
+        // Confirm original order is not updated
+        const orderResult = (
+          await api.get(`/admin/orders/${orderId}`, adminHeaders)
+        ).data.order
+
+        expect(orderResult.total).toEqual(13)
+        expect(orderResult.shipping_methods[0].adjustments).toEqual([
+          expect.objectContaining({
+            code: shippingPromotion.code!,
+            amount: 2,
+          }),
+        ])
+
+        // Confirm the order edit
+        await api.post(
+          `/admin/order-edits/${orderId}/confirm`,
+          {},
+          adminHeaders
+        )
+
+        const orderResult2 = (
+          await api.get(`/admin/orders/${orderId}`, adminHeaders)
+        ).data.order
+
+        expect(orderResult2.total).toEqual(26.2)
+        expect(orderResult2.original_total).toEqual(28.2)
+        expect(orderResult2.shipping_methods[0].adjustments).toEqual([
+          expect.objectContaining({
+            code: shippingPromotion.code!,
+            amount: 2,
+          }),
+        ])
+      })
     })
   },
 })

--- a/packages/core/core-flows/src/draft-order/workflows/compute-draft-order-adjustments.ts
+++ b/packages/core/core-flows/src/draft-order/workflows/compute-draft-order-adjustments.ts
@@ -8,6 +8,7 @@ import {
 } from "@medusajs/framework/workflows-sdk"
 import type {
   ComputeActionContext,
+  ComputeActionShippingLine,
   OrderChangeDTO,
   OrderDTO,
   PromotionDTO,
@@ -145,7 +146,7 @@ export const computeDraftOrderAdjustmentsWorkflow = createWorkflow(
           .filter((p) => p !== undefined)
       })
 
-      const actionsToComputeItemsInput = transform(
+      const actionsToComputeContext = transform(
         { previewedOrder, order },
         ({ previewedOrder, order }) => {
           return {
@@ -155,12 +156,14 @@ export const computeDraftOrderAdjustmentsWorkflow = createWorkflow(
               // Buy-Get promotions rely on the product ID, so we need to manually set it before refreshing adjustments
               product: { id: item.product_id },
             })),
+            shipping_methods:
+              previewedOrder.shipping_methods as unknown as ComputeActionShippingLine[],
           } as ComputeActionContext
         }
       )
 
       const actions = getActionsToComputeFromPromotionsStep({
-        computeActionContext: actionsToComputeItemsInput,
+        computeActionContext: actionsToComputeContext,
         promotionCodesToApply: orderPromotions,
       })
 

--- a/packages/core/core-flows/src/order/workflows/compute-adjustments-for-preview.ts
+++ b/packages/core/core-flows/src/order/workflows/compute-adjustments-for-preview.ts
@@ -1,5 +1,6 @@
 import {
   ComputeActionContext,
+  ComputeActionShippingLine,
   OrderChangeDTO,
   OrderDTO,
   PromotionDTO,
@@ -87,7 +88,7 @@ export const computeAdjustmentsForPreviewWorkflow = createWorkflow(
          */
         !!order.promotions.length && !!input.orderChange.carry_over_promotions
     ).then(() => {
-      const actionsToComputeItemsInput = transform(
+      const actionsToComputeContext = transform(
         { previewedOrder, order: input.order },
         ({ previewedOrder, order }) => {
           return {
@@ -97,6 +98,8 @@ export const computeAdjustmentsForPreviewWorkflow = createWorkflow(
               // Buy-Get promotions rely on the product ID, so we need to manually set it before refreshing adjustments
               product: { id: item.product_id },
             })),
+            shipping_methods:
+              previewedOrder.shipping_methods as unknown as ComputeActionShippingLine[],
           } as ComputeActionContext
         }
       )
@@ -108,7 +111,7 @@ export const computeAdjustmentsForPreviewWorkflow = createWorkflow(
       })
 
       const actions = getActionsToComputeFromPromotionsStep({
-        computeActionContext: actionsToComputeItemsInput,
+        computeActionContext: actionsToComputeContext,
         promotionCodesToApply: orderPromotions,
         options: {
           skip_usage_limit_checks: true,


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Pass `shipping_methods` to `computeActions` context when computing adjustments for previews and draft orders.

**Why** — Why are these changes relevant or necessary?  

If a promotion targeting shipping methods is defined, then the `computeActions` method will throw an error when called through the preview and draft order computation flows, as we are only passing the items as part of the context for the computation.

**How** — How have these changes been implemented?

Pass `shipping_methods` alongside the items in said flows.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes CORE-1359
