### PR TITLE
fix(cli): show clear error when running outside a Medusa project

### DIFF
--- a/.changeset/nine-forks-jog.md
+++ b/.changeset/nine-forks-jog.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/cli": patch
+---
+
+fix(cli): show clear error when running outside a Medusa directory

--- a/packages/cli/medusa-cli/src/create-cli.ts
+++ b/packages/cli/medusa-cli/src/create-cli.ts
@@ -593,12 +593,11 @@ function isLocalMedusaProject() {
       `./package.json`
     ))
     inMedusaProject = !!(
-      (dependencies && dependencies["@medusajs/medusa"]) ||
-      (devDependencies && devDependencies["@medusajs/medusa"]) ||
-      // need it for plugin projects like draft order,
-      // which can't have @medusajs/medusa as dependency
-      (dependencies && dependencies["@medusajs/cli"]) ||
-      (devDependencies && devDependencies["@medusajs/cli"])
+      (dependencies &&
+        (dependencies["@medusajs/medusa"] || dependencies["@medusajs/cli"])) ||
+      (devDependencies &&
+        (devDependencies["@medusajs/medusa"] ||
+          devDependencies["@medusajs/cli"]))
     )
   } catch (err) {
     // ignore

--- a/packages/cli/medusa-cli/src/create-cli.ts
+++ b/packages/cli/medusa-cli/src/create-cli.ts
@@ -592,6 +592,8 @@ function isLocalMedusaProject() {
     const { dependencies, devDependencies } = require(path.resolve(
       `./package.json`
     ))
+    // Draft order plugin can't have @medusajs/medusa as dependency,
+    // so we also check for @medusajs/cli 
     inMedusaProject = !!(
       (dependencies &&
         (dependencies["@medusajs/medusa"] || dependencies["@medusajs/cli"])) ||

--- a/packages/cli/medusa-cli/src/create-cli.ts
+++ b/packages/cli/medusa-cli/src/create-cli.ts
@@ -37,7 +37,7 @@ function buildLocalCommands(cli, isLocalProject) {
       console.error(
         `The "${command}" command must be run inside a Medusa project. Make sure you are in the root directory of a Medusa project and try again.`
       )
-      return
+      process.exit(1)
     }
 
     try {
@@ -52,11 +52,9 @@ function buildLocalCommands(cli, isLocalProject) {
   function getCommandHandler(command, handler) {
     return (argv) => {
       const localCmd = resolveLocalCommand(command)
-      if (localCmd) {
-        const args = { ...argv, ...projectInfo, useYarn }
+      const args = { ...argv, ...projectInfo, useYarn }
 
-        return handler ? handler(args, localCmd) : localCmd(args)
-      }
+      return handler ? handler(args, localCmd) : localCmd(args)
     }
   }
 

--- a/packages/cli/medusa-cli/src/create-cli.ts
+++ b/packages/cli/medusa-cli/src/create-cli.ts
@@ -33,8 +33,11 @@ function buildLocalCommands(cli, isLocalProject) {
   }
 
   function resolveLocalCommand(command) {
-    if (!isLocalProject) {
-      cli.showHelp((s: string) => console.log(s))
+    if (!isLocalProject && command !== "new") {
+      console.error(
+        `The "${command}" command must be run inside a Medusa project. Make sure you are in the root directory of a Medusa project and try again.`
+      )
+      return
     }
 
     try {
@@ -49,9 +52,11 @@ function buildLocalCommands(cli, isLocalProject) {
   function getCommandHandler(command, handler) {
     return (argv) => {
       const localCmd = resolveLocalCommand(command)
-      const args = { ...argv, ...projectInfo, useYarn }
+      if (localCmd) {
+        const args = { ...argv, ...projectInfo, useYarn }
 
-      return handler ? handler(args, localCmd) : localCmd(args)
+        return handler ? handler(args, localCmd) : localCmd(args)
+      }
     }
   }
 

--- a/packages/cli/medusa-cli/src/create-cli.ts
+++ b/packages/cli/medusa-cli/src/create-cli.ts
@@ -594,7 +594,11 @@ function isLocalMedusaProject() {
     ))
     inMedusaProject = !!(
       (dependencies && dependencies["@medusajs/medusa"]) ||
-      (devDependencies && devDependencies["@medusajs/medusa"])
+      (devDependencies && devDependencies["@medusajs/medusa"]) ||
+      // need it for plugin projects like draft order,
+      // which can't have @medusajs/medusa as dependency
+      (dependencies && dependencies["@medusajs/cli"]) ||
+      (devDependencies && devDependencies["@medusajs/cli"])
     )
   } catch (err) {
     // ignore


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Show a clear error when running a CLI command outside a Medusa project

Closes DX-2445

**Why** — Why are these changes relevant or necessary?  

When users run a Medusa CLI command outside a Medusa project, the error right now is unclear and messy:

```
medusa user

Create a user

Options:
      --verbose                Turn on verbose output [boolean] [default: false]
      --no-color, --no-colors  Turn off the color in output
                                                      [boolean] [default: false]
      --json                   Turn on the JSON logger[boolean] [default: false]
  -e, --email                  User's email.                            [string]
  -p, --password               User's password.                         [string]
  -i, --id                     User's id.                               [string]
      --invite                 If flag is set, an invitation will be created
                               instead of a new user and the invite token will
                               be returned.           [boolean] [default: false]
  -h, --help                   Show help                               [boolean]
  -v, --version                Show the version of the Medusa CLI and the Medusa
                               package in the current project          [boolean]
TypeError [ERR_INVALID_ARG_TYPE]: The "id" argument must be of type string. Received undefined
    at Module.require (node:internal/modules/cjs/loader:1456:3)
    at require (node:internal/modules/helpers:147:16)
    at resolveLocalCommand (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/dist/create-cli.js:31:20)
    at /Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/dist/create-cli.js:40:30
    at Object.handler (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/dist/create-cli.js:15:21)
    at /Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:8993
    at j (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:4956)
    at _.handleValidationAndGetResult (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:8962)
    at _.applyMiddlewareAndGetResult (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:9604)
    at _.runCommand (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:7231) {
  code: 'ERR_INVALID_ARG_TYPE'
}
medusa user

Create a user

Options:
      --verbose                Turn on verbose output [boolean] [default: false]
      --no-color, --no-colors  Turn off the color in output
                                                      [boolean] [default: false]
      --json                   Turn on the JSON logger[boolean] [default: false]
  -e, --email                  User's email.                            [string]
  -p, --password               User's password.                         [string]
  -i, --id                     User's id.                               [string]
      --invite                 If flag is set, an invitation will be created
                               instead of a new user and the invite token will
                               be returned.           [boolean] [default: false]
  -h, --help                   Show help                               [boolean]
  -v, --version                Show the version of the Medusa CLI and the Medusa
                               package in the current project          [boolean]
TypeError: cmd is not a function
    at /Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/dist/create-cli.js:438:13
    at /Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/dist/create-cli.js:42:30
    at Object.handler (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/dist/create-cli.js:15:21)
    at /Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:8993
    at j (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:4956)
    at _.handleValidationAndGetResult (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:8962)
    at _.applyMiddlewareAndGetResult (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:9604)
    at _.runCommand (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:7231)
    at [runYargsParserAndExecuteCommands] (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:58539)
    at te.parse (/Users/shahednasser/.nvm/versions/node/v22.21.1/lib/node_modules/@medusajs/cli/node_modules/yargs/build/index.cjs:1:40478)
```

This leads to confusion as users are unsure what the issue is. By improving the error message to the following, users know what the problem is and can fix it immediately:

```
The user command must be run inside a Medusa project. Make sure you are in the root directory of a Medusa project and try again.
```

**How** — How have these changes been implemented?

When resolving the command's handler, we exit early if the project isn't a Medusa project and show a clear error message

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Install the Medusa CLI globally either from the changes in this PR or snapshot below, then run a Medusa command in a non-Medusa directory:

```
medusa user -e admin@test.com -p supersecret
```

You should see the following message:

```
The user command must be run inside a Medusa project. Make sure you are in the root directory of a Medusa project and try again.
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves CLI behavior and project detection.
> 
> - Enforces early exit with a clear error when resolving local commands outside a Medusa project (all except `new`)
> - Extends `isLocalMedusaProject` to detect projects that depend on `@medusajs/cli` (in addition to `@medusajs/medusa`)
> - Adds changeset for a patch release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cf79eabdcf0c207117f940d52a609a58f7543c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->