### PR TITLE
fix(types): fix item type for shipping option price calculation

### DIFF
--- a/.changeset/pretty-spiders-shake.md
+++ b/.changeset/pretty-spiders-shake.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": patch
+---
+
+fix(types): fix item type for shipping option price calculation

--- a/packages/core/types/src/fulfillment/common/cart.ts
+++ b/packages/core/types/src/fulfillment/common/cart.ts
@@ -1,4 +1,4 @@
-import { CartDTO } from "../.."
+import { CartDTO, CartLineItemDTO } from "../.."
 
 /**
  * A cart's details relevant for fulfillment.
@@ -15,7 +15,7 @@ export type CartPropsForFulfillment = {
   /**
    * The cart's items
    */
-  items: CartDTO["items"] & {
+  items: (CartLineItemDTO & {
     /**
      * The item's variant.
      */
@@ -85,5 +85,5 @@ export type CartPropsForFulfillment = {
         id: string
       }[]
     }
-  }
+  })[]
 }


### PR DESCRIPTION
The `CartPropsForFulfillment` type, used as the context type for calculating and validating shipping options, has an `items` property that is the cart line item with variant and product information expanded. However, the type incorrectly add the expanded variant and product fields outside the array rather than to each object in the array.

This PR fixes it by correctly adding the expanded information to the array items

Closes #14716