### PR TITLE
docs: add missing .yarn/releases in dockerfile

### DIFF
--- a/www/apps/book/app/learn/installation/docker/page.mdx
+++ b/www/apps/book/app/learn/installation/docker/page.mdx
@@ -221,7 +221,7 @@ FROM node:20-alpine
 WORKDIR /server
 
 # Copy package files and yarn config
-COPY package.json yarn.lock .yarnrc.yml ./
+COPY package.json yarn.lock .yarnrc.yml .yarn/releases ./
 
 # Install all dependencies using yarn
 RUN yarn install

--- a/www/apps/book/generated/edit-dates.mjs
+++ b/www/apps/book/generated/edit-dates.mjs
@@ -123,7 +123,7 @@ export const generatedEditDates = {
   "app/learn/fundamentals/module-links/index/page.mdx": "2025-05-23T07:57:58.958Z",
   "app/learn/fundamentals/module-links/index-module/page.mdx": "2026-01-06T15:53:03.957Z",
   "app/learn/introduction/build-with-llms-ai/page.mdx": "2025-12-09T14:17:13.295Z",
-  "app/learn/installation/docker/page.mdx": "2025-12-18T11:18:25.856Z",
+  "app/learn/installation/docker/page.mdx": "2026-01-19T11:26:15.574Z",
   "app/learn/fundamentals/generated-types/page.mdx": "2026-01-06T06:38:15.719Z",
   "app/learn/introduction/from-v1-to-v2/page.mdx": "2025-10-29T11:55:11.531Z",
   "app/learn/debugging-and-testing/debug-workflows/page.mdx": "2025-07-30T13:45:14.117Z",


### PR DESCRIPTION
Closes DX-2444

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Docker installation docs to ensure Yarn release files are included in Docker builds.
> 
> - In `app/learn/installation/docker/page.mdx` and `public/llms-full.txt`, the Yarn Dockerfile `COPY` now includes `.yarn/releases`
> - Regenerates `generated/edit-dates.mjs` for the updated page
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed708e643b49d754dc65aa749869e3d16c6a6d87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->