### PR TITLE
chore: fix typos in comments

### DIFF
--- a/packages/admin/dashboard/src/components/data-grid/hooks/use-data-grid-keydown-event.tsx
+++ b/packages/admin/dashboard/src/components/data-grid/hooks/use-data-grid-keydown-event.tsx
@@ -353,7 +353,7 @@ export const useDataGridKeydownEvent = <
         setSingleRange(pos)
         scrollToCoordinates(pos, "vertical")
       } else {
-        // If the the user is at the last cell, we want to focus the container of the cell.
+        // If the user is at the last cell, we want to focus the container of the cell.
         const container = queryTool?.getContainer(anchor)
 
         container?.focus()

--- a/packages/core/orchestration/src/transaction/types.ts
+++ b/packages/core/orchestration/src/transaction/types.ts
@@ -25,7 +25,7 @@ export type TransactionStepsDefinition = {
 
   /**
    * Indicates whether the workflow should continue even if there is a permanent failure in this step.
-   * In case it is set to true, the the current step will be marked as TransactionStepState.PERMANENT_FAILURE and the next steps will be executed.
+   * In case it is set to true, the current step will be marked as TransactionStepState.PERMANENT_FAILURE and the next steps will be executed.
    */
   continueOnPermanentFailure?: boolean
 

--- a/packages/core/types/src/common/config-module.ts
+++ b/packages/core/types/src/common/config-module.ts
@@ -887,7 +887,7 @@ export type ProjectConfigOptions = {
      * This configuration specifies the supported authentication providers per actor type (such as `user`, `customer`, or any custom actors).
      * For example, you only want to allow SSO logins for `users`, while you want to allow email/password logins for `customers` to the storefront.
      *
-     * `authMethodsPerActor` is a a map where the actor type (eg. 'user') is the key, and the value is an array of supported auth provider IDs.
+     * `authMethodsPerActor` is a map where the actor type (eg. 'user') is the key, and the value is an array of supported auth provider IDs.
      *
      * @example
      * Some example values of common use cases:

--- a/packages/core/types/src/http/inventory-level/admin/payloads.ts
+++ b/packages/core/types/src/http/inventory-level/admin/payloads.ts
@@ -53,7 +53,7 @@ export interface AdminBatchInventoryItemLocationLevels {
   delete?: string[]
   /**
    * Whether to force the deletion of the inventory levels,
-   * even if the the location has stocked quantity.
+   * even if the location has stocked quantity.
    */
   force?: boolean
 }

--- a/packages/core/types/src/http/workflow-execution/admin/entities.ts
+++ b/packages/core/types/src/http/workflow-execution/admin/entities.ts
@@ -114,7 +114,7 @@ export interface WorkflowExecutionDefinition {
   noCompensation?: boolean
   /**
    * Indicates whether the workflow should continue even if there is a permanent failure in this step.
-   * In case it is set to true, the the current step will be marked as TransactionStepState.PERMANENT_FAILURE and the next steps will be executed.
+   * In case it is set to true, the current step will be marked as TransactionStepState.PERMANENT_FAILURE and the next steps will be executed.
    */
   continueOnPermanentFailure?: boolean
   /**

--- a/packages/core/types/src/modules-sdk/index.ts
+++ b/packages/core/types/src/modules-sdk/index.ts
@@ -278,7 +278,7 @@ export type ModuleExports<T = Constructor<any>> = {
     moduleDeclaration?: InternalModuleDeclaration
   ): Promise<void>
   /**
-   * Explicitly set the the true location of the module resources.
+   * Explicitly set the true location of the module resources.
    * Can be used to re-export the module from a different location and specify its original location.
    */
   discoveryPath?: string

--- a/packages/core/types/src/modules-sdk/module-provider.ts
+++ b/packages/core/types/src/modules-sdk/module-provider.ts
@@ -29,7 +29,7 @@ export type ModuleProviderExports<Service = any> = {
     moduleDeclaration?: any
   ): Promise<void>
   /**
-   * Explicitly set the the true location of the module resources.
+   * Explicitly set the true location of the module resources.
    * Can be used to re-export the module from a different location and specify its original location.
    */
   discoveryPath?: string

--- a/packages/core/utils/src/payment/abstract-payment-provider.ts
+++ b/packages/core/utils/src/payment/abstract-payment-provider.ts
@@ -537,7 +537,7 @@ export abstract class AbstractPaymentProvider<TConfig = Record<string, unknown>>
    * This method retrieves the payment's data from the third-party payment provider.
    *
    * @param input - The input to retrieve the payment. The `data` field should contain the data from the payment provider when the payment was created.
-   * @returns The payment's data as found in the the payment provider.
+   * @returns The payment's data as found in the payment provider.
    *
    * @example
    * // other imports...

--- a/www/utils/generated/oas-output/operations/admin/post_admin_products_[id]_variants_inventory-items_batch.ts
+++ b/www/utils/generated/oas-output/operations/admin/post_admin_products_[id]_variants_inventory-items_batch.ts
@@ -25,7 +25,7 @@
  *         properties:
  *           create:
  *             type: array
- *             description: The The associations to create between product variants and inventory items.
+ *             description: The associations to create between product variants and inventory items.
  *             items:
  *               type: object
  *               description: The associations to create between a product variant and an inventory item.

--- a/www/utils/packages/react-docs-generator/src/resolvers/custom-resolver.ts
+++ b/www/utils/packages/react-docs-generator/src/resolvers/custom-resolver.ts
@@ -66,7 +66,7 @@ export default class CustomResolver
               return
             }
             if (utils.isReactForwardRefCall(path)) {
-              // If the the inner function was previously identified as a component
+              // If the inner function was previously identified as a component
               // replace it with the parent node
               const inner = utils.resolveToValue(argument) as ComponentNodePath
               state.foundDefinitions.delete(inner)


### PR DESCRIPTION
Fix typos in comments:
- `The The` → `The`
- `the the` → `the` (x7)
- `a a` → `a`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up duplicated-word typos (e.g., `the the`, `The The`) across comments and documentation.
> 
> - Admin dashboard: small comment fix in `use-data-grid-keydown-event.tsx`
> - Orchestration/types, workflow-execution entities: JSDoc wording corrections
> - Core types: config module, inventory payloads, modules SDK (index/provider) comment fixes
> - Utils: payment provider JSDoc `retrievePayment` return description clarified
> - Docs/OAS: admin product variants inventory batch operation description fix
> - React docs generator: comment typo fix
> 
> No runtime or API changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feed3a7b428e0a8bb98a5b2fe2d0a3d5004f5360. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->