### PR TITLE
feat: Allow passing session_token to s3 credentials when using an acc…

### DIFF
--- a/packages/core/types/src/file/providers/s3.ts
+++ b/packages/core/types/src/file/providers/s3.ts
@@ -2,6 +2,7 @@ export interface S3FileServiceOptions {
   file_url: string
   access_key_id?: string
   secret_access_key?: string
+  session_token?: string
   authentication_method?: "access-key" | "s3-iam-role"
   region: string
   bucket: string

--- a/packages/modules/providers/file-s3/src/services/s3-file.ts
+++ b/packages/modules/providers/file-s3/src/services/s3-file.ts
@@ -30,6 +30,7 @@ interface S3FileServiceConfig {
   fileUrl: string
   accessKeyId?: string
   secretAccessKey?: string
+  sessionToken?: string
   authenticationMethod?: "access-key" | "s3-iam-role"
   region: string
   bucket: string
@@ -67,6 +68,7 @@ export class S3FileService extends AbstractFileProviderService {
       fileUrl: options.file_url,
       accessKeyId: options.access_key_id,
       secretAccessKey: options.secret_access_key,
+      sessionToken: options.session_token,
       authenticationMethod: authenticationMethod,
       region: options.region,
       bucket: options.bucket,
@@ -85,9 +87,10 @@ export class S3FileService extends AbstractFileProviderService {
     const credentials =
       this.config_.authenticationMethod === "access-key"
         ? {
-            accessKeyId: this.config_.accessKeyId!,
-            secretAccessKey: this.config_.secretAccessKey!,
-          }
+          accessKeyId: this.config_.accessKeyId!,
+          secretAccessKey: this.config_.secretAccessKey!,
+          sessionToken: this.config_.sessionToken,
+        }
         : undefined
 
     const config: S3ClientConfigType = {
@@ -117,9 +120,8 @@ export class S3FileService extends AbstractFileProviderService {
     const parsedFilename = path.parse(file.filename)
 
     // TODO: Allow passing a full path for storage per request, not as a global config.
-    const fileKey = `${this.config_.prefix}${parsedFilename.name}-${ulid()}${
-      parsedFilename.ext
-    }`
+    const fileKey = `${this.config_.prefix}${parsedFilename.name}-${ulid()}${parsedFilename.ext
+      }`
 
     let content: Buffer
     try {
@@ -180,9 +182,8 @@ export class S3FileService extends AbstractFileProviderService {
     }
 
     const parsedFilename = path.parse(fileData.filename)
-    const fileKey = `${this.config_.prefix}${parsedFilename.name}-${ulid()}${
-      parsedFilename.ext
-    }`
+    const fileKey = `${this.config_.prefix}${parsedFilename.name}-${ulid()}${parsedFilename.ext
+      }`
 
     const pass = new PassThrough()
     const upload = new Upload({


### PR DESCRIPTION
This allows using authentication such as R2 temporary credentials, which require the session token in order to sign requests correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive credentials configuration change; low risk aside from potential misconfiguration affecting S3 authentication in deployments that start using `session_token`.
> 
> **Overview**
> Adds optional `session_token` to `S3FileServiceOptions` and threads it through the S3 provider so `S3Client` credentials include `sessionToken` when using `access-key` authentication (enabling temporary credentials).
> 
> Also includes a small formatting-only change to how `fileKey` strings are constructed in `upload` and `getUploadStream` (no behavioral change intended).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 998c02ef72de521f7b24e520189e3f0df27eb3ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->