### PR TITLE
fix(utils): support both path and parentPath in migration file

### DIFF
--- a/.changeset/tender-teams-mate.md
+++ b/.changeset/tender-teams-mate.md
@@ -2,4 +2,4 @@
 "@medusajs/utils": patch
 ---
 
-fix(utils): add warning and throw if version mismatch is found in directory signature
+fix(utils): support both path and parentPath in migration file

--- a/.changeset/tender-teams-mate.md
+++ b/.changeset/tender-teams-mate.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+fix(utils): add warning and throw if version mismatch is found in directory signature

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -210,7 +210,8 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
     )
 
     if (snapshotFile) {
-      const absoluteName = join(snapshotFile.parentPath, snapshotFile.name)
+      const absoluteName = join(snapshotFile.parentPath || snapshotFile.path, snapshotFile.name)
+
       if (absoluteName !== snapshotPath) {
         await rename(absoluteName, snapshotPath)
       }


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

supports both path and parentPath. parentPath is present from v21.5* onwards, but not present before. 

**Why** — Why are these changes relevant or necessary?  

To support migration generation for older versions

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures migration snapshot file renaming works across versions of directory entry metadata.
> 
> - In `migrations/index.ts`, `migrateSnapshotFile` now derives `absoluteName` using `join(snapshotFile.parentPath || snapshotFile.path, snapshotFile.name)` to support entries that expose either `parentPath` (newer) or `path` (older)
> - Adds a patch changeset for `@medusajs/utils`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c497b48b7553cb09399efb62f8be98c4fb39ad1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->