### PR TITLE
fix: return HTTP 400 for malformed JSON request body instead of 500

### DIFF
--- a/.changeset/fix-malformed-json-body-parser.md
+++ b/.changeset/fix-malformed-json-body-parser.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/framework": patch
+---
+
+fix: return HTTP 400 for malformed JSON request bodies instead of 500
+
+Express body-parser throws a `SyntaxError` with type `entity.parse.failed` when the request body contains invalid JSON. The error handler did not match this error type, causing it to fall through to the default 500 handler. This patch catches the body-parser `SyntaxError` early and returns a proper `400` with type `invalid_data`.

--- a/packages/core/framework/src/http/middlewares/error-handler.ts
+++ b/packages/core/framework/src/http/middlewares/error-handler.ts
@@ -32,6 +32,22 @@ export function errorHandler() {
 
     err = formatException(err)
 
+    // Express body-parser throws a SyntaxError with type "entity.parse.failed"
+    // when the request body contains malformed JSON. Catch it early and return
+    // a proper 400 instead of falling through to the default 500 handler.
+    if (
+      err instanceof SyntaxError &&
+      "type" in err &&
+      (err as any).type === "entity.parse.failed"
+    ) {
+      logger.info("Invalid JSON in request body")
+      res.status(400).json({
+        type: MedusaError.Types.INVALID_DATA,
+        message: "Invalid JSON in request body",
+      })
+      return
+    }
+
     const errorType = err.type || err.name
     const errObj = {
       code: err.code,


### PR DESCRIPTION
## What

The global error handler in `@medusajs/framework` now returns HTTP 400 (instead of 500) when a request body contains malformed JSON.

## Why

When Express's `json()` body-parser encounters invalid JSON, it throws a `SyntaxError` with `type: "entity.parse.failed"`. The error handler's switch statement did not match this error type, so it fell through to the `default` case — returning `500` with `"An unknown error occurred."`.

This is incorrect for several reasons:

- **HTTP semantics**: Malformed request bodies are client errors (4xx), not server errors (5xx). [RFC 9110 §15.5.1](https://httpwg.org/specs/rfc9110.html#status.400).
- **Observability**: 500 errors from client mistakes pollute error tracking (Sentry, Datadog, etc.) with noise that should be filtered as 4xx.
- **Developer experience**: API consumers see `"unknown_error"` and have no signal that their JSON is malformed.
- **Security**: Returning 500 for client-controlled input can be misleading in security audits.

## How

Added an early check in `errorHandler()`, after `formatException()` but before the main switch:

```ts
if (
  err instanceof SyntaxError &&
  "type" in err &&
  (err as any).type === "entity.parse.failed"
) {
  logger.info("Invalid JSON in request body")
  res.status(400).json({
    type: MedusaError.Types.INVALID_DATA,
    message: "Invalid JSON in request body",
  })
  return
}
```

This specifically targets Express body-parser errors (via the `entity.parse.failed` type) and does not affect any other `SyntaxError` that might come from application code.

### Behavioral change

| Request | Before | After |
|---------|--------|-------|
| `POST /store/carts` with `Content-Type: application/json` and body `{bad json` | `500 {"type":"unknown_error","message":"An unknown error occurred."}` | `400 {"type":"invalid_data","message":"Invalid JSON in request body"}` |

All other error handling paths remain unchanged.

## Testing

Verified locally on `@medusajs/medusa@2.13.1`:

```bash
# All four return 400 after the fix (were 500 before)
curl -X POST http://localhost:9000/store/carts -H "Content-Type: application/json" -d '{bad'
curl -X POST http://localhost:9000/admin/products -H "Content-Type: application/json" -d '{bad'
curl -X POST http://localhost:9000/store/customers -H "Content-Type: application/json" -d '{bad'
curl -X POST http://localhost:9000/auth/user/emailpass -H "Content-Type: application/json" -d '{bad'
```

There are no existing unit tests for the error handler middleware. Happy to add a test file if you can point me to the preferred test setup for `@medusajs/framework`.

Fixes #14796

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, narrowly-scoped change to error mapping that only affects responses for malformed JSON request bodies; low risk of side effects outside this error path.
> 
> **Overview**
> The global `errorHandler` now detects Express body-parser malformed-JSON errors (`SyntaxError` with `type: "entity.parse.failed"`) and returns **HTTP 400** with `type: invalid_data` and a clear message, instead of falling through to the generic 500 handler.
> 
> Adds a patch changeset for `@medusajs/framework` documenting the behavioral change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdd051dc7027770ce38018d0c04f824248e48239. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->