### PR TITLE
fix(orchestration): continueOnPermanentFailure when timeout

### DIFF
--- a/.changeset/fifty-teeth-prove.md
+++ b/.changeset/fifty-teeth-prove.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/orchestration": patch
+---
+
+fix(orchestration): continueOnPermanentFailure when timeout

--- a/integration-tests/modules/__tests__/workflow-engine/workflow-engine.spec.ts
+++ b/integration-tests/modules/__tests__/workflow-engine/workflow-engine.spec.ts
@@ -165,6 +165,82 @@ medusaIntegrationTestRunner({
           )
         })
       })
+
+      describe("Step timeout with continueOnPermanentFailure", () => {
+        it("should continue the workflow when an async step with retryIntervalAwaiting reaches timeout and continueOnPermanentFailure is set", async () => {
+          const invokeSpy = jest.fn()
+
+          const step1 = createStep(
+            {
+              name: "step-sync",
+            },
+            async () => {
+              return new StepResponse({ result: "from-step-1" })
+            }
+          )
+
+          const step2 = createStep(
+            {
+              name: "step-async-timeout",
+              async: true,
+              timeout: 1,
+              retryIntervalAwaiting: 0.3,
+              maxAwaitingRetries: 2,
+              continueOnPermanentFailure: true,
+              noCompensation: true,
+            },
+            async () => {
+              invokeSpy()
+            }
+          )
+
+          const step3 = createStep(
+            {
+              name: "step-after-timeout",
+            },
+            async () => {
+              return new StepResponse({ result: "from-step-3" })
+            }
+          )
+
+          createWorkflow(
+            {
+              name: "wf-timeout-continue",
+              retentionTime: 50,
+            },
+            function () {
+              step1()
+              step2()
+              const res3 = step3()
+              return new WorkflowResponse(res3)
+            }
+          )
+
+          const container = getContainer()
+          const engine = container.resolve(Modules.WORKFLOW_ENGINE)
+
+          const transactionId = "trx-timeout-continue"
+          const { transaction } = await engine.run("wf-timeout-continue", {
+            transactionId,
+            throwOnError: false,
+          })
+
+          // The workflow should be waiting for the async step
+          expect(transaction.getState()).toBe(TransactionState.INVOKING)
+
+          // Wait for the step timeout to fire (1s) plus some buffer
+          await new Promise((resolve) => global.setTimeout(resolve, 2000))
+
+          const executions = await engine.listWorkflowExecutions({
+            transaction_id: transactionId,
+          })
+
+          expect(executions.length).toBe(1)
+          expect(executions[0].state).toBe(TransactionState.DONE)
+
+          expect(invokeSpy).toHaveBeenCalled()
+        })
+      })
     })
   },
 })

