### PR TITLE
feat: emit workflow events for price lists, promotions, and campaigns…

### DIFF
--- a/.changeset/price-list-promotion-campaign-workflow-events.md
+++ b/.changeset/price-list-promotion-campaign-workflow-events.md
@@ -1,0 +1,8 @@
+---
+"@medusajs/utils": patch
+"@medusajs/core-flows": patch
+---
+
+feat: emit workflow events for price lists, promotions, and campaigns (Omnibus)
+
+Add workflow event constants and emit events from create/update/delete (and related) workflows for price lists, promotions, and campaigns to support Omnibus-compliant behaviour (e.g. lowest price in 30 days).

--- a/packages/core/core-flows/src/price-list/workflows/batch-price-list-prices.ts
+++ b/packages/core/core-flows/src/price-list/workflows/batch-price-list-prices.ts
@@ -2,6 +2,7 @@ import {
   BatchPriceListPricesWorkflowDTO,
   BatchPriceListPricesWorkflowResult,
 } from "@medusajs/framework/types"
+import { PriceListWorkflowEvents } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   WorkflowResponse,
@@ -9,6 +10,7 @@ import {
   parallelize,
   transform,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { createPriceListPricesWorkflow } from "./create-price-list-prices"
 import { removePriceListPricesWorkflow } from "./remove-price-list-prices"
 import { updatePriceListPricesWorkflow } from "./update-price-list-prices"
@@ -91,6 +93,21 @@ export const batchPriceListPricesWorkflow = createWorkflow(
         },
       })
     )
