### PR TITLE
fix(core-flows): credit only successful refunds upon order cancellation

### DIFF
--- a/.changeset/twenty-islands-give.md
+++ b/.changeset/twenty-islands-give.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): credit only successful refunds upon order cancellation

--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -1135,7 +1135,7 @@ medusaIntegrationTestRunner({
         )
       })
 
-      it.only("should only create credit lines for successfully refunded payments when some refunds fail", async () => {
+      it("should only create credit lines for successfully refunded payments when some refunds fail", async () => {
         const paymentModule = container.resolve(Modules.PAYMENT)
         const payment = order.payment_collections[0].payments[0]
         const paymentCollectionId = order.payment_collections[0].id

--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -56,8 +56,6 @@ medusaIntegrationTestRunner({
         order = seeder.order
       })
 
-
-
       it("should search orders by display_id", async () => {
         let response = await api.get(`/admin/orders`, adminHeaders)
 
@@ -1135,6 +1133,113 @@ medusaIntegrationTestRunner({
             ],
           })
         )
+      })
+
+      it.only("should only create credit lines for successfully refunded payments when some refunds fail", async () => {
+        const paymentModule = container.resolve(Modules.PAYMENT)
+        const payment = order.payment_collections[0].payments[0]
+        const paymentCollectionId = order.payment_collections[0].id
+
+        // Capture the original payment for 50
+        await api.post(
+          `/admin/payments/${payment.id}/capture`,
+          { amount: 50 },
+          adminHeaders
+        )
+
+        // Create a second payment session, authorize it, and capture it for 30
+        const session2 = await paymentModule.createPaymentSession(
+          paymentCollectionId,
+          {
+            provider_id: "pp_system_default",
+            amount: 100,
+            currency_code: "usd",
+            data: {},
+          }
+        )
+        const payment2 = await paymentModule.authorizePaymentSession(
+          session2.id,
+          {}
+        )
+        await paymentModule.capturePayment({
+          payment_id: payment2.id,
+          amount: 30,
+        })
+
+        // Verify both payments are captured before canceling
+        const orderBeforeCancel = (
+          await api.get(
+            `/admin/orders/${order.id}?fields=*payment_collections.payments.amount,*payment_collections.payments.captures.amount`,
+            adminHeaders
+          )
+        ).data.order
+
+        const capturedPayments =
+          orderBeforeCancel.payment_collections[0].payments.filter(
+            (p) => p.captures.length > 0
+          )
+        expect(capturedPayments).toHaveLength(2)
+
+        // Mock refundPayment to fail for the second payment
+        const originalRefundPayment =
+          paymentModule.refundPayment.bind(paymentModule)
+        jest
+          .spyOn(paymentModule, "refundPayment")
+          .mockImplementation(async (data: any, sharedContext?: any) => {
+            if (data.payment_id === payment2.id) {
+              throw new Error("Refund failed at payment provider")
+            }
+            return originalRefundPayment(data, sharedContext)
+          })
+
+        // Cancel the order
+        const cancelResponse = await api.post(
+          `/admin/orders/${order.id}/cancel`,
+          {},
+          adminHeaders
+        )
+
+        expect(cancelResponse.status).toBe(200)
+
+        // Restore the mock
+        jest.restoreAllMocks()
+
+        // Get the canceled order with credit lines and summary
+        const canceledOrder = (
+          await api.get(
+            `/admin/orders/${order.id}?fields=*credit_lines.amount,*payment_collections.payments.amount,*payment_collections.payments.captures.amount,*payment_collections.payments.refunds.amount`,
+            adminHeaders
+          )
+        ).data.order
+
+        expect(canceledOrder.status).toBe("canceled")
+
+        // Only the first payment (50) was successfully refunded
+        // The second payment (30) refund failed, so it should NOT be in credit lines
+        const totalCreditLineAmount = canceledOrder.credit_lines.reduce(
+          (sum, cl) => sum + cl.amount,
+          0
+        )
+
+        // Credit line should only reflect the successful refund (50), not both (50 + 30)
+        expect(totalCreditLineAmount).toBe(50)
+        expect(canceledOrder.summary.credit_line_total).toBe(50)
+
+        // Verify only the first payment has a refund record
+        const originalPaymentAfter =
+          canceledOrder.payment_collections[0].payments.find(
+            (p) => p.id === payment.id
+          )
+        const payment2After =
+          canceledOrder.payment_collections[0].payments.find(
+            (p) => p.id === payment2.id
+          )
+
+        expect(originalPaymentAfter.refunds).toHaveLength(1)
+        expect(originalPaymentAfter.refunds[0].amount).toBe(50)
+
+        // The failed payment should have no refund records
+        expect(payment2After.refunds).toHaveLength(0)
       })
     })
 

