### PR TITLE
docs: fix list products api route response

### DIFF
--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProductListResponse.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProductListResponse.yaml
@@ -1,0 +1,33 @@
+type: object
+description: The paginated list of products.
+x-schemaName: StoreProductListResponse
+required:
+  - limit
+  - offset
+  - count
+  - products
+properties:
+  limit:
+    type: number
+    title: limit
+    description: The maximum number of items returned.
+  offset:
+    type: number
+    title: offset
+    description: The number of items skipped before retrieving the returned items.
+  count:
+    type: number
+    title: count
+    description: The total count of items.
+  products:
+    type: array
+    description: The list of products.
+    items:
+      $ref: ./StoreProduct.yaml
+  estimate_count:
+    type: number
+    title: estimate_count
+    description: >-
+      The estimated count retrieved from the PostgreSQL query planner, which may
+      be inaccurate.
+    x-featureFlag: index_engine

--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -98750,6 +98750,38 @@ components:
           type: number
           title: rank
           description: The image's rank among its sibling images
+    StoreProductListResponse:
+      type: object
+      description: The paginated list of products.
+      x-schemaName: StoreProductListResponse
+      required:
+        - limit
+        - offset
+        - count
+        - products
+      properties:
+        limit:
+          type: number
+          title: limit
+          description: The maximum number of items returned.
+        offset:
+          type: number
+          title: offset
+          description: The number of items skipped before retrieving the returned items.
+        count:
+          type: number
+          title: count
+          description: The total count of items.
+        products:
+          type: array
+          description: The list of products.
+          items:
+            $ref: '#/components/schemas/StoreProduct'
+        estimate_count:
+          type: number
+          title: estimate_count
+          description: The estimated count retrieved from the PostgreSQL query planner, which may be inaccurate.
+          x-featureFlag: index_engine
     StoreProductOption:
       type: object
       description: The product option's details.

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProductListResponse.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProductListResponse.yaml
@@ -1,0 +1,33 @@
+type: object
+description: The paginated list of products.
+x-schemaName: StoreProductListResponse
+required:
+  - limit
+  - offset
+  - count
+  - products
+properties:
+  limit:
+    type: number
+    title: limit
+    description: The maximum number of items returned.
+  offset:
+    type: number
+    title: offset
+    description: The number of items skipped before retrieving the returned items.
+  count:
+    type: number
+    title: count
+    description: The total count of items.
+  products:
+    type: array
+    description: The list of products.
+    items:
+      $ref: ./StoreProduct.yaml
+  estimate_count:
+    type: number
+    title: estimate_count
+    description: >-
+      The estimated count retrieved from the PostgreSQL query planner, which may
+      be inaccurate.
+    x-featureFlag: index_engine

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -9169,36 +9169,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - type: object
-                    description: The paginated list of products.
-                    required:
-                      - limit
-                      - offset
-                      - count
-                    properties:
-                      limit:
-                        type: number
-                        title: limit
-                        description: The maximum number of items returned.
-                      offset:
-                        type: number
-                        title: offset
-                        description: The number of items skipped before retrieving the returned items.
-                      count:
-                        type: number
-                        title: count
-                        description: The total number of items.
-                  - type: object
-                    description: The paginated list of products.
-                    required:
-                      - products
-                    properties:
-                      products:
-                        type: array
-                        description: The list of products.
-                        items:
-                          type: object
+                $ref: '#/components/schemas/StoreProductListResponse'
         '400':
           $ref: '#/components/responses/400_error'
         '401':
@@ -41465,6 +41436,38 @@ components:
           type: number
           title: rank
           description: The image's rank among its sibling images
