### PR TITLE
Fix small typo in file name import

### DIFF
--- a/www/apps/resources/app/how-to-tutorials/tutorials/product-feed/page.mdx
+++ b/www/apps/resources/app/how-to-tutorials/tutorials/product-feed/page.mdx
@@ -434,7 +434,7 @@ Create the file `src/workflows/generate-product-feed.ts` with the following cont
 ```ts title="src/workflows/generate-product-feed.ts"
 import { createWorkflow, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
 import { getProductFeedItemsStep } from "./steps/get-product-feed-items"
-import { buildProductFeedXmlStep } from "./steps/build-product-field-xml"
+import { buildProductFeedXmlStep } from "./steps/build-product-feed-xml"
 
 type GenerateProductFeedWorkflowInput = {
   currency_code: string


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix small typo in file import in the Meta product feed tutorial

**Why** — Why are these changes relevant or necessary?  

The typo in the import path causes confusion when following the Meta product feed tutorial and can lead to runtime or build errors for developers implementing the feature.
Fixing it ensures the documentation matches the actual file structure and improves the developer experience.

**How** — How have these changes been implemented?

The incorrect import path in the tutorial was corrected to reference the proper file name.
No logic or behavior was changed—only the documentation example was updated.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

This change affects documentation only.

---

## Examples

Not applicable. This PR only corrects a typo in the documentation.


## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context
Resolves #14522


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the product feed tutorial to correct a typo in an import path.
> 
> - In `src/workflows/generate-product-feed.ts` snippet within `page.mdx`, change `./steps/build-product-field-xml` to `./steps/build-product-feed-xml`. Documentation-only; no runtime code modified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 560f3a356f696be1d05fca9931593daff3217059. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->