### PR TITLE
Use ENTRYPOINT instead of CMD in Dockerfile

### DIFF
--- a/www/apps/book/app/learn/installation/docker/page.mdx
+++ b/www/apps/book/app/learn/installation/docker/page.mdx
@@ -1,4 +1,4 @@
-import { 
+import {
   Prerequisites,
   CodeTabs,
   CodeTab
@@ -233,7 +233,7 @@ COPY . .
 EXPOSE 9000
 
 # Start with migrations and then the development server
-CMD ["./start.sh"]
+ENTRYPOINT ["./start.sh"]
 ```
   </CodeTab>
   <CodeTab value="npm" label="NPM">
@@ -257,7 +257,7 @@ COPY . .
 EXPOSE 9000
 
 # Start with migrations and then the development server
-CMD ["./start.sh"]
+ENTRYPOINT ["./start.sh"]
 ```
   </CodeTab>
 </CodeTabs>
@@ -383,7 +383,7 @@ module.exports = defineConfig({
           hmr: {
             ...config.server?.hmr,
             // HMR websocket port inside container
-            port: 5173, 
+            port: 5173,
             // Port browser connects to (exposed in docker-compose.yml)
             clientPort: 5173,
           },


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?
ENTRYPOINT is changed in Dockerfile to CMD

**Why** — Why are these changes relevant or necessary?

Because node:20-alpine is built with /use/local/bin/entrypoint-docker.sh as ENTRYPOINT and butthing shell script in CMD makes no sense

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Docker installation guide to use `ENTRYPOINT` for running `./start.sh` in both Yarn and NPM `Dockerfile` examples. Minor formatting cleanups in imports and Vite HMR config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc3c6a34853ffc4c701956f624ae16be56cd712e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->