### PR TITLE
Update page.mdx, change `run --rm` to `exec` for `npm`

### DIFF
--- a/www/apps/book/app/learn/installation/docker/page.mdx
+++ b/www/apps/book/app/learn/installation/docker/page.mdx
@@ -531,7 +531,7 @@ docker compose run --rm medusa pnpm medusa user -e admin@example.com -p supersec
   <CodeTab value="npm" label="npm">
 
 ```bash
-docker compose run --rm medusa npx medusa user -e admin@example.com -p supersecret
+docker compose exec medusa npx medusa user -e admin@example.com -p supersecret
 ```
 
   </CodeTab>


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

This PR updates the documentation to recommend using `docker compose exec` instead of `docker compose run --rm` when creating an admin user or running CLI commands in a Dockerized Medusa environment.

**Why** — Why are these changes relevant or necessary?  

Using `run --rm` triggers the `start.sh` entrypoint, which includes a `medusa seed` command. If a database already exists, the seed script fails because countries (such as "de, dk, es, fr") cannot be assigned to more than one region. This blocks the user from successfully creating an admin account or executing other CLI tasks.

**How** — How have these changes been implemented?

The documentation commands have been updated to target the already-running Medusa container.

**Old Command:** `docker compose run --rm medusa npx medusa user ...` (triggers entrypoint logic/seeding).

**New Command:** `docker compose exec medusa npx medusa user ...` (executes directly within the active runtime, bypassing the seed script).


## Additional Context

By using `exec`, you are interacting with the environment as it exists in memory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change affecting a single command example; no runtime code or behavior is modified.
> 
> **Overview**
> Updates the Docker installation guide’s **npm** command for creating an admin user to use `docker compose exec` instead of `docker compose run --rm`, so the CLI runs inside the existing `medusa` container rather than starting a new one.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44aba0f401ced8c56d598ccdc9e6b69d8086ec37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->