### PR TITLE
fix(core-flows): prevent exception when deleting product/variant with orphaned inventory

### DIFF
--- a/.changeset/ten-lemons-peel.md
+++ b/.changeset/ten-lemons-peel.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): prevent exception when deleting product/variant with orphaned inventory

--- a/integration-tests/http/__tests__/product/admin/product.spec.ts
+++ b/integration-tests/http/__tests__/product/admin/product.spec.ts
@@ -1,4 +1,5 @@
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { Modules } from "@medusajs/framework/utils"
 import {
   adminHeaders,
   createAdminUser,
@@ -3205,6 +3206,110 @@ medusaIntegrationTestRunner({
           expect(item2Response.data.inventory_item).toEqual(
             expect.objectContaining({ id: inventoryItem2.id })
           )
+        })
+
+        it("successfully deletes a product when a linked inventory item was already deleted", async () => {
+          const stockLocation = (
+            await api.post(
+              `/admin/stock-locations`,
+              { name: "loc" },
+              adminHeaders
+            )
+          ).data.stock_location
+
+          const inventoryItem1 = (
+            await api.post(
+              `/admin/inventory-items`,
+              { sku: "inventory-orphan-1" },
+              adminHeaders
+            )
+          ).data.inventory_item
+
+          const inventoryItem2 = (
+            await api.post(
+              `/admin/inventory-items`,
+              { sku: "inventory-orphan-2" },
+              adminHeaders
+            )
+          ).data.inventory_item
+
+          await api.post(
+            `/admin/inventory-items/${inventoryItem1.id}/location-levels`,
+            {
+              location_id: stockLocation.id,
+              stocked_quantity: 10,
+            },
+            adminHeaders
+          )
+
+          await api.post(
+            `/admin/inventory-items/${inventoryItem2.id}/location-levels`,
+            {
+              location_id: stockLocation.id,
+              stocked_quantity: 5,
+            },
+            adminHeaders
+          )
+
+          const productWithInventory = (
+            await api.post(
+              `/admin/products`,
+              {
+                title: "Product with orphan link",
+                handle: "product-orphan-link",
+                options: [{ title: "size", values: ["m"] }],
+                shipping_profile_id: shippingProfile.id,
+                variants: [
+                  {
+                    title: "Variant with orphan inventory link",
+                    prices: [{ currency_code: "usd", amount: 100 }],
+                    manage_inventory: true,
+                    options: { size: "m" },
+                    inventory_items: [
+                      {
+                        inventory_item_id: inventoryItem1.id,
+                        required_quantity: 1,
+                      },
+                      {
+                        inventory_item_id: inventoryItem2.id,
+                        required_quantity: 1,
+                      },
+                    ],
+                  },
+                ],
+              },
+              adminHeaders
+            )
+          ).data.product
+
+          // Delete one inventory item directly via the module service,
+          // bypassing the workflow that would clean up the link.
+          // This creates an orphan link (variant still references a
+          // deleted inventory item).
+          const inventoryModule = getContainer().resolve(Modules.INVENTORY)
+          await inventoryModule.deleteInventoryItems(inventoryItem1.id)
+
+          // Deleting the product should succeed despite the orphan link
+          const response = await api.delete(
+            `/admin/products/${productWithInventory.id}`,
+            adminHeaders
+          )
+
+          expect(response.status).toEqual(200)
+          expect(response.data).toEqual(
+            expect.objectContaining({ deleted: true })
+          )
+
+          // The remaining inventory item should also be deleted since it
+          // was only associated with this product's variant
+          const item2Response = await api
+            .get(
+              `/admin/inventory-items/${inventoryItem2.id}`,
+              adminHeaders
+            )
+            .catch((err) => err.response)
+
+          expect(item2Response.status).toEqual(404)
         })
 
         it("should throw if product that has a reservation is being deleted", async () => {

--- a/integration-tests/http/__tests__/product/admin/variant.spec.ts
+++ b/integration-tests/http/__tests__/product/admin/variant.spec.ts
@@ -1,4 +1,5 @@
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { Modules } from "@medusajs/framework/utils"
 import {
   adminHeaders,
   createAdminUser,
@@ -1076,6 +1077,114 @@ medusaIntegrationTestRunner({
         expect(deletedLinkVariant.inventory_items[0].id).not.toEqual(
           inventoryItemToDelete.id
         )
+      })
+    })
+
+    describe("DELETE /admin/products/:id/variants/:variant_id", () => {
+      it("successfully deletes a variant when a linked inventory item was already deleted", async () => {
+        const stockLocation = (
+          await api.post(
+            `/admin/stock-locations`,
+            { name: "loc" },
+            adminHeaders
+          )
+        ).data.stock_location
+
+        const inventoryItem1 = (
+          await api.post(
+            `/admin/inventory-items`,
+            { sku: "variant-orphan-1" },
+            adminHeaders
+          )
+        ).data.inventory_item
+
+        const inventoryItem2 = (
+          await api.post(
+            `/admin/inventory-items`,
+            { sku: "variant-orphan-2" },
+            adminHeaders
+          )
+        ).data.inventory_item
+
+        await api.post(
+          `/admin/inventory-items/${inventoryItem1.id}/location-levels`,
+          {
+            location_id: stockLocation.id,
+            stocked_quantity: 10,
+          },
+          adminHeaders
+        )
+
+        await api.post(
+          `/admin/inventory-items/${inventoryItem2.id}/location-levels`,
+          {
+            location_id: stockLocation.id,
+            stocked_quantity: 5,
+          },
+          adminHeaders
+        )
+
+        const product = (
+          await api.post(
+            `/admin/products`,
+            {
+              title: "Product with orphan variant link",
+              handle: "product-orphan-variant-link",
+              options: [{ title: "size", values: ["m"] }],
+              shipping_profile_id: shippingProfile.id,
+              variants: [
+                {
+                  title: "Variant with orphan inventory link",
+                  prices: [{ currency_code: "usd", amount: 100 }],
+                  manage_inventory: true,
+                  options: { size: "m" },
+                  inventory_items: [
+                    {
+                      inventory_item_id: inventoryItem1.id,
+                      required_quantity: 1,
+                    },
+                    {
+                      inventory_item_id: inventoryItem2.id,
+                      required_quantity: 1,
+                    },
+                  ],
+                },
+              ],
+            },
+            adminHeaders
+          )
+        ).data.product
+
+        const variantId = product.variants[0].id
+
+        // Delete one inventory item directly via the module service,
+        // bypassing the workflow that would clean up the link.
+        // This creates an orphan link (variant still references a
+        // deleted inventory item).
+        const inventoryModule = getContainer().resolve(Modules.INVENTORY)
+        await inventoryModule.deleteInventoryItems(inventoryItem1.id)
+
+        // Deleting the variant should succeed despite the orphan link
+        const response = await api.delete(
+          `/admin/products/${product.id}/variants/${variantId}`,
+          adminHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data).toEqual(
+          expect.objectContaining({
+            id: variantId,
+            deleted: true,
+          })
+        )
+
+        // The remaining inventory item should also be deleted since it
+        // was only associated with this variant
+        const item2Response = await api
+          .get(`/admin/inventory-items/${inventoryItem2.id}`, adminHeaders)
+          .catch((err) => err.response)
+
+        expect(item2Response.status).toEqual(404)
       })
     })
   },

--- a/packages/core/core-flows/src/product/workflows/delete-product-variants.ts
+++ b/packages/core/core-flows/src/product/workflows/delete-product-variants.ts
@@ -85,7 +85,10 @@ export const deleteProductVariantsWorkflow = createWorkflow(
           }
 
           for (const inventoryItem of variant.inventory) {
-            if (inventoryItem.variants.every((v) => variantsMap.has(v.id))) {
+            if (
+              !!inventoryItem &&
+              inventoryItem.variants.every((v) => variantsMap.has(v.id))
+            ) {
               toDeleteIds.add(inventoryItem.id)
             }
           }

--- a/packages/core/core-flows/src/product/workflows/delete-products.ts
+++ b/packages/core/core-flows/src/product/workflows/delete-products.ts
@@ -87,7 +87,10 @@ export const deleteProductsWorkflow = createWorkflow(
           }
 
           for (const inventoryItem of variant.inventory) {
-            if (inventoryItem.variants.every((v) => variantsMap.has(v.id))) {
+            if (
+              !!inventoryItem &&
+              inventoryItem.variants.every((v) => variantsMap.has(v.id))
+            ) {
               toDeleteIds.add(inventoryItem.id)
             }
           }


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Prevent product/variant <> inventory links with orphaned inventory item (when the inventory item is deleted, for example, directly with the Inventory Module, without removing the link) from failing when deleting product/variant

**Why** — Why are these changes relevant or necessary?  

Without this check, an exception would be raised when deleting the product/variant.

**How** — How have these changes been implemented?

Added a check to only iterate the invenotry items that are defined.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

Solves Cloud inquiry via email.