### PR TITLE
chore: reset event worker concurrency to 1

### DIFF
--- a/.changeset/fuzzy-grapes-smoke.md
+++ b/.changeset/fuzzy-grapes-smoke.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+Chore/reset event worker concurrency to 1

--- a/packages/core/utils/src/common/__tests__/define-config.spec.ts
+++ b/packages/core/utils/src/common/__tests__/define-config.spec.ts
@@ -1115,7 +1115,7 @@ describe("defineConfig", function () {
             "options": {
               "redisUrl": "redis://localhost:6379",
               "workerOptions": {
-                "concurrency": 3,
+                "concurrency": 1,
               },
             },
             "resolve": "@medusajs/medusa/event-bus-redis",
@@ -1342,7 +1342,7 @@ describe("defineConfig", function () {
             "options": {
               "redisUrl": "redis://localhost:6379",
               "workerOptions": {
-                "concurrency": 3,
+                "concurrency": 1,
               },
             },
             "resolve": "@medusajs/medusa/event-bus-redis",
@@ -1585,7 +1585,7 @@ describe("defineConfig", function () {
             "options": {
               "redisUrl": "redis://localhost:6379",
               "workerOptions": {
-                "concurrency": 3,
+                "concurrency": 1,
               },
             },
             "resolve": "@medusajs/medusa/event-bus-redis",

--- a/packages/core/utils/src/common/define-config.ts
+++ b/packages/core/utils/src/common/define-config.ts
@@ -45,9 +45,7 @@ export const DEFAULT_STORE_RESTRICTED_FIELDS = [
  * make an application work seamlessly, but still provide you the ability
  * to override configuration as needed.
  */
-export function defineConfig(
-  config?: InputConfigWithArrayModules
-): ConfigModule
+export function defineConfig(config?: InputConfigWithArrayModules): ConfigModule
 /**
  * @deprecated Use array-based modules configuration instead
  */
@@ -284,7 +282,7 @@ function resolveModules(
       resolve: TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.EVENT_BUS],
       options: {
         redisUrl: process.env.REDIS_URL,
-        workerOptions: { concurrency: 3 },
+        workerOptions: { concurrency: 1 },
       },
     },
     {


### PR DESCRIPTION
**What**
Make the event worker concurrency default to 1 instead of 3 and instead document how users can manage that option themselves

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Change**
> 
> - Set `workerOptions.concurrency` to `1` for the Redis `event_bus` in `define-config.ts` (cloud defaults), replacing the previous default of `3`.
> 
> **Tests & Release**
> 
> - Update inline snapshots in `define-config.spec.ts` to reflect `concurrency: 1`.
> - Add changeset marking a patch release for `@medusajs/utils`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3be37c44093dc16293bbacb0202527711ca2169e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->