--- a/packages/core/core-flows/src/order/workflows/cancel-order.ts
+++ b/packages/core/core-flows/src/order/workflows/cancel-order.ts
@@ -165,42 +165,52 @@ export const cancelOrderWorkflow = createWorkflow(
       return uncapturedPayments.map((payment) => payment.id)
     })
 
-    const creditLineAmount = transform({ order }, ({ order }) => {
-      const payments = deepFlatMap(
-        order,
-        "payment_collections.payments",
-        ({ payments }) => payments
-      )
-
-      return payments
-        .flatMap((payment) => payment.captures)
-        .reduce(
-          (acc, capture) => MathBN.sum(acc, capture.raw_amount),
-          MathBN.convert(0)
-        )
-    })
-
     const lineItemIds = transform({ order }, ({ order }) => {
       return order.items?.map((i) => i.id)
     })
 
-    parallelize(
-      createOrderRefundCreditLinesWorkflow.runAsStep({
-        input: {
-          order_id: order.id,
-          amount: creditLineAmount,
-        },
-      }),
-      deleteReservationsByLineItemsStep(lineItemIds),
-      cancelPaymentStep({ paymentIds: uncapturedPaymentIds }),
+    const [refundedPayments] = parallelize(
       refundCapturedPaymentsWorkflow.runAsStep({
         input: { order_id: order.id, created_by: input.canceled_by },
       }),
+      deleteReservationsByLineItemsStep(lineItemIds),
+      cancelPaymentStep({ paymentIds: uncapturedPaymentIds }),
       emitEventStep({
         eventName: OrderWorkflowEvents.CANCELED,
         data: { id: order.id },
       })
     )
+
+    const refundedPaymentIds = transform(
+      { refundedPayments },
+      ({ refundedPayments }) => {
+        return refundedPayments.map((payment) => payment.id)
+      }
+    )
+
+    const refundedCapturesQuery = useQueryGraphStep({
+      entity: "captures",
+      fields: ["raw_amount"],
+      filters: { payment_id: refundedPaymentIds },
+    }).config({ name: "get-refunded-captures" })
+
+    const creditLineAmount = transform(
+      { refundedCapturesQuery },
+      ({ refundedCapturesQuery }) => {
+        const captures = refundedCapturesQuery.data
+        return captures.reduce(
+          (acc, capture) => MathBN.sum(acc, capture.raw_amount),
+          MathBN.convert(0)
+        )
+      }
+    )
+
+    createOrderRefundCreditLinesWorkflow.runAsStep({
+      input: {
+        order_id: order.id,
+        amount: creditLineAmount,
+      },
+    })
 
     const paymentCollectionids = transform({ order }, ({ order }) =>
       order.payment_collections?.map((pc) => pc.id)

--- a/packages/core/core-flows/src/order/workflows/payments/refund-captured-payments.ts
+++ b/packages/core/core-flows/src/order/workflows/payments/refund-captured-payments.ts
@@ -5,6 +5,7 @@ import {
   transform,
   when,
   WorkflowData,
+  WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep } from "../../../common"
 import { refundPaymentsWorkflow } from "../../../payment/workflows/refund-payments"
@@ -92,10 +93,12 @@ export const refundCapturedPaymentsWorkflow = createWorkflow(
         )
     )
 
-    when({ totalCaptured }, ({ totalCaptured }) => {
+    const refundedPayments = when({ totalCaptured }, ({ totalCaptured }) => {
       return !!MathBN.gt(totalCaptured, 0)
     }).then(() => {
-      refundPaymentsWorkflow.runAsStep({ input: refundPaymentsData })
+      return refundPaymentsWorkflow.runAsStep({ input: refundPaymentsData })
     })
+
+    return new WorkflowResponse(refundedPayments ?? [])
   }
 )

--- a/packages/core/core-flows/src/order/workflows/payments/refund-captured-payments.ts
+++ b/packages/core/core-flows/src/order/workflows/payments/refund-captured-payments.ts
@@ -99,6 +99,10 @@ export const refundCapturedPaymentsWorkflow = createWorkflow(
       return refundPaymentsWorkflow.runAsStep({ input: refundPaymentsData })
     })
 
-    return new WorkflowResponse(refundedPayments ?? [])
+    const response = transform(
+      { refundedPayments },
+      ({ refundedPayments }) => refundedPayments ?? []
+    )
+    return new WorkflowResponse(response as PaymentDTO[])
   }
 )


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Only create credit lines for successful refunds upon order cancellation, to ensure accounting records are in a consistent state.

**Why** — Why are these changes relevant or necessary?  

Accounting records were left in an inconsistent state after an order is cancelled and some of its refunds failed to complete. Particularly, since credit lines were created for the total amount, accounting would show more has been refunded than it actually was.

**How** — How have these changes been implemented?

Ensure we are generating a credit line for the amount corresponding to the successful refunds, instead of all the order's captures.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration test.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes CORE-1390