### PR TITLE
fix(core-flows): Prevent calling list methods unnecessarily in various update workflows

### DIFF
--- a/.changeset/modern-chairs-sit.md
+++ b/.changeset/modern-chairs-sit.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): Prevent calling list methods unnecessarily in various update workflows

--- a/integration-tests/http/__tests__/cart/store/cart.spec.ts
+++ b/integration-tests/http/__tests__/cart/store/cart.spec.ts
@@ -1,4 +1,7 @@
-import { createCartCreditLinesWorkflow } from "@medusajs/core-flows"
+import {
+  createCartCreditLinesWorkflow,
+  updateCartsStep,
+} from "@medusajs/core-flows"
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
 import {
   Modules,
@@ -19,6 +22,10 @@ import {
 import { setupTaxStructure } from "../../../../modules/__tests__/fixtures"
 import { createAuthenticatedCustomer } from "../../../../modules/helpers/create-authenticated-customer"
 import { medusaTshirtProduct } from "../../../__fixtures__/product"
+import {
+  createWorkflow,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
 
 jest.setTimeout(100000)
 
@@ -37,8 +44,13 @@ const shippingAddressData = {
 medusaIntegrationTestRunner({
   env,
   testSuite: ({ dbConnection, getContainer, api }) => {
+    let appContainer
+
+    beforeAll(async () => {
+      appContainer = getContainer()
+    })
+
     describe("Store Carts API", () => {
-      let appContainer
       let storeHeaders
       let storeHeadersWithCustomer
       let region,
@@ -50,10 +62,6 @@ medusaIntegrationTestRunner({
         promotion,
         shippingProfile,
         taxSeedData
-
-      beforeAll(async () => {
-        appContainer = getContainer()
-      })
 
       beforeEach(async () => {
         await createAdminUser(dbConnection, adminHeaders, appContainer)
@@ -5917,6 +5925,26 @@ medusaIntegrationTestRunner({
             message: "Shipping Options are invalid for cart.",
           })
         })
+      })
+    })
+
+    describe("workflows", () => {
+      it("updateCartsStep - should not call listCarts when data is empty", async () => {
+        const cartService = appContainer.resolve(Modules.CART)
+        const listCartsSpy = jest.spyOn(cartService, "listCarts")
+
+        const workflow = createWorkflow("test-workflow", () => {
+          return new WorkflowResponse(updateCartsStep([]))
+        })
+
+        const { result } = await workflow(appContainer).run({
+          input: [],
+        })
+
+        expect(result).toEqual([])
+        expect(listCartsSpy).not.toHaveBeenCalled()
+
+        listCartsSpy.mockRestore()
       })
     })
   },

--- a/integration-tests/http/__tests__/inventory/admin/inventory.spec.ts
+++ b/integration-tests/http/__tests__/inventory/admin/inventory.spec.ts
@@ -4,6 +4,7 @@ import {
   adminHeaders,
   createAdminUser,
 } from "../../../../helpers/create-admin-user"
+import { updateInventoryItemsWorkflow } from "@medusajs/core-flows"
 
 jest.setTimeout(30000)
 
@@ -16,8 +17,11 @@ medusaIntegrationTestRunner({
     let stockLocation3
 
     let shippingProfile
+    let container
     beforeEach(async () => {
       await createAdminUser(dbConnection, adminHeaders, getContainer())
+
+      container = getContainer()
 
       shippingProfile = (
         await api.post(
@@ -1088,6 +1092,29 @@ medusaIntegrationTestRunner({
           ).data.variant
 
           expect(updatedVariant2.inventory_items).toHaveLength(0)
+        })
+      })
+
+      describe("workflows", () => {
+        describe("updateInventoryItemsWorkflow", () => {
+          it("should not call listInventoryItems when updates is empty", async () => {
+            const inventoryService = container.resolve(Modules.INVENTORY)
+            const listInventoryItemsSpy = jest.spyOn(
+              inventoryService,
+              "listInventoryItems"
+            )
+
+            const { result } = await updateInventoryItemsWorkflow(
+              container
+            ).run({
+              input: { updates: [] },
+            })
+
+            expect(result).toEqual([])
+            expect(listInventoryItemsSpy).not.toHaveBeenCalled()
+
+            listInventoryItemsSpy.mockRestore()
+          })
         })
       })
     })

--- a/integration-tests/http/__tests__/inventory/admin/inventory.spec.ts
+++ b/integration-tests/http/__tests__/inventory/admin/inventory.spec.ts
@@ -1,4 +1,5 @@
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { Modules } from "@medusajs/utils"
 import {
   adminHeaders,
   createAdminUser,
@@ -274,6 +275,39 @@ medusaIntegrationTestRunner({
               deleted: [locationLevel2.id],
             })
           )
+        })
+
+        it("should not call listInventoryLevels when update array is empty", async () => {
+          const container = getContainer()
+          const inventoryService = container.resolve(Modules.INVENTORY)
+
+          const listInventoryLevelsSpy = jest.spyOn(
+            inventoryService,
+            "listInventoryLevels"
+          )
+
+          const result = await api.post(
+            `/admin/inventory-items/location-levels/batch`,
+            {
+              update: [],
+              create: [],
+              delete: [],
+            },
+            adminHeaders
+          )
+
+          expect(result.status).toEqual(200)
+          expect(result.data).toEqual(
+            expect.objectContaining({
+              created: [],
+              updated: [],
+              deleted: [],
+            })
+          )
+
+          expect(listInventoryLevelsSpy).not.toHaveBeenCalled()
+
+          listInventoryLevelsSpy.mockRestore()
         })
       })
 

--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -1,6 +1,6 @@
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
 import { AdminShippingOption } from "@medusajs/types"
-import { ModuleRegistrationName, ProductStatus } from "@medusajs/utils"
+import { ModuleRegistrationName, Modules, ProductStatus } from "@medusajs/utils"
 import {
   adminHeaders,
   createAdminUser,
@@ -10,6 +10,15 @@ import {
 import { setupTaxStructure } from "../../../../modules/__tests__/fixtures"
 import { createOrderSeeder } from "../../fixtures/order"
 import { createShippingOptionSeeder } from "../../fixtures/shipping"
+import {
+  updateOrderChangeActionsWorkflow,
+  updateOrderChangesWorkflow,
+  updateOrderShippingMethodsStep,
+} from "@medusajs/core-flows"
+import {
+  createWorkflow,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
 
 jest.setTimeout(300000)
 
@@ -20,10 +29,11 @@ medusaIntegrationTestRunner({
       inventoryItemOverride3,
       productOverride3,
       shippingProfile,
-      productOverride4
+      productOverride4,
+      container
 
     beforeEach(async () => {
-      const container = getContainer()
+      container = getContainer()
 
       await setupTaxStructure(container.resolve(ModuleRegistrationName.TAX))
       await createAdminUser(dbConnection, adminHeaders, container)
@@ -3582,6 +3592,60 @@ medusaIntegrationTestRunner({
         expect(response3.response.data.message).toBe(
           "Can only create credit lines if the order has a positive or negative pending difference"
         )
+      })
+    })
+
+    describe("workflows", () => {
+      it("updateOrderChangeActionsWorkflow - should not call listOrderChangeActions when orderChangeActions is empty", async () => {
+        const orderService = container.resolve(Modules.ORDER)
+        const listOrderChangeActionsSpy = jest.spyOn(
+          orderService,
+          "listOrderChangeActions"
+        )
+
+        const { result } = await updateOrderChangeActionsWorkflow(
+          container
+        ).run({
+          input: [],
+        })
+
+        expect(result).toEqual([])
+
+        expect(listOrderChangeActionsSpy).not.toHaveBeenCalled()
+        listOrderChangeActionsSpy.mockRestore()
+      })
+
+      it("updateOrderChangesWorkflow - should not call listOrderChanges when orderChanges is empty", async () => {
+        const orderService = container.resolve(Modules.ORDER)
+        const listOrderChangesSpy = jest.spyOn(orderService, "listOrderChanges")
+
+        const { result } = await updateOrderChangesWorkflow(container).run({
+          input: [],
+        })
+
+        expect(result).toEqual([])
+
+        expect(listOrderChangesSpy).not.toHaveBeenCalled()
+        listOrderChangesSpy.mockRestore()
+      })
+
+      it("updateOrderShippingMethodsStep - should not call listOrderShippingMethods when shipping methods is empty", async () => {
+        const orderService = container.resolve(Modules.ORDER)
+        const listOrderShippingMethodsSpy = jest.spyOn(
+          orderService,
+          "listOrderShippingMethods"
+        )
+
+        const workflow = createWorkflow("test-workflow", () => {
+          return new WorkflowResponse(updateOrderShippingMethodsStep([]))
+        })
+
+        const { result } = await workflow(container).run()
+
+        expect(result).toEqual([])
+
+        expect(listOrderShippingMethodsSpy).not.toHaveBeenCalled()
+        listOrderShippingMethodsSpy.mockRestore()
       })
     })
   },

--- a/integration-tests/http/__tests__/promotions/admin/promotions.spec.ts
+++ b/integration-tests/http/__tests__/promotions/admin/promotions.spec.ts
@@ -1,5 +1,10 @@
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
-import { Modules, ProductStatus, PromotionStatus, PromotionType } from "@medusajs/utils"
+import {
+  Modules,
+  ProductStatus,
+  PromotionStatus,
+  PromotionType,
+} from "@medusajs/utils"
 import {
   createAdminUser,
   generatePublishableKey,
@@ -7,6 +12,11 @@ import {
 } from "../../../../helpers/create-admin-user"
 import { setupTaxStructure } from "../../../../modules/__tests__/fixtures/tax"
 import { medusaTshirtProduct } from "../../../__fixtures__/product"
+import {
+  updateCampaignsWorkflow,
+  updatePromotionRulesWorkflow,
+  updatePromotionsWorkflow,
+} from "@medusajs/core-flows"
 
 jest.setTimeout(500000)
 
@@ -53,8 +63,12 @@ const standardPromotionPayload = {
 
 medusaIntegrationTestRunner({
   testSuite: ({ dbConnection, getContainer, api }) => {
+    let appContainer
+    beforeAll(async () => {
+      appContainer = getContainer()
+    })
+
     describe("Admin Promotions API", () => {
-      let appContainer
       let promotion
       let standardPromotion
       let shippingProfile
@@ -64,10 +78,6 @@ medusaIntegrationTestRunner({
         attribute: "old_attr",
         values: ["old value"],
       }
-
-      beforeAll(async () => {
-        appContainer = getContainer()
-      })
 
       beforeEach(async () => {
         await createAdminUser(dbConnection, adminHeaders, appContainer)
@@ -4113,6 +4123,55 @@ medusaIntegrationTestRunner({
             ])
           )
         })
+      })
+    })
+
+    describe("Promotions Workflows", () => {
+      it("updateCampaignsWorkflow - should not call listCampaigns when campaignsData is empty", async () => {
+        const promotionService = appContainer.resolve(Modules.PROMOTION)
+        const listCampaignsSpy = jest.spyOn(promotionService, "listCampaigns")
+
+        const { result } = await updateCampaignsWorkflow(appContainer).run({
+          input: { campaignsData: [] },
+        })
+
+        expect(result).toEqual([])
+        expect(listCampaignsSpy).not.toHaveBeenCalled()
+
+        listCampaignsSpy.mockRestore()
+      })
+
+      it("updatePromotionRulesWorkflow - should not call listPromotionRules when data is empty", async () => {
+        const promotionService = appContainer.resolve(Modules.PROMOTION)
+        const listPromotionRulesSpy = jest.spyOn(
+          promotionService,
+          "listPromotionRules"
+        )
+
+        const { result } = await updatePromotionRulesWorkflow(appContainer).run(
+          {
+            input: { data: [] },
+          }
+        )
+
+        expect(result).toEqual([])
+        expect(listPromotionRulesSpy).not.toHaveBeenCalled()
+
+        listPromotionRulesSpy.mockRestore()
+      })
+
+      it("updatePromotionsWorkflow - should not call listPromotions when promotionsData is empty", async () => {
+        const promotionService = appContainer.resolve(Modules.PROMOTION)
+        const listPromotionsSpy = jest.spyOn(promotionService, "listPromotions")
+
+        const { result } = await updatePromotionsWorkflow(appContainer).run({
+          input: { promotionsData: [] },
+        })
+
+        expect(result).toEqual([])
+        expect(listPromotionsSpy).not.toHaveBeenCalled()
+
+        listPromotionsSpy.mockRestore()
       })
     })
   },

--- a/integration-tests/http/__tests__/refund-reason/refund-reason.spec.ts
+++ b/integration-tests/http/__tests__/refund-reason/refund-reason.spec.ts
@@ -3,6 +3,8 @@ import {
   adminHeaders,
   createAdminUser,
 } from "../../../helpers/create-admin-user"
+import { Modules } from "@medusajs/utils"
+import { updateRefundReasonsWorkflow } from "@medusajs/core-flows"
 
 jest.setTimeout(30000)
 
@@ -10,9 +12,10 @@ medusaIntegrationTestRunner({
   testSuite: ({ dbConnection, api, getContainer }) => {
     let refundReason1
     let refundReason2
+    let appContainer
 
     beforeEach(async () => {
-      const appContainer = getContainer()
+      appContainer = getContainer()
       await createAdminUser(dbConnection, adminHeaders, appContainer)
 
       refundReason1 = (
@@ -44,11 +47,26 @@ medusaIntegrationTestRunner({
         expect(response.data.count).toEqual(5) // There are 3 default ones
         expect(response.data.refund_reasons).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ label: "Customer Care Adjustment", code: "customer_care_adjustment" }),
-            expect.objectContaining({ label: "Shipping Issue", code: "shipping_issue" }),
-            expect.objectContaining({ label: "Pricing Error", code: "pricing_error" }),
-            expect.objectContaining({ label: "reason 1 - too big", code: "too_big"  }),
-            expect.objectContaining({ label: "reason 2 - too small", code: "too_small"  }),
+            expect.objectContaining({
+              label: "Customer Care Adjustment",
+              code: "customer_care_adjustment",
+            }),
+            expect.objectContaining({
+              label: "Shipping Issue",
+              code: "shipping_issue",
+            }),
+            expect.objectContaining({
+              label: "Pricing Error",
+              code: "pricing_error",
+            }),
+            expect.objectContaining({
+              label: "reason 1 - too big",
+              code: "too_big",
+            }),
+            expect.objectContaining({
+              label: "reason 2 - too small",
+              code: "too_small",
+            }),
           ])
         )
       })
@@ -154,6 +172,25 @@ medusaIntegrationTestRunner({
               `Refund reason with id: ${refundReason1.id.id} not found`
             )
           })
+      })
+    })
+
+    describe("workflows", () => {
+      it("updateRefundReasonsWorkflow - should not call listRefundReasons when data is empty", async () => {
+        const paymentService = appContainer.resolve(Modules.PAYMENT)
+        const listRefundReasonsSpy = jest.spyOn(
+          paymentService,
+          "listRefundReasons"
+        )
+
+        const { result } = await updateRefundReasonsWorkflow(appContainer).run({
+          input: [],
+        })
+
+        expect(result).toEqual([])
+        expect(listRefundReasonsSpy).not.toHaveBeenCalled()
+
+        listRefundReasonsSpy.mockRestore()
       })
     })
   },

--- a/integration-tests/http/__tests__/reservations/admin/reservations.spec.ts
+++ b/integration-tests/http/__tests__/reservations/admin/reservations.spec.ts
@@ -3,6 +3,8 @@ import {
   adminHeaders,
   createAdminUser,
 } from "../../../../helpers/create-admin-user"
+import { Modules } from "@medusajs/utils"
+import { updateReservationsWorkflow } from "@medusajs/core-flows"
 
 jest.setTimeout(50000)
 
@@ -12,9 +14,14 @@ medusaIntegrationTestRunner({
     let inventoryItem2
     let stockLocation1
     let stockLocation2
+    let appContainer
+
+    beforeAll(async () => {
+      appContainer = getContainer()
+    })
 
     beforeEach(async () => {
-      await createAdminUser(dbConnection, adminHeaders, getContainer())
+      await createAdminUser(dbConnection, adminHeaders, appContainer)
 
       stockLocation1 = (
         await api.post(`/admin/stock-locations`, { name: "loc1" }, adminHeaders)
@@ -551,6 +558,26 @@ medusaIntegrationTestRunner({
           expect(reservationsRes.data.reservations.length).toBe(1)
           expect(reservationsRes.data.reservations[0].id).toBe(reservation2.id)
         })
+      })
+    })
+
+    describe("workflows", () => {
+      it("updateReservationsWorklow - should not call listReservations when data is empty", async () => {
+        const reservationService = appContainer.resolve(Modules.INVENTORY)
+
+        const listReservationItemsSpy = jest.spyOn(
+          reservationService,
+          "listReservationItems"
+        )
+
+        const { result } = await updateReservationsWorkflow(appContainer).run({
+          input: { updates: [] },
+        })
+
+        expect(result).toEqual([])
+        expect(listReservationItemsSpy).not.toHaveBeenCalled()
+
+        listReservationItemsSpy.mockRestore()
       })
     })
   },

--- a/integration-tests/http/__tests__/store/admin/store.spec.ts
+++ b/integration-tests/http/__tests__/store/admin/store.spec.ts
@@ -69,7 +69,7 @@ medusaIntegrationTestRunner({
         })
       })
 
-      describe.only("workflows", () => {
+      describe("workflows", () => {
         describe("createStoresWorkflow", () => {
           it("should not call listPricePreferences when supported_currencies is empty", async () => {
             const priceService = container.resolve(Modules.PRICING)

--- a/integration-tests/http/__tests__/store/admin/store.spec.ts
+++ b/integration-tests/http/__tests__/store/admin/store.spec.ts
@@ -5,6 +5,10 @@ import {
   adminHeaders,
   createAdminUser,
 } from "../../../../helpers/create-admin-user"
+import {
+  createStoresWorkflow,
+  updateStoresWorkflow,
+} from "@medusajs/core-flows"
 
 jest.setTimeout(90000)
 
@@ -65,20 +69,55 @@ medusaIntegrationTestRunner({
         })
       })
 
-      describe("POST /admin/stores", () => {
+      describe.only("workflows", () => {
+        describe("createStoresWorkflow", () => {
+          it("should not call listPricePreferences when supported_currencies is empty", async () => {
+            const priceService = container.resolve(Modules.PRICING)
+            const listPricePreferencesSpy = jest.spyOn(
+              priceService,
+              "listPricePreferences"
+            )
+
+            const { result } = await createStoresWorkflow(container).run({
+              input: {
+                stores: [
+                  {
+                    name: "New store",
+                    supported_currencies: [],
+                  },
+                ],
+              },
+            })
+
+            expect(result).toEqual([
+              expect.objectContaining({
+                name: "New store",
+                supported_currencies: [],
+              }),
+            ])
+
+            expect(listPricePreferencesSpy).not.toHaveBeenCalled()
+            listPricePreferencesSpy.mockRestore()
+          })
+        })
+      })
+
+      describe("POST /admin/stores/:id", () => {
         it("should update store", async () => {
-          const response = await api.post(
-            `/admin/stores/${store.id}`,
-            {
-              name: "Updated store",
-              
-              supported_currencies: [
-                { currency_code: "eur", is_default: true },
-                { currency_code: "usd" },
-              ],
-            },
-            adminHeaders
-          ).catch((e) => e)
+          const response = await api
+            .post(
+              `/admin/stores/${store.id}`,
+              {
+                name: "Updated store",
+
+                supported_currencies: [
+                  { currency_code: "eur", is_default: true },
+                  { currency_code: "usd" },
+                ],
+              },
+              adminHeaders
+            )
+            .catch((e) => e)
 
           expect(response.status).toEqual(200)
           expect(response.data.store).toEqual(

--- a/integration-tests/http/__tests__/tax-region/admin/tax-region.spec.ts
+++ b/integration-tests/http/__tests__/tax-region/admin/tax-region.spec.ts
@@ -1,5 +1,7 @@
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
 import { createAdminUser } from "../../../../helpers/create-admin-user"
+import { Modules } from "@medusajs/utils"
+import { updateTaxRegionsWorkflow } from "@medusajs/core-flows"
 
 jest.setTimeout(50000)
 
@@ -11,9 +13,15 @@ const adminHeaders = {
 medusaIntegrationTestRunner({
   env,
   testSuite: ({ dbConnection, getContainer, api }) => {
+    let container
+
+    beforeAll(async () => {
+      container = getContainer()
+    })
+
     describe("/admin/tax-regions", () => {
       beforeEach(async () => {
-        await createAdminUser(dbConnection, adminHeaders, getContainer())
+        await createAdminUser(dbConnection, adminHeaders, container)
       })
 
       describe("POST /admin/tax-regions/:id", () => {
@@ -152,6 +160,22 @@ medusaIntegrationTestRunner({
             message: 'TaxRegion with id "does-not-exist" not found',
             type: "not_found",
           })
+        })
+      })
+
+      describe("workflows", () => {
+        it("updateTaxRegionsWorkflow - should not call listTaxRegions when data is empty", async () => {
+          const taxService = container.resolve(Modules.TAX)
+          const listTaxRegionsSpy = jest.spyOn(taxService, "listTaxRegions")
+
+          const { result } = await updateTaxRegionsWorkflow(container).run({
+            input: [],
+          })
+
+          expect(result).toEqual([])
+          expect(listTaxRegionsSpy).not.toHaveBeenCalled()
+
+          listTaxRegionsSpy.mockRestore()
         })
       })
     })

--- a/integration-tests/modules/__tests__/product/workflows/update-product-variants.spec.ts
+++ b/integration-tests/modules/__tests__/product/workflows/update-product-variants.spec.ts
@@ -27,6 +27,25 @@ medusaIntegrationTestRunner({
           })
         })
 
+        describe("invocation", () => {
+          it("should not call listProductVariants when update array is empty", async () => {
+            const workflow = updateProductVariantsWorkflow(appContainer)
+            const listProductVariantsSpy = jest.spyOn(
+              service,
+              "listProductVariants"
+            )
+
+            const { result } = await workflow.run({
+              input: { product_variants: [] },
+              throwOnError: false,
+            })
+
+            expect(result).toHaveLength(0)
+
+            expect(listProductVariantsSpy).not.toHaveBeenCalled()
+            listProductVariantsSpy.mockRestore()
+          })
+        })
         describe("compensation", () => {
           it("should revert the updated variants using product_variants if the hook fails", async () => {
             const workflow = updateProductVariantsWorkflow(appContainer)

--- a/packages/core/core-flows/src/cart/steps/update-carts.ts
+++ b/packages/core/core-flows/src/cart/steps/update-carts.ts
@@ -30,6 +30,13 @@ export const updateCartsStep = createStep(
   async (data: UpdateCartsStepInput, { container }) => {
     const cartModule = container.resolve<ICartModuleService>(Modules.CART)
 
+    if (!data.length) {
+      return new StepResponse([], {
+        cartsBeforeUpdate: [],
+        addressesBeforeUpdate: [],
+      })
+    }
+
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data, {
       requiredFields: [
         "id",
@@ -81,18 +88,18 @@ export const updateCartsStep = createStep(
       return
     }
 
-	const { cartsBeforeUpdate, addressesBeforeUpdate } = dataToCompensate
+    const { cartsBeforeUpdate, addressesBeforeUpdate } = dataToCompensate
 
     const cartModule = container.resolve<ICartModuleService>(Modules.CART)
 
-	const addressesToUpdate: UpdateAddressDTO[] = []
-	for (const address of addressesBeforeUpdate) {
-		addressesToUpdate.push({
-			...address,
-			metadata: address.metadata ?? undefined
-		})
-	}
-	await cartModule.updateAddresses(addressesToUpdate)
+    const addressesToUpdate: UpdateAddressDTO[] = []
+    for (const address of addressesBeforeUpdate) {
+      addressesToUpdate.push({
+        ...address,
+        metadata: address.metadata ?? undefined,
+      })
+    }
+    await cartModule.updateAddresses(addressesToUpdate)
 
     const dataToUpdate: UpdateCartDTO[] = []
 

--- a/packages/core/core-flows/src/inventory/steps/update-inventory-items.ts
+++ b/packages/core/core-flows/src/inventory/steps/update-inventory-items.ts
@@ -26,6 +26,15 @@ export const updateInventoryItemsStep = createStep(
     const inventoryService = container.resolve<IInventoryService>(
       Modules.INVENTORY
     )
+
+    if (!input.length) {
+      return new StepResponse([], {
+        dataBeforeUpdate: [],
+        selects: [],
+        relations: [],
+      })
+    }
+
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(input)
 
     const dataBeforeUpdate = await inventoryService.listInventoryItems(

--- a/packages/core/core-flows/src/inventory/steps/update-inventory-levels.ts
+++ b/packages/core/core-flows/src/inventory/steps/update-inventory-levels.ts
@@ -27,6 +27,14 @@ export const updateInventoryLevelsStep = createStep(
       Modules.INVENTORY
     )
 
+    if (!input.length) {
+      return new StepResponse([], {
+        dataBeforeUpdate: [],
+        selects: [],
+        relations: [],
+      })
+    }
+
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(input)
 
     const dataBeforeUpdate = await inventoryService.listInventoryLevels(

--- a/packages/core/core-flows/src/order/steps/update-order-change-actions.ts
+++ b/packages/core/core-flows/src/order/steps/update-order-change-actions.ts
@@ -23,6 +23,10 @@ export const updateOrderChangeActionsStep = createStep(
   async (data: UpdateOrderChangeActionsStepInput, { container }) => {
     const service = container.resolve<IOrderModuleService>(Modules.ORDER)
 
+    if (!data.length) {
+      return new StepResponse([], [])
+    }
+
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data, {
       objectFields: ["metadata", "details"],
     })

--- a/packages/core/core-flows/src/order/steps/update-order-changes.ts
+++ b/packages/core/core-flows/src/order/steps/update-order-changes.ts
@@ -22,6 +22,10 @@ export const updateOrderChangesStep = createStep(
   async (data: UpdateOrderChangesStepInput, { container }) => {
     const service = container.resolve<IOrderModuleService>(Modules.ORDER)
 
+    if (!data.length) {
+      return new StepResponse([], [])
+    }
+
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data, {
       objectFields: ["metadata"],
     })

--- a/packages/core/core-flows/src/order/steps/update-shipping-methods.ts
+++ b/packages/core/core-flows/src/order/steps/update-shipping-methods.ts
@@ -22,6 +22,10 @@ export const updateOrderShippingMethodsStep = createStep(
   async (data: UpdateOrderShippingMethodsStepInput, { container }) => {
     const service = container.resolve<IOrderModuleService>(Modules.ORDER)
 
+    if (!data.length) {
+      return new StepResponse([], [])
+    }
+
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data, {
       objectFields: ["metadata"],
     })

--- a/packages/core/core-flows/src/payment-collection/steps/update-refund-reasons.ts
+++ b/packages/core/core-flows/src/payment-collection/steps/update-refund-reasons.ts
@@ -22,6 +22,11 @@ export const updateRefundReasonsStep = createStep(
   updateRefundReasonStepId,
   async (data: UpdateRefundReasonStepInput, { container }) => {
     const ids = data.map((d) => d.id)
+
+    if (!data.length) {
+      return new StepResponse([], [])
+    }
+
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data)
     const service = container.resolve<IPaymentModuleService>(Modules.PAYMENT)
 

--- a/packages/core/core-flows/src/pricing/steps/update-price-preferences-as-array.ts
+++ b/packages/core/core-flows/src/pricing/steps/update-price-preferences-as-array.ts
@@ -19,7 +19,7 @@ export const updatePricePreferencesAsArrayStepId =
   "update-price-preferences-as-array"
 /**
  * This step creates or updates price preferences.
- * 
+ *
  * @example
  * const data = updatePricePreferencesAsArrayStep([
  *   {
@@ -33,6 +33,10 @@ export const updatePricePreferencesAsArrayStep = createStep(
   updatePricePreferencesAsArrayStepId,
   async (input: UpdatePricePreferencesAsArrayStepInput, { container }) => {
     const service = container.resolve<IPricingModuleService>(Modules.PRICING)
+
+    if (!input.length) {
+      return new StepResponse([], { prevData: [], newDataIds: [] })
+    }
 
     const prevData = await service.listPricePreferences({
       $or: input.map((entry) => {

--- a/packages/core/core-flows/src/product/steps/update-product-variants.ts
+++ b/packages/core/core-flows/src/product/steps/update-product-variants.ts
@@ -74,6 +74,10 @@ export const updateProductVariantsStep = createStep(
         )
       }
 
+      if (!data.product_variants.length) {
+        return new StepResponse([], [])
+      }
+
       const prevData = await service.listProductVariants({
         id: data.product_variants.map((p) => p.id) as string[],
       })

--- a/packages/core/core-flows/src/promotion/steps/update-campaigns.ts
+++ b/packages/core/core-flows/src/promotion/steps/update-campaigns.ts
@@ -12,7 +12,7 @@ import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
 export const updateCampaignsStepId = "update-campaigns"
 /**
  * This step updates one or more campaigns.
- * 
+ *
  * @example
  * const data = updateCampaignsStep([{
  *   id: "camp_123",
@@ -25,6 +25,14 @@ export const updateCampaignsStep = createStep(
     const promotionModule = container.resolve<IPromotionModuleService>(
       Modules.PROMOTION
     )
+
+    if (!data.length) {
+      return new StepResponse([], {
+        dataBeforeUpdate: [],
+        selects: [],
+        relations: [],
+      })
+    }
 
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data)
     const dataBeforeUpdate = await promotionModule.listCampaigns(

--- a/packages/core/core-flows/src/promotion/steps/update-promotion-rules.ts
+++ b/packages/core/core-flows/src/promotion/steps/update-promotion-rules.ts
@@ -8,7 +8,7 @@ import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
 export const updatePromotionRulesStepId = "update-promotion-rules"
 /**
  * This step updates one or more promotion rules.
- * 
+ *
  * @example
  * const data = updatePromotionRulesStep({
  *   data: [
@@ -27,6 +27,10 @@ export const updatePromotionRulesStep = createStep(
     const promotionModule = container.resolve<IPromotionModuleService>(
       Modules.PROMOTION
     )
+
+    if (!data.length) {
+      return new StepResponse([], [])
+    }
 
     const promotionRulesBeforeUpdate = await promotionModule.listPromotionRules(
       { id: data.map((d) => d.id) },

--- a/packages/core/core-flows/src/promotion/steps/update-promotions.ts
+++ b/packages/core/core-flows/src/promotion/steps/update-promotions.ts
@@ -12,7 +12,7 @@ import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
 export const updatePromotionsStepId = "update-promotions"
 /**
  * This step updates one or more promotions.
- * 
+ *
  * @example
  * const data = updatePromotionsStep([
  *   {
@@ -27,6 +27,14 @@ export const updatePromotionsStep = createStep(
     const promotionModule = container.resolve<IPromotionModuleService>(
       Modules.PROMOTION
     )
+
+    if (!data.length) {
+      return new StepResponse([], {
+        dataBeforeUpdate: [],
+        selects: [],
+        relations: [],
+      })
+    }
 
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data)
     const dataBeforeUpdate = await promotionModule.listPromotions(

--- a/packages/core/core-flows/src/reservation/steps/update-reservations.ts
+++ b/packages/core/core-flows/src/reservation/steps/update-reservations.ts
@@ -35,6 +35,14 @@ export const updateReservationsStep = createStep(
       Modules.INVENTORY
     )
 
+    if (!data.length) {
+      return new StepResponse([], {
+        dataBeforeUpdate: [],
+        selects: [],
+        relations: [],
+      })
+    }
+
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data)
     const dataBeforeUpdate = await inventoryModuleService.listReservationItems(
       { id: data.map((d) => d.id) },

--- a/packages/core/core-flows/src/tax/steps/update-tax-regions.ts
+++ b/packages/core/core-flows/src/tax/steps/update-tax-regions.ts
@@ -30,6 +30,11 @@ export const updateTaxRegionsStep = createStep(
   updateTaxRegionsStepId,
   async (data: UpdateTaxRegionDTO[], { container }) => {
     const service = container.resolve<ITaxModuleService>(Modules.TAX)
+
+    if (!data.length) {
+      return new StepResponse([], [])
+    }
+
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data)
 
     const prevData = await service.listTaxRegions(


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Prevent unnecessary list queries on various update workflows.

**Why** — Why are these changes relevant or necessary?  

Passing empty inputs to various update workflows/steps causes unnecessary queries.

**How** — How have these changes been implemented?

Added checks to short-circuit the execution if the input is empty.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #14490

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix:** Skip unnecessary queries when update inputs are empty.
> 
> - Add empty-input short-circuits to `updateCartsStep`, `updateInventoryItemsStep`, `updateInventoryLevelsStep`, `updateOrderChangeActionsStep`, `updateOrderChangesStep`, `updateOrderShippingMethodsStep`, `updateRefundReasonsStep`, `updatePricePreferencesAsArrayStep`, `updateProductVariantsStep`, `updateCampaignsStep`, `updatePromotionRulesStep`, `updatePromotionsStep`, `updateReservationsStep`, and `updateTaxRegionsStep`
> - Integration tests across carts, inventory, orders, promotions, refund reasons, reservations, store pricing, tax regions, and product variants to assert no `list*` calls on empty inputs and return `[]`
> - Minor test setup refactors to reuse `container`/`appContainer`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1335a64ba958b0df2d0e9db7acb9f27a39c78e0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->