### PR TITLE
fix(medusa): use http type for batch translation settings request

### DIFF
--- a/.changeset/slick-shoes-drive.md
+++ b/.changeset/slick-shoes-drive.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): use http type for batch translation settings request

--- a/packages/core/js-sdk/src/admin/translation.ts
+++ b/packages/core/js-sdk/src/admin/translation.ts
@@ -105,7 +105,6 @@ export class Translation {
    * .then(({ created, updated, deleted }) => {
    *   console.log(created, updated, deleted)
    * })
-   * ```
    */
   async batch(body: HttpTypes.AdminBatchTranslations, headers?: ClientHeaders) {
     return await this.client.fetch<HttpTypes.AdminTranslationsBatchResponse>(

--- a/packages/medusa/src/api/admin/translations/settings/batch/route.ts
+++ b/packages/medusa/src/api/admin/translations/settings/batch/route.ts
@@ -3,14 +3,13 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { defineFileConfig, FeatureFlag } from "@medusajs/framework/utils"
 import { HttpTypes } from "@medusajs/types"
 import TranslationFeatureFlag from "../../../../../feature-flags/translation"
-import { AdminBatchTranslationSettingsType } from "../../validators"
 
 /**
  * @since 2.13.0
  * @featureFlag translation
  */
 export const POST = async (
-  req: AuthenticatedMedusaRequest<AdminBatchTranslationSettingsType>,
+  req: AuthenticatedMedusaRequest<HttpTypes.AdminBatchTranslationSettings>,
   res: MedusaResponse<HttpTypes.AdminBatchTranslationSettingsResponse>
 ) => {
   const { create = [], update = [], delete: deleteIds = [] } = req.validatedBody


### PR DESCRIPTION
use http type for batch translation settings request to ensure it's generated in the API reference correctly.