### PR TITLE
docs: improve sections in Index Module docs + fix supported storefront frameworks on Cloud

### DIFF
--- a/www/apps/book/app/learn/fundamentals/module-links/index-module/page.mdx
+++ b/www/apps/book/app/learn/fundamentals/module-links/index-module/page.mdx
@@ -28,13 +28,9 @@ The Index Module solves this problem by ingesting data into a central data store
 
 ### Ingested Data Models
 
-Data models are ingested if they're linked to other data models with the `filterable` property set, as you'll learn in the [Ingest Custom Data Models](#how-to-ingest-custom-data-models) section. Medusa also ingests some core data models by default, such as `Product`, `ProductVariant`, `Price`, and `SalesChannel`.
+By default, Medusa only ingests the `Product`, `ProductVariant`, `Price`, `PriceSet`, and `SalesChannel` data models into the Index Module's data store.
 
-<Note>
-
-Prior to [Medusa v2.10.2](https://github.com/medusajs/medusa/releases/tag/v2.10.2), only the `Product`, `ProductVariant`, `Price`, and `SalesChannel` data models were ingested. Make sure to update to the latest version to ingest all core data models.
-
-</Note>
+You can also ingest custom data models into the Index Module, as explained in the [How to Ingest Custom Data Models](#how-to-ingest-custom-data-models) section. Medusa will then ingest the custom and core data models into the Index Module's data store.
 
 ---
 
@@ -177,7 +173,7 @@ The `index` method accepts an object with the same properties as the `graph` met
 
 ## How to Ingest Custom Data Models
 
-You can ingest core and custom data models into the Index Module. You can do so by defining a link between your custom data model and one of the core data models, and setting the `filterable` property in the link definition.
+You can ingest core and custom data models into the Index Module by defining a link between them and setting the `filterable` property in the link definition.
 
 <Note>
 

--- a/www/apps/book/generated/edit-dates.mjs
+++ b/www/apps/book/generated/edit-dates.mjs
@@ -121,7 +121,7 @@ export const generatedEditDates = {
   "app/learn/fundamentals/workflows/errors/page.mdx": "2025-04-25T14:26:25.000Z",
   "app/learn/fundamentals/api-routes/override/page.mdx": "2025-12-22T12:56:06.558Z",
   "app/learn/fundamentals/module-links/index/page.mdx": "2025-05-23T07:57:58.958Z",
-  "app/learn/fundamentals/module-links/index-module/page.mdx": "2026-01-06T15:53:03.957Z",
+  "app/learn/fundamentals/module-links/index-module/page.mdx": "2026-01-20T15:21:00.723Z",
   "app/learn/introduction/build-with-llms-ai/page.mdx": "2026-01-20T12:33:34.160Z",
   "app/learn/installation/docker/page.mdx": "2026-01-19T11:26:15.574Z",
   "app/learn/fundamentals/generated-types/page.mdx": "2026-01-06T06:38:15.719Z",

--- a/www/apps/cloud/app/projects/prerequisites/page.mdx
+++ b/www/apps/cloud/app/projects/prerequisites/page.mdx
@@ -220,7 +220,7 @@ This ensures that all packages in your monorepo use compatible versions of `reac
 
 Cloud currently supports deploying storefronts built with the following frameworks:
 
-1. [Next.js](https://nextjs.org/) v15+
+1. [Next.js](https://nextjs.org/) v15
 2. [SvelteKit](https://kit.svelte.dev/) v2.40.0+
 3. [Tanstack Start](https://tanstack.com/start) v1.132.0+
 

--- a/www/apps/cloud/generated/edit-dates.mjs
+++ b/www/apps/cloud/generated/edit-dates.mjs
@@ -30,6 +30,6 @@ export const generatedEditDates = {
   "app/emails/react-email/page.mdx": "2025-11-12T15:41:56.365Z",
   "app/user/page.mdx": "2025-12-17T12:03:18.968Z",
   "app/deployments/access/page.mdx": "2026-01-08T08:52:48.924Z",
-  "app/projects/prerequisites/page.mdx": "2026-01-16T11:43:33.796Z",
+  "app/projects/prerequisites/page.mdx": "2026-01-20T15:21:29.787Z",
   "app/storefront/page.mdx": "2026-01-08T08:56:47.209Z"
 }


### PR DESCRIPTION
1. Clarify the ingested data models section in the Index Module docs. Only select data models are ingested by default, and core and custom data models can be ingested through links
2. Fix supported storefront frameworks in Cloud. For Next.js, only v15 is supported

Closes DX-2448