### PR TITLE
fix(core-flows): pass created_by to fulfillment input

### DIFF
--- a/.changeset/eight-nails-drop.md
+++ b/.changeset/eight-nails-drop.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): pass created_by to fulfillment input

--- a/integration-tests/modules/__tests__/order/workflows/create-fulfillment.spec.ts
+++ b/integration-tests/modules/__tests__/order/workflows/create-fulfillment.spec.ts
@@ -560,6 +560,52 @@ medusaIntegrationTestRunner({
         )
         expect(stockAvailability.valueOf()).toEqual(1)
       })
+
+      it("should persist created_by field when creating a fulfillment", async () => {
+        const order = await createOrderFixture({ container, product, location })
+        const itemWithInventory = order.items!.find(
+          (o) => o.variant_sku === variantSkuWithInventory
+        )!
+
+        const createdByUserId = "user_test_123"
+
+        // Create a fulfillment with created_by
+        const createOrderFulfillmentData: OrderWorkflow.CreateOrderFulfillmentWorkflowInput =
+          {
+            order_id: order.id,
+            created_by: createdByUserId,
+            items: [
+              {
+                id: itemWithInventory.id,
+                quantity: 1,
+              },
+            ],
+            no_notification: false,
+            location_id: undefined,
+          }
+
+        await createOrderFulfillmentWorkflow(container).run({
+          input: createOrderFulfillmentData,
+        })
+
+        const remoteQuery = container.resolve(
+          ContainerRegistrationKeys.REMOTE_QUERY
+        )
+        const remoteQueryObject = remoteQueryObjectFromString({
+          entryPoint: "order",
+          variables: {
+            id: order.id,
+          },
+          fields: ["*", "fulfillments.*"],
+        })
+
+        const [orderWithFulfillment] = await remoteQuery(remoteQueryObject)
+
+        expect(orderWithFulfillment.fulfillments).toHaveLength(1)
+        expect(orderWithFulfillment.fulfillments[0].created_by).toEqual(
+          createdByUserId
+        )
+      })
     })
   },
 })

--- a/packages/core/core-flows/src/order/workflows/create-fulfillment.ts
+++ b/packages/core/core-flows/src/order/workflows/create-fulfillment.ts
@@ -256,6 +256,7 @@ function prepareFulfillmentData({
       requires_shipping: someItemsRequireShipping,
       labels: input.labels ?? [],
       delivery_address: shippingAddress as any,
+      created_by: input.created_by,
       packed_at: new Date(),
       metadata: input.metadata,
     },


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Pass `created_by` to the return of the prepare fulfillment data function.

**Why** — Why are these changes relevant or necessary?  

Fulfillments get created without `created_by` fields.

**How** — How have these changes been implemented?

Pass missing fields in return.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration test

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #14492