### PR TITLE
chore(types): add external_id to product list params type

### DIFF
--- a/.changeset/wicked-insects-spend.md
+++ b/.changeset/wicked-insects-spend.md
@@ -1,0 +1,6 @@
+---
+"integration-tests-http": patch
+"@medusajs/types": patch
+---
+
+Add filtering of products based on external_id

--- a/.changeset/wicked-insects-spend.md
+++ b/.changeset/wicked-insects-spend.md
@@ -3,4 +3,4 @@
 "@medusajs/types": patch
 ---
 
-Add filtering of products based on external_id
+chore(types): add external_id to product list params type

--- a/integration-tests/http/__tests__/product/admin/product.spec.ts
+++ b/integration-tests/http/__tests__/product/admin/product.spec.ts
@@ -953,6 +953,36 @@ medusaIntegrationTestRunner({
           ])
         })
 
+        it("should return products filtered by external_id", async () => {
+
+          const newProduct = (
+            await api.post(
+              "/admin/products",
+              getProductFixture({
+                title: "Test saleschannel",
+                external_id: "test-external-id",
+                shipping_profile_id: shippingProfile.id,
+              }),
+              adminHeaders
+            )
+          ).data.product
+
+          const res = await api.get(
+            `/admin/products?external_id[]=test-external-id`,
+            adminHeaders
+          )
+
+          expect(res.status).toEqual(200)
+          expect(res.data.products.length).toEqual(1)
+          expect(res.data.products).toEqual([
+            expect.objectContaining({
+              id: newProduct.id,
+            }),
+          ])
+        })
+
+
+
         it("returns a list of products filtered by variants[ean]", async () => {
           const productWithEan = await api.post(
             "/admin/products",

--- a/integration-tests/http/__tests__/product/store/product.spec.ts
+++ b/integration-tests/http/__tests__/product/store/product.spec.ts
@@ -521,6 +521,7 @@ medusaIntegrationTestRunner({
           title: "test product 1",
           collection_id: collection.id,
           status: ProductStatus.PUBLISHED,
+          external_id: "my-prod-001",
           shipping_profile_id: shippingProfile.id,
           options: [
             { title: "size", values: ["large", "small"] },
@@ -853,6 +854,34 @@ medusaIntegrationTestRunner({
       it("returns a list of products with a given tag", async () => {
         const response = await api.get(
           `/store/products?tag_id[]=${product.tags[0].id}`,
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.count).toEqual(1)
+        expect(response.data.products).toEqual([
+          expect.objectContaining({ id: product.id }),
+        ])
+      })
+
+      it('returns the external_id field when requested with `fields` param', async () => {  
+        const response  = await api.get('/store/products/' + product.id, storeHeaders);
+        expect(response.status).toEqual(200);
+        expect(response.data.product.external_id).toBeUndefined();
+
+        const response2  = await api.get('/store/products/' + product.id + "?fields=+external_id", storeHeaders);
+        expect(response2.status).toEqual(200);
+        expect(response2.data.product.external_id).toEqual(product.external_id);
+      });
+
+      it("returns a list of products with given external_id", async () => {
+        const response2  = await api.get('/store/products/' + product.id + "?fields=+external_id", storeHeaders);
+        expect(response2.status).toEqual(200);
+        expect(response2.data.product.external_id).toBeTruthy();
+        expect(response2.data.product.external_id).toEqual(product.external_id);
+
+        const response = await api.get(
+          `/store/products?external_id[]=${product.external_id}`,
           storeHeaders
         )
 

--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -384,6 +384,10 @@ export interface BaseProductListParams
    */
   handle?: string | string[]
   /**
+   * Filter by the product's external ID(s).
+   */
+  external_id?: string | string[]
+  /**
    * Filter by the product's id(s).
    */
   id?: string | string[]


### PR DESCRIPTION
add filtering by external_id to both /store and /admin endpoints

## Summary

**What** — What changes are introduced in this PR?

Added `external_id` as a filtering option for the `/admin/products` and `/store/products` endpoints

**Why** — Why are these changes relevant or necessary?  

For admin side, to allow for `push` style integrations, where the rest of the environment knows the product by its external_id, and need to either look it up in medusa, or look it up to get the internal medusa id, with which to then call `update` (POST)

For store api, to allow storefront to receive recommendations from existing external system, that uses a globally known id for the product, rather than medusas internal id, and then be able to resolve those globally known ids, to medusa ids.

**How** — How have these changes been implemented?

Added to base query list params for the product type

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration testing/unittest updated for both admin and store endpoints.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
  const product = await sdk.store.product.list({
     external_id: 'test-external-id'
    });

```

```ts
  const product = await sdk.admin.product.list({
     external_id: 'test-external-id'
    });

```

---

## Checklist

Please ensure the following before requesting a review:

- [X] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [X] The changes are covered by relevant **tests**
- [X] I have verified the code works as intended locally
- [X] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
