### PR TITLE
chore(api,types): allow filtering on variant sku/barcode/ean/upc on both /store and /admin apis

### DIFF
--- a/.changeset/rich-nights-stand.md
+++ b/.changeset/rich-nights-stand.md
@@ -1,0 +1,7 @@
+---
+"integration-tests-http": patch
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+chore(product): allow filtering on variant sku/barcode/ean/upc on both /store and /admin apis

--- a/.changeset/rich-nights-stand.md
+++ b/.changeset/rich-nights-stand.md
@@ -4,4 +4,4 @@
 "@medusajs/medusa": patch
 ---
 
-chore(product): allow filtering on variant sku/barcode/ean/upc on both /store and /admin apis
+chore(api,types): allow filtering on variant sku/barcode/ean/upc on both /store and /admin apis

--- a/.changeset/rich-nights-stand.md
+++ b/.changeset/rich-nights-stand.md
@@ -4,4 +4,4 @@
 "@medusajs/medusa": patch
 ---
 
-chore(api,types): allow filtering on variant sku/barcode/ean/upc on both /store and /admin apis
+chore(medusa,types): allow filtering on variant sku/barcode/ean/upc on both /store and /admin apis

--- a/integration-tests/http/__tests__/product/admin/product.spec.ts
+++ b/integration-tests/http/__tests__/product/admin/product.spec.ts
@@ -984,6 +984,71 @@ medusaIntegrationTestRunner({
 
 
 
+        it("returns a list of products filtered by variants[sku]", async () => {
+          const productWithSku = await api.post(
+            "/admin/products",
+            getProductFixture({
+              title: "Product with SKU",
+              shipping_profile_id: shippingProfile.id,
+              variants: [
+                {
+                  title: "Test variant",
+                  sku: "SKU1234567890123",
+                  prices: [{ currency_code: "usd", amount: 100 }],
+                  options: {
+                    size: "large",
+                    color: "green",
+                  },
+                },
+              ],
+            }),
+            adminHeaders
+          )
+
+          await api.post(
+            "/admin/products",
+            getProductFixture({
+              title: "Product with different SKU",
+              shipping_profile_id: shippingProfile.id,
+              variants: [
+                {
+                  title: "Test variant 2",
+                  sku: "SKU9876543210987",
+                  prices: [{ currency_code: "usd", amount: 150 }],
+                  options: {
+                    size: "large",
+                    color: "green",
+                  },
+                },
+              ],
+            }),
+            adminHeaders
+          )
+
+          const response = await api
+            .get("/admin/products?variants[sku]=SKU1234567890123", adminHeaders)
+            .catch((err) => {
+              console.log(err)
+            })
+
+          expect(response.status).toEqual(200)
+          expect(response.data.products).toHaveLength(1)
+          expect(response.data.products).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                id: productWithSku.data.product.id,
+                title: "Product with SKU",
+                variants: expect.arrayContaining([
+                  expect.objectContaining({
+                    sku: "SKU1234567890123",
+                  }),
+                ]),
+              }),
+            ])
+          )
+        })
+
+
         it("returns a list of products filtered by variants[ean]", async () => {
           const productWithEan = await api.post(
             "/admin/products",
@@ -1414,6 +1479,47 @@ medusaIntegrationTestRunner({
             }),
           ])
         })
