### PR TITLE
fix(medusa): prevent plugin:db:generate crash when model files export…

### DIFF
--- a/.changeset/fix-plugin-db-generate-enum.md
+++ b/.changeset/fix-plugin-db-generate-enum.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): prevent plugin:db:generate crash when model files export enums

--- a/packages/medusa/src/commands/plugin/db/generate.ts
+++ b/packages/medusa/src/commands/plugin/db/generate.ts
@@ -7,7 +7,6 @@ import {
   isFileSkipped,
   toUnixSlash,
 } from "@medusajs/framework/utils"
-import { MetadataStorage } from "@medusajs/framework/mikro-orm/core"
 import { MikroORM } from "@medusajs/framework/mikro-orm/postgresql"
 import { glob } from "glob"
 import { dirname, join } from "path"
@@ -78,7 +77,7 @@ async function getEntitiesForModule(path: string) {
       (potentialEntity) => {
         return (
           DmlEntity.isDmlEntity(potentialEntity) ||
-          !!MetadataStorage.getMetadataFromDecorator(potentialEntity as any)
+          typeof potentialEntity === "function"
         )
       }
     )

--- a/packages/medusa/src/commands/plugin/db/generate.ts
+++ b/packages/medusa/src/commands/plugin/db/generate.ts
@@ -7,6 +7,7 @@ import {
   isFileSkipped,
   toUnixSlash,
 } from "@medusajs/framework/utils"
+import { MetadataStorage } from "@medusajs/framework/mikro-orm/core"
 import { MikroORM } from "@medusajs/framework/mikro-orm/postgresql"
 import { glob } from "glob"
 import { dirname, join } from "path"
@@ -77,7 +78,10 @@ async function getEntitiesForModule(path: string) {
       (potentialEntity) => {
         return (
           DmlEntity.isDmlEntity(potentialEntity) ||
-          typeof potentialEntity === "function"
+          Object.hasOwn(
+            potentialEntity as object,
+            MetadataStorage.PATH_SYMBOL
+          )
         )
       }
     )

--- a/packages/medusa/src/commands/plugin/db/integration-tests/__fixtures__/plugins-1-with-enum/src/modules/module-1/index.ts
+++ b/packages/medusa/src/commands/plugin/db/integration-tests/__fixtures__/plugins-1-with-enum/src/modules/module-1/index.ts
@@ -1,0 +1,4 @@
+import { MedusaService, Module } from "@medusajs/framework/utils"
+export default Module("module1_with_enum", {
+  service: class Module1Service extends MedusaService({}) {},
+})

--- a/packages/medusa/src/commands/plugin/db/integration-tests/__fixtures__/plugins-1-with-enum/src/modules/module-1/models/module-model-1.ts
+++ b/packages/medusa/src/commands/plugin/db/integration-tests/__fixtures__/plugins-1-with-enum/src/modules/module-1/models/module-model-1.ts
@@ -1,0 +1,14 @@
+import { model } from "@medusajs/framework/utils"
+
+// This enum export previously caused plugin:db:generate to crash
+export enum MyStatus {
+  ACTIVE = "active",
+  INACTIVE = "inactive",
+}
+
+const model1 = model.define("module_model_1_with_enum", {
+  id: model.id().primaryKey(),
+  name: model.text(),
+})
+
+export default model1

--- a/packages/medusa/src/commands/plugin/db/integration-tests/__tests__/plugin-generate.spec.ts
+++ b/packages/medusa/src/commands/plugin/db/integration-tests/__tests__/plugin-generate.spec.ts
@@ -70,6 +70,19 @@ describe("plugin-generate", () => {
       )
     )
     await emptyModule.remove("migrations")
