### PR TITLE
docs: fix scrolling inside subcategories in the sidebar

### DIFF
--- a/www/packages/docs-ui/src/components/Sidebar/Item/SubCategory/index.tsx
+++ b/www/packages/docs-ui/src/components/Sidebar/Item/SubCategory/index.tsx
@@ -64,7 +64,7 @@ export const SidebarItemSubCategory = ({
       {hasChildren && (
         <ul
           className={clsx(
-            "ease-ease overflow-hidden",
+            "ease-ease",
             "flex flex-col gap-docs_0.125",
             "pb-docs_0.5 pt-docs_0.125"
           )}


### PR DESCRIPTION
Scrolling the sidebar while the cursor is hovering a subcategory prevents you from scrolling. This PR fixes the issue