### PR TITLE
fix(event-bus-redis): remove local subscriber filtering before queue

### DIFF
--- a/.changeset/stupid-seas-wave.md
+++ b/.changeset/stupid-seas-wave.md
@@ -1,0 +1,4 @@
+---
+"@medusajs/event-bus-redis": patch
+---
+remove local subscriber filtering before queue emission

--- a/packages/modules/event-bus-redis/src/services/event-bus-redis.ts
+++ b/packages/modules/event-bus-redis/src/services/event-bus-redis.ts
@@ -214,17 +214,8 @@ export default class RedisEventBusService extends AbstractEventBusModuleService 
         this.callInterceptors(eventData, { isGrouped: false })
       )
 
-      const eventsWithSubscribers = eventsToEmit.filter((eventData) => {
-        const eventSubscribers =
-          this.eventToSubscribersMap.get(eventData.name) || []
-        const wildcardSubscribers = this.eventToSubscribersMap.get("*") || []
-        return eventSubscribers.length || wildcardSubscribers.length
-      })
-
-      if (eventsWithSubscribers.length) {
-        const emitData = this.buildEvents(eventsWithSubscribers, options)
-        promises.push(this.queue_.addBulk(emitData))
-      }
+      const emitData = this.buildEvents(eventsToEmit, options)
+      promises.push(this.queue_.addBulk(emitData))
     }
 
     for (const [groupId, events] of groupEventsMap.entries()) {
@@ -291,15 +282,8 @@ export default class RedisEventBusService extends AbstractEventBusModuleService 
       })
     })
 
-    const eventsWithSubscribers = groupedEvents.filter((jobData) => {
-      const eventSubscribers =
-        this.eventToSubscribersMap.get(jobData.name) || []
-      const wildcardSubscribers = this.eventToSubscribersMap.get("*") || []
-      return eventSubscribers.length || wildcardSubscribers.length
-    })
-
-    if (eventsWithSubscribers.length) {
-      await this.queue_.addBulk(eventsWithSubscribers)
+    if (groupedEvents.length) {
+      await this.queue_.addBulk(groupedEvents)
     }
 
     await this.clearGroupedEvents(eventGroupId)


### PR DESCRIPTION
To those concerned, if there is already a fix for this please let me know. I could not find any relevant issues or fixes pertaining to this issue. I just needed to get this resolved myself and thought I'd share.

The event-bus-redis module was filtering events based on the local process's in-memory eventToSubscribersMap before adding them to the Redis queue. This causes event loss in distributed deployments where different worker instances may have different subscribers registered.

## Summary

**What** — What changes are introduced in this PR?

Removed local event filtering

**Why** — Why are these changes relevant or necessary?  

The event-bus-redis module was filtering events based on the local process's in-memory eventToSubscribersMap before adding them to the Redis queue. This causes event loss in distributed deployments where different worker instances may have different subscribers registered.

**How** — How have these changes been implemented?

Removed the local event filtering

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Deployed into two production stores and monitored events emissions following order placement and fulfillment modifications to said orders. Events were successfully emitting and being heard.

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures all events are enqueued to Redis rather than filtered locally, aligning behavior for distributed workers.
> 
> - Removes local `eventToSubscribersMap` filtering before `queue_.addBulk` for both immediate and grouped emissions; all events are now enqueued
> - Retains interceptor invocation; `releaseGroupedEvents` enqueues when any grouped events exist
> - Adds patch changeset for `@medusajs/event-bus-redis`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff8d599445df28c3b8a8de0ebb191ca671374b83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->