### PR TITLE
fix(admin): Fix table cell stacking in RTL languages

### DIFF
--- a/.changeset/rtl-table-start-68px.md
+++ b/.changeset/rtl-table-start-68px.md
@@ -2,4 +2,4 @@
 "@medusajs/dashboard": patch
 ---
 
-Use start-[68px] for RTL table sticky cells.
+fix(dashboard): Use start-[68px] for RTL table sticky cells.

--- a/.changeset/rtl-table-start-68px.md
+++ b/.changeset/rtl-table-start-68px.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+Use start-[68px] for RTL table sticky cells.

--- a/packages/admin/dashboard/src/components/table/data-table/data-table-root/data-table-root.tsx
+++ b/packages/admin/dashboard/src/components/table/data-table/data-table-root/data-table-root.tsx
@@ -178,7 +178,7 @@ export const DataTableRoot = <TData,>({
                             className={clx({
                               "bg-ui-bg-subtle sticky left-0 after:absolute after:inset-y-0 after:right-0 after:h-full after:w-px after:bg-transparent after:content-['']":
                                 isStickyHeader,
-                              "left-[68px]":
+                              "start-[68px]":
                                 isStickyHeader && hasSelect && !isSelectHeader,
                               "after:bg-ui-border-base":
                                 showStickyBorder &&
@@ -267,7 +267,7 @@ export const DataTableRoot = <TData,>({
                               isStickyCell,
                             "bg-ui-bg-subtle group-hover/row:bg-ui-bg-subtle-hover":
                               isOdd && isStickyCell,
-                            "left-[68px]": hasLeftOffset,
+                            "start-[68px]": hasLeftOffset,
                             "after:bg-ui-border-base":
                               showStickyBorder && isStickyCell && !isSelectCell,
                             "!bg-ui-bg-disabled !hover:bg-ui-bg-disabled":

--- a/packages/admin/dashboard/src/components/table/data-table/data-table-root/data-table-root.tsx
+++ b/packages/admin/dashboard/src/components/table/data-table/data-table-root/data-table-root.tsx
@@ -176,7 +176,7 @@ export const DataTableRoot = <TData,>({
                                 : undefined,
                             }}
                             className={clx({
-                              "bg-ui-bg-subtle sticky left-0 after:absolute after:inset-y-0 after:right-0 after:h-full after:w-px after:bg-transparent after:content-['']":
+                              "bg-ui-bg-subtle sticky start-0 after:absolute after:inset-y-0 after:right-0 after:h-full after:w-px after:bg-transparent after:content-['']":
                                 isStickyHeader,
                               "start-[68px]":
                                 isStickyHeader && hasSelect && !isSelectHeader,
@@ -263,7 +263,7 @@ export const DataTableRoot = <TData,>({
                           key={cell.id}
                           className={clx({
                             "!ps-0 !pe-0": shouldRenderAsLink,
-                            "bg-ui-bg-base group-data-[selected=true]/row:bg-ui-bg-highlight group-data-[selected=true]/row:group-hover/row:bg-ui-bg-highlight-hover group-hover/row:bg-ui-bg-base-hover transition-fg group-has-[[data-row-link]:focus-visible]:bg-ui-bg-base-hover sticky left-0 after:absolute after:inset-y-0 after:right-0 after:h-full after:w-px after:bg-transparent after:content-['']":
+                            "bg-ui-bg-base group-data-[selected=true]/row:bg-ui-bg-highlight group-data-[selected=true]/row:group-hover/row:bg-ui-bg-highlight-hover group-hover/row:bg-ui-bg-base-hover transition-fg group-has-[[data-row-link]:focus-visible]:bg-ui-bg-base-hover sticky start-0 after:absolute after:inset-y-0 after:right-0 after:h-full after:w-px after:bg-transparent after:content-['']":
                               isStickyCell,
                             "bg-ui-bg-subtle group-hover/row:bg-ui-bg-subtle-hover":
                               isOdd && isStickyCell,


### PR DESCRIPTION
Replace 'left-[68px]' with 'start-[68px]' in data table sticky cells to properly support RTL languages

The 'start-*' utility automatically adapts to text direction (left in LTR, right in RTL), preventing table cells from stacking and hiding checkboxes in Hebrew and other RTL languages.

Fixes #14489

## Summary

**What** — What changes are introduced in this PR?

Changed the CSS positioning utility from `left-[68px]` to `start-[68px]` in two locations within the data table component for sticky header and body cells.

**Why** — Why are these changes relevant or necessary?

In RTL (Right-to-Left) languages like Hebrew and Arabic, the admin dashboard's data tables were displaying incorrectly. Table cells with checkboxes were stacking on top of each other, making checkboxes invisible in the Fulfillment Providers section (Settings → Locations & Shipping → Edit Fulfillment Providers). This prevented users from selecting providers in RTL language mode.

**How** — How have these changes been implemented?

Replaced the absolute positioning class `left-[68px]` with the logical property `start-[68px]` in the `data-table-root.tsx` component. Tailwind's `start-*` utility is a logical property that automatically becomes `left-*` in LTR languages and `right-*` in RTL languages, ensuring proper layout in both text directions.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

1. Build verification: The admin dashboard builds successfully with no errors
2. Unit tests: All existing tests pass
3. Manual testing steps:
   - Switch admin dashboard language to Hebrew (עברית) or Arabic
   - Navigate to Settings → Locations & Shipping
   - Select a location → Edit Fulfillment Providers
   - Verify checkboxes are visible and table cells are properly aligned (not stacked)

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.
```tsx
// Before (broken in RTL):
className={clx({
  "left-[68px]": hasLeftOffset,  // Always positions from left side
})}

// After (works in both LTR and RTL):
className={clx({
  "start-[68px]": hasLeftOffset,  // Positions from start (left in LTR, right in RTL)
})}
```

Visual comparison:
- LTR (English): `start-[68px]` → `left: 68px` ✅
- RTL (Hebrew): `start-[68px]` → `right: 68px` ✅

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

- This is a CSS-only fix with no breaking changes
- The `start-*` Tailwind utility is a standard logical property supported in all modern browsers
- Only affects the visual positioning in RTL languages; LTR behavior remains unchanged
- Reported by @amir-konimbo with screenshots showing the issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures sticky table header and first-column cells position correctly in RTL.
> 
> - In `data-table-root.tsx`, replace `left-0`/`left-[68px]` with `start-0`/`start-[68px]` for sticky header and body cells
> - Add changeset entry `rtl-table-start-68px.md` for `@medusajs/dashboard` patch release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39a1eafc5fe3f70dabe06e6bfdc0f34004025bfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->