### PR TITLE
docs: fix digital products recipe duplicates bug

### DIFF
--- a/www/apps/book/app/learn/fundamentals/workflows/constructor-constraints/page.mdx
+++ b/www/apps/book/app/learn/fundamentals/workflows/constructor-constraints/page.mdx
@@ -331,6 +331,42 @@ In a workflow, don't use try-catch blocks to handle errors.
 
 Instead, refer to the [Error Handling](../errors/page.mdx) chapter for alternative ways to handle errors.
 
+### No Object Property Spreading
+
+You can’t spread object properties using the spread operator (`...`) in a workflow's constructor function.
+
+Instead, use `transform` to create new objects with the desired properties.
+
+```ts
+// Don't
+const myWorkflow = createWorkflow(
+  "hello-world", 
+  function (input: WorkflowInput) {
+    const { prop1, ...rest } = input
+    
+    // use rest
+})
+
+// Do
+import { transform } from "@medusajs/framework/workflows-sdk"
+
+const myWorkflow = createWorkflow(
+  "hello-world", 
+  function (input: WorkflowInput) {
+    const rest = transform(
+      {
+        input,
+      },
+      (data) => {
+        const { prop1, ...rest } = data.input
+        return rest
+      }
+    )
+
+    // use rest
+})
+```
+
 ---
 
 ## Returned Value Constraints