+
+    const batchUpdatedEventPayload = transform(
+      { input: input.data, created, updated, deleted },
+      ({ input, created, updated, deleted }) => ({
+        price_list_id: input.id,
+        created,
+        updated,
+        deleted,
+      })
+    )
+
+    emitEventStep({
+      eventName: PriceListWorkflowEvents.PRICES_BATCH_UPDATED,
+      data: batchUpdatedEventPayload,
+    })
 
     return new WorkflowResponse(
       transform({ created, updated, deleted }, (data) => data)

--- a/packages/core/core-flows/src/price-list/workflows/create-price-lists.ts
+++ b/packages/core/core-flows/src/price-list/workflows/create-price-lists.ts
@@ -2,11 +2,14 @@ import {
   CreatePriceListWorkflowInputDTO,
   PriceListDTO,
 } from "@medusajs/framework/types"
+import { PriceListWorkflowEvents } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   WorkflowResponse,
   createWorkflow,
+  transform,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { createPriceListsStep, validateVariantPriceLinksStep } from "../steps"
 
 /**
@@ -58,11 +61,22 @@ export const createPriceListsWorkflow = createWorkflow(
       input.price_lists_data
     )
 
-    return new WorkflowResponse(
-      createPriceListsStep({
-        data: input.price_lists_data,
-        variant_price_map: variantPriceMap,
-      })
+    const createdPriceLists = createPriceListsStep({
+      data: input.price_lists_data,
+      variant_price_map: variantPriceMap,
+    })
+
+    const priceListIdEvents = transform(
+      { createdPriceLists },
+      ({ createdPriceLists }) =>
+        createdPriceLists.map((pl) => ({ id: pl.id }))
     )
+
+    emitEventStep({
+      eventName: PriceListWorkflowEvents.CREATED,
+      data: priceListIdEvents,
+    })
+
+    return new WorkflowResponse(createdPriceLists)
   }
 )

--- a/packages/core/core-flows/src/price-list/workflows/delete-price-lists.ts
+++ b/packages/core/core-flows/src/price-list/workflows/delete-price-lists.ts
@@ -1,5 +1,10 @@
-import { Modules } from "@medusajs/framework/utils"
-import { createWorkflow, WorkflowData } from "@medusajs/framework/workflows-sdk"
+import { Modules, PriceListWorkflowEvents } from "@medusajs/framework/utils"
+import {
+  createWorkflow,
+  transform,
+  WorkflowData,
+} from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { removeRemoteLinkStep } from "../../common/steps/remove-remote-links"
 import { deletePriceListsStep } from "../steps"
 
@@ -42,6 +47,15 @@ export const deletePriceListsWorkflow = createWorkflow(
       [Modules.PRICING]: {
         price_list_id: input.ids,
       },
+    })
+
+    const priceListIdEvents = transform({ input }, ({ input }) =>
+      input.ids?.map((id) => ({ id })) ?? []
+    )
+
+    emitEventStep({
+      eventName: PriceListWorkflowEvents.DELETED,
+      data: priceListIdEvents,
     })
 
     return deletedPriceLists

--- a/packages/core/core-flows/src/price-list/workflows/update-price-lists.ts
+++ b/packages/core/core-flows/src/price-list/workflows/update-price-lists.ts
@@ -1,5 +1,11 @@
 import type { UpdatePriceListWorkflowInputDTO } from "@medusajs/framework/types"
-import { WorkflowData, createWorkflow } from "@medusajs/framework/workflows-sdk"
+import { PriceListWorkflowEvents } from "@medusajs/framework/utils"
+import {
+  WorkflowData,
+  createWorkflow,
+  transform,
+} from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { updatePriceListsStep, validatePriceListsStep } from "../steps"
 
 /**
@@ -44,6 +50,22 @@ export const updatePriceListsWorkflow = createWorkflow(
   ): WorkflowData<void> => {
     validatePriceListsStep(input.price_lists_data)
 
-    updatePriceListsStep(input.price_lists_data)
+    const updatedPriceLists = updatePriceListsStep(input.price_lists_data)
+
+    const priceListIdEvents = transform(
+      { updatedPriceLists },
+      ({ updatedPriceLists }) => {
+        if (!updatedPriceLists) return []
+        const arr = Array.isArray(updatedPriceLists)
+          ? updatedPriceLists
+          : [updatedPriceLists]
+        return arr.map((pl) => ({ id: pl.id }))
+      }
+    )
+
+    emitEventStep({
+      eventName: PriceListWorkflowEvents.UPDATED,
+      data: priceListIdEvents,
+    })
   }
 )

--- a/packages/core/core-flows/src/promotion/workflows/add-or-remove-campaign-promotions.ts
+++ b/packages/core/core-flows/src/promotion/workflows/add-or-remove-campaign-promotions.ts
@@ -1,9 +1,12 @@
 import type { LinkWorkflowInput } from "@medusajs/framework/types"
+import { CampaignWorkflowEvents } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   createWorkflow,
   parallelize,
+  transform,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import {
   addCampaignPromotionsStep,
   removeCampaignPromotionsStep,
@@ -50,5 +53,16 @@ export const addOrRemoveCampaignPromotionsWorkflow = createWorkflow(
       addCampaignPromotionsStep(input),
       removeCampaignPromotionsStep(input)
     )
+
+    const promotionsUpdatedPayload = transform({ input }, ({ input }) => ({
+      campaign_id: input.id,
+      add: input.add ?? [],
+      remove: input.remove ?? [],
+    }))
+
+    emitEventStep({
+      eventName: CampaignWorkflowEvents.PROMOTIONS_UPDATED,
+      data: promotionsUpdatedPayload,
+    })
   }
 )

--- a/packages/core/core-flows/src/promotion/workflows/batch-promotion-rules.ts
+++ b/packages/core/core-flows/src/promotion/workflows/batch-promotion-rules.ts
@@ -5,7 +5,7 @@ import {
   PromotionRuleDTO,
   UpdatePromotionRuleDTO,
 } from "@medusajs/framework/types"
-import { RuleType } from "@medusajs/framework/utils"
+import { PromotionWorkflowEvents, RuleType } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   WorkflowResponse,
@@ -13,6 +13,7 @@ import {
   parallelize,
   transform,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { deletePromotionRulesWorkflowStep } from "../steps/delete-promotion-rules-workflow"
 import { createPromotionRulesWorkflow } from "./create-promotion-rules"
 import { updatePromotionRulesWorkflow } from "./update-promotion-rules"
@@ -109,6 +110,22 @@ export const batchPromotionRulesWorkflow = createWorkflow(
       }),
       deletePromotionRulesWorkflowStep(deleteInput)
     )
+
+    const rulesBatchUpdatedPayload = transform(
+      { input, created, updated, deleted },
+      ({ input, created, updated, deleted }) => ({
+        promotion_id: input.id,
+        rule_type: input.rule_type,
+        created,
+        updated,
+        deleted,
+      })
+    )
+
+    emitEventStep({
+      eventName: PromotionWorkflowEvents.RULES_BATCH_UPDATED,
+      data: rulesBatchUpdatedPayload,
+    })
 
     return new WorkflowResponse(
       transform({ created, updated, deleted }, (data) => data)

--- a/packages/core/core-flows/src/promotion/workflows/create-campaigns.ts
+++ b/packages/core/core-flows/src/promotion/workflows/create-campaigns.ts
@@ -2,12 +2,15 @@ import type {
   AdditionalData,
   CreateCampaignDTO,
 } from "@medusajs/framework/types"
+import { CampaignWorkflowEvents } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   WorkflowResponse,
   createHook,
   createWorkflow,
+  transform,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { createCampaignsStep } from "../steps"
 
 /**
@@ -64,6 +67,17 @@ export const createCampaignsWorkflow = createWorkflow(
     const campaignsCreated = createHook("campaignsCreated", {
       campaigns: createdCampaigns,
       additional_data: input.additional_data,
+    })
+
+    const campaignIdEvents = transform(
+      { createdCampaigns },
+      ({ createdCampaigns }) =>
+        createdCampaigns.map((c) => ({ id: c.id }))
+    )
+
+    emitEventStep({
+      eventName: CampaignWorkflowEvents.CREATED,
+      data: campaignIdEvents,
     })
 
     return new WorkflowResponse(createdCampaigns, {

--- a/packages/core/core-flows/src/promotion/workflows/create-promotions.ts
+++ b/packages/core/core-flows/src/promotion/workflows/create-promotions.ts
@@ -2,12 +2,15 @@ import type {
   AdditionalData,
   CreatePromotionDTO,
 } from "@medusajs/framework/types"
+import { PromotionWorkflowEvents } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   WorkflowResponse,
   createHook,
   createWorkflow,
+  transform,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { createPromotionsStep } from "../steps"
 
 /**
@@ -66,6 +69,17 @@ export const createPromotionsWorkflow = createWorkflow(
     const promotionsCreated = createHook("promotionsCreated", {
       promotions: createdPromotions,
       additional_data: input.additional_data,
+    })
+
+    const promotionIdEvents = transform(
+      { createdPromotions },
+      ({ createdPromotions }) =>
+        createdPromotions.map((p) => ({ id: p.id }))
+    )
+
+    emitEventStep({
+      eventName: PromotionWorkflowEvents.CREATED,
+      data: promotionIdEvents,
     })
 
     return new WorkflowResponse(createdPromotions, {

--- a/packages/core/core-flows/src/promotion/workflows/delete-campaigns.ts
+++ b/packages/core/core-flows/src/promotion/workflows/delete-campaigns.ts
@@ -1,9 +1,12 @@
+import { CampaignWorkflowEvents } from "@medusajs/framework/utils"
 import {
   createHook,
   createWorkflow,
+  transform,
   WorkflowData,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { deleteCampaignsStep } from "../steps"
 
 /**
@@ -42,6 +45,15 @@ export const deleteCampaignsWorkflow = createWorkflow(
     const deletedCampaigns = deleteCampaignsStep(input.ids)
     const campaignsDeleted = createHook("campaignsDeleted", {
       ids: input.ids,
+    })
+
+    const campaignIdEvents = transform({ input }, ({ input }) =>
+      input.ids?.map((id) => ({ id })) ?? []
+    )
+
+    emitEventStep({
+      eventName: CampaignWorkflowEvents.DELETED,
+      data: campaignIdEvents,
     })
 
     return new WorkflowResponse(deletedCampaigns, {

--- a/packages/core/core-flows/src/promotion/workflows/delete-promotions.ts
+++ b/packages/core/core-flows/src/promotion/workflows/delete-promotions.ts
@@ -1,9 +1,12 @@
+import { PromotionWorkflowEvents } from "@medusajs/framework/utils"
 import {
   createHook,
   createWorkflow,
+  transform,
   WorkflowData,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { deletePromotionsStep } from "../steps"
 
 /**
@@ -42,6 +45,15 @@ export const deletePromotionsWorkflow = createWorkflow(
     const deletedPromotions = deletePromotionsStep(input.ids)
     const promotionsDeleted = createHook("promotionsDeleted", {
       ids: input.ids,
+    })
+
+    const promotionIdEvents = transform({ input }, ({ input }) =>
+      input.ids?.map((id) => ({ id })) ?? []
+    )
+
+    emitEventStep({
+      eventName: PromotionWorkflowEvents.DELETED,
+      data: promotionIdEvents,
     })
 
     return new WorkflowResponse(deletedPromotions, {

--- a/packages/core/core-flows/src/promotion/workflows/update-campaigns.ts
+++ b/packages/core/core-flows/src/promotion/workflows/update-campaigns.ts
@@ -2,12 +2,15 @@ import type {
   AdditionalData,
   UpdateCampaignDTO,
 } from "@medusajs/framework/types"
+import { CampaignWorkflowEvents } from "@medusajs/framework/utils"
 import {
   WorkflowData,
   WorkflowResponse,
   createHook,
   createWorkflow,
+  transform,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { updateCampaignsStep } from "../steps"
 
 /**
@@ -59,6 +62,21 @@ export const updateCampaignsWorkflow = createWorkflow(
     const campaignsUpdated = createHook("campaignsUpdated", {
       campaigns: updatedCampaigns,
       additional_data: input.additional_data,
+    })
+
+    const campaignIdEvents = transform(
+      { updatedCampaigns },
+      ({ updatedCampaigns }) => {
+        const arr = Array.isArray(updatedCampaigns)
+          ? updatedCampaigns
+          : [updatedCampaigns]
+        return arr?.map((c) => ({ id: c.id })) ?? []
+      }
+    )
+
+    emitEventStep({
+      eventName: CampaignWorkflowEvents.UPDATED,
+      data: campaignIdEvents,
     })
 
     return new WorkflowResponse(updatedCampaigns, {

--- a/packages/core/core-flows/src/promotion/workflows/update-promotions-status.ts
+++ b/packages/core/core-flows/src/promotion/workflows/update-promotions-status.ts
@@ -2,13 +2,19 @@ import {
   AdditionalData,
   PromotionStatusValues,
 } from "@medusajs/framework/types"
-import { MedusaError, PromotionStatus } from "@medusajs/framework/utils"
+import {
+  MedusaError,
+  PromotionStatus,
+  PromotionWorkflowEvents,
+} from "@medusajs/framework/utils"
 import {
   WorkflowResponse,
   createHook,
   createStep,
   createWorkflow,
+  transform,
 } from "@medusajs/framework/workflows-sdk"
+import { emitEventStep } from "../../common/steps/emit-event"
 import { updatePromotionsStep } from "../steps"
 
 /**
@@ -87,6 +93,21 @@ export const updatePromotionsStatusWorkflow = createWorkflow(
     const promotionStatusUpdated = createHook("promotionStatusUpdated", {
       promotions: updatedPromotions,
       additional_data: input.additional_data,
+    })
+
+    const promotionIdEvents = transform(
+      { updatedPromotions },
+      ({ updatedPromotions }) => {
+        const arr = Array.isArray(updatedPromotions)
+          ? updatedPromotions
+          : [updatedPromotions]
+        return arr?.map((p) => ({ id: p.id })) ?? []
+      }
+    )
+
+    emitEventStep({
+      eventName: PromotionWorkflowEvents.STATUS_UPDATED,
+      data: promotionIdEvents,
     })
 
     return new WorkflowResponse(updatedPromotions, {

--- a/packages/core/core-flows/src/promotion/workflows/update-promotions.ts
+++ b/packages/core/core-flows/src/promotion/workflows/update-promotions.ts
@@ -4,7 +4,7 @@ import {
   PromotionStatusValues,
   UpdatePromotionDTO,
 } from "@medusajs/framework/types"
-import { isString } from "@medusajs/framework/utils"
+import { isString, PromotionWorkflowEvents } from "@medusajs/framework/utils"
 import {
   createHook,
   createWorkflow,
@@ -13,7 +13,7 @@ import {
   WorkflowData,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
-import { useRemoteQueryStep } from "../../common"
+import { emitEventStep, useRemoteQueryStep } from "../../common"
 import { updatePromotionsStep } from "../steps"
 import { updatePromotionsStatusWorkflow } from "./update-promotions-status"
 
@@ -112,6 +112,21 @@ export const updatePromotionsWorkflow = createWorkflow(
     const updatedPromotions = updatePromotionsStep(
       promotionInputs.promotionsUpdateInput
     )
+
+    const promotionIdEvents = transform(
+      { updatedPromotions },
+      ({ updatedPromotions }) => {
+        const arr = Array.isArray(updatedPromotions)
+          ? updatedPromotions
+          : [updatedPromotions]
+        return arr?.map((p) => ({ id: p.id })) ?? []
+      }
+    )
+
+    emitEventStep({
+      eventName: PromotionWorkflowEvents.UPDATED,
+      data: promotionIdEvents,
+    })
 
     when({ promotionInputs }, ({ promotionInputs }) => {
       return !!promotionInputs.promotionsStatusUpdateInput?.length

--- a/packages/core/utils/src/core-flows/events.ts
+++ b/packages/core/utils/src/core-flows/events.ts
@@ -912,6 +912,179 @@ export const ShippingOptionWorkflowEvents = {
 } as const
 
 /**
+ * @category Price List
+ * @customNamespace Pricing
+ */
+export const PriceListWorkflowEvents = {
+  /**
+   * Emitted when price lists are created.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the price list
+   * }
+   * ```
+   */
+  CREATED: "price-list.created",
+  /**
+   * Emitted when price lists are updated.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the price list
+   * }
+   * ```
+   */
+  UPDATED: "price-list.updated",
+  /**
+   * Emitted when price lists are deleted.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the price list
+   * }
+   * ```
+   */
+  DELETED: "price-list.deleted",
+  /**
+   * Emitted when prices on a price list are batch created, updated, or deleted.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   price_list_id, // The ID of the price list
+   *   created, // The created prices
+   *   updated, // The updated prices
+   *   deleted, // The IDs of the deleted prices
+   * }
+   * ```
+   */
+  PRICES_BATCH_UPDATED: "price-list-prices.batch-updated",
+} as const
+
+/**
+ * @category Promotion
+ * @customNamespace Promotion
+ */
+export const PromotionWorkflowEvents = {
+  /**
+   * Emitted when promotions are created.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the promotion
+   * }
+   * ```
+   */
+  CREATED: "promotion.created",
+  /**
+   * Emitted when promotions are updated.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the promotion
+   * }
+   * ```
+   */
+  UPDATED: "promotion.updated",
+  /**
+   * Emitted when promotions are deleted.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the promotion
+   * }
+   * ```
+   */
+  DELETED: "promotion.deleted",
+  /**
+   * Emitted when promotion status is updated.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the promotion
+   * }
+   * ```
+   */
+  STATUS_UPDATED: "promotion.status-updated",
+  /**
+   * Emitted when promotion rules are batch created, updated, or deleted.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   promotion_id, // The ID of the promotion
+   *   rule_type, // The rule type (e.g. "rules", "buy_rules", "target_rules")
+   *   created, // The created rules
+   *   updated, // The updated rules
+   *   deleted, // The IDs of the deleted rules
+   * }
+   * ```
+   */
+  RULES_BATCH_UPDATED: "promotion-rules.batch-updated",
+} as const
+
+/**
+ * @category Campaign
+ * @customNamespace Promotion
+ */
+export const CampaignWorkflowEvents = {
+  /**
+   * Emitted when campaigns are created.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the campaign
+   * }
+   * ```
+   */
+  CREATED: "campaign.created",
+  /**
+   * Emitted when campaigns are updated.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the campaign
+   * }
+   * ```
+   */
+  UPDATED: "campaign.updated",
+  /**
+   * Emitted when campaigns are deleted.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   id, // The ID of the campaign
+   * }
+   * ```
+   */
+  DELETED: "campaign.deleted",
+  /**
+   * Emitted when promotions are added to or removed from a campaign.
+   *
+   * @eventPayload
+   * ```ts
+   * {
+   *   campaign_id, // The ID of the campaign
+   *   add, // The IDs of the promotions added
+   *   remove, // The IDs of the promotions removed
+   * }
+   * ```
+   */
+  PROMOTIONS_UPDATED: "campaign.promotions-updated",
+} as const
+
+/**
  * @category Payment
  * @customNamespace Payment
  */


### PR DESCRIPTION
… (Omnibus)

## Summary

**What** — What changes are introduced in this PR?

This PR adds workflow events for price lists, promotions, and campaigns so subscribers can react to these changes.

**Concretely:**

- **Price lists:** price-list.created, price-list.updated, price-list.deleted, price-list-prices.batch-updated
- **Promotions:** promotion.created, promotion.updated, promotion.deleted, promotion.status-updated, promotion-rules.batch-updated
- **Campaigns:** campaign.created, campaign.updated, campaign.deleted, campaign.promotions-updated

New event constants are added in @medusajs/utils (PriceListWorkflowEvents, PromotionWorkflowEvents, CampaignWorkflowEvents), and the existing create/update/delete/batch workflows in @medusajs/core-flows call emitEventStep so these events are emitted. No new API surface or breaking changes.

**Why** — Why are these changes relevant or necessary?  

The EU Omnibus Directive requires showing the lowest price applied in the 30 days before a current reduction when displaying a discount. To support that, storefronts and packages need to know when prices and promotions/campaigns change. Without workflow events for these operations, there is no supported, event-driven way to maintain price history and discount applicability. These events allow subscribers (e.g. Omnibus-oriented packages) to react to changes and stay in sync with Medusa’s pricing and promotion state.

**How** — How have these changes been implemented?

- packages/core/utils/src/core-flows/events.ts

New constants with JSDoc and @eventPayload in the same style as existing workflow events (e.g. CartWorkflowEvents, SalesChannelWorkflowEvents).

- packages/core/core-flows

In the relevant workflows we:
- Use transform() to build the payload (e.g. [{ id: pl.id }] or { price_list_id, created, updated, deleted }).
- Call emitEventStep({ eventName: ..., data: ... }) after the main step(s), following the same pattern as other workflows (e.g. sales channel, translation).

Workflows touched: create/update/delete price lists, batch price list prices; create/update/delete promotions, update promotion status, batch promotion rules; create/update/delete campaigns, add-or-remove campaign promotions.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

- Existing unit and integration tests for the affected workflows were run; no regressions.
- No new tests were added for event emission, to stay consistent with the rest of the repo (workflow events are not asserted in API-level integration tests; only the auth password-reset event is tested that way).
- How to verify: Run the app, subscribe to one of the new events (e.g. price-list.created), perform the corresponding Admin API action (e.g. create a price list), and confirm the subscriber receives the event with the expected payload (e.g. { id: "<price_list_id>" }).

---

## Examples

Subscribing to the new events in a Medusa subscriber:

```
// src/subscribers/omnibus.ts
import { PriceListWorkflowEvents, PromotionWorkflowEvents } from "@medusajs/framework/utils"

export default function omnibusSubscriber({ eventBusService }) {
  eventBusService.subscribe(PriceListWorkflowEvents.CREATED, async (event) => {
    const { id } = event.data
    // e.g. fetch price list and write to price history for "lowest in 30 days"
  })

  eventBusService.subscribe(PriceListWorkflowEvents.PRICES_BATCH_UPDATED, async (event) => {
    const { price_list_id, created, updated, deleted } = event.data
    // update price history for this price list
  })

  eventBusService.subscribe(PromotionWorkflowEvents.UPDATED, async (event) => {
    const { id } = event.data
    // refresh promotion/campaign applicability for Omnibus
  })
}
```

Payload shapes (as in JSDoc):

- Lifecycle events: { id: string } per entity.
- price-list-prices.batch-updated: { price_list_id, created, updated, deleted }.
- promotion-rules.batch-updated: { promotion_id, rule_type, created, updated, deleted }.
- campaign.promotions-updated: { campaign_id, add, remove }.

## Checklist

Please ensure the following before requesting a review:

- [ x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

I implemented the changes in this PR as a local patch and built a separate package on top of these workflow events (Omnibus compliance). I plan to release that package to the community once this PR is merged upstream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new event emissions across multiple pricing/promotion workflows; risk is mainly around unintended extra event traffic or payload/ordering assumptions for subscribers, but core business logic remains largely unchanged.
> 
> **Overview**
> Adds new workflow event constants in `packages/core/utils/src/core-flows/events.ts` for **price lists**, **promotions**, and **campaigns** (including batch-update style events for price list prices and promotion rules, plus campaign promotion link updates).
> 
> Updates the corresponding `@medusajs/core-flows` create/update/delete (and related) workflows to call `emitEventStep` with transformed payloads (typically `{ id }` arrays or a batch summary object), so external subscribers can react to pricing/promotion state changes.
> 
> Includes a changeset bumping `@medusajs/utils` and `@medusajs/core-flows` as patch releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 617a00bd31cb681313e520e40d881a71c9984bff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->