### PR TITLE
fix(order): item relation loading in select-in path

### DIFF
--- a/.changeset/rare-waves-grow.md
+++ b/.changeset/rare-waves-grow.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/order": patch
+---
+
+fix(order): load order items data correctly with select in strategy

--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -22,6 +22,7 @@ import {
 
 jest.setTimeout(300000)
 
+
 medusaIntegrationTestRunner({
   testSuite: ({ dbConnection, getContainer, api }) => {
     let order,
@@ -127,6 +128,31 @@ medusaIntegrationTestRunner({
         expect(response.data.orders).toEqual([])
       })
 
+      it("should return the total in list same as the total in the order detail", async () => {
+        /**
+         * Ensure both loading strategies return same data for calculation
+         */
+
+        const detailResponse = await api.get(
+          `/admin/orders/${order.id}`,
+          adminHeaders
+        )
+        const expectedTotal = detailResponse.data.order.total
+
+        const listResponse = await api.get(
+          `/admin/orders?fields=id,status,total`,
+          adminHeaders
+        )
+
+        const listedOrder = listResponse.data.orders.find(
+          (listed) => listed.id === order.id
+        )
+
+        expect(listedOrder).toBeTruthy()
+        expect(listedOrder.total).toBeGreaterThan(0)
+        expect(listedOrder.total).toBe(expectedTotal)
+      })
+
       it("should search orders by billing address", async () => {
         let response = await api.get(
           `/admin/orders?fields=+billing_address.address_1,+billing_address.address_2`,
@@ -182,7 +208,7 @@ medusaIntegrationTestRunner({
         )
       })
 
-      it("should return billing_address when pagination included", async () => {        
+      it("should return billing_address when pagination included", async () => {
         const response = await api.get(
           `/admin/orders?fields=*billing_address&offset=0`,
           adminHeaders
@@ -1936,8 +1962,7 @@ medusaIntegrationTestRunner({
 
         // cancel the fulfillment
         await api.post(
-          `/admin/orders/${tabletOrder.id}/fulfillments/${
-            fulOrder2.fulfillments.find((f) => !f.canceled_at).id
+          `/admin/orders/${tabletOrder.id}/fulfillments/${fulOrder2.fulfillments.find((f) => !f.canceled_at).id
           }/cancel`,
           {},
           adminHeaders
@@ -2330,8 +2355,7 @@ medusaIntegrationTestRunner({
 
         // 7. cancel the entire fulfillment once again
         await api.post(
-          `/admin/orders/${fulOrderFull.id}/fulfillments/${
-            fulOrderFull.fulfillments.find((f) => !f.canceled_at)!.id
+          `/admin/orders/${fulOrderFull.id}/fulfillments/${fulOrderFull.fulfillments.find((f) => !f.canceled_at)!.id
           }/cancel?fields=*fulfillments,*fulfillments.items`,
           {},
           adminHeaders
@@ -2835,8 +2859,7 @@ medusaIntegrationTestRunner({
 
         // cancel the fulfillment for the entire order
         await api.post(
-          `/admin/orders/${bottleOrder.id}/fulfillments/${
-            fulOrder3.fulfillments.find((f) => !f.canceled_at)!.id
+          `/admin/orders/${bottleOrder.id}/fulfillments/${fulOrder3.fulfillments.find((f) => !f.canceled_at)!.id
           }/cancel`,
           {},
           adminHeaders

--- a/packages/modules/order/src/utils/base-repository-find.ts
+++ b/packages/modules/order/src/utils/base-repository-find.ts
@@ -5,6 +5,47 @@ import { Order, OrderClaim, OrderLineItemAdjustment } from "@models"
 
 import { mapRepositoryToOrderModel } from "."
 
+function ensureOrderItemFieldsSelection(config: any, isRelatedEntity: boolean) {
+  const populate = config.options?.populate ?? []
+  const fields = config.options?.fields ?? []
+
+  const hasItemsItemPopulate = populate.some(
+    (p: string) =>
+      p === "items.item" ||
+      p.startsWith("items.item.") ||
+      p === "order.items.item" ||
+      p.startsWith("order.items.item.")
+  )
+
+  if (!hasItemsItemPopulate) {
+    return
+  }
+
+  const hasOrderItemFields = fields.some((field: string) => {
+    if (field === "items.*" || field === "order.items.*") {
+      return true
+    }
+
+    if (field.startsWith("items.") && !field.startsWith("items.item.")) {
+      return true
+    }
+
+    if (
+      field.startsWith("order.items.") &&
+      !field.startsWith("order.items.item.")
+    ) {
+      return true
+    }
+
+    return false
+  })
+
+  if (!hasOrderItemFields) {
+    fields.push(isRelatedEntity ? "order.items.*" : "items.*")
+    config.options.fields = fields
+  }
+}
+
 export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
   klass.prototype.find = async function find(
     this: any,
@@ -104,6 +145,7 @@ export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
     config.where ??= {}
 
     if (strategy === LoadStrategy.SELECT_IN) {
+      ensureOrderItemFieldsSelection(config, isRelatedEntity)
       MikroOrmBaseRepository.compensateRelationFieldsSelectionFromLoadStrategy({
         findOptions: config,
       })
@@ -205,6 +247,7 @@ export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
     }
 
     if (strategy === LoadStrategy.SELECT_IN) {
+      ensureOrderItemFieldsSelection(config, isRelatedEntity)
       MikroOrmBaseRepository.compensateRelationFieldsSelectionFromLoadStrategy({
         findOptions: config,
       })


### PR DESCRIPTION
**What**
- ensure correct `item` data is loaded when calculating totals

**Issue**
- adding `compensateRelationFieldsSelectionFromLoadStrategy` in the select-in path forces explicit field selection for populated relations
- In `mapRepositoryToOrderModel`, `items.*` is remapped to `items.item.*`, which drops `OrderItem` fields (quantity) because those live on `items/items.detail`, not on `items.item` (`OrderLineItem`).

---

CLOSES https://github.com/medusajs/medusa/issues/14628