### PR TITLE
chore: bump RR minor version

### DIFF
--- a/.changeset/real-doors-watch.md
+++ b/.changeset/real-doors-watch.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/draft-order": patch
+"@medusajs/dashboard": patch
+---
+
+chore: bump RR minor version

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "6.20.1",
+    "react-router-dom": "6.30.3",
     "resize-observer-polyfill": "^1.5.1",
     "resolve-cwd": "^3.0.0",
     "rimraf": "^5.0.1",

--- a/packages/admin/dashboard/package.json
+++ b/packages/admin/dashboard/package.json
@@ -76,7 +76,7 @@
     "react-hook-form": "7.49.1",
     "react-i18next": "13.5.0",
     "react-jwt": "^1.2.0",
-    "react-router-dom": "6.20.1",
+    "react-router-dom": "6.30.3",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/packages/plugins/draft-order/package.json
+++ b/packages/plugins/draft-order/package.json
@@ -71,7 +71,7 @@
     "@medusajs/ui": "4.0.33",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "6.20.1"
+    "react-router-dom": "6.30.3"
   },
   "peerDependenciesMeta": {
     "@medusajs/admin-sdk": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,7 +3481,7 @@ __metadata:
     react-hook-form: 7.49.1
     react-i18next: 13.5.0
     react-jwt: ^1.2.0
-    react-router-dom: 6.20.1
+    react-router-dom: 6.30.3
     zod: 3.25.76
   languageName: unknown
   linkType: soft
@@ -3539,7 +3539,7 @@ __metadata:
     "@medusajs/ui": 4.0.33
     react: ^18.3.1
     react-dom: ^18.3.1
-    react-router-dom: 6.20.1
+    react-router-dom: 6.30.3
   peerDependenciesMeta:
     "@medusajs/admin-sdk":
       optional: true
@@ -9165,10 +9165,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.13.1":
-  version: 1.13.1
-  resolution: "@remix-run/router@npm:1.13.1"
-  checksum: 2f8c213dd0f1ebc0c2c1357badf6e1a65a42c40d38558f5e5085fbe7b144439eb326955d97ae0b2505f95ec8defa77a2492d44f5b10f351a0a90a50758169a22
+"@remix-run/router@npm:1.23.2":
+  version: 1.23.2
+  resolution: "@remix-run/router@npm:1.23.2"
+  checksum: 7096b7f2086b2cd80c9e06873b71a8317e04858c01edc06a6fed187b660408a90f47c8e120e8af4c369cf1fa6b6a316a66b0917f42b6eb8a566e98b277c50449
   languageName: node
   linkType: hard
 
@@ -24070,27 +24070,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:6.20.1":
-  version: 6.20.1
-  resolution: "react-router-dom@npm:6.20.1"
+"react-router-dom@npm:6.30.3":
+  version: 6.30.3
+  resolution: "react-router-dom@npm:6.30.3"
   dependencies:
-    "@remix-run/router": 1.13.1
-    react-router: 6.20.1
+    "@remix-run/router": 1.23.2
+    react-router: 6.30.3
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 85d94fe4d21120c8782030cb94546a2a59cf057583dceb8e9a7f804655680af9488f4438533e0e5a128412e5c2dcac8c17b934907a7669085fdca19ec6bd5123
+  checksum: e8a1e13c662ed6ee71a785bd3418ba04b700bcd8aff6ea7b32524371e8abb1c85568cd4fe9b9e9d555b8101fd415f6f1796531f593da60be179ce75b37038657
   languageName: node
   linkType: hard
 
-"react-router@npm:6.20.1":
-  version: 6.20.1
-  resolution: "react-router@npm:6.20.1"
+"react-router@npm:6.30.3":
+  version: 6.30.3
+  resolution: "react-router@npm:6.30.3"
   dependencies:
-    "@remix-run/router": 1.13.1
+    "@remix-run/router": 1.23.2
   peerDependencies:
     react: ">=16.8"
-  checksum: 5249f42048633fef42361e08b6fb879e6a575415ac3068a0805ae5464fec998a3149ca262cc1939ae8f4607ee24caa6ec0623c0fef702f1d323faba4a5f87d53
+  checksum: a0a74bf5a933cf0abd47e0eac1d3a505cd66b866e3ee8f20d8016885d3b4361ba3ba72dee026248c6125e631b191ba6ad109184c892281cea6cb747c71bf5940
   languageName: node
   linkType: hard
 
@@ -24956,7 +24956,7 @@ __metadata:
     prop-types: ^15.8.1
     react: ^18.3.1
     react-dom: ^18.3.1
-    react-router-dom: 6.20.1
+    react-router-dom: 6.30.3
     resize-observer-polyfill: ^1.5.1
     resolve-cwd: ^3.0.0
     rimraf: ^5.0.1


### PR DESCRIPTION
**What**
- update React Router v6 to the lates minor version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Upgrade React Router to latest v6 minor**
> 
> - Bump `react-router-dom` to `6.30.3` in root and `@medusajs/dashboard`; update `@remix-run/router` to `1.23.2` and `react-router` to `6.30.3` in `yarn.lock`
> - Align `@medusajs/draft-order` peer dependency to `react-router-dom@6.30.3`
> - Add changeset marking patch releases for `@medusajs/draft-order` and `@medusajs/dashboard`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9328cae7e73f3e63023d9fc06ffcef7f5d9e1930. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->