### PR TITLE
chore: expand fetch order tests

### DIFF
--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -57,6 +57,8 @@ medusaIntegrationTestRunner({
         order = seeder.order
       })
 
+
+
       it("should search orders by display_id", async () => {
         let response = await api.get(`/admin/orders`, adminHeaders)
 
@@ -128,29 +130,181 @@ medusaIntegrationTestRunner({
         expect(response.data.orders).toEqual([])
       })
 
-      it("should return the total in list same as the total in the order detail", async () => {
-        /**
-         * Ensure both loading strategies return same data for calculation
-         */
+      describe("with matching list vs detail order totals with varying request fields", () => {
+        const getDetailTotal = async (query?: string) => {
+          const detailResponse = await api.get(
+            `/admin/orders/${order.id}${query ? `?${query}` : ""}`,
+            adminHeaders
+          )
 
-        const detailResponse = await api.get(
-          `/admin/orders/${order.id}`,
-          adminHeaders
-        )
-        const expectedTotal = detailResponse.data.order.total
+          return detailResponse.data.order.total
+        }
 
-        const listResponse = await api.get(
-          `/admin/orders?fields=id,status,total`,
-          adminHeaders
-        )
+        const getListTotal = async (query: string) => {
+          const listResponse = await api.get(
+            `/admin/orders?${query}`,
+            adminHeaders
+          )
 
-        const listedOrder = listResponse.data.orders.find(
-          (listed) => listed.id === order.id
-        )
+          const listedOrder = listResponse.data.orders.find(
+            (listed) => listed.id === order.id
+          )
 
-        expect(listedOrder).toBeTruthy()
-        expect(listedOrder.total).toBeGreaterThan(0)
-        expect(listedOrder.total).toBe(expectedTotal)
+          expect(listedOrder).toBeTruthy()
+          return listedOrder!.total
+        }
+
+        it("should match totals across key fields with default list and detail responses", async () => {
+          const detailResponse = await api.get(
+            `/admin/orders/${order.id}`,
+            adminHeaders
+          )
+          const listResponse = await api.get(`/admin/orders`, adminHeaders)
+
+          const listedOrder = listResponse.data.orders.find(
+            (listed) => listed.id === order.id
+          ) as any
+
+          expect(listedOrder).toBeTruthy()
+
+          const detailOrder = detailResponse.data.order as any
+          const fieldsToCompare = [
+            // default admin order list endpoint only has total
+            "total",
+            // admin order detail endpoint has more fields
+            // "original_total",
+            // "discount_total",
+            // "discount_subtotal",
+            // "shipping_total",
+            // "tax_total",
+          ]
+
+          for (const field of fieldsToCompare) {
+            expect(listedOrder).toHaveProperty(field)
+            expect(listedOrder[field]).toBeDefined()
+            expect(listedOrder[field]).toBe(detailOrder[field])
+          }
+        })
+
+        it("should return the same total using default list fields", async () => {
+          const expectedTotal = await getDetailTotal()
+          const listTotal = await getListTotal(
+            // fields we use on the admin list page
+            `fields=${encodeURIComponent(
+              "id,status,created_at,email,display_id,custom_display_id,payment_status,fulfillment_status,total,currency_code,*customer,*sales_channel,*payment_collections"
+            )}`
+          )
+
+          expect(listTotal).toBe(expectedTotal)
+        })
+
+        it("should return the same total using minimal list fields", async () => {
+          const expectedTotal = await getDetailTotal()
+          const listTotal = await getListTotal("fields=id,total")
+
+          expect(listTotal).toBe(expectedTotal)
+        })
+
+        it("should return the same total when requesting item fields", async () => {
+          const expectedTotal = await getDetailTotal()
+          const listTotal = await getListTotal(
+            `fields=${encodeURIComponent("id,total,*items,+items.detail")}`
+          )
+
+          expect(listTotal).toBe(expectedTotal)
+        })
+
+        it("should return the same total when requesting shipping fields", async () => {
+          const expectedTotal = await getDetailTotal()
+          const listTotal = await getListTotal(
+            `fields=${encodeURIComponent(
+              "id,total,*shipping_methods,+shipping_methods.tax_lines"
+            )}`
+          )
+
+          expect(listTotal).toBe(expectedTotal)
+        })
+
+        it("should return the same total when using mixed list fields", async () => {
+          const expectedTotal = await getDetailTotal()
+          const listTotal = await getListTotal(
+            `fields=${encodeURIComponent(
+              "id,status,total,currency_code,*items,+items.detail,*shipping_methods,+shipping_methods.tax_lines"
+            )}`
+          )
+
+          expect(listTotal).toBe(expectedTotal)
+        })
+
+        it("should return the same total when using + / - field modifiers", async () => {
+          const expectedTotal = await getDetailTotal()
+          const listTotal = await getListTotal(
+            `fields=${encodeURIComponent("+total,-email")}`
+          )
+
+          expect(listTotal).toBe(expectedTotal)
+        })
+
+        it("should return the same total when ordering results", async () => {
+          const expectedTotal = await getDetailTotal()
+          const listTotal = await getListTotal(
+            "fields=id,total&order=-created_at"
+          )
+
+          expect(listTotal).toBe(expectedTotal)
+        })
+
+        it("should return the same total when requesting minimal detail fields", async () => {
+          const listTotal = await getListTotal(
+            `fields=${encodeURIComponent(
+              "id,status,created_at,email,display_id,custom_display_id,payment_status,fulfillment_status,total,currency_code,*customer,*sales_channel,*payment_collections"
+            )}`
+          )
+          const detailTotal = await getDetailTotal("fields=id,total")
+
+          expect(detailTotal).toBe(listTotal)
+        })
+
+        it("should return the same total when requesting item detail fields", async () => {
+          const listTotal = await getListTotal(
+            `fields=${encodeURIComponent(
+              "id,status,created_at,email,display_id,custom_display_id,payment_status,fulfillment_status,total,currency_code,*customer,*sales_channel,*payment_collections"
+            )}`
+          )
+          const detailTotal = await getDetailTotal(
+            `fields=${encodeURIComponent("id,total,*items,+items.detail")}`
+          )
+
+          expect(detailTotal).toBe(listTotal)
+        })
+
+        it("should return the same total when requesting shipping detail fields", async () => {
+          const listTotal = await getListTotal(
+            `fields=${encodeURIComponent(
+              "id,status,created_at,email,display_id,custom_display_id,payment_status,fulfillment_status,total,currency_code,*customer,*sales_channel,*payment_collections"
+            )}`
+          )
+          const detailTotal = await getDetailTotal(
+            `fields=${encodeURIComponent(
+              "id,total,*shipping_methods,+shipping_methods.tax_lines"
+            )}`
+          )
+
+          expect(detailTotal).toBe(listTotal)
+        })
+
+        it("should return the same total when using + / - field modifiers on detail", async () => {
+          const listTotal = await getListTotal(
+            `fields=${encodeURIComponent(
+              "id,status,created_at,email,display_id,custom_display_id,payment_status,fulfillment_status,total,currency_code,*customer,*sales_channel,*payment_collections"
+            )}`
+          )
+          const detailTotal = await getDetailTotal(
+            `fields=${encodeURIComponent("+total,-email")}`
+          )
+
+          expect(detailTotal).toBe(listTotal)
+        })
       })
 
       it("should search orders by billing address", async () => {


### PR DESCRIPTION
**What**
- expand testing for order retrieval ensuring responses match for the list and details endpoint across totals fields