### PR TITLE
fix(dashboard): filter feed channel notifications in admin dashboard

### DIFF
--- a/.changeset/lucky-buttons-yell.md
+++ b/.changeset/lucky-buttons-yell.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): filter feed channel notifications in admin dashboard

--- a/packages/admin/dashboard/src/components/layout/notifications/notifications.tsx
+++ b/packages/admin/dashboard/src/components/layout/notifications/notifications.tsx
@@ -89,7 +89,12 @@ export const Notifications = () => {
           >
             responseKey="notifications"
             queryKey={notificationQueryKeys.all}
-            queryFn={(params) => sdk.admin.notification.list(params)}
+            queryFn={(params) =>
+              sdk.admin.notification.list({
+                ...params,
+                channel: "feed",
+              })
+            }
             queryOptions={{ enabled: open }}
             renderEmpty={() => <NotificationsEmptyState t={t} />}
             renderItem={(notification) => {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Filter only `channel=feed` notifications in Admin dashboard.

**Why** — Why are these changes relevant or necessary?  

Otherwise, other channel notifications are incorrectly fetched and break the view, since they don't have the expected content format to render in the component.

**How** — How have these changes been implemented?

Added `channel=feed` to the API call.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Validated only feed notifications are retrieved at runtime.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes CORE-1363
