### PR TITLE
fix(core-flows): ensure reason ids is an array in `validateReturnReasons` util

### DIFF
--- a/.changeset/modern-tires-melt.md
+++ b/.changeset/modern-tires-melt.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): ensure reason ids is an array in `validateReturnReasons` util

--- a/integration-tests/http/__tests__/returns/returns.spec.ts
+++ b/integration-tests/http/__tests__/returns/returns.spec.ts
@@ -2,28 +2,35 @@ import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
 import {
   ContainerRegistrationKeys,
   Modules,
+  ReturnStatus,
   RuleOperator,
 } from "@medusajs/utils"
 import {
   adminHeaders,
   createAdminUser,
+  generatePublishableKey,
+  generateStoreHeaders,
 } from "../../../helpers/create-admin-user"
 
 jest.setTimeout(60000)
 
 medusaIntegrationTestRunner({
   testSuite: ({ dbConnection, getContainer, api }) => {
-    let order, order2
+    let order, order2, storeOrder
     let returnShippingOption
     let shippingProfile
     let fulfillmentSet
-    let returnReason
+    let returnReason, returnReasonTwo
     let inventoryItem
     let location
+    let storeHeaders
 
     beforeEach(async () => {
       const container = getContainer()
       await createAdminUser(dbConnection, adminHeaders, container)
+
+      const publishableKey = await generatePublishableKey(container)
+      storeHeaders = generateStoreHeaders({ publishableKey })
 
       shippingProfile = (
         await api.post(
@@ -67,6 +74,18 @@ medusaIntegrationTestRunner({
           {
             value: "return-reason-test",
             label: "Test return reason",
+            description: "This is the reason description!!!",
+          },
+          adminHeaders
+        )
+      ).data.return_reason
+
+      returnReasonTwo = (
+        await api.post(
+          "/admin/return-reasons",
+          {
+            value: "return-reason-test-two",
+            label: "Test return reason two",
             description: "This is the reason description!!!",
           },
           adminHeaders
@@ -313,7 +332,7 @@ medusaIntegrationTestRunner({
       )
     })
 
-    describe("Returns lifecycle", () => {
+    describe("Admin Returns lifecycle", () => {
       it("Full flow with 2 orders", async () => {
         let result = await api.post(
           "/admin/returns",
@@ -1344,6 +1363,64 @@ medusaIntegrationTestRunner({
             deleted: true,
           })
         })
+      })
+    })
+
+    describe("Store Returns lifecycle", () => {
+      it("should request a return", async () => {
+        const createdReturn = (
+          await api.post(
+            "/store/returns",
+            {
+              order_id: order.id,
+              items: [
+                {
+                  id: order.items[0].id,
+                  quantity: 1,
+                  reason_id: returnReason.id,
+                },
+                {
+                  id: order.items[0].id,
+                  quantity: 1,
+                  reason_id: returnReasonTwo.id,
+                },
+              ],
+              return_shipping: {
+                option_id: returnShippingOption.id,
+              },
+            },
+            storeHeaders
+          )
+        ).data.return
+
+        expect(createdReturn).toEqual(
+          expect.objectContaining({
+            id: expect.any(String),
+            order_id: order.id,
+            status: ReturnStatus.REQUESTED,
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                id: expect.any(String),
+                item_id: order.items[0].id,
+                quantity: 1,
+                reason_id: returnReason.id,
+              }),
+              expect.objectContaining({
+                id: expect.any(String),
+                item_id: order.items[0].id,
+                quantity: 1,
+                reason_id: returnReasonTwo.id,
+              }),
+            ]),
+            shipping_methods: expect.arrayContaining([
+              expect.objectContaining({
+                id: expect.any(String),
+                shipping_option_id: returnShippingOption.id,
+                name: returnShippingOption.name,
+              }),
+            ]),
+          })
+        )
       })
     })
   },

--- a/packages/core/core-flows/src/order/utils/validate-return-reason.ts
+++ b/packages/core/core-flows/src/order/utils/validate-return-reason.ts
@@ -30,7 +30,7 @@ export async function validateReturnReasons(
       "parent_return_reason",
       "return_reason_children.id",
     ],
-    variables: { id: [inputItems.map((item) => item.reason_id)], limit: null },
+    variables: { id: inputItems.map((item) => item.reason_id), limit: null },
   })
 
   const returnReasons = await remoteQuery(remoteQueryObject)


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix return reasons id filter used inside `validateReturnReasons` util.

**Why** — Why are these changes relevant or necessary?  

We were incorrectly generating a two-dimensional array which generated the following SQL error: `operator does not exist: character varying = record` due to the malformed IN operator resolved from the filter value.

**How** — How have these changes been implemented?

Set the filter value as the map return, which is an array.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration test.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #14709