### PR TITLE
fix(event-bus-redis): prevent stalled subscribers from blocking queue

### DIFF
--- a/packages/modules/event-bus-redis/src/services/__tests__/event-bus.ts
+++ b/packages/modules/event-bus-redis/src/services/__tests__/event-bus.ts
@@ -1015,6 +1015,45 @@ describe("RedisEventBusService", () => {
         eventBus = new RedisEventBusService(moduleDeps, {}, moduleDeclaration)
       })
 
+      it("should timeout hanging subscribers and treat them as failed", async () => {
+        eventBus = new RedisEventBusService(
+          moduleDeps,
+          { subscriberExecutionTimeout: 20 },
+          moduleDeclaration
+        )
+
+        eventBus.subscribe(
+          "eventName",
+          () => {
+            return new Promise(() => undefined)
+          },
+          {
+            subscriberId: "hanging-subscriber",
+          }
+        )
+
+        await eventBus.worker_({
+          name: "eventName",
+          data: { data: { test: 1 } },
+          opts: { attempts: 1 },
+        } as any)
+
+        expect(loggerMock.warn).toHaveBeenCalledWith(
+          "An error occurred while processing eventName:"
+        )
+
+        const timeoutError = (loggerMock.warn as jest.Mock).mock.calls.find(
+          (call) =>
+            call[0] instanceof Error &&
+            call[0].message.includes("hanging-subscriber timed out")
+        )?.[0]
+
+        expect(timeoutError).toBeInstanceOf(Error)
+        expect(loggerMock.warn).toHaveBeenCalledWith(
+          "One or more subscribers of eventName failed. Retrying is not configured. Use 'attempts' option when emitting events."
+        )
+      })
+
       it("should process a simple event with no options", async () => {
         const test: string[] = []
 

--- a/packages/modules/event-bus-redis/src/services/event-bus-redis.ts
+++ b/packages/modules/event-bus-redis/src/services/event-bus-redis.ts
@@ -42,6 +42,9 @@ type IORedisEventType<T = unknown> = {
   opts: BulkJobOptions
 }
 
+const DEFAULT_SUBSCRIBER_EXECUTION_TIMEOUT_MS = 300000
+const WORKER_RESTART_DELAY_MS = 5000
+
 /**
  * Can keep track of multiple subscribers to different events and run the
  * subscribers when events happen. Events will run asynchronously.
@@ -55,11 +58,14 @@ export default class RedisEventBusService extends AbstractEventBusModuleService 
   protected readonly queueOptions_: Omit<QueueOptions, "connection">
   protected readonly workerOptions_: Omit<WorkerOptions, "connection">
   protected readonly jobOptions_: EmitOptions
+  protected readonly subscriberExecutionTimeout_: number
   // TODO: Comment temporarely and we will re enable it in the near future #14478
   // private readonly eventOptions_: EventBusEventsOptions
 
   protected queue_: Queue
   protected bullWorker_: Worker
+  protected workerRunLoopPromise_: Promise<void> | null = null
+  protected shouldStopWorker_ = false
 
   constructor(
     {
@@ -83,6 +89,10 @@ export default class RedisEventBusService extends AbstractEventBusModuleService 
     this.queueOptions_ = eventBusRedisQueueOptions ?? {}
     this.workerOptions_ = eventBusRedisWorkerOptions ?? {}
     this.jobOptions_ = eventBusRedisJobOptions ?? {}
+    this.subscriberExecutionTimeout_ =
+      typeof _moduleOptions.subscriberExecutionTimeout === "number"
+        ? _moduleOptions.subscriberExecutionTimeout
+        : DEFAULT_SUBSCRIBER_EXECUTION_TIMEOUT_MS
     // TODO: Comment temporarely and we will re enable it in the near future #14478
     // this.eventOptions_ =
     //   _moduleOptions.eventOptions ??
@@ -106,9 +116,77 @@ export default class RedisEventBusService extends AbstractEventBusModuleService 
     }
   }
 
+  private async sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
+  private startWorkerLoop(): void {
+    if (!this.bullWorker_ || this.workerRunLoopPromise_) {
+      return
+    }
+
+    this.shouldStopWorker_ = false
+    this.workerRunLoopPromise_ = this.runWorkerLoop().finally(() => {
+      this.workerRunLoopPromise_ = null
+    })
+  }
+
+  private async runWorkerLoop(): Promise<void> {
+    while (!this.shouldStopWorker_) {
+      try {
+        await this.bullWorker_.run()
+      } catch (err) {
+        if (this.shouldStopWorker_) {
+          return
+        }
+
+        this.logger_.error(
+          "Event bus worker stopped due to an error and will be restarted."
+        )
+        this.logger_.error(err)
+      }
+
+      if (this.shouldStopWorker_) {
+        return
+      }
+
+      this.logger_.warn(
+        `Event bus worker stopped unexpectedly. Restarting in ${WORKER_RESTART_DELAY_MS}ms.`
+      )
+      await this.sleep(WORKER_RESTART_DELAY_MS)
+    }
+  }
+
+  private withSubscriberTimeout<T>(
+    subscriberId: string,
+    eventName: string,
+    operation: Promise<T>
+  ): Promise<T> {
+    if (this.subscriberExecutionTimeout_ <= 0) {
+      return operation
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new Error(
+            `Subscriber ${subscriberId} timed out while processing ${eventName} after ${this.subscriberExecutionTimeout_}ms`
+          )
+        )
+      }, this.subscriberExecutionTimeout_)
+    })
+
+    return Promise.race([operation, timeoutPromise]).finally(() => {
+      if (timer) {
+        clearTimeout(timer)
+      }
+    })
+  }
+
   __hooks = {
     onApplicationStart: async () => {
-      await this.bullWorker_?.run()
+      this.startWorkerLoop()
     },
     onApplicationShutdown: async () => {
       await this.queue_.close()
@@ -116,7 +194,9 @@ export default class RedisEventBusService extends AbstractEventBusModuleService 
       this.eventBusRedisConnection_.disconnect()
     },
     onApplicationPrepareShutdown: async () => {
+      this.shouldStopWorker_ = true
       await this.bullWorker_?.close()
+      await this.workerRunLoopPromise_
     },
   }
 
@@ -422,7 +502,11 @@ export default class RedisEventBusService extends AbstractEventBusModuleService 
         }
 
         try {
-          return await subscriber(event).then((data) => {
+          return await this.withSubscriberTimeout(
+            id,
+            name,
+            Promise.resolve(subscriber(event))
+          ).then((data) => {
             // For every subscriber that completes successfully, add their id to the list of completed subscribers
             completedSubscribersInCurrentAttempt.push(id)
             return data

--- a/packages/modules/event-bus-redis/src/types/index.ts
+++ b/packages/modules/event-bus-redis/src/types/index.ts
@@ -76,6 +76,17 @@ export type EventBusRedisModuleOptions = {
    */
   jobOptions?: EmitOptions
 
+  /**
+   * Maximum time in milliseconds to wait for an individual subscriber to finish.
+   * If exceeded, the subscriber is treated as failed for this attempt and the job
+   * can retry based on `attempts`.
+   *
+   * Set to `0` or a negative number to disable timeout enforcement.
+   *
+   * @default 300000 (5 minutes)
+   */
+  subscriberExecutionTimeout?: number
+
   // eventOptions?: EventBusEventsOptions
 }
 


### PR DESCRIPTION
## Summary
- add subscriber execution timeout handling to Redis event bus workers
- add worker run-loop restart behavior so worker run failures/stops are auto-recovered
- add a typed module option `subscriberExecutionTimeout` with docs
- add unit coverage for hanging subscriber timeout behavior

## Why
Issue #14357 reports event queues accumulating indefinitely when subscribers are not consumed/completed under load. This patch limits per-subscriber execution time and keeps the worker loop resilient to unexpected stop/error states.

## Testing
- `yarn workspace @medusajs/event-bus-redis test src/services/__tests__/event-bus.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worker lifecycle management and subscriber execution behavior; misconfiguration or edge cases could cause premature subscriber failures or restart loops that impact event processing reliability.
> 
> **Overview**
> Adds **per-subscriber execution timeouts** to the Redis event bus worker so a hanging subscriber is rejected after `subscriberExecutionTimeout` (default 5 minutes, disable with `<= 0`) and treated as a failed subscriber for retry/attempt handling.
> 
> Reworks worker startup into a **resilient run loop** that auto-restarts the BullMQ worker after unexpected stops/errors, and updates shutdown hooks to stop the loop cleanly.
> 
> Updates module types/docs to expose `subscriberExecutionTimeout`, and adds a unit test ensuring a hanging subscriber times out and logs failure warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c30c4aaba490607eae2fc3782730f17ac5fbfc4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->