### PR TITLE
fix(core-flows): only consider captures amounts for credit line amount computation

### DIFF
--- a/.changeset/eager-doors-kneel.md
+++ b/.changeset/eager-doors-kneel.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): only consider captures amounts for credit line amount computation

--- a/integration-tests/http/__tests__/order/admin/order-cancel-credit-line.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order-cancel-credit-line.spec.ts
@@ -1,0 +1,262 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { ModuleRegistrationName, Modules } from "@medusajs/utils"
+import {
+  adminHeaders,
+  createAdminUser,
+} from "../../../../helpers/create-admin-user"
+import { setupTaxStructure } from "../../../../modules/__tests__/fixtures"
+import { createOrderSeeder } from "../../fixtures/order"
+
+jest.setTimeout(300000)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ dbConnection, getContainer, api }) => {
+    let container
+
+    beforeEach(async () => {
+      container = getContainer()
+      await setupTaxStructure(container.resolve(ModuleRegistrationName.TAX))
+      await createAdminUser(dbConnection, adminHeaders, container)
+    })
+
+    describe("POST /admin/orders/:id/cancel - Credit Line Calculation with Multiple Payments", () => {
+      describe("when order has multiple payments with different statuses", () => {
+        it("should only include captured payment amounts in credit line, not other status payments", async () => {
+          // Create order with initial payment
+          const seeder = await createOrderSeeder({
+            api,
+            container,
+          })
+          const order = seeder.order
+          const paymentModule = container.resolve(Modules.PAYMENT)
+
+          // Get the original payment collection and payment
+          const originalPayment = order.payment_collections[0].payments[0]
+          const paymentCollectionId = order.payment_collections[0].id
+
+          // Use the authorized payment amount
+          // Note: Amounts in Medusa are already in the correct format (e.g., 1272 for $1272 USD)
+          const paymentAmount = originalPayment.amount
+          const partialCaptureAmount = 50 // Capture a fixed partial amount for testing
+
+          // Capture the original payment for partial amount
+          await api.post(
+            `/admin/payments/${originalPayment.id}/capture`,
+            { amount: partialCaptureAmount },
+            adminHeaders
+          )
+
+          // Create additional payment sessions to simulate failed payment attempts
+          // Payment session 1 - will be authorized then canceled (failed intent)
+          const failedSession1 = await paymentModule.createPaymentSession(
+            paymentCollectionId,
+            {
+              provider_id: "pp_system_default",
+              amount: paymentAmount,
+              currency_code: "usd",
+              data: {},
+            }
+          )
+          const failedPayment1 = await paymentModule.authorizePaymentSession(
+            failedSession1.id,
+            {}
+          )
+          await paymentModule.cancelPayment(failedPayment1.id)
+
+          // Payment session 2 - will be authorized then canceled (another failed intent)
+          const failedSession2 = await paymentModule.createPaymentSession(
+            paymentCollectionId,
+            {
+              provider_id: "pp_system_default",
+              amount: paymentAmount,
+              currency_code: "usd",
+              data: {},
+            }
+          )
+          const failedPayment2 = await paymentModule.authorizePaymentSession(
+            failedSession2.id,
+            {}
+          )
+          await paymentModule.cancelPayment(failedPayment2.id)
+
+          // Payment session 3 - authorized but not captured (pending)
+          const pendingSession = await paymentModule.createPaymentSession(
+            paymentCollectionId,
+            {
+              provider_id: "pp_system_default",
+              amount: 75, // Fixed amount for pending payment
+              currency_code: "usd",
+              data: {},
+            }
+          )
+          const pendingPayment = await paymentModule.authorizePaymentSession(
+            pendingSession.id,
+            {}
+          )
+
+          // Get updated order with all payments
+          const orderBeforeCancel = (
+            await api.get(
+              `/admin/orders/${order.id}?fields=*payment_collections.payments.amount,*payment_collections.payments.captured_at,*payment_collections.payments.canceled_at,*payment_collections.payments.captures.amount,*credit_lines.amount`,
+              adminHeaders
+            )
+          ).data.order
+
+          // Verify we have the expected payment states
+          expect(
+            orderBeforeCancel.payment_collections[0].payments
+          ).toHaveLength(4)
+
+          const payments = orderBeforeCancel.payment_collections[0].payments
+
+          // Find payments by their characteristics
+          const capturedPayment = payments.find(
+            (p) => p.id === originalPayment.id
+          )
+          const canceledPayments = payments.filter(
+            (p) => p.canceled_at !== null
+          )
+          const authorizedOnlyPayments = payments.filter(
+            (p) =>
+              p.captured_at === null &&
+              p.canceled_at === null &&
+              p.captures.length === 0
+          )
+
+          expect(capturedPayment).toBeDefined()
+          expect(capturedPayment.captures).toHaveLength(1)
+          expect(capturedPayment.captures[0].amount).toBe(partialCaptureAmount)
+          expect(canceledPayments).toHaveLength(2)
+          expect(authorizedOnlyPayments).toHaveLength(1)
+
+          // Cancel the order
+          const cancelResponse = await api.post(
+            `/admin/orders/${order.id}/cancel`,
+            {},
+            adminHeaders
+          )
+
+          expect(cancelResponse.status).toBe(200)
+
+          // Get order with credit lines
+          const canceledOrder = (
+            await api.get(
+              `/admin/orders/${order.id}?fields=*credit_lines.amount,*credit_lines.reference,*credit_lines.reference_id,*payment_collections.payments.amount,*payment_collections.payments.captured_at,*payment_collections.payments.canceled_at,*payment_collections.payments.captures.amount`,
+              adminHeaders
+            )
+          ).data.order
+
+          expect(canceledOrder.status).toBe("canceled")
+
+          // The critical assertion: credit lines should only account for captured amounts
+          // Expected: Only 50 (the partialCaptureAmount) should be credited
+          // Bug behavior: Would credit all payment amounts (50 + paymentAmount + paymentAmount + 75)
+          const totalCreditLineAmount = canceledOrder.credit_lines.reduce(
+            (sum, cl) => sum + cl.amount,
+            0
+          )
+
+          // This test expects ONLY the captured amount (50) to be credited
+          // If the bug exists, this will fail because it would credit all payment amounts
+          expect(totalCreditLineAmount).toBe(50)
+
+          // Verify that credit line total matches only captured amounts, not all payment amounts
+          expect(canceledOrder.summary.credit_line_total).toBe(50)
+
+          // The order total should be properly balanced (1272 - 50 = 1222)
+          expect(canceledOrder.summary.current_order_total).toBe(1222)
+          expect(canceledOrder.summary.accounting_total).toBe(1222)
+        })
+
+        it("should handle order with all payments canceled - zero credit line", async () => {
+          // Create order with initial payment
+          const seeder = await createOrderSeeder({
+            api,
+            container,
+          })
+          const order = seeder.order
+          const paymentModule = container.resolve(Modules.PAYMENT)
+
+          // Cancel the original payment (customer never successfully paid)
+          const originalPayment = order.payment_collections[0].payments[0]
+          const paymentAmount = originalPayment.amount
+          await paymentModule.cancelPayment(originalPayment.id)
+
+          // Create additional canceled payment sessions (all failed)
+          const paymentCollectionId = order.payment_collections[0].id
+
+          const failedSession1 = await paymentModule.createPaymentSession(
+            paymentCollectionId,
+            {
+              provider_id: "pp_system_default",
+              amount: paymentAmount,
+              currency_code: "usd",
+              data: {},
+            }
+          )
+          const failedPayment1 = await paymentModule.authorizePaymentSession(
+            failedSession1.id,
+            {}
+          )
+          await paymentModule.cancelPayment(failedPayment1.id)
+
+          const failedSession2 = await paymentModule.createPaymentSession(
+            paymentCollectionId,
+            {
+              provider_id: "pp_system_default",
+              amount: paymentAmount,
+              currency_code: "usd",
+              data: {},
+            }
+          )
+          const failedPayment2 = await paymentModule.authorizePaymentSession(
+            failedSession2.id,
+            {}
+          )
+          await paymentModule.cancelPayment(failedPayment2.id)
+
+          // Get order before cancel
+          const orderBeforeCancel = (
+            await api.get(
+              `/admin/orders/${order.id}?fields=*payment_collections.payments.canceled_at`,
+              adminHeaders
+            )
+          ).data.order
+
+          // Verify all payments are canceled
+          const allPaymentsCanceled =
+            orderBeforeCancel.payment_collections[0].payments.every(
+              (p) => p.canceled_at !== null
+            )
+          expect(allPaymentsCanceled).toBe(true)
+
+          // Try to cancel the order
+          const cancelResponse = await api
+            .post(`/admin/orders/${order.id}/cancel`, {}, adminHeaders)
+            .catch((e) => e.response)
+
+          // The order should cancel successfully
+          expect(cancelResponse.status).toBe(200)
+
+          // Get order with credit lines
+          const canceledOrder = (
+            await api.get(
+              `/admin/orders/${order.id}?fields=*credit_lines.amount`,
+              adminHeaders
+            )
+          ).data.order
+
+          // No captured payments = no credit line amount
+          // Bug behavior: Would credit sum of all canceled payment amounts
+          const totalCreditLineAmount = canceledOrder.credit_lines.reduce(
+            (sum, cl) => sum + cl.amount,
+            0
+          )
+
+          expect(totalCreditLineAmount).toBe(0)
+          expect(canceledOrder.summary.credit_line_total).toBe(0)
+        })
+      })
+    })
+  },
+})

