### PR TITLE
feat: Add dynamodb packages as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@atomico/rollup-plugin-sizes": "^1.1.4",
-    "@aws-sdk/client-dynamodb": "^3.218.0",
     "@faker-js/faker": "^9.2.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-replace": "^5.0.2",
@@ -77,7 +76,6 @@
     "axios-mock-adapter": "^1.19.0",
     "chromatic": "^6.20.0",
     "configstore": "^5.0.1",
-    "connect-dynamodb": "^3.0.5",
     "cross-env": "^5.2.1",
     "esbuild": "^0.25.0",
     "eslint": "^8.40.0",

--- a/packages/core/framework/package.json
+++ b/packages/core/framework/package.json
@@ -74,6 +74,7 @@
     "@medusajs/cli": "2.13.1"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.218.0",
     "@jercle/yargonaut": "^1.1.5",
     "@medusajs/deps": "2.13.1",
     "@medusajs/modules-sdk": "2.13.1",
@@ -85,6 +86,7 @@
     "@types/express": "^4.17.21",
     "chokidar": "^4.0.3",
     "compression": "^1.8.1",
+    "connect-dynamodb": "^3.0.5",
     "connect-redis": "5.2.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
@@ -99,18 +101,10 @@
     "zod-validation-error": "3.5.1"
   },
   "peerDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.218.0",
     "@medusajs/cli": "2.13.1",
-    "connect-dynamodb": "^3.0.5",
     "ioredis": "^5.4.1"
   },
   "peerDependenciesMeta": {
-    "@aws-sdk/client-dynamodb": {
-      "optional": true
-    },
-    "connect-dynamodb": {
-      "optional": true
-    },
     "ioredis": {
       "optional": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3623,6 +3623,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@medusajs/framework@workspace:packages/core/framework"
   dependencies:
+    "@aws-sdk/client-dynamodb": ^3.218.0
     "@jercle/yargonaut": ^1.1.5
     "@medusajs/cli": 2.13.1
     "@medusajs/deps": 2.13.1
@@ -3635,6 +3636,7 @@ __metadata:
     "@types/express": ^4.17.21
     chokidar: ^4.0.3
     compression: ^1.8.1
+    connect-dynamodb: ^3.0.5
     connect-redis: 5.2.0
     cookie-parser: ^1.4.6
     cors: ^2.8.5
@@ -3648,15 +3650,9 @@ __metadata:
     tsconfig-paths: ^4.2.0
     zod-validation-error: 3.5.1
   peerDependencies:
-    "@aws-sdk/client-dynamodb": ^3.218.0
     "@medusajs/cli": 2.13.1
-    connect-dynamodb: ^3.0.5
     ioredis: ^5.4.1
   peerDependenciesMeta:
-    "@aws-sdk/client-dynamodb":
-      optional: true
-    connect-dynamodb:
-      optional: true
     ioredis:
       optional: true
     vite:
@@ -24865,7 +24861,6 @@ __metadata:
   resolution: "root@workspace:."
   dependencies:
     "@atomico/rollup-plugin-sizes": ^1.1.4
-    "@aws-sdk/client-dynamodb": ^3.218.0
     "@changesets/changelog-github": ^0.4.8
     "@changesets/cli": ^2.26.0
     "@faker-js/faker": ^9.2.0
@@ -24923,7 +24918,6 @@ __metadata:
     axios-mock-adapter: ^1.19.0
     chromatic: ^6.20.0
     configstore: ^5.0.1
-    connect-dynamodb: ^3.0.5
     cross-env: ^5.2.1
     esbuild: ^0.25.0
     eslint: ^8.40.0


### PR DESCRIPTION
We move the dynamodb packages from peer to production dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with no runtime logic modifications; main risk is package size/duplication or downstream install/resolution differences.
> 
> **Overview**
> Updates dependency management so DynamoDB session support is bundled with `@medusajs/framework`: `@aws-sdk/client-dynamodb` and `connect-dynamodb` are moved from `peerDependencies` (and root `devDependencies`) into the framework package’s `dependencies`.
> 
> `yarn.lock` is updated accordingly to reflect the new workspace dependency graph, reducing the need for consumers to manually install these packages when using DynamoDB-backed sessions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c5ab04b9c24c662f863a8179a2ad38724c93e86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->