### PR TITLE
docs: disable AI assistant in bloom docs

### DIFF
--- a/www/apps/bloom/config/index.ts
+++ b/www/apps/bloom/config/index.ts
@@ -31,4 +31,7 @@ export const config: DocsConfig = {
     ...globalConfig.version,
     hide: true,
   },
+  features: {
+    aiAssistant: false,
+  },
 }

--- a/www/packages/docs-ui/src/components/CodeBlock/Actions/AskAi/__tests__/index.test.tsx
+++ b/www/packages/docs-ui/src/components/CodeBlock/Actions/AskAi/__tests__/index.test.tsx
@@ -3,12 +3,26 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 import { fireEvent, render } from "@testing-library/react"
 import * as AiAssistantMocks from "../../../../AiAssistant/__mocks__"
 
+// mock functions
+const mockUseSiteConfig = vi.fn()
+
+const defaultUseSiteConfigReturn = {
+  config: {
+    features: {
+      aiAssistant: true,
+    },
+  },
+}
+
 // mock components
 vi.mock("@/providers/AiAssistant", () => ({
   useAiAssistant: () => AiAssistantMocks.mockUseAiAssistant(),
 }))
 vi.mock("@kapaai/react-sdk", () => ({
   useChat: () => AiAssistantMocks.mockUseChat(),
+}))
+vi.mock("@/providers/SiteConfig", () => ({
+  useSiteConfig: () => mockUseSiteConfig(),
 }))
 vi.mock("@/components/Tooltip", () => ({
   Tooltip: ({
@@ -39,9 +53,27 @@ beforeEach(() => {
   AiAssistantMocks.mockUseChat.mockReturnValue(
     AiAssistantMocks.defaultUseChatReturn
   )
+  mockUseSiteConfig.mockReturnValue(defaultUseSiteConfigReturn)
 })
 
 describe("rendering", () => {
+  test("does not render when ai assistant feature is disabled", () => {
+    mockUseSiteConfig.mockReturnValueOnce({
+      config: {
+        features: {
+          aiAssistant: false,
+        },
+      },
+    })
+    const { container } = render(
+      <CodeBlockAskAiAction
+        source="console.log('Hello, world!');"
+        inHeader={false}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
   test("render code block ask ai action in header", () => {
     const { container } = render(
       <CodeBlockAskAiAction

--- a/www/packages/docs-ui/src/components/CodeBlock/Actions/AskAi/index.tsx
+++ b/www/packages/docs-ui/src/components/CodeBlock/Actions/AskAi/index.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx"
 import { Tooltip } from "../../../Tooltip"
 import { useChat } from "@kapaai/react-sdk"
 import { BloomIcon } from "../../../Icons"
+import { useSiteConfig } from "../../../../providers/SiteConfig"
 
 export type CodeBlockCopyActionProps = {
   source: string
@@ -17,7 +18,12 @@ export const CodeBlockAskAiAction = ({
   inHeader,
 }: CodeBlockCopyActionProps) => {
   const { setChatOpened, loading } = useAiAssistant()
+  const { config } = useSiteConfig()
   const { submitQuery } = useChat()
+
+  if (!config.features?.aiAssistant) {
+    return null
+  }
 
   const handleClick = () => {
     if (loading) {

--- a/www/packages/docs-ui/src/components/MainNav/__tests__/index.test.tsx
+++ b/www/packages/docs-ui/src/components/MainNav/__tests__/index.test.tsx
@@ -8,6 +8,9 @@ import { ButtonProps } from "../../Button"
 const mockConfig = {
   baseUrl: "https://docs.medusajs.com",
   logo: "/logo.png",
+  features: {
+    aiAssistant: true,
+  },
 }
 
 const defaultUseSiteConfigReturn = {
@@ -173,6 +176,22 @@ describe("rendering", () => {
     )
     expect(version).toBeInTheDocument()
     expect(helpDropdown).toBeInTheDocument()
+  })
+
+  test("does not render ai assistant trigger when ai assistant feature is disabled", () => {
+    mockUseSiteConfig.mockReturnValueOnce({
+      config: {
+        ...mockConfig,
+        features: {
+          aiAssistant: false,
+        },
+      },
+    })
+    const { container } = render(<MainNav />)
+    const aiTrigger = container.querySelector(
+      "[data-testid='ai-assistant-trigger']"
+    )
+    expect(aiTrigger).not.toBeInTheDocument()
   })
 
   test("renders nav items when not collapsed", () => {

--- a/www/packages/docs-ui/src/components/MainNav/index.tsx
+++ b/www/packages/docs-ui/src/components/MainNav/index.tsx
@@ -110,7 +110,7 @@ export const MainNav = ({ className, itemsClassName }: MainNavProps) => {
               />
             </div>
             <div className="flex items-center">
-              <AiAssistantTriggerButton />
+              {config.features?.aiAssistant && <AiAssistantTriggerButton />}
               <SearchModalOpener />
               <MainNavDesktopMenu />
               <MainNavMobileMenu />

--- a/www/packages/docs-ui/src/providers/SiteConfig/__tests__/index.test.tsx
+++ b/www/packages/docs-ui/src/providers/SiteConfig/__tests__/index.test.tsx
@@ -42,6 +42,9 @@ const TestComponent = () => {
       <div data-testid="version-number">{config.version?.number}</div>
       <div data-testid="release-url">{config.version?.releaseUrl}</div>
       <div data-testid="toc-length">{toc?.length || 0}</div>
+      <div data-testid="ai-assistant-feature">
+        {String(config.features?.aiAssistant ?? false)}
+      </div>
       <div data-testid="is-in-product">{String(isInProduct)}</div>
       <div data-testid="product-view">{productView || "none"}</div>
       <button
@@ -204,6 +207,44 @@ describe("SiteConfigProvider", () => {
       fireEvent.click(getByTestId("update-toc"))
 
       expect(getByTestId("toc-length")).toHaveTextContent("1")
+    })
+
+    test("enables ai assistant feature by default", () => {
+      const { getByTestId } = render(
+        <SiteConfigProvider>
+          <TestComponent />
+        </SiteConfigProvider>
+      )
+
+      expect(getByTestId("ai-assistant-feature")).toHaveTextContent("true")
+    })
+
+    test("allows overriding ai assistant feature via config", () => {
+      const config: DocsConfig = {
+        baseUrl: "",
+        project: {
+          title: "",
+          key: "",
+        },
+        sidebars: [],
+        logo: "",
+        features: {
+          aiAssistant: false,
+        },
+        version: {
+          number: "1.0.0",
+          releaseUrl: "",
+          releaseDate: "",
+        }
+      }
+
+      const { getByTestId } = render(
+        <SiteConfigProvider config={config}>
+          <TestComponent />
+        </SiteConfigProvider>
+      )
+
+      expect(getByTestId("ai-assistant-feature")).toHaveTextContent("false")
     })
 
     test("throws error when used outside provider", () => {

--- a/www/packages/docs-ui/src/providers/SiteConfig/index.tsx
+++ b/www/packages/docs-ui/src/providers/SiteConfig/index.tsx
@@ -45,6 +45,9 @@ export const SiteConfigProvider = ({
         },
         reportIssueLink: GITHUB_ISSUES_LINK,
         logo: "",
+        features: {
+          aiAssistant: true,
+        },
       },
       globalConfig,
       initConfig || {}

--- a/www/packages/types/src/config.ts
+++ b/www/packages/types/src/config.ts
@@ -32,4 +32,7 @@ export declare type DocsConfig = {
   }
   reportIssueLink?: string
   logo: string
+  features?: {
+    aiAssistant?: boolean
+  }
 }


### PR DESCRIPTION
1. add mechanism to disable features
2. Disable AI assistant in bloom docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple feature-flag gating of UI components plus type/config updates; minimal behavior change outside optionally hiding AI assistant entry points.
> 
> **Overview**
> Adds a `features.aiAssistant` flag to `DocsConfig` and `SiteConfigProvider` (defaulting to enabled) so docs apps can selectively turn off the AI assistant.
> 
> Updates the UI to respect this flag by hiding the main nav AI trigger and the code-block “Ask Bloom” action when disabled, and configures Bloom docs to disable it (`features.aiAssistant: false`). Tests were updated/added to cover both enabled and disabled rendering paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95b1f46de5b14d4a6eebbac8fb4b0d50a3510eef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->