### PR TITLE
docs: fix updating schemas in generated OAS

### DIFF
--- a/www/apps/api-reference/specs/admin/components/schemas/StoreProductListResponse.yaml
+++ b/www/apps/api-reference/specs/admin/components/schemas/StoreProductListResponse.yaml
@@ -1,33 +1,40 @@
 type: object
 description: The paginated list of products.
 x-schemaName: StoreProductListResponse
-required:
-  - limit
-  - offset
-  - count
-  - products
-properties:
-  limit:
-    type: number
-    title: limit
-    description: The maximum number of items returned.
-  offset:
-    type: number
-    title: offset
-    description: The number of items skipped before retrieving the returned items.
-  count:
-    type: number
-    title: count
-    description: The total count of items.
-  products:
-    type: array
+allOf:
+  - type: object
+    description: Pagination details
+    required:
+      - limit
+      - offset
+      - count
+    properties:
+      limit:
+        type: number
+        title: limit
+        description: The maximum number of items returned.
+      offset:
+        type: number
+        title: offset
+        description: The number of items skipped before retrieving the returned items.
+      count:
+        type: number
+        title: count
+        description: The total count of items.
+      estimate_count:
+        type: number
+        title: estimate_count
+        description: >-
+          The estimated count retrieved from the PostgreSQL query planner, which
+          may be inaccurate.
+        x-featureFlag: index_engine
+  - type: object
     description: The list of products.
-    items:
-      $ref: ./StoreProduct.yaml
-  estimate_count:
-    type: number
-    title: estimate_count
-    description: >-
-      The estimated count retrieved from the PostgreSQL query planner, which may
-      be inaccurate.
-    x-featureFlag: index_engine
+    required:
+      - products
+    properties:
+      products:
+        type: array
+        description: The list of products.
+        items:
+          $ref: ./StoreProduct.yaml

--- a/www/apps/api-reference/specs/admin/openapi.full.yaml
+++ b/www/apps/api-reference/specs/admin/openapi.full.yaml
@@ -98754,34 +98754,41 @@ components:
       type: object
       description: The paginated list of products.
       x-schemaName: StoreProductListResponse
-      required:
-        - limit
-        - offset
-        - count
-        - products
-      properties:
-        limit:
-          type: number
-          title: limit
-          description: The maximum number of items returned.
-        offset:
-          type: number
-          title: offset
-          description: The number of items skipped before retrieving the returned items.
-        count:
-          type: number
-          title: count
-          description: The total count of items.
-        products:
-          type: array
+      allOf:
+        - type: object
+          description: Pagination details
+          required:
+            - limit
+            - offset
+            - count
+          properties:
+            limit:
+              type: number
+              title: limit
+              description: The maximum number of items returned.
+            offset:
+              type: number
+              title: offset
+              description: The number of items skipped before retrieving the returned items.
+            count:
+              type: number
+              title: count
+              description: The total count of items.
+            estimate_count:
+              type: number
+              title: estimate_count
+              description: The estimated count retrieved from the PostgreSQL query planner, which may be inaccurate.
+              x-featureFlag: index_engine
+        - type: object
           description: The list of products.
-          items:
-            $ref: '#/components/schemas/StoreProduct'
-        estimate_count:
-          type: number
-          title: estimate_count
-          description: The estimated count retrieved from the PostgreSQL query planner, which may be inaccurate.
-          x-featureFlag: index_engine
+          required:
+            - products
+          properties:
+            products:
+              type: array
+              description: The list of products.
+              items:
+                $ref: '#/components/schemas/StoreProduct'
     StoreProductOption:
       type: object
       description: The product option's details.

--- a/www/apps/api-reference/specs/store/components/schemas/StoreProductListResponse.yaml
+++ b/www/apps/api-reference/specs/store/components/schemas/StoreProductListResponse.yaml
@@ -1,33 +1,40 @@
 type: object
 description: The paginated list of products.
 x-schemaName: StoreProductListResponse
-required:
-  - limit
-  - offset
-  - count
-  - products
-properties:
-  limit:
-    type: number
-    title: limit
-    description: The maximum number of items returned.
-  offset:
-    type: number
-    title: offset
-    description: The number of items skipped before retrieving the returned items.
-  count:
-    type: number
-    title: count
-    description: The total count of items.
-  products:
-    type: array
+allOf:
+  - type: object
+    description: Pagination details
+    required:
+      - limit
+      - offset
+      - count
+    properties:
+      limit:
+        type: number
+        title: limit
+        description: The maximum number of items returned.
+      offset:
+        type: number
+        title: offset
+        description: The number of items skipped before retrieving the returned items.
+      count:
+        type: number
+        title: count
+        description: The total count of items.
+      estimate_count:
+        type: number
+        title: estimate_count
+        description: >-
+          The estimated count retrieved from the PostgreSQL query planner, which
+          may be inaccurate.
+        x-featureFlag: index_engine
+  - type: object
     description: The list of products.
