### PR TITLE
fix: exit build with error if types generation fails

### DIFF
--- a/.changeset/eager-spies-read.md
+++ b/.changeset/eager-spies-read.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+exit build with error if type generation fails

--- a/packages/medusa/src/commands/build.ts
+++ b/packages/medusa/src/commands/build.ts
@@ -16,11 +16,16 @@ export default async function build({
   })
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
 
-  await generateTypes({
-    directory,
-    container,
-    logger,
-  })
+  try {
+    await generateTypes({
+      directory,
+      container,
+      logger,
+    })
+  } catch (error) {
+    logger.error("Error generating types", error)
+    process.exit(1)
+  }
 
   logger.info("Starting build...")
   const compiler = new Compiler(directory, logger)


### PR DESCRIPTION
## Summary

**What** —
Exit with error code 1 if types generation fails

**Why** —
Currently, when types generation fails, `medusa build` still returns a successful 0, which in CI means the build continues instead of failing.

**How** — How have these changes been implemented?
Just a try-catch, to keep with the pattern of handling errors locally in the build function, but I think it would be better in general to catch errors in the cli package instead.

**Testing**

Locally

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI control-flow change; risk is limited to builds now failing fast when type generation throws.
> 
> **Overview**
> `medusa build` now treats type generation failures as fatal: `generateTypes` is wrapped in a try/catch, logs an error, and exits with code 1 instead of continuing the build.
> 
> Adds a patch changeset noting the corrected build failure behavior in CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 297ff7697a2694335f72b45610cb9e3017956a20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->