### PR TITLE
Only encode uploaded filenames not filename and prefix.

### DIFF
--- a/.changeset/perky-peas-find.md
+++ b/.changeset/perky-peas-find.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/file-s3": patch
+---
+
+Only encode filename in image url, rather than both prefix and filename

--- a/packages/modules/providers/file-s3/src/services/s3-file.ts
+++ b/packages/modules/providers/file-s3/src/services/s3-file.ts
@@ -9,15 +9,8 @@ import {
 } from "@aws-sdk/client-s3"
 import { Upload } from "@aws-sdk/lib-storage"
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
-import {
-  FileTypes,
-  Logger,
-  S3FileServiceOptions,
-} from "@medusajs/framework/types"
-import {
-  AbstractFileProviderService,
-  MedusaError,
-} from "@medusajs/framework/utils"
+import { FileTypes, Logger, S3FileServiceOptions, } from "@medusajs/framework/types"
+import { AbstractFileProviderService, MedusaError, } from "@medusajs/framework/utils"
 import path from "path"
 import { PassThrough, Readable, Writable } from "stream"
 import { ulid } from "ulid"
@@ -117,9 +110,10 @@ export class S3FileService extends AbstractFileProviderService {
     const parsedFilename = path.parse(file.filename)
 
     // TODO: Allow passing a full path for storage per request, not as a global config.
-    const fileKey = `${this.config_.prefix}${parsedFilename.name}-${ulid()}${
+    const encodedFilename = encodeURIComponent(`${parsedFilename.name}-${ulid()}${
       parsedFilename.ext
-    }`
+    }`)
+    const fileKey = `${this.config_.prefix}${encodedFilename}`
 
     let content: Buffer
     try {
@@ -161,7 +155,7 @@ export class S3FileService extends AbstractFileProviderService {
     }
 
     return {
-      url: `${this.config_.fileUrl}/${encodeURIComponent(fileKey)}`,
+      url: `${this.config_.fileUrl}/${fileKey}`,
       key: fileKey,
     }
   }


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

A fix to only encode the filename of upload images, rather than the filename and prefix

**Why** — Why are these changes relevant or necessary?  

Currently, if the prefix includes paths (e.g. media/medusa), the resultant url will be URLescaped (https://s3.bucket/bucket/media%25medusa%25filename.png)

When this is passed to front-ends, this can lead to double encoding errors


---

## Checklist

Please ensure the following before requesting a review:

- [ x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ x] The changes are covered by relevant **tests**
- [ x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `upload()` generates S3 object keys and public URLs by encoding only the filename portion; this can affect downstream consumers that persist or compare returned `key` values or rely on previous URL encoding behavior.
> 
> **Overview**
> Fixes S3 upload URL construction so `prefix` path segments are no longer URL-escaped, preventing malformed URLs when prefixes contain `/`.
> 
> `upload()` now URL-encodes only the generated filename component (and returns the URL without additionally encoding the full key), which also changes the returned `key` to include the encoded filename. Adds a changeset for a patch release of `@medusajs/file-s3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0baba94dac35e260f5bc2ba484155c62c17cd3f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

fixes #14756