### PR TITLE
fix(payment-collection): enable idempotency to prevent race conditions

### DIFF
--- a/.changeset/slow-parts-know.md
+++ b/.changeset/slow-parts-know.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/core-flows": patch
+"@medusajs/medusa": patch
+---
+
+fix(payment-collections): add idempotency to prevent duplicate payment collections on concurrent requests

--- a/packages/core/core-flows/src/cart/workflows/create-payment-collection-for-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/create-payment-collection-for-cart.ts
@@ -84,7 +84,7 @@ export const createPaymentCollectionForCartWorkflowId =
 export const createPaymentCollectionForCartWorkflow = createWorkflow(
   {
     name: createPaymentCollectionForCartWorkflowId,
-    idempotent: false,
+    idempotent: true,
   },
   (
     input: WorkflowData<CreatePaymentCollectionForCartWorkflowInputDTO>

--- a/packages/medusa/src/api/store/payment-collections/route.ts
+++ b/packages/medusa/src/api/store/payment-collections/route.ts
@@ -20,7 +20,7 @@ export const POST = async (
   const remoteQuery = req.scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
   const { cart_id } = req.body
 
-  // We can potentially refactor the workflow to behave more like an upsert and return an existing collection if there is one.
+  // FIXED: Using custom idempotent workflow to prevent race conditions
   const [cartCollectionRelation] = await remoteQuery(
     remoteQueryObjectFromString({
       entryPoint: "cart_payment_collection",
@@ -34,6 +34,7 @@ export const POST = async (
     const we = req.scope.resolve(Modules.WORKFLOW_ENGINE)
     await we.run(createPaymentCollectionForCartWorkflowId, {
       input: req.body,
+      transactionId: "create-payment-collection-" + cart_id,
     })
 
     const [cartCollectionRelation] = await remoteQuery(


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Adds idempotency to the POST /store/payment-collections API to prevent duplicate payment collections from being created on simultaneous requests.

**Why** — Why are these changes relevant or necessary?  

When multiple concurrent requests hit `POST /store/payment-collections` for the same cart (e.g. due to double-tap or network retry), both requests could pass the existing-collection check before either had finished creating one, resulting in duplicate payment collections linked to the same cart.

**How** — How have these changes been implemented?

*Two changes were made:*

1. **`createPaymentCollectionForCartWorkflow`** — Set `idempotent: true` in the workflow config. This tells the Workflow Engine that concurrent executions with the same `transactionId` are the same logical operation — only one runs, others wait and receive the same result.                                                                                               
                                                                                                                                                                                          
2. **`POST /store/payment-collections` route** — Pass a deterministic `transactionId` of `"create-payment-collection-" + cart_id` when running the workflow. This ensures concurrent requests for the same cart are deduplicated at the engine level, working together with the existing `acquireLockStep` and `validateExistingPaymentCollectionStep` already present in the workflow.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Send two simultaneous requests for the same cart_id and verify only one payment collection is created:*
```curl
curl 'https://<your-domain>/store/payment-collections' \
    -H 'content-type: application/json' \
    -H 'x-publishable-api-key: pk_xyz' \
    --data-raw '{"cart_id":"cart_abc"}' &

  curl 'https://<your-domain>/store/payment-collections' \
    -H 'content-type: application/json' \
    -H 'x-publishable-api-key: pk_xyz' \
    --data-raw '{"cart_id":"cart_abc"}' &
```

---

## Examples

```ts
// Both concurrent calls resolve to the same payment collection
  await we.run(createPaymentCollectionForCartWorkflowId, {
    input: req.body,
    transactionId: "create-payment-collection-" + cart_id,
  })
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches payment-collection creation and workflow execution semantics; idempotency/transaction ID behavior could affect how retries and concurrent requests resolve if mis-scoped.
> 
> **Overview**
> Prevents duplicate payment collections when `POST /store/payment-collections` is hit concurrently for the same cart.
> 
> The `createPaymentCollectionForCartWorkflow` is now **idempotent**, and the store route runs it with a deterministic `transactionId` (`create-payment-collection-${cart_id}`) so concurrent requests collapse into a single workflow execution. A changeset bumps `@medusajs/core-flows` and `@medusajs/medusa` as patch releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2353e4b2b4d414279ebe97ba0224590a70d16a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->