+    StoreProductListResponse:
+      type: object
+      description: The paginated list of products.
+      x-schemaName: StoreProductListResponse
+      required:
+        - limit
+        - offset
+        - count
+        - products
+      properties:
+        limit:
+          type: number
+          title: limit
+          description: The maximum number of items returned.
+        offset:
+          type: number
+          title: offset
+          description: The number of items skipped before retrieving the returned items.
+        count:
+          type: number
+          title: count
+          description: The total count of items.
+        products:
+          type: array
+          description: The list of products.
+          items:
+            $ref: '#/components/schemas/StoreProduct'
+        estimate_count:
+          type: number
+          title: estimate_count
+          description: The estimated count retrieved from the PostgreSQL query planner, which may be inaccurate.
+          x-featureFlag: index_engine
     StoreProductOption:
       type: object
       description: The product option's details.

--- a/www/apps/api-reference/specs/store/paths/store_products.yaml
+++ b/www/apps/api-reference/specs/store/paths/store_products.yaml
@@ -894,38 +894,7 @@ get:
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                description: The paginated list of products.
-                required:
-                  - limit
-                  - offset
-                  - count
-                properties:
-                  limit:
-                    type: number
-                    title: limit
-                    description: The maximum number of items returned.
-                  offset:
-                    type: number
-                    title: offset
-                    description: >-
-                      The number of items skipped before retrieving the returned
-                      items.
-                  count:
-                    type: number
-                    title: count
-                    description: The total number of items.
-              - type: object
-                description: The paginated list of products.
-                required:
-                  - products
-                properties:
-                  products:
-                    type: array
-                    description: The list of products.
-                    items:
-                      type: object
+            $ref: ../components/schemas/StoreProductListResponse.yaml
     '400':
       $ref: ../components/responses/400_error.yaml
     '401':

--- a/www/utils/generated/oas-output/operations/store/get_store_products.ts
+++ b/www/utils/generated/oas-output/operations/store/get_store_products.ts
@@ -796,36 +796,7 @@
  *     content:
  *       application/json:
  *         schema:
- *           allOf:
- *             - type: object
- *               description: The paginated list of products.
- *               required:
- *                 - limit
- *                 - offset
- *                 - count
- *               properties:
- *                 limit:
- *                   type: number
- *                   title: limit
- *                   description: The maximum number of items returned.
- *                 offset:
- *                   type: number
- *                   title: offset
- *                   description: The number of items skipped before retrieving the returned items.
- *                 count:
- *                   type: number
- *                   title: count
- *                   description: The total number of items.
- *             - type: object
- *               description: The paginated list of products.
- *               required:
- *                 - products
- *               properties:
- *                 products:
- *                   type: array
- *                   description: The list of products.
- *                   items:
- *                     $ref: "#/components/schemas/StoreProduct"
+ *           $ref: "#/components/schemas/StoreProductListResponse"
  *   "400":
  *     $ref: "#/components/responses/400_error"
  *   "401":

--- a/www/utils/generated/oas-output/schemas/StoreProductListResponse.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProductListResponse.ts
@@ -1,0 +1,36 @@
+/**
+ * @schema StoreProductListResponse
+ * type: object
+ * description: The paginated list of products.
+ * x-schemaName: StoreProductListResponse
+ * required:
+ *   - limit
+ *   - offset
+ *   - count
+ *   - products
+ * properties:
+ *   limit:
+ *     type: number
+ *     title: limit
+ *     description: The maximum number of items returned.
+ *   offset:
+ *     type: number
+ *     title: offset
+ *     description: The number of items skipped before retrieving the returned items.
+ *   count:
+ *     type: number
+ *     title: count
+ *     description: The total count of items.
+ *   products:
+ *     type: array
+ *     description: The list of products.
+ *     items:
+ *       $ref: "#/components/schemas/StoreProduct"
+ *   estimate_count:
+ *     type: number
+ *     title: estimate_count
+ *     description: The estimated count retrieved from the PostgreSQL query planner, which may be inaccurate.
+ *     x-featureFlag: index_engine
+ * 
+*/
+


### PR DESCRIPTION
Fix the list products API route not showing the product structure in the response

> Note: need to resolve the root issue for the schema generated wrongly separately