### PR TITLE
chore: fix TSDocs for JS SDK order edit methods

### DIFF
--- a/packages/core/js-sdk/src/admin/order-edit.ts
+++ b/packages/core/js-sdk/src/admin/order-edit.ts
@@ -18,12 +18,12 @@ export class OrderEdit {
    * This method creates an order edit request. It sends a HTTP request to the
    * [Create Order Edit](https://docs.medusajs.com/api/admin#order-edits_postorderedits)
    * API route.
-   * 
+   *
    * @param body - The order edit's details.
    * @param query - Configure the fields to retrieve in the order edit.
    * @param headers - Headers to pass in the request.
    * @returns The order edit's details.
-   * 
+   *
    * @example
    * sdk.admin.orderEdit.initiateRequest({
    *   order_id: "order_123"
@@ -52,14 +52,14 @@ export class OrderEdit {
    * This method changes an order edit to requested. It sends a request to the
    * [Request Order Edit](https://docs.medusajs.com/api/admin#order-edits_postordereditsidrequest)
    * API route.
-   * 
-   * @param id - The order edit's ID.
+   *
+   * @param id - The ID of the order that is being edited.
    * @param query - Configure the fields to retrieve in the order preview.
    * @param headers - Headers to pass in the request.
    * @returns The order preview's details.
-   * 
+   *
    * @example
-   * sdk.admin.orderEdit.request("ordch_123")
+   * sdk.admin.orderEdit.request("order_123")
    * .then(({ order_preview }) => {
    *   console.log(order_preview)
    * })
@@ -83,14 +83,14 @@ export class OrderEdit {
    * This method confirms an order edit and applies it on the order. It sends a request
    * to the [Confirm Order Edit](https://docs.medusajs.com/api/admin#order-edits_postordereditsidconfirm)
    * API route.
-   * 
-   * @param id - The order edit's ID.
+   *
+   * @param id - The ID of the order that is being edited.
    * @param query - Configure the fields to retrieve in the order preview.
    * @param headers - Headers to pass in the request.
    * @returns The order preview's details.
-   * 
+   *
    * @example
-   * sdk.admin.orderEdit.confirm("ordch_123")
+   * sdk.admin.orderEdit.confirm("order_123")
    * .then(({ order_preview }) => {
    *   console.log(order_preview)
    * })
@@ -114,14 +114,14 @@ export class OrderEdit {
    * This method cancels a requested order edit. It sends a request to the
    * [Cancel Order Edit](https://docs.medusajs.com/api/admin#order-edits_deleteordereditsid)
    * API route.
-   * 
-   * @param id - The order edit's ID.
+   *
+   * @param id - The ID of the order that is being edited.
    * @param query - Query parameters
    * @param headers - Headers to pass in the request.
    * @returns The deletion's details.
-   * 
+   *
    * @example
-   * sdk.admin.orderEdit.cancelRequest("ordch_123")
+   * sdk.admin.orderEdit.cancelRequest("order_123")
    * .then(({ deleted }) => {
    *   console.log(deleted)
    * })
@@ -143,18 +143,18 @@ export class OrderEdit {
 
   /**
    * This method adds items to an order edit. These items will have the action `ITEM_ADD`.
-   * 
+   *
    * The method sends a request to the [Add Items](https://docs.medusajs.com/api/admin#order-edits_postordereditsiditems)
    * API route.
-   * 
-   * @param id - The order edit's ID.
+   *
+   * @param id - The ID of the order that is being edited.
    * @param body - The items to add.
    * @param query - Configure the fields to retrieve in the order preview.
    * @param headers - Headers to pass in the request.
    * @returns The order preview's details.
-   * 
+   *
    * @example
-   * sdk.admin.orderEdit.addItems("ordch_123", {
+   * sdk.admin.orderEdit.addItems("order_123", {
    *   items: [
    *     {
    *       variant_id: "variant_123",
@@ -187,19 +187,19 @@ export class OrderEdit {
    * This method updates the quantity and other details of an item in an order. It sends a request to the
    * [Update Item Quantity](https://docs.medusajs.com/api/admin#order-edits_postordereditsiditemsitemitem_id)
    * API route.
-   * 
+   *
    * You can also use this method to remove an item from an order by setting the `quantity` to `0`.
-   * 
-   * @param id - The order edit's ID.
+   *
+   * @param id - The ID of the order that is being edited.
    * @param itemId - The item's ID in the order.
    * @param body - The data to edit in the item.
    * @param query - Configure the fields to retrieve in the order preview.
    * @param headers - Headers to pass in the request.
    * @returns The order preview's details.
-   * 
+   *
    * @example
    * sdk.admin.orderEdit.updateOriginalItem(
-   *   "ordch_123", 
+   *   "order_123",
    *   "orli_123",
    *   {
    *     quantity: 1
@@ -229,24 +229,24 @@ export class OrderEdit {
 
   /**
    * This method updates an added item in the order edit by the ID of the item's `ITEM_ADD` action.
-   * 
-   * Every item has an `actions` property, whose value is an array of actions. 
+   *
+   * Every item has an `actions` property, whose value is an array of actions.
    * You can check the action's name using its `action` property, and use the value of the `id` property.
-   * 
+   *
    * It sends a request
    * to the [Update Item](https://docs.medusajs.com/api/admin#order-edits_postordereditsiditemsaction_id)
    * API route.
-   * 
-   * @param id - The order edit's ID.
+   *
+   * @param id - The ID of the order that is being edited.
    * @param actionId - The id of the new item's `ITEM_ADD` action.
    * @param body - The data to update.
    * @param query - Configure the fields to retrieve in the order preview.
    * @param headers - Headers to pass in the request.
    * @returns The order preview's details.
-   * 
+   *
    * @example
    * sdk.admin.orderEdit.updateAddedItem(
-   *   "ordch_123", 
+   *   "order_123",
    *   "orli_123",
    *   {
    *     quantity: 1
@@ -276,19 +276,19 @@ export class OrderEdit {
 
   /**
    * This method removes an added item in the order edit by the ID of the item's `ITEM_ADD` action.
-   * 
-   * Every item has an `actions` property, whose value is an array of actions. 
+   *
+   * Every item has an `actions` property, whose value is an array of actions.
    * You can check the action's name using its `action` property, and use the value of the `id` property.
-   * 
-   * @param id - The order edit's ID.
+   *
+   * @param id - The ID of the order that is being edited.
    * @param actionId - The id of the new item's `ITEM_ADD` action.
    * @param query - Configure the fields to retrieve in the order preview.
    * @param headers - Headers to pass in the request.
    * @returns The order preview's details.
-   * 
+   *
    * @example
    * sdk.admin.orderEdit.removeAddedItem(
-   *   "ordch_123", 
+   *   "order_123",
    *   "orli_123",
    * )
    * .then(({ order_preview }) => {


### PR DESCRIPTION
Fix TSDocs of the JS SDK order edits to mention that the `id` parameter is actually the ID of the order, not order edit