### PR TITLE
docs: fix Dockerfile COPY command for .yarn/releases directory

### DIFF
--- a/www/apps/book/app/learn/installation/docker/page.mdx
+++ b/www/apps/book/app/learn/installation/docker/page.mdx
@@ -238,7 +238,8 @@ FROM node:20-alpine
 WORKDIR /server
 
 # Copy package files and yarn config
-COPY package.json yarn.lock .yarnrc.yml .yarn/releases ./
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn/releases .yarn/releases
 
 # Install all dependencies using yarn
 RUN yarn install


### PR DESCRIPTION
## Summary

- Fixes the Dockerfile example in the Docker installation guide where `.yarn/releases` directory structure is not preserved during COPY
- When using `COPY` with multiple sources, Docker copies the **contents** of directories directly into the destination, causing `yarn-4.12.0.cjs` to end up in `/server/` instead of `/server/.yarn/releases/`
- This results in the error: `Cannot find module '/server/.yarn/releases/yarn-4.12.0.cjs'`

## Solution

Split the COPY command into two separate commands to preserve the directory structure:

```dockerfile
# Before (broken)
COPY package.json yarn.lock .yarnrc.yml .yarn/releases ./

# After (working)
COPY package.json yarn.lock .yarnrc.yml ./
COPY .yarn/releases .yarn/releases
```

## Test plan

- [ ] Clone medusa-starter-default
- [ ] Follow the Docker installation guide with the updated Dockerfile
- [ ] Verify `yarn install` succeeds inside the container

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that updates a Dockerfile snippet; no runtime code changes, but it affects copy/paste build steps in the installation guide.
> 
> **Overview**
> Fixes the Docker installation guide’s Yarn `Dockerfile` example so `.yarn/releases` is copied *as a directory* rather than flattening its contents.
> 
> The single multi-source `COPY` is split into two `COPY` commands to ensure Yarn’s release file ends up at `/server/.yarn/releases/...`, preventing module-not-found errors during `yarn install`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b7c3fa3988085bc0cf44eac70a1041947813e3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->