### PR TITLE
fix(product): avoid loading all variants on scalar variant updates

### DIFF
--- a/packages/medusa/src/api/admin/products/middlewares.ts
+++ b/packages/medusa/src/api/admin/products/middlewares.ts
@@ -231,7 +231,7 @@ export const adminProductRoutesMiddlewares: MiddlewareRoute[] = [
       validateAndTransformBody(AdminCreateProductVariant),
       validateAndTransformQuery(
         AdminGetProductParams,
-        QueryConfig.retrieveProductQueryConfig
+        QueryConfig.retrieveProductWithoutVariantsQueryConfig
       ),
     ],
     policies: [
@@ -301,7 +301,7 @@ export const adminProductRoutesMiddlewares: MiddlewareRoute[] = [
       validateAndTransformBody(AdminUpdateProductVariant),
       validateAndTransformQuery(
         AdminGetProductParams,
-        QueryConfig.retrieveProductQueryConfig
+        QueryConfig.retrieveProductWithoutVariantsQueryConfig
       ),
     ],
   },
@@ -311,7 +311,7 @@ export const adminProductRoutesMiddlewares: MiddlewareRoute[] = [
     middlewares: [
       validateAndTransformQuery(
         AdminGetProductParams,
-        QueryConfig.retrieveProductQueryConfig
+        QueryConfig.retrieveProductWithoutVariantsQueryConfig
       ),
     ],
     policies: [
@@ -351,7 +351,7 @@ export const adminProductRoutesMiddlewares: MiddlewareRoute[] = [
       validateAndTransformBody(AdminCreateProductOption),
       validateAndTransformQuery(
         AdminGetProductParams,
-        QueryConfig.retrieveProductQueryConfig
+        QueryConfig.retrieveProductWithoutVariantsQueryConfig
       ),
     ],
   },
@@ -362,7 +362,7 @@ export const adminProductRoutesMiddlewares: MiddlewareRoute[] = [
       validateAndTransformBody(AdminUpdateProductOption),
       validateAndTransformQuery(
         AdminGetProductParams,
-        QueryConfig.retrieveProductQueryConfig
+        QueryConfig.retrieveProductWithoutVariantsQueryConfig
       ),
     ],
   },
@@ -372,7 +372,7 @@ export const adminProductRoutesMiddlewares: MiddlewareRoute[] = [
     middlewares: [
       validateAndTransformQuery(
         AdminGetProductParams,
-        QueryConfig.retrieveProductQueryConfig
+        QueryConfig.retrieveProductWithoutVariantsQueryConfig
       ),
     ],
     policies: [

--- a/packages/medusa/src/api/admin/products/query-config.ts
+++ b/packages/medusa/src/api/admin/products/query-config.ts
@@ -84,6 +84,22 @@ export const retrieveProductQueryConfig = {
   entity: Entities.product,
 }
 
+// Lean product config that excludes heavy variant relations.
+// Used by variant POST/DELETE routes where refetching all variants
+// with prices/options after a single variant change is unnecessary
+// and causes severe performance degradation for products with many variants.
+export const defaultAdminProductFieldsWithoutVariants =
+  defaultAdminProductFields.filter(
+    (field) =>
+      !field.startsWith("*variants") && !field.startsWith("variants.")
+  )
+
+export const retrieveProductWithoutVariantsQueryConfig = {
+  defaults: defaultAdminProductFieldsWithoutVariants,
+  isList: false,
+  entity: Entities.product,
+}
+
 export const listProductQueryConfig = {
   ...retrieveProductQueryConfig,
   defaultLimit: 50,

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -518,12 +518,6 @@ export default class ProductModuleService
       sharedContext
     )
 
-    const allVariants = await this.productVariantService_.list(
-      { product_id: variants.map((v) => v.product_id) },
-      { relations: ["options"] },
-      sharedContext
-    )
-
     if (variants.length !== data.length) {
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
@@ -560,6 +554,12 @@ export default class ProductModuleService
       )
 
     if (data.some((d) => !!d.options)) {
+      const allVariants = await this.productVariantService_.list(
+        { product_id: variants.map((v) => v.product_id) },
+        { relations: ["options"] },
+        sharedContext
+      )
+
       ProductModuleService.checkIfVariantWithOptionsAlreadyExists(
         productVariantsWithOptions as any,
         allVariants


### PR DESCRIPTION
## What

Fixes mutation response performance for products with many variants (400+). 

### The problem

Multiple product sub-resource mutation routes (variant CRUD, option CRUD) use `retrieveProductQueryConfig` for the post-mutation `refetchEntity` call. This config includes `*variants`, `*variants.prices`, `variants.prices.price_rules.*`, `*variants.options` — loading ALL variants with all their prices, rules, and options after a single sub-resource change.

**Profiling results** on a product with 414 variants:

| Operation | Time |
|---|---|
| `updateProductVariantsWorkflow` | **3.5s** |
| `refetchEntity` with full product config | **11min 51s** |
| Total POST response | **11min 54s** |

The admin dashboard already fetches variants separately via GET requests (using `fields=-variants`). The mutation responses don't need to include all variant data.

### The fix

**1. Lean product query config for sub-resource mutations**

Added `retrieveProductWithoutVariantsQueryConfig` that filters out `*variants` and `variants.*` fields. Applied to these middleware configs:

- `POST /admin/products/:id/variants` (create variant)
- `POST /admin/products/:id/variants/:variant_id` (update variant)
- `DELETE /admin/products/:id/variants/:variant_id` (delete variant)
- `POST /admin/products/:id/options` (create option)
- `POST /admin/products/:id/options/:option_id` (update option)
- `DELETE /admin/products/:id/options/:option_id` (delete option)

**2. Conditional allVariants loading in `updateVariants_`**

`updateVariants_()` unconditionally loads all sibling variants with options for the `checkIfVariantWithOptionsAlreadyExists` validation, even when options aren't being updated. Moved the query inside the conditional so it only runs when options are present in the update payload.

## Files changed

- `packages/medusa/src/api/admin/products/query-config.ts` — add lean product config
- `packages/medusa/src/api/admin/products/middlewares.ts` — use lean config for 6 sub-resource routes
- `packages/modules/product/src/services/product-module-service.ts` — conditional allVariants loading

## Impact

- Sub-resource mutations no longer refetch all variants with prices
- No behavior change for product-level GET/POST/DELETE routes
- No behavior change for variant creation or option-changing updates in the service layer
- Follow-up to #14150 which fixed product update performance

Fixes #14727