### PR TITLE
fix(js-sdk): fix return type of listAddresses

### DIFF
--- a/.changeset/tricky-owls-rule.md
+++ b/.changeset/tricky-owls-rule.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/js-sdk": patch
+---
+
+fix(js-sdk): fix return type of listAddresses

--- a/packages/core/js-sdk/src/admin/customer.ts
+++ b/packages/core/js-sdk/src/admin/customer.ts
@@ -389,7 +389,7 @@ export class Customer {
    * })
    */
   async listAddresses(id: string, headers?: ClientHeaders) {
-    return await this.client.fetch<HttpTypes.AdminCustomerResponse>(
+    return await this.client.fetch<HttpTypes.AdminCustomerAddressListResponse>(
       `/admin/customers/${id}/addresses`,
       {
         headers,


### PR DESCRIPTION
The `admin.customer.listAddresses` returns the addresses in the response. However, the method's typing shows that it returns a customer. this PR fixes it

Closes #14708
