### PR TITLE
fix(admin): Handle deleted stock locations gracefully in order details

### DIFF
--- a/.changeset/tough-falcons-sing.md
+++ b/.changeset/tough-falcons-sing.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix: Handle deleted stock locations gracefully in order details

--- a/packages/admin/dashboard/src/i18n/translations/en.json
+++ b/packages/admin/dashboard/src/i18n/translations/en.json
@@ -1435,7 +1435,9 @@
       },
       "trackingLabel": "Tracking",
       "shippingFromLabel": "Shipping from",
-      "itemsLabel": "Items"
+      "itemsLabel": "Items",
+      "locationDeleted": "Location deleted",
+      "locationUnavailable": "Location unavailable"
     },
     "refund": {
       "title": "Create Refund",

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-fulfillment-section/__tests__/order-fulfillment-section.spec.ts
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-fulfillment-section/__tests__/order-fulfillment-section.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { FetchError } from "@medusajs/js-sdk"
+
+/**
+ * Tests for the location error classification logic used in the
+ * Fulfillment component to distinguish deleted stock locations (404)
+ * from other errors (network, 500, 403, etc.).
+ *
+ * The component uses:
+ *   const isLocationDeleted = isError && (error as FetchError)?.status === 404
+ *
+ * - When isLocationDeleted is true, it renders t("orders.fulfillment.locationDeleted")
+ * - When isError is true but not 404, it renders t("orders.fulfillment.locationUnavailable")
+ * - When stock_location exists, it renders the location name as a link
+ * - Otherwise, it renders a loading skeleton
+ */
+
+// Extract the same logic from the component for direct unit testing
+const isLocationDeleted = (isError: boolean, error: unknown): boolean => {
+  return isError && (error as FetchError)?.status === 404
+}
+
+describe("Order Fulfillment Section - Location Error Handling", () => {
+  it("should identify a 404 error as a deleted location", () => {
+    const error = new FetchError("Not Found", "Not Found", 404)
+    expect(isLocationDeleted(true, error)).toBe(true)
+  })
+
+  it("should not treat a 500 error as a deleted location", () => {
+    const error = new FetchError("Internal Server Error", "Internal Server Error", 500)
+    expect(isLocationDeleted(true, error)).toBe(false)
+  })
+
+  it("should not treat a 403 error as a deleted location", () => {
+    const error = new FetchError("Forbidden", "Forbidden", 403)
+    expect(isLocationDeleted(true, error)).toBe(false)
+  })
+
+  it("should not treat a network error as a deleted location", () => {
+    const error = new Error("Network Error")
+    expect(isLocationDeleted(true, error)).toBe(false)
+  })
+
+  it("should return false when isError is false", () => {
+    const error = new FetchError("Not Found", "Not Found", 404)
+    expect(isLocationDeleted(false, error)).toBe(false)
+  })
+
+  it("should return false when error is null", () => {
+    expect(isLocationDeleted(true, null)).toBe(false)
+  })
+
+  it("should return false when error is undefined", () => {
+    expect(isLocationDeleted(true, undefined)).toBe(false)
+  })
+
+  it("should return false when error has no status property", () => {
+    const error = { message: "something went wrong" }
+    expect(isLocationDeleted(true, error)).toBe(false)
+  })
+})

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -218,7 +218,7 @@ const Fulfillment = ({
     fulfillment.shipping_option?.service_zone.fulfillment_set.type ===
     FulfillmentSetType.Pickup
 
-  const { stock_location, isError, error } = useStockLocation(
+  const { stock_location, isError, error, isLoading } = useStockLocation(
     fulfillment.location_id!,
     undefined,
     {
@@ -316,10 +316,6 @@ const Fulfillment = ({
     }
   }
 
-  if (isError) {
-    throw error
-  }
-
   const isValidUrl = (url?: string) => url && url.length > 0 && url !== "#"
 
   return (
@@ -388,6 +384,10 @@ const Fulfillment = ({
                 {stock_location.name}
               </Text>
             </Link>
+          ) : isError ? (
+            <Text size="small" leading="compact" className="text-ui-fg-muted italic">
+              Location deleted
+            </Text>
           ) : (
             <Skeleton className="w-16" />
           )}

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -1,3 +1,4 @@
+import { FetchError } from "@medusajs/js-sdk"
 import { Buildings, XCircle } from "@medusajs/icons"
 import {
   AdminOrder,
@@ -218,13 +219,15 @@ const Fulfillment = ({
     fulfillment.shipping_option?.service_zone.fulfillment_set.type ===
     FulfillmentSetType.Pickup
 
-  const { stock_location, isError, error, isLoading } = useStockLocation(
+  const { stock_location, isError, error } = useStockLocation(
     fulfillment.location_id!,
     undefined,
     {
       enabled: showLocation,
     }
   )
+
+  const isLocationDeleted = isError && (error as FetchError)?.status === 404
 
   let statusText = fulfillment.requires_shipping
     ? isPickUpFulfillment
@@ -384,9 +387,13 @@ const Fulfillment = ({
                 {stock_location.name}
               </Text>
             </Link>
+          ) : isLocationDeleted ? (
+            <Text size="small" leading="compact" className="text-ui-fg-muted italic">
+              {t("orders.fulfillment.locationDeleted")}
+            </Text>
           ) : isError ? (
             <Text size="small" leading="compact" className="text-ui-fg-muted italic">
-              Location deleted
+              {t("orders.fulfillment.locationUnavailable")}
             </Text>
           ) : (
             <Skeleton className="w-16" />


### PR DESCRIPTION
## What

Handle deleted stock locations gracefully in the order details fulfillment section instead of crashing the page.

## Why

When a stock location referenced by a fulfillment is deleted, the `useStockLocation` hook returns a 404 error. Previously, this error was thrown directly, triggering the React error boundary and crashing the entire order details page. This made it impossible to view or manage orders that had fulfillments from deleted locations.

Fixes #14672

## How

- Check the error status code from `FetchError` to distinguish between a 404 (deleted location) and other errors (network, 500, 403)
- Render a translated `Location deleted` placeholder for 404 errors and `Location unavailable` for other error types
- Use the `t()` translation function with new i18n keys (`orders.fulfillment.locationDeleted` and `orders.fulfillment.locationUnavailable`) instead of hardcoded English strings
- Remove the unused `isLoading` destructuring from `useStockLocation`

## Testing

1. Create a stock location and fulfill an order from it
2. Delete the stock location
3. Open the order details page
4. Verify the page no longer crashes and shows a muted italic `Location deleted` text where the location name would be
5. Simulate a network error (e.g. disconnect) and verify it shows `Location unavailable` instead