--- a/www/apps/book/generated/edit-dates.mjs
+++ b/www/apps/book/generated/edit-dates.mjs
@@ -31,7 +31,7 @@ export const generatedEditDates = {
   "app/learn/fundamentals/modules/module-link-directions/page.mdx": "2024-07-24T09:16:01+02:00",
   "app/learn/fundamentals/admin/page.mdx": "2025-11-26T10:47:12.412Z",
   "app/learn/fundamentals/workflows/long-running-workflow/page.mdx": "2025-08-01T07:16:21.736Z",
-  "app/learn/fundamentals/workflows/constructor-constraints/page.mdx": "2025-08-01T13:11:18.823Z",
+  "app/learn/fundamentals/workflows/constructor-constraints/page.mdx": "2026-01-19T08:52:11.486Z",
   "app/learn/fundamentals/data-models/write-migration/page.mdx": "2025-12-30T11:36:13.929Z",
   "app/learn/fundamentals/data-models/manage-relationships/page.mdx": "2025-04-25T14:16:41.124Z",
   "app/learn/fundamentals/modules/remote-query/page.mdx": "2024-07-21T21:20:24+02:00",

--- a/www/apps/resources/app/integrations/guides/paypal/page.mdx
+++ b/www/apps/resources/app/integrations/guides/paypal/page.mdx
@@ -210,7 +210,7 @@ Add the following method to the `PayPalPaymentProviderService` class:
 
 ```ts title="src/modules/paypal/service.ts"
 import { 
-  MedusaError
+  MedusaError,
 } from "@medusajs/framework/utils"
 
 class PayPalPaymentProviderService extends AbstractPaymentProvider<Options> {
@@ -317,7 +317,7 @@ class PayPalPaymentProviderService extends AbstractPaymentProvider<Options> {
           status: order.status,
           approval_url: approvalUrl,
           session_id: input.data?.session_id,
-          currency_code
+          currency_code,
         },
       }
     } catch (error: any) {
@@ -570,7 +570,7 @@ class PayPalPaymentProviderService extends AbstractPaymentProvider<Options> {
           currencyCode: (input.data?.currency_code as string | undefined)
             ?.toUpperCase() || "",
           value: new BigNumber(input.amount).numeric.toString(),
-        }
+        },
       }
 
       const response = await this.paymentsController_.refundCapturedPayment({
@@ -659,8 +659,8 @@ class PayPalPaymentProviderService extends AbstractPaymentProvider<Options> {
             op: PatchOp.Replace,
             path: "/purchase_units/@reference_id=='default'/amount/value",
             value: new BigNumber(input.amount).numeric.toString(),
-          }
-        ]
+          },
+        ],
       })
 
       return {
@@ -1151,7 +1151,7 @@ class PayPalPaymentProviderService extends AbstractPaymentProvider<Options> {
 
       // Extract order ID and amount from webhook payload
       const resource = (data as any)?.resource
-      let sessionId: string | undefined = (data as any)?.resource?.custom_id
+      const sessionId: string | undefined = (data as any)?.resource?.custom_id
 
       if (!sessionId) {
         this.logger_.warn("Session ID not found in PayPal webhook resource")

--- a/www/apps/resources/app/recipes/digital-products/examples/standard/page.mdx
+++ b/www/apps/resources/app/recipes/digital-products/examples/standard/page.mdx
@@ -583,10 +583,10 @@ In the compensation function, you delete the digital product medias.
 Finally, create the file `src/workflows/create-digital-product/index.ts` with the following content:
 
 export const createDpWorkflowHighlights = [
-  ["36", "createProductsWorkflow", "Create the Medusa product."],
-  ["42", "createDigitalProductStep", "Create the digital product."],
-  ["46", "createDigitalProductMediasStep", "Create the digital product's medias."],
-  ["60", "createRemoteLinkStep", "Link the digital product to the first variant of the product."],
+  ["34", "createProductsWorkflow", "Create the Medusa product."],
+  ["47", "createDigitalProductStep", "Create the digital product."],
+  ["51", "createDigitalProductMediasStep", "Create the digital product's medias."],
+  ["65", "createRemoteLinkStep", "Link the digital product to the first variant of the product."],
 ]
 
 ```ts title="src/workflows/create-digital-product/index.ts" highlights={createDpWorkflowHighlights} collapsibleLines="1-23" expandMoreLabel="Show Imports"
@@ -623,13 +623,18 @@ type CreateDigitalProductWorkflowInput = {
 const createDigitalProductWorkflow = createWorkflow(
   "create-digital-product",
   (input: CreateDigitalProductWorkflowInput) => {
-    const { medias, ...digitalProductData } = input.digital_product
-
     const product = createProductsWorkflow.runAsStep({
       input: {
         products: [input.product],
       },
     })
+
+    const digitalProductData = transform(
+      input,
+      (data) => ({
+        name: data.digital_product.name,
+      })
+    )
 
     const { digital_product } = createDigitalProductStep(
       digitalProductData
@@ -638,10 +643,10 @@ const createDigitalProductWorkflow = createWorkflow(
     const { digital_product_medias } = createDigitalProductMediasStep(
       transform({
         digital_product,
-        medias,
+        input,
       },
       (data) => ({
-        medias: data.medias.map((media) => ({
+        medias: data.input.digital_product.medias.map((media) => ({
           ...media,
           digital_product_id: data.digital_product.id,
         })),
@@ -658,12 +663,20 @@ const createDigitalProductWorkflow = createWorkflow(
       },
     }])
 
-    return new WorkflowResponse({
-      digital_product: {
-        ...digital_product,
-        medias: digital_product_medias,
+    const returnData = transform(
+      {
+        digital_product,
+        digital_product_medias,
       },
-    })
+      (data) => ({
+        digital_product: {
+          ...data.digital_product,
+          medias: data.digital_product_medias,
+        },
+      })
+    )
+
+    return new WorkflowResponse(returnData)
   }
 )
 
@@ -727,7 +740,7 @@ export const POST = async (
         medias: req.validatedBody.medias.map((media) => ({
           fileId: media.file_id,
           mimeType: media.mime_type,
-          ...media,
+          type: media.type,
         })) as Omit<CreateDigitalProductMediaInput, "digital_product_id">[],
       },
       product: {

--- a/www/apps/resources/generated/edit-dates.mjs
+++ b/www/apps/resources/generated/edit-dates.mjs
@@ -110,7 +110,7 @@ export const generatedEditDates = {
   "app/nextjs-starter/page.mdx": "2026-01-14T08:32:07.149Z",
   "app/recipes/b2b/page.mdx": "2025-05-20T07:51:40.718Z",
   "app/recipes/commerce-automation/page.mdx": "2025-05-20T07:51:40.719Z",
-  "app/recipes/digital-products/examples/standard/page.mdx": "2025-11-28T09:43:09.959Z",
+  "app/recipes/digital-products/examples/standard/page.mdx": "2026-01-19T08:52:36.209Z",
   "app/recipes/digital-products/page.mdx": "2025-05-20T07:51:40.719Z",
   "app/recipes/ecommerce/page.mdx": "2025-06-24T08:50:10.116Z",
   "app/recipes/marketplace/examples/vendors/page.mdx": "2025-11-28T10:09:41.993Z",
@@ -6937,5 +6937,6 @@ export const generatedEditDates = {
   "app/integrations/guides/okta/page.mdx": "2025-12-30T06:35:28.653Z",
   "app/nextjs-starter/guides/remove-country-code/page.mdx": "2025-12-30T10:28:10.072Z",
   "app/commerce-modules/translation/custom-data-models/page.mdx": "2026-01-06T15:54:25.801Z",
-  "app/troubleshooting/nextjs-node-25/page.mdx": "2026-01-14T08:34:00.550Z"
+  "app/troubleshooting/nextjs-node-25/page.mdx": "2026-01-14T08:34:00.550Z",
+  "app/integrations/guides/paypal/page.mdx": "2026-01-19T08:52:36.209Z"
 }


### PR DESCRIPTION
1. Fix a bug in the digital products recipe that caused duplicate medias to be created.
2. Other: document object spreading as workflow constraint

Closes #14499

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an additional workflow constructor constraint and updates the digital products recipe to remove object spreading that led to duplicate media creation.
> 
> - Adds **“No Object Property Spreading”** constraint to `learn/fundamentals/workflows/constructor-constraints/page.mdx` with `transform`-based alternatives
> - Refactors `create-digital-product` workflow and admin API example to use `transform` instead of spreading, ensuring medias are mapped once and fixing duplicates (`createDigitalProductWorkflow`, API `POST /admin/digital-products` mapping)
> - Adjusts code samples/highlights in the digital products recipe to updated line numbers and data flow
> - Minor doc cleanups: PayPal guide sample fixes (trailing commas, `const` usage), typo fix (“exchaneg” → “exchange”), Dockerfile snippet uses `ENTRYPOINT` instead of `CMD`, and removes unnecessary spread in Vite config examples
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56158d9064d3726fa0db3708eeada8828831a59b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->