### PR TITLE
docs: add code to code block copy tracking

### DIFF
--- a/www/packages/docs-ui/src/components/CodeBlock/Actions/Copy/index.tsx
+++ b/www/packages/docs-ui/src/components/CodeBlock/Actions/Copy/index.tsx
@@ -31,6 +31,9 @@ export const CodeBlockCopyAction = ({
     track({
       event: {
         event: DocsTrackingEvents.CODE_BLOCK_COPY,
+        options: {
+          text: source.substring(0, 150),
+        },
       },
     })
   }, [copied])

--- a/www/packages/docs-ui/src/components/CodeBlock/__tests__/index.test.tsx
+++ b/www/packages/docs-ui/src/components/CodeBlock/__tests__/index.test.tsx
@@ -428,6 +428,9 @@ describe("interaction", () => {
     expect(mockTrack).toHaveBeenCalledWith({
       event: {
         event: DocsTrackingEvents.CODE_BLOCK_COPY,
+        options: {
+          text: mockSource.substring(0, 150),
+        }
       },
     })
   })

--- a/www/packages/docs-ui/src/components/CodeBlock/index.tsx
+++ b/www/packages/docs-ui/src/components/CodeBlock/index.tsx
@@ -304,6 +304,9 @@ export const CodeBlock = ({
     track({
       event: {
         event: DocsTrackingEvents.CODE_BLOCK_COPY,
+        options: {
+          text: source.substring(0, 150),
+        },
       },
     })
   }


### PR DESCRIPTION
Add text being copied to code block copy event