### PR TITLE
fix(core-flows): Avoid throwing if no prices found for variant when adding to cart custom price item

### DIFF
--- a/.changeset/pretty-planes-switch.md
+++ b/.changeset/pretty-planes-switch.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): Avoid throwing if no prices found for variant when adding to cart custom price item

--- a/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
@@ -2474,6 +2474,103 @@ medusaIntegrationTestRunner({
           ])
         })
 
+        it("should add item to cart with unit_price when variant has no price set", async () => {
+          const salesChannel = await scModuleService.createSalesChannels({
+            name: "Webshop",
+          })
+
+          const location = await stockLocationModule.createStockLocations({
+            name: "Warehouse",
+          })
+
+          let cart = await cartModuleService.createCarts({
+            currency_code: "usd",
+            sales_channel_id: salesChannel.id,
+          })
+
+          const [product] = await productModule.createProducts([
+            {
+              title: "Test product",
+              status: ProductStatus.PUBLISHED,
+              variants: [
+                {
+                  title: "Test variant",
+                },
+              ],
+            },
+          ])
+
+          const inventoryItem = await inventoryModule.createInventoryItems({
+            sku: "inv-1234",
+          })
+
+          await inventoryModule.createInventoryLevels([
+            {
+              inventory_item_id: inventoryItem.id,
+              location_id: location.id,
+              stocked_quantity: 2,
+              reserved_quantity: 0,
+            },
+          ])
+
+          await remoteLink.create([
+            {
+              [Modules.SALES_CHANNEL]: {
+                sales_channel_id: salesChannel.id,
+              },
+              [Modules.STOCK_LOCATION]: {
+                stock_location_id: location.id,
+              },
+            },
+            {
+              [Modules.PRODUCT]: {
+                variant_id: product.variants[0].id,
+              },
+              [Modules.INVENTORY]: {
+                inventory_item_id: inventoryItem.id,
+              },
+            },
+          ])
+
+          cart = await cartModuleService.retrieveCart(cart.id, {
+            select: ["id", "region_id", "currency_code", "sales_channel_id"],
+          })
+
+          // Add item with unit_price specified even though variant has no price set
+          await addToCartWorkflow(appContainer).run({
+            input: {
+              items: [
+                {
+                  variant_id: product.variants[0].id,
+                  quantity: 1,
+                  unit_price: 5000,
+                },
+              ],
+              cart_id: cart.id,
+            },
+          })
+
+          cart = await cartModuleService.retrieveCart(cart.id, {
+            relations: ["items"],
+          })
+
+          expect(cart).toEqual(
+            expect.objectContaining({
+              id: cart.id,
+              currency_code: "usd",
+              items: expect.arrayContaining([
+                expect.objectContaining({
+                  unit_price: 5000,
+                  is_custom_price: true,
+                  quantity: 1,
+                  title: "Test product",
+                  subtitle: "Test variant",
+                }),
+              ]),
+            })
+          )
+        })
+
         describe("setPricingContext hook", () => {
           it("should use context provided by the hook", async () => {
             const salesChannel = await scModuleService.createSalesChannels({

--- a/packages/core/core-flows/src/cart/steps/get-variant-price-sets.ts
+++ b/packages/core/core-flows/src/cart/steps/get-variant-price-sets.ts
@@ -91,13 +91,15 @@ async function fetchVariantPriceSets(
 }
 
 /**
- * Validates that all variants have price sets and throws error for missing ones
+ * Validates that all variants without a custom price have price sets and throws error for missing ones
  */
 function validateVariantPriceSets(
-  variantPriceSets: VariantPriceSetData[]
+  variantPriceSets: VariantPriceSetData[],
+  variantsWithCustomPrice: string[] = []
 ): void {
+  const variantsWithCustomPriceSet = new Set(variantsWithCustomPrice)
   const notFound = variantPriceSets
-    .filter((v) => !v.price_set?.id)
+    .filter((v) => !v.price_set?.id && !variantsWithCustomPriceSet.has(v.id))
     .map((v) => v.id)
 
   if (notFound.length) {
@@ -287,7 +289,10 @@ export const getVariantPriceSetsStep = createStep(
       const variantIds = bulkData.map((item) => item.variantId)
       const variantPriceSets = await fetchVariantPriceSets(query, variantIds)
 
-      validateVariantPriceSets(variantPriceSets)
+      const variantsWithCustomPrice = bulkData
+        .filter((item) => !!item.context?.is_custom_price)
+        .map((item) => item.variantId)
+      validateVariantPriceSets(variantPriceSets, variantsWithCustomPrice)
 
       // Map variant IDs to price set IDs
       const variantToPriceSetId = new Map<string, string>()

--- a/packages/core/core-flows/src/cart/workflows/get-variants-and-items-with-prices.ts
+++ b/packages/core/core-flows/src/cart/workflows/get-variants-and-items-with-prices.ts
@@ -125,6 +125,7 @@ export const getVariantsAndItemsWithPrices = createWorkflow(
               context: {
                 ...baseContext,
                 quantity: item.quantity,
+                is_custom_price: !!item.unit_price,
               },
             }
           })

--- a/packages/core/core-flows/src/cart/workflows/get-variants-and-items-with-prices.ts
+++ b/packages/core/core-flows/src/cart/workflows/get-variants-and-items-with-prices.ts
@@ -180,7 +180,10 @@ export const getVariantsAndItemsWithPrices = createWorkflow(
             calculatedPriceSet = calculatedPriceSets[item_.variant_id!]
           }
 
-          if (!calculatedPriceSet && item_.variant_id) {
+          const isCustomPrice =
+            item_.is_custom_price ?? isDefined(item?.unit_price)
+
+          if (!calculatedPriceSet && item_.variant_id && !isCustomPrice) {
             priceNotFound.push(item_.variant_id)
           }
 
@@ -197,9 +200,6 @@ export const getVariantsAndItemsWithPrices = createWorkflow(
           if (variant) {
             variant.calculated_price = calculatedPriceSet
           }
-
-          const isCustomPrice =
-            item_.is_custom_price ?? isDefined(item?.unit_price)
 
           const input: PrepareLineItemDataInput = {
             item: item_,


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

When adding to cart a line item with custom unit price via workflow, avoid throwing an error if no price is found for the linked variant.

**Why** — Why are these changes relevant or necessary?  

Without this, it is not possible to have product variants whose price is going to be resolved exclusively dynamically.

**How** — How have these changes been implemented?

Avoid throwing when adding to cart if the variant doesn't have prices defined and the line item has a custom price.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration test.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

Closes CORE-1362
