### PR TITLE
docs: add tanstack start solid to supported storefront framework in Cloud

### DIFF
--- a/www/apps/cloud/app/projects/prerequisites/page.mdx
+++ b/www/apps/cloud/app/projects/prerequisites/page.mdx
@@ -193,8 +193,8 @@ If you're using `npm` as your package manager, and you're using the [Next.js Sta
   "overrides": {
     // other overrides...
     "@medusajs/icons": {
-      "react": "19.0.3",
-      "react-dom": "19.0.3"
+      "react": "19.0.4",
+      "react-dom": "19.0.4"
     }
   }
 }
@@ -208,8 +208,8 @@ Also, add the following override in your monorepo's root `package.json`:
 {
   "overrides": {
     // other overrides...
-    "react": "19.0.3",
-    "react-dom": "19.0.3"
+    "react": "19.0.4",
+    "react-dom": "19.0.4"
   }
 }
 ```
@@ -222,7 +222,7 @@ Cloud currently supports deploying storefronts built with the following framewor
 
 1. [Next.js](https://nextjs.org/) v15
 2. [SvelteKit](https://kit.svelte.dev/) v2.40.0+
-3. [Tanstack Start](https://tanstack.com/start) v1.132.0+
+3. [Tanstack Start](https://tanstack.com/start) v1.132.0+ (React and Solid)
 
 If you're using a different framework for your storefront, contact support to request it.
 

--- a/www/apps/cloud/app/storefront/page.mdx
+++ b/www/apps/cloud/app/storefront/page.mdx
@@ -61,7 +61,7 @@ Cloud currently supports deploying storefronts built with the following framewor
 
 1. [Next.js](https://nextjs.org/) v15+
 2. [SvelteKit](https://kit.svelte.dev/) v2.40.0+
-3. [Tanstack Start](https://tanstack.com/start) v1.132.0+
+3. [Tanstack Start](https://tanstack.com/start) v1.132.0+ (React and Solid)
 
 If you're using a different framework for your storefront, contact support to request it.
 

--- a/www/apps/cloud/generated/edit-dates.mjs
+++ b/www/apps/cloud/generated/edit-dates.mjs
@@ -30,6 +30,6 @@ export const generatedEditDates = {
   "app/emails/react-email/page.mdx": "2025-11-12T15:41:56.365Z",
   "app/user/page.mdx": "2025-12-17T12:03:18.968Z",
   "app/deployments/access/page.mdx": "2026-01-08T08:52:48.924Z",
-  "app/projects/prerequisites/page.mdx": "2026-01-20T15:21:29.787Z",
-  "app/storefront/page.mdx": "2026-01-08T08:56:47.209Z"
+  "app/projects/prerequisites/page.mdx": "2026-01-27T08:41:13.100Z",
+  "app/storefront/page.mdx": "2026-01-27T08:41:42.215Z"
 }


### PR DESCRIPTION
Mention that both Tanstack Start React and Solid are supported in Cloud