+
+        it('should get product variants filtered by sku', async () => {
+          const payload = {
+            title: "Test product - 1",
+            handle: "test-1",
+            options: [{ title: "size", values: ["x", "l"] }],
+            shipping_profile_id: shippingProfile.id,
+            variants: [
+              {
+                title: "Custom inventory 1",
+                prices: [{ currency_code: "usd", amount: 100 }],
+                options: { size: "x" },
+                sku: "sku-123",
+              },
+              {
+                title: "Custom inventory 2",
+                prices: [{ currency_code: "usd", amount: 100 }],
+                options: { size: "l" },
+                sku: "sku-456",
+              },
+            ],
+          }
+
+          const product = (
+            await api.post(`/admin/products`, payload, adminHeaders)
+          ).data.product
+
+          const variants = (
+            await api.get(
+              `/admin/products/${product.id}/variants?sku=sku-123`,
+              adminHeaders
+            )
+          ).data.variants
+
+          expect(variants).toEqual([
+            expect.objectContaining({
+              title: "Custom inventory 1",
+              product_id: product.id,
+            }),
+          ])
+        });
 
         it("should get product variants filtered by manage_inventory", async () => {
           const payload = {

--- a/integration-tests/http/__tests__/product/store/product.spec.ts
+++ b/integration-tests/http/__tests__/product/store/product.spec.ts
@@ -532,6 +532,10 @@ medusaIntegrationTestRunner({
             {
               title: "test variant 1",
               manage_inventory: true,
+              sku: 'test-sku',
+              ean: 'test-ean',
+              upc: 'test-upc',
+              barcode: 'test-barcode',
               options: {
                 size: "large",
                 color: "green",
@@ -891,6 +895,65 @@ medusaIntegrationTestRunner({
           expect.objectContaining({ id: product.id }),
         ])
       })
+
+
+
+
+      it("can filter products by ean", async () => {
+        const response = await api.get(
+          `/store/products?variants[ean]=${product.variants[0].ean}`,
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.count).toEqual(1)
+        expect(response.data.products).toEqual([
+          expect.objectContaining({ id: product.id }),
+        ])
+      })
+
+      it("can filter products by upc", async () => {
+        const response = await api.get(
+          `/store/products?variants[upc]=${product.variants[0].upc}`,
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.count).toEqual(1)
+        expect(response.data.products).toEqual([
+          expect.objectContaining({ id: product.id }),
+        ])
+      })
+
+      it("can filter products by barcode", async () => {
+        const response = await api.get(
+          `/store/products?variants[barcode]=${product.variants[0].barcode}`,
+          storeHeaders
+        )
+        expect(response.status).toEqual(200)
+        expect(response.data.count).toEqual(1)
+        expect(response.data.products).toEqual([
+          expect.objectContaining({ id: product.id }),
+        ])
+      })
+
+
+      it("can filter products by sku", async () => {
+        const response = await api.get(
+          `/store/products?variants[sku]=${product.variants[0].sku}`,
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.count).toEqual(1)
+        expect(response.data.products).toEqual([
+          expect.objectContaining({ id: product.id }),
+        ])
+      })
+
+
+
+
 
       it("returns a list of products with one of the given handles", async () => {
         const response = await api.get(

--- a/packages/core/types/src/http/product/admin/queries.ts
+++ b/packages/core/types/src/http/product/admin/queries.ts
@@ -25,6 +25,10 @@ export interface AdminProductVariantParams
    */
   allow_backorder?: boolean
   /**
+   * Filter by sku(s).
+   */
+  sku?: string | string[]
+  /**
    * Filter by variant ean(s).
    */
   ean?: string | string[]
@@ -66,6 +70,12 @@ export interface AdminProductExportParams extends Omit<AdminProductListParams, "
     id?: string[]
   }
   variants?: { 
+
+    sku?: string | string[] | OperatorMap<string | string[]>
+    ean?: string | string[] | OperatorMap<string | string[]>
+    upc?: string | string[] | OperatorMap<string | string[]>
+    barcode?: string | string[] | OperatorMap<string | string[]>
+    
     options?: { 
       value?: string
       option_id?: string

--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -446,7 +446,11 @@ export interface BaseProductVariantParams
   options?: {
     value: string
     option_id: string
-  }
+  },
+  sku?: string | string[]
+  ean?: string | string[]
+  upc?: string | string[]
+  barcode?: string | string[]
   created_at?: OperatorMap<string>
   updated_at?: OperatorMap<string>
   deleted_at?: OperatorMap<string>

--- a/packages/core/types/src/http/product/store/queries.ts
+++ b/packages/core/types/src/http/product/store/queries.ts
@@ -47,7 +47,7 @@ export interface StoreProductListParams
   /**
    * Filter by the product's variants.
    */
-  variants?: Pick<StoreProductVariantParams, "options">
+  variants?: Pick<StoreProductVariantParams, "options" | "sku" | "ean" | "upc" | "barcode">
   /**
    * The locale code in BCP 47 format. Information of the
    * product and related entities will be localized based on the provided locale.

--- a/packages/core/types/src/product/common.ts
+++ b/packages/core/types/src/product/common.ts
@@ -739,6 +739,12 @@ export interface FilterableProductProps
    * Filters on a product's variant properties.
    */
   variants?: {
+
+    sku?: string | string[] | OperatorMap<string | string[]>
+    ean?: string | string[] | OperatorMap<string | string[]>
+    upc?: string | string[] | OperatorMap<string | string[]>
+    barcode?: string | string[] | OperatorMap<string | string[]>
+
     options?: {
       value?: string
       option_id?: string
@@ -931,6 +937,23 @@ export interface FilterableProductVariantProps
    * The SKUs to filter product variants by.
    */
   sku?: string | string[] | OperatorMap<string | string[]>
+
+  /**
+   * The EANs to filter product variants by.
+   */
+  ean?: string | string[] | OperatorMap<string | string[]>
+
+  /**
+   * The UPCs to filter product variants by.
+   */
+  upc?: string | string[] | OperatorMap<string | string[]>
+
+  /**
+   * The barcodes to filter product variants by.
+   */
+  barcode?: string | string[] | OperatorMap<string | string[]>    
+   
+
   /**
    * Filter the product variants by their associated products' IDs.
    */

--- a/packages/medusa/src/api/admin/product-variants/validators.ts
+++ b/packages/medusa/src/api/admin/product-variants/validators.ts
@@ -10,6 +10,7 @@ export const AdminGetProductVariantsParamsFields = z.object({
   id: z.union([z.string(), z.array(z.string())]).optional(),
   manage_inventory: booleanString().optional(),
   allow_backorder: booleanString().optional(),
+  sku: z.union([z.string(), z.array(z.string())]).optional(),
   ean: z.union([z.string(), z.array(z.string())]).optional(),
   upc: z.union([z.string(), z.array(z.string())]).optional(),
   barcode: z.union([z.string(), z.array(z.string())]).optional(),

--- a/packages/medusa/src/api/store/products/validators.ts
+++ b/packages/medusa/src/api/store/products/validators.ts
@@ -29,6 +29,10 @@ export const StoreGetProductVariantsParamsFields = z.object({
   q: z.string().optional(),
   id: z.union([z.string(), z.array(z.string())]).optional(),
   sku: z.union([z.string(), z.array(z.string())]).optional(),
+  ean: z.union([z.string(), z.array(z.string())]).optional(),
+  upc: z.union([z.string(), z.array(z.string())]).optional(),
+  barcode: z.union([z.string(), z.array(z.string())]).optional(),
+    
   options: z
     .object({ value: z.string().optional(), option_id: z.string().optional() })
     .optional(),


### PR DESCRIPTION
from both /admin and /store endpoints. Covers both /admin/products and /admin/products/:id/variants

## Summary

**What** — What changes are introduced in this PR?

add ability to filter products by variant `sku`/`ean`/`upc`/`barcode` in addition to `option`

**Why** — Why are these changes relevant or necessary?  

for /store/products
These are real-world identities that a storefront might encounter from barcodes, qr-codes or other entities. 


for /admin/products
it already had an option to filter by 'ean'/'upc' and 'barcode' but in larger setups, the SKU would be dictated by the ERP or Inventory system, so it makes it easier to react to environment events/webhooks to find the product/variant to deal with.

for /admin/product/:id/variant 
it can now filter the skus by `sku=12356`


note: for /store, the `variants[sku]` already works, but was not reflected into the type system, so it didn't work/was suggested on the js-sdk.

**How** — How have these changes been implemented?

Updated validators and types

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Unittests provided for both /store  and /admin

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

/store/products
```ts
const productResponse = await sdk.store.products.list({
    variants: {
        sku: 'SKU1234567'
     }
});
```

/admin/products
```ts
const productResponse = await sdk.admin.products.list({
    variants: {
        sku: 'SKU1234567'
     }
});
```

/admin/products/:id/variants
```
const productResponse = await sdk.admin.productVariants.list({
        sku: 'SKU1234567'
});
```
---

## Checklist

Please ensure the following before requesting a review:

- [X] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [X] The changes are covered by relevant **tests**
- [X] I have verified the code works as intended locally
- [X] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