--- a/integration-tests/modules/__tests__/workflow-engine/workflow-engine.spec.ts
+++ b/integration-tests/modules/__tests__/workflow-engine/workflow-engine.spec.ts
@@ -169,6 +169,7 @@ medusaIntegrationTestRunner({
       describe("Step timeout with continueOnPermanentFailure", () => {
         it("should continue the workflow when an async step with retryIntervalAwaiting reaches timeout and continueOnPermanentFailure is set", async () => {
           const invokeSpy = jest.fn()
+          const invokeSpyB = jest.fn()
 
           const step1 = createStep(
             {
@@ -176,6 +177,20 @@ medusaIntegrationTestRunner({
             },
             async () => {
               return new StepResponse({ result: "from-step-1" })
+            }
+          )
+
+          const step2b = createStep(
+            {
+              name: "step-async-timeout-b",
+              async: true,
+              timeout: 1,
+              retryIntervalAwaiting: 0.3,
+              maxAwaitingRetries: 2,
+              continueOnPermanentFailure: true,
+            },
+            async () => {
+              invokeSpyB()
             }
           )
 
@@ -211,6 +226,7 @@ medusaIntegrationTestRunner({
             function () {
               step1()
               step2()
+              step2b()
               const res3 = step3()
               return new WorkflowResponse(res3)
             }
@@ -228,8 +244,8 @@ medusaIntegrationTestRunner({
           // The workflow should be waiting for the async step
           expect(transaction.getState()).toBe(TransactionState.INVOKING)
 
-          // Wait for the step timeout to fire (1s) plus some buffer
-          await new Promise((resolve) => global.setTimeout(resolve, 2000))
+          // Wait for the step timeout to fire plus some buffer
+          await new Promise((resolve) => global.setTimeout(resolve, 4000))
 
           const executions = await engine.listWorkflowExecutions({
             transaction_id: transactionId,
@@ -239,6 +255,7 @@ medusaIntegrationTestRunner({
           expect(executions[0].state).toBe(TransactionState.DONE)
 
           expect(invokeSpy).toHaveBeenCalled()
+          expect(invokeSpyB).toHaveBeenCalled()
         })
       })
     })

--- a/packages/core/orchestration/src/__tests__/transaction/transaction-orchestrator.ts
+++ b/packages/core/orchestration/src/__tests__/transaction/transaction-orchestrator.ts
@@ -1609,6 +1609,408 @@ describe("Transaction Orchestrator", () => {
       expect(transaction.getState()).toBe(TransactionState.DONE)
     })
 
+    it("should continue the transaction when the Step Timeout is reached but the step is set to 'continueOnPermanentFailure'", async () => {
+      const mocks = {
+        f1: jest.fn(() => {
+          return "content f1"
+        }),
+        f2: jest.fn(async () => {
+          await setTimeout(200)
+          return "delayed content f2"
+        }),
+        f3: jest.fn(() => {
+          return "content f3"
+        }),
+      }
+
+      async function handler(
+        actionId: string,
+        functionHandlerType: TransactionHandlerType,
+        payload: TransactionPayload
+      ) {
+        const command = {
+          action1: {
+            [TransactionHandlerType.INVOKE]: () => {
+              return mocks.f1()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f1()
+            },
+          },
+          action2: {
+            [TransactionHandlerType.INVOKE]: async () => {
+              return await mocks.f2()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f2()
+            },
+          },
+          action3: {
+            [TransactionHandlerType.INVOKE]: () => {
+              return mocks.f3()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f3()
+            },
+          },
+        }
+
+        return command[actionId][functionHandlerType]()
+      }
+
+      const flow: TransactionStepsDefinition = {
+        next: {
+          action: "action1",
+          next: {
+            timeout: 0.1, // 100ms
+            action: "action2",
+            continueOnPermanentFailure: true,
+            next: {
+              action: "action3",
+            },
+          },
+        },
+      }
+
+      const strategy = new TransactionOrchestrator({
+        id: "transaction-name",
+        definition: flow,
+      })
+
+      const transaction = await strategy.beginTransaction({
+        transactionId: "transaction_id_123",
+        handler,
+      })
+
+      await strategy.resume(transaction)
+
+      expect(transaction.transactionId).toBe("transaction_id_123")
+      expect(mocks.f1).toHaveBeenCalledTimes(1)
+      expect(mocks.f2).toHaveBeenCalledTimes(1)
+      expect(mocks.f3).toHaveBeenCalledTimes(1)
+      expect(transaction.getContext().invoke.action1).toBe("content f1")
+      expect(transaction.getContext().invoke.action2).toBe("delayed content f2")
+      expect(transaction.getContext().invoke.action3).toBe("content f3")
+      expect(
+        transaction.getFlow().steps["_root.action1.action2"].invoke.state
+      ).toBe(TransactionStepState.TIMEOUT)
+      expect(
+        transaction.getFlow().steps["_root.action1.action2"].invoke.status
+      ).toBe(TransactionStepStatus.PERMANENT_FAILURE)
+      expect(
+        transaction.getFlow().steps["_root.action1.action2"].compensate.state
+      ).toBe(TransactionStepState.DORMANT)
+      expect(
+        transaction.getFlow().steps["_root.action1.action2.action3"].invoke
+          .state
+      ).toBe(TransactionStepState.DONE)
+
+      expect(transaction.getState()).toBe(TransactionState.DONE)
+      expect(transaction.isPartiallyCompleted).toBe(true)
+    })
+
+    it("should continue the transaction with parallel steps when one times out with 'continueOnPermanentFailure'", async () => {
+      const mocks = {
+        f1: jest.fn(() => {
+          return "content f1"
+        }),
+        f2: jest.fn(async () => {
+          await setTimeout(200)
+          return "delayed content f2"
+        }),
+        f3: jest.fn(() => {
+          return "content f3"
+        }),
+        f4: jest.fn(() => {
+          return "content f4"
+        }),
+      }
+
+      async function handler(
+        actionId: string,
+        functionHandlerType: TransactionHandlerType,
+        payload: TransactionPayload
+      ) {
+        const command = {
+          action1: {
+            [TransactionHandlerType.INVOKE]: () => {
+              return mocks.f1()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f1()
+            },
+          },
+          action2: {
+            [TransactionHandlerType.INVOKE]: async () => {
+              return await mocks.f2()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f2()
+            },
+          },
+          action3: {
+            [TransactionHandlerType.INVOKE]: () => {
+              return mocks.f3()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f3()
+            },
+          },
+          action4: {
+            [TransactionHandlerType.INVOKE]: () => {
+              return mocks.f4()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f4()
+            },
+          },
+        }
+
+        return command[actionId][functionHandlerType]()
+      }
+
+      const flow: TransactionStepsDefinition = {
+        next: {
+          action: "action1",
+          next: [
+            {
+              timeout: 0.1, // 100ms
+              action: "action2",
+              continueOnPermanentFailure: true,
+              next: {
+                action: "action4",
+              },
+            },
+            {
+              action: "action3",
+            },
+          ],
+        },
+      }
+
+      const strategy = new TransactionOrchestrator({
+        id: "transaction-name",
+        definition: flow,
+      })
+
+      const transaction = await strategy.beginTransaction({
+        transactionId: "transaction_id_123",
+        handler,
+      })
+
+      await strategy.resume(transaction)
+
+      expect(transaction.transactionId).toBe("transaction_id_123")
+      expect(mocks.f1).toHaveBeenCalledTimes(1)
+      expect(mocks.f2).toHaveBeenCalledTimes(1)
+      expect(mocks.f3).toHaveBeenCalledTimes(1)
+      expect(mocks.f4).toHaveBeenCalledTimes(1)
+      expect(transaction.getContext().invoke.action1).toBe("content f1")
+      expect(transaction.getContext().invoke.action2).toBe("delayed content f2")
+      expect(transaction.getContext().invoke.action3).toBe("content f3")
+      expect(transaction.getContext().invoke.action4).toBe("content f4")
+      expect(
+        transaction.getFlow().steps["_root.action1.action2"].invoke.state
+      ).toBe(TransactionStepState.TIMEOUT)
+      expect(
+        transaction.getFlow().steps["_root.action1.action2"].invoke.status
+      ).toBe(TransactionStepStatus.PERMANENT_FAILURE)
+      expect(
+        transaction.getFlow().steps["_root.action1.action3"].invoke.state
+      ).toBe(TransactionStepState.DONE)
+      expect(
+        transaction.getFlow().steps["_root.action1.action2.action4"].invoke
+          .state
+      ).toBe(TransactionStepState.DONE)
+
+      expect(transaction.getState()).toBe(TransactionState.DONE)
+      expect(transaction.isPartiallyCompleted).toBe(true)
+    })
+
+    it("should revert the transaction if the Transaction Timeout is reached even if the step is set as 'continueOnPermanentFailure'", async () => {
+      const mocks = {
+        f1: jest.fn(() => {
+          return "content f1"
+        }),
+        f2: jest.fn(async () => {
+          await setTimeout(200)
+          return "delayed content f2"
+        }),
+        f3: jest.fn(() => {
+          return "content f3"
+        }),
+      }
+
+      async function handler(
+        actionId: string,
+        functionHandlerType: TransactionHandlerType,
+        payload: TransactionPayload
+      ) {
+        const command = {
+          action1: {
+            [TransactionHandlerType.INVOKE]: () => {
+              return mocks.f1()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f1()
+            },
+          },
+          action2: {
+            [TransactionHandlerType.INVOKE]: async () => {
+              return await mocks.f2()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f2()
+            },
+          },
+          action3: {
+            [TransactionHandlerType.INVOKE]: () => {
+              return mocks.f3()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f3()
+            },
+          },
+        }
+
+        return command[actionId][functionHandlerType]()
+      }
+
+      const flow: TransactionStepsDefinition = {
+        next: {
+          action: "action1",
+          next: {
+            action: "action2",
+            continueOnPermanentFailure: true,
+            next: {
+              action: "action3",
+            },
+          },
+        },
+      }
+
+      const strategy = new TransactionOrchestrator({
+        id: "transaction-name",
+        definition: flow,
+        options: {
+          timeout: 0.1, // 100ms - transaction timeout
+        },
+      })
+
+      const transaction = await strategy.beginTransaction({
+        transactionId: "transaction_id_123",
+        handler,
+      })
+
+      await strategy.resume(transaction)
+
+      expect(transaction.transactionId).toBe("transaction_id_123")
+      expect(mocks.f1).toHaveBeenCalledTimes(2) // invoke + compensate
+      expect(mocks.f2).toHaveBeenCalledTimes(2) // invoke + compensate
+
+      expect(transaction.getErrors()).toHaveLength(1)
+      expect(
+        TransactionTimeoutError.isTransactionTimeoutError(
+          transaction.getErrors()[0].error
+        )
+      ).toBe(true)
+
+      expect(transaction.getState()).toBe(TransactionState.REVERTED)
+    })
+
+    it("should revert the transaction if the Transaction Timeout is reached even if the step has both 'timeout' and 'continueOnPermanentFailure'", async () => {
+      const mocks = {
+        f1: jest.fn(() => {
+          return "content f1"
+        }),
+        f2: jest.fn(async () => {
+          await setTimeout(500)
+          return "delayed content f2"
+        }),
+        f3: jest.fn(() => {
+          return "content f3"
+        }),
+      }
+
+      async function handler(
+        actionId: string,
+        functionHandlerType: TransactionHandlerType,
+        payload: TransactionPayload
+      ) {
+        const command = {
+          action1: {
+            [TransactionHandlerType.INVOKE]: () => {
+              return mocks.f1()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f1()
+            },
+          },
+          action2: {
+            [TransactionHandlerType.INVOKE]: async () => {
+              return await mocks.f2()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f2()
+            },
+          },
+          action3: {
+            [TransactionHandlerType.INVOKE]: () => {
+              return mocks.f3()
+            },
+            [TransactionHandlerType.COMPENSATE]: () => {
+              return mocks.f3()
+            },
+          },
+        }
+
+        return command[actionId][functionHandlerType]()
+      }
+
+      const flow: TransactionStepsDefinition = {
+        next: {
+          action: "action1",
+          next: {
+            timeout: 1, // 1s step timeout
+            action: "action2",
+            continueOnPermanentFailure: true,
+            next: {
+              action: "action3",
+            },
+          },
+        },
+      }
+
+      const strategy = new TransactionOrchestrator({
+        id: "transaction-name",
+        definition: flow,
+        options: {
+          timeout: 0.1, // 100ms - transaction timeout fires first
+        },
+      })
+
+      const transaction = await strategy.beginTransaction({
+        transactionId: "transaction_id_123",
+        handler,
+      })
+
+      await strategy.resume(transaction)
+
+      expect(transaction.transactionId).toBe("transaction_id_123")
+      expect(mocks.f1).toHaveBeenCalledTimes(2) // invoke + compensate
+      expect(mocks.f3).toHaveBeenCalledTimes(0) // never reached
+
+      expect(transaction.getErrors()).toHaveLength(1)
+      expect(
+        TransactionTimeoutError.isTransactionTimeoutError(
+          transaction.getErrors()[0].error
+        )
+      ).toBe(true)
+      expect(transaction.getErrors()[0].action).toBe("action2")
+
+      expect(transaction.getState()).toBe(TransactionState.REVERTED)
+    })
+
     it("should fail the current steps and revert the transaction if the Step Timeout is reached", async () => {
       const mocks = {
         f1: jest.fn(() => {

--- a/packages/core/orchestration/src/transaction/transaction-orchestrator.ts
+++ b/packages/core/orchestration/src/transaction/transaction-orchestrator.ts
@@ -830,12 +830,11 @@ export class TransactionOrchestrator extends EventEmitter {
       if (!step.isCompensating()) {
         const isTransactionTimeout =
           TransactionTimeoutError.isTransactionTimeoutError(timeoutError!)
-        const isStepTimeout = hasTimedOut && !isTransactionTimeout
 
         const canContinueOnFailure =
           (step.definition.continueOnPermanentFailure ||
             step.definition.skipOnPermanentFailure) &&
-          (!isTransactionTimeout || isStepTimeout)
+          !isTransactionTimeout
 
         if (canContinueOnFailure) {
           if (step.definition.skipOnPermanentFailure) {

--- a/packages/core/orchestration/src/transaction/transaction-orchestrator.ts
+++ b/packages/core/orchestration/src/transaction/transaction-orchestrator.ts
@@ -487,7 +487,10 @@ export class TransactionOrchestrator extends EventEmitter {
           hasSkipped = true
         } else if (curState.state === TransactionStepState.REVERTED) {
           hasReverted = true
-        } else if (curState.state === TransactionStepState.FAILED) {
+        } else if (
+          curState.state === TransactionStepState.FAILED ||
+          curState.state === TransactionStepState.TIMEOUT
+        ) {
           if (
             stepDef.definition.continueOnPermanentFailure ||
             stepDef.definition.skipOnPermanentFailure
@@ -825,11 +828,16 @@ export class TransactionOrchestrator extends EventEmitter {
       }
 
       if (!step.isCompensating()) {
-        if (
+        const isTransactionTimeout =
+          TransactionTimeoutError.isTransactionTimeoutError(timeoutError!)
+        const isStepTimeout = hasTimedOut && !isTransactionTimeout
+
+        const canContinueOnFailure =
           (step.definition.continueOnPermanentFailure ||
             step.definition.skipOnPermanentFailure) &&
-          !TransactionTimeoutError.isTransactionTimeoutError(timeoutError!)
-        ) {
+          (!isTransactionTimeout || isStepTimeout)
+
+        if (canContinueOnFailure) {
           if (step.definition.skipOnPermanentFailure) {
             const until = isString(step.definition.skipOnPermanentFailure)
               ? step.definition.skipOnPermanentFailure

--- a/packages/modules/workflow-engine-redis/src/utils/workflow-orchestrator-storage.ts
+++ b/packages/modules/workflow-engine-redis/src/utils/workflow-orchestrator-storage.ts
@@ -738,7 +738,12 @@ export class RedisDistributedTransactionStorage
     const key = [type, transaction.modelId, transaction.transactionId]
 
     if (step) {
-      key.push(step.id, step.attempts + "")
+      key.push(step.id)
+
+      // Step timeout has a single job per step
+      if (type !== JobType.STEP_TIMEOUT) {
+        key.push(step.attempts + "")
+      }
 
       // Add suffix for retry scheduling (interval > 0) to avoid collision with async execution (interval = 0)
       if (type === JobType.RETRY && isDefined(interval) && interval > 0) {

--- a/packages/modules/workflow-engine-redis/src/utils/workflow-orchestrator-storage.ts
+++ b/packages/modules/workflow-engine-redis/src/utils/workflow-orchestrator-storage.ts
@@ -24,7 +24,13 @@ import {
   TransactionStepState,
 } from "@medusajs/framework/utils"
 import { WorkflowOrchestratorService } from "@services"
-import { Queue, QueueOptions, RepeatOptions, Worker, WorkerOptions } from "bullmq"
+import {
+  Queue,
+  QueueOptions,
+  RepeatOptions,
+  Worker,
+  WorkerOptions,
+} from "bullmq"
 import Redis from "ioredis"
 
 enum JobType {
@@ -661,7 +667,10 @@ export class RedisDistributedTransactionStorage
     step: TransactionStep
   ): Promise<void> {
     // Pass retry interval to ensure we remove the correct job (with -retry suffix if interval > 0)
-    const interval = step.definition.retryInterval || 0
+    const interval =
+      step.definition.retryInterval ||
+      step.definition.retryIntervalAwaiting ||
+      0
     await this.removeJob(JobType.RETRY, transaction, step, interval)
   }
 


### PR DESCRIPTION
**What**
Fixes the behavior of `continueOnPermanentFailure` when the step times out