### PR TITLE
fix(create-medusa-app): fix installations with storefronts for pnpm

### DIFF
--- a/.changeset/moody-baboons-reply.md
+++ b/.changeset/moody-baboons-reply.md
@@ -1,0 +1,5 @@
+---
+"create-medusa-app": patch
+---
+
+fix(create-medusa-app): fix installations with storefronts for pnpm

--- a/packages/cli/create-medusa-app/src/utils/nextjs-utils.ts
+++ b/packages/cli/create-medusa-app/src/utils/nextjs-utils.ts
@@ -74,10 +74,21 @@ export async function installNextjsStarter({
       { verbose }
     )
 
+    const packageJsonPath = path.join(nextjsDirectory, "package.json")
+    let packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"))
+
     if (version) {
-      const packageJsonPath = path.join(nextjsDirectory, "package.json")
-      updatePackageVersions(packageJsonPath, version, { applyChanges: true })
+      packageJson = updatePackageVersions(packageJsonPath, version, {
+        applyChanges: false,
+      })
     }
+
+    // Update packageManager field to match user's chosen package manager
+    const packageManagerString = await packageManager.getPackageManagerString()
+    if (packageManagerString) {
+      packageJson.packageManager = packageManagerString
+    }
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
 
     const execOptions = {
       signal: abortController?.signal,

--- a/packages/cli/create-medusa-app/src/utils/package-manager.ts
+++ b/packages/cli/create-medusa-app/src/utils/package-manager.ts
@@ -197,14 +197,6 @@ export default class PackageManager {
     if (!this.packageManager) {
       await this.setPackageManager(execOptions)
     }
-    if (this.verbose) {
-      logMessage({
-        type: "info",
-        message: `Installing dependencies using ${
-          this.packageManager
-        } and options: ${JSON.stringify(execOptions)}`,
-      })
-    }
 
     // Remove lock files from other package managers
     if (execOptions.cwd && typeof execOptions.cwd === "string") {

--- a/packages/cli/create-medusa-app/src/utils/package-manager.ts
+++ b/packages/cli/create-medusa-app/src/utils/package-manager.ts
@@ -197,6 +197,14 @@ export default class PackageManager {
     if (!this.packageManager) {
       await this.setPackageManager(execOptions)
     }
+    if (this.verbose) {
+      logMessage({
+        type: "info",
+        message: `Installing dependencies using ${
+          this.packageManager
+        } and options: ${JSON.stringify(execOptions)}`,
+      })
+    }
 
     // Remove lock files from other package managers
     if (execOptions.cwd && typeof execOptions.cwd === "string") {

--- a/packages/cli/create-medusa-app/src/utils/update-package-versions.ts
+++ b/packages/cli/create-medusa-app/src/utils/update-package-versions.ts
@@ -4,7 +4,7 @@ export function updatePackageVersions(
   packageJsonOrPath: string | Record<string, any>,
   version: string,
   { applyChanges = false }: { applyChanges?: boolean } = {}
-) {
+): Record<string, any> {
   const packageJson =
     typeof packageJsonOrPath === "string"
       ? JSON.parse(readFileSync(packageJsonOrPath, "utf-8"))
@@ -28,6 +28,8 @@ export function updatePackageVersions(
   if (applyChanges && typeof packageJsonOrPath === "string") {
     writeFileSync(packageJsonOrPath, JSON.stringify(packageJson, null, 2))
   }
+
+  return packageJson
 }
 
 function shouldUpdateVersion(dependency: string): boolean {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fixes installation errors when installing Medusa with pnpm and enabling the Next.js Starter Storefront

Closes #14675

**Why** — Why are these changes relevant or necessary?  

When installing Medusa with pnpm and enabling the Next.js Starter Storefront, users run into the following error:

```
The specified package manager "pnpm" is not available. Please install it or choose another package manager.
```

**How** — How have these changes been implemented?

This PR fixes the issue by updating the package manager used in the `package.json` file in the Next.js Starter Storefront to the package manager that the user is using, which is `pnpm` in this case. This is the same strategy we use for the backend.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

You can test this out by running:

```
pnpm dlx create-medusa-app@2.13.2-snapshot-20260202072528
```

and enabling Next.js Starter Storefront. the installation should complete successfully.

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable
