### PR TITLE
fix(docs): Remove spread operators and let mergeConfig handle merging

### DIFF
--- a/www/apps/book/app/learn/installation/docker/page.mdx
+++ b/www/apps/book/app/learn/installation/docker/page.mdx
@@ -369,9 +369,7 @@ module.exports = defineConfig({
   admin: {
     vite: (config) => {
       return {
-        ...config,
         server: {
-          ...config.server,
           host: "0.0.0.0",
           // Allow all hosts when running in Docker (development mode)
           // In production, this should be more restrictive
@@ -381,7 +379,6 @@ module.exports = defineConfig({
             "127.0.0.1",
           ],
           hmr: {
-            ...config.server?.hmr,
             // HMR websocket port inside container
             port: 5173,
             // Port browser connects to (exposed in docker-compose.yml)


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

We are already using `mergeConfig` to merge core vite config plus consuming project one and using the spread operator was causing duplicate plugin registration like stated [here](https://github.com/TanStack/router/issues/2718). Removed this from the docs.

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #14545 