+
+    const module1WithEnum = new FileSystem(
+      join(
+        __dirname,
+        "..",
+        "__fixtures__",
+        "plugins-1-with-enum",
+        "src",
+        "modules",
+        "module-1"
+      )
+    )
+    await module1WithEnum.remove("migrations")
   })
 
   describe("main function", () => {
@@ -185,6 +198,24 @@ describe("plugin-generate", () => {
       expect(logger.info).toHaveBeenNthCalledWith(
         3,
         "No entities found for module moduleEmpty, skipping..."
+      )
+      expect(logger.info).toHaveBeenNthCalledWith(4, "Migrations generated")
+      expect(process.exit).toHaveBeenCalledWith()
+    })
+
+    it("should successfully generate migrations when model files export enums alongside entities", async () => {
+      await main({
+        directory: join(__dirname, "..", "__fixtures__", "plugins-1-with-enum"),
+      })
+
+      expect(logger.info).toHaveBeenNthCalledWith(1, "Generating migrations...")
+      expect(logger.info).toHaveBeenNthCalledWith(
+        2,
+        "Generating migrations for module module1_with_enum..."
+      )
+      expect(logger.info).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining("Migration created")
       )
       expect(logger.info).toHaveBeenNthCalledWith(4, "Migrations generated")
       expect(process.exit).toHaveBeenCalledWith()


### PR DESCRIPTION
fix(medusa): prevent plugin:db:generate crash when model files export enums

`MetadataStorage.getMetadataFromDecorator()` returns a truthy `EntityMetadata` for any input with a `.name` property, causing TypeScript enums to be incorrectly treated as database entities. This crashes MikroORM when it tries to process them during migration generation.

Replace the `MetadataStorage` check with `typeof === "function"`, which correctly identifies MikroORM class entities while rejecting enum objects. This matches the proven pattern already used in `load-internal.ts` `cleanupResources` for the regular `db:generate` path.

## Summary

**What** — Fix entity detection in `plugin:db:generate` to prevent TypeScript enums from being treated as MikroORM entities.

**Why** — When model files export enums, MikroORM crashes during migration generation because enums are mistakenly identified as database entities. `MetadataStorage.getMetadataFromDecorator()` returns truthy for anything with a `.name` property, which includes compiled TypeScript enums.

**How** — Replaced the `MetadataStorage.getMetadataFromDecorator()` check with `typeof potentialEntity === "function"` in the entity filter inside `getEntitiesForModule()` (`packages/medusa/src/commands/plugin/db/generate.ts`). Class constructors are functions; enum objects are not — so this correctly filters out enums while keeping real entities. This aligns with the same pattern already used in `load-internal.ts` `cleanupResources`.

**Testing** — Create a plugin with a model file that exports both a MikroORM entity and a TypeScript enum, then run `npx medusa plugin:db:generate`. Before this fix the command crashes; after it generates migrations correctly.

---

## Examples

```ts
// packages/my-plugin/src/models/my-entity.ts

// This enum export previously caused plugin:db:generate to crash
export enum MyStatus {
  ACTIVE = "active",
  INACTIVE = "inactive",
}

@Entity()
export class MyEntity {
  @PrimaryKey()
  id: string

  @Enum(() => MyStatus)
  status: MyStatus
}
```

```bash
# Reproduce
npx medusa plugin:db:generate

# Before fix: MikroORM crashes trying to process the enum as an entity
# After fix: migration generated successfully
```

---

## Checklist

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

The regular (non-plugin) `db:generate` path in `load-internal.ts` already uses the same `typeof === "function"` pattern in its `cleanupResources` function. This PR aligns the plugin path with that existing approach.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes entity/resource detection for migrations and module loading; if `MetadataStorage.PATH_SYMBOL` isn’t present in some valid entities, they may be skipped and migrations could be incomplete, but the change is small and localized.
> 
> **Overview**
> Prevents `plugin:db:generate` from crashing when model files export non-entity values by tightening the entity filter to only accept DML entities or exports marked with MikroORM `MetadataStorage.PATH_SYMBOL`.
> 
> Aligns the module auto-loader’s `cleanupResources` logic with the same `PATH_SYMBOL` check so only real entities/services are kept when scanning module directories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d5e0a9af2383f73d7b09b5765293d306702e5fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

fixes #15077