--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -22,7 +22,6 @@ import {
 
 jest.setTimeout(300000)
 
-
 medusaIntegrationTestRunner({
   testSuite: ({ dbConnection, getContainer, api }) => {
     let order,
@@ -822,8 +821,8 @@ medusaIntegrationTestRunner({
             status: "canceled",
 
             summary: expect.objectContaining({
-              current_order_total: 0,
-              accounting_total: 0,
+              current_order_total: 106,
+              accounting_total: 106,
             }),
 
             payment_collections: [
@@ -951,8 +950,8 @@ medusaIntegrationTestRunner({
             status: "canceled",
 
             summary: expect.objectContaining({
-              current_order_total: 0,
-              accounting_total: 0,
+              current_order_total: 56,
+              accounting_total: 56,
             }),
 
             payment_collections: [
@@ -1962,7 +1961,8 @@ medusaIntegrationTestRunner({
 
         // cancel the fulfillment
         await api.post(
-          `/admin/orders/${tabletOrder.id}/fulfillments/${fulOrder2.fulfillments.find((f) => !f.canceled_at).id
+          `/admin/orders/${tabletOrder.id}/fulfillments/${
+            fulOrder2.fulfillments.find((f) => !f.canceled_at).id
           }/cancel`,
           {},
           adminHeaders
@@ -2355,7 +2355,8 @@ medusaIntegrationTestRunner({
 
         // 7. cancel the entire fulfillment once again
         await api.post(
-          `/admin/orders/${fulOrderFull.id}/fulfillments/${fulOrderFull.fulfillments.find((f) => !f.canceled_at)!.id
+          `/admin/orders/${fulOrderFull.id}/fulfillments/${
+            fulOrderFull.fulfillments.find((f) => !f.canceled_at)!.id
           }/cancel?fields=*fulfillments,*fulfillments.items`,
           {},
           adminHeaders
@@ -2859,7 +2860,8 @@ medusaIntegrationTestRunner({
 
         // cancel the fulfillment for the entire order
         await api.post(
-          `/admin/orders/${bottleOrder.id}/fulfillments/${fulOrder3.fulfillments.find((f) => !f.canceled_at)!.id
+          `/admin/orders/${bottleOrder.id}/fulfillments/${
+            fulOrder3.fulfillments.find((f) => !f.canceled_at)!.id
           }/cancel`,
           {},
           adminHeaders

--- a/packages/core/core-flows/src/order/workflows/cancel-order.ts
+++ b/packages/core/core-flows/src/order/workflows/cancel-order.ts
@@ -138,6 +138,7 @@ export const cancelOrderWorkflow = createWorkflow(
         "payment_collections.payments.refunds.amount",
         "payment_collections.payments.captures.id",
         "payment_collections.payments.captures.amount",
+        "payment_collections.payments.captures.raw_amount",
       ],
       filters: { id: input.order_id },
       options: { throwIfKeyNotFound: true },
@@ -174,7 +175,7 @@ export const cancelOrderWorkflow = createWorkflow(
       return payments
         .flatMap((payment) => payment.captures)
         .reduce(
-          (acc, capture) => MathBN.sum(acc, capture.amount),
+          (acc, capture) => MathBN.sum(acc, capture.raw_amount),
           MathBN.convert(0)
         )
     })

--- a/packages/core/core-flows/src/order/workflows/cancel-order.ts
+++ b/packages/core/core-flows/src/order/workflows/cancel-order.ts
@@ -171,10 +171,12 @@ export const cancelOrderWorkflow = createWorkflow(
         ({ payments }) => payments
       )
 
-      return payments.reduce(
-        (acc, payment) => MathBN.sum(acc, payment.amount),
-        MathBN.convert(0)
-      )
+      return payments
+        .flatMap((payment) => payment.captures)
+        .reduce(
+          (acc, capture) => MathBN.sum(acc, capture.amount),
+          MathBN.convert(0)
+        )
     })
 
     const lineItemIds = transform({ order }, ({ order }) => {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix the credit line amount computation logic upon order cancellation.

**Why** — Why are these changes relevant or necessary?  

Currently wehen cancelling an order, the credit line amount is incorrectly computed based on the amounts of the payments linked to the order, regardless of their statuses.

**How** — How have these changes been implemented?

Only take into consideration the amounts of the captures (if any) to resolve the total credit line amount. This prevents situations like we currently have, where, for an order with multiple cancelled/pending payments you end up with really big negative pending differences.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes CORE-1382