-    items:
-      $ref: ./StoreProduct.yaml
-  estimate_count:
-    type: number
-    title: estimate_count
-    description: >-
-      The estimated count retrieved from the PostgreSQL query planner, which may
-      be inaccurate.
-    x-featureFlag: index_engine
+    required:
+      - products
+    properties:
+      products:
+        type: array
+        description: The list of products.
+        items:
+          $ref: ./StoreProduct.yaml

--- a/www/apps/api-reference/specs/store/openapi.full.yaml
+++ b/www/apps/api-reference/specs/store/openapi.full.yaml
@@ -41440,34 +41440,41 @@ components:
       type: object
       description: The paginated list of products.
       x-schemaName: StoreProductListResponse
-      required:
-        - limit
-        - offset
-        - count
-        - products
-      properties:
-        limit:
-          type: number
-          title: limit
-          description: The maximum number of items returned.
-        offset:
-          type: number
-          title: offset
-          description: The number of items skipped before retrieving the returned items.
-        count:
-          type: number
-          title: count
-          description: The total count of items.
-        products:
-          type: array
+      allOf:
+        - type: object
+          description: Pagination details
+          required:
+            - limit
+            - offset
+            - count
+          properties:
+            limit:
+              type: number
+              title: limit
+              description: The maximum number of items returned.
+            offset:
+              type: number
+              title: offset
+              description: The number of items skipped before retrieving the returned items.
+            count:
+              type: number
+              title: count
+              description: The total count of items.
+            estimate_count:
+              type: number
+              title: estimate_count
+              description: The estimated count retrieved from the PostgreSQL query planner, which may be inaccurate.
+              x-featureFlag: index_engine
+        - type: object
           description: The list of products.
-          items:
-            $ref: '#/components/schemas/StoreProduct'
-        estimate_count:
-          type: number
-          title: estimate_count
-          description: The estimated count retrieved from the PostgreSQL query planner, which may be inaccurate.
-          x-featureFlag: index_engine
+          required:
+            - products
+          properties:
+            products:
+              type: array
+              description: The list of products.
+              items:
+                $ref: '#/components/schemas/StoreProduct'
     StoreProductOption:
       type: object
       description: The product option's details.

--- a/www/utils/generated/oas-output/schemas/StoreProductListResponse.ts
+++ b/www/utils/generated/oas-output/schemas/StoreProductListResponse.ts
@@ -3,34 +3,39 @@
  * type: object
  * description: The paginated list of products.
  * x-schemaName: StoreProductListResponse
- * required:
- *   - limit
- *   - offset
- *   - count
- *   - products
- * properties:
- *   limit:
- *     type: number
- *     title: limit
- *     description: The maximum number of items returned.
- *   offset:
- *     type: number
- *     title: offset
- *     description: The number of items skipped before retrieving the returned items.
- *   count:
- *     type: number
- *     title: count
- *     description: The total count of items.
- *   products:
- *     type: array
+ * allOf:
+ *   - type: object
+ *     description: Pagination details
+ *     required:
+ *       - limit
+ *       - offset
+ *       - count
+ *     properties:
+ *       limit:
+ *         type: number
+ *         title: limit
+ *         description: The maximum number of items returned.
+ *       offset:
+ *         type: number
+ *         title: offset
+ *         description: The number of items skipped before retrieving the returned items.
+ *       count:
+ *         type: number
+ *         title: count
+ *         description: The total count of items.
+ *       estimate_count:
+ *         type: number
+ *         title: estimate_count
+ *         description: The estimated count retrieved from the PostgreSQL query planner, which may be inaccurate.
+ *         x-featureFlag: index_engine
+ *   - type: object
  *     description: The list of products.
- *     items:
- *       $ref: "#/components/schemas/StoreProduct"
- *   estimate_count:
- *     type: number
- *     title: estimate_count
- *     description: The estimated count retrieved from the PostgreSQL query planner, which may be inaccurate.
- *     x-featureFlag: index_engine
- * 
+ *     required:
+ *       - products
+ *     properties:
+ *       products:
+ *         type: array
+ *         description: The list of products.
+ *         items:
+ *           $ref: "#/components/schemas/StoreProduct"
 */
-

--- a/www/utils/packages/docs-generator/src/classes/kinds/oas.ts
+++ b/www/utils/packages/docs-generator/src/classes/kinds/oas.ts
@@ -2573,11 +2573,14 @@ class OasKindGenerator extends FunctionKindGenerator {
         false
 
       const schemaNameChanged =
-        oldSchemaObj!["x-schemaName"] !== newSchemaObj?.["x-schemaName"]
+        !!newSchemaObj?.["x-schemaName"] &&
+        oldSchemaObj!["x-schemaName"] !== newSchemaObj["x-schemaName"]
       wasUpdated = requiredChanged || schemaNameChanged
     }
     oldSchemaObj!.required = newSchemaObj?.required
-    oldSchemaObj!["x-schemaName"] = newSchemaObj?.["x-schemaName"]
+    if (newSchemaObj?.["x-schemaName"]) {
+      oldSchemaObj!["x-schemaName"] = newSchemaObj?.["x-schemaName"]
+    }
 
     return {
       schema: oldSchemaObj,


### PR DESCRIPTION
Fix schema updates that remove existing schema names, which causes incorrect replacements in generated schemas