### PR TITLE
feat(product,medusa,types): add external id to product tags, collections and types

### DIFF
--- a/.changeset/strict-guests-report.md
+++ b/.changeset/strict-guests-report.md
@@ -1,0 +1,8 @@
+---
+"@medusajs/product": patch
+"integration-tests-http": patch
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+feat(product-collection,product-tag,product-type): add external_id to both admin and store apis

--- a/.changeset/strict-guests-report.md
+++ b/.changeset/strict-guests-report.md
@@ -5,4 +5,4 @@
 "@medusajs/medusa": patch
 ---
 
-feat(product-collection,product-tag,product-type): add external_id to both admin and store apis
+feat(product,medusa,types): add external id to product tags, collections and types

--- a/integration-tests/http/__tests__/collection/admin/collection.spec.ts
+++ b/integration-tests/http/__tests__/collection/admin/collection.spec.ts
@@ -25,7 +25,7 @@ medusaIntegrationTestRunner({
       baseCollection = (
         await api.post(
           "/admin/collections",
-          { title: "test-collection" },
+          { title: "test-collection", external_id: "ext-collection-01" },
           adminHeaders
         )
       ).data.collection
@@ -86,6 +86,7 @@ medusaIntegrationTestRunner({
           {
             title: "New collection",
             handle: "test-new-collection",
+            external_id: "ext-collection-new",
           },
           adminHeaders
         )
@@ -96,6 +97,7 @@ medusaIntegrationTestRunner({
             id: expect.stringMatching(/^pcol_*/),
             title: "New collection",
             handle: "test-new-collection",
+            external_id: "ext-collection-new",
             created_at: expect.any(String),
             updated_at: expect.any(String),
             metadata: null,
@@ -115,6 +117,7 @@ medusaIntegrationTestRunner({
               {
                 id: baseCollection.id,
                 created_at: expect.any(String),
+                external_id: "ext-collection-01",
                 updated_at: expect.any(String),
                 handle: "test-collection",
                 metadata: null,
@@ -123,6 +126,7 @@ medusaIntegrationTestRunner({
               {
                 id: baseCollection1.id,
                 created_at: expect.any(String),
+                external_id: null,
                 updated_at: expect.any(String),
                 handle: "test-collection1",
                 metadata: null,
@@ -131,6 +135,7 @@ medusaIntegrationTestRunner({
               {
                 id: baseCollection2.id,
                 created_at: expect.any(String),
+                external_id: null,
                 updated_at: expect.any(String),
                 handle: "test-collection2",
                 metadata: null,
@@ -154,6 +159,7 @@ medusaIntegrationTestRunner({
               {
                 id: baseCollection.id,
                 created_at: expect.any(String),
+                external_id: "ext-collection-01",
                 updated_at: expect.any(String),
                 handle: "test-collection",
                 metadata: null,
@@ -164,6 +170,29 @@ medusaIntegrationTestRunner({
         )
       })
 
+      it('filters collection by external_id', async () => {
+        const response = await api.get(
+          "/admin/collections?external_id=ext-collection-01",
+          adminHeaders
+        )
+
+        expect(response.data).toEqual(
+          expect.objectContaining({
+            count: 1,
+            collections: expect.arrayContaining([
+              {
+                id: baseCollection.id,
+                created_at: expect.any(String),
+                external_id: "ext-collection-01",
+                updated_at: expect.any(String),
+                handle: "test-collection",
+                metadata: null,
+                title: "test-collection",
+              },
+            ]),
+          })
+        )
+      });
       // BREAKING: There is no longer discount condition ID filtering for collections (test case: "returns a list of collections filtered by discount condition id")
     })
 
@@ -185,6 +214,7 @@ medusaIntegrationTestRunner({
               id: expect.stringMatching(/^pcol_*/),
               title: "test collection creation",
               handle: "test-handle-creation",
+              external_id: "ext-collection-01",
               created_at: expect.any(String),
               updated_at: expect.any(String),
               metadata: null,

--- a/integration-tests/http/__tests__/collection/store/collection.spec.ts
+++ b/integration-tests/http/__tests__/collection/store/collection.spec.ts
@@ -25,7 +25,7 @@ medusaIntegrationTestRunner({
       baseCollection = (
         await api.post(
           "/admin/collections",
-          { title: "test-collection" },
+          { title: "test-collection", external_id: "ext-collection-01" },
           adminHeaders
         )
       ).data.collection
@@ -58,6 +58,7 @@ medusaIntegrationTestRunner({
           expect(response.data.collection).toEqual(
             expect.objectContaining({
               id: baseCollection.id,
+              external_id: "ext-collection-01",
               created_at: expect.any(String),
               updated_at: expect.any(String),
             })
@@ -66,6 +67,24 @@ medusaIntegrationTestRunner({
       })
 
       describe("/store/collections", () => {
+        it('lists collections matching external_id search param', async () => {
+          const response = await api.get("/store/collections?external_id=ext-collection-01", storeHeaders)
+
+          expect(response.data).toEqual({
+            collections: [
+              expect.objectContaining({
+                id: baseCollection.id,
+                external_id: "ext-collection-01",
+                created_at: expect.any(String),
+                updated_at: expect.any(String),
+              }),
+            ],
+            count: 1,
+            limit: 10,
+            offset: 0,
+          })
+        });
+
         it("lists collections", async () => {
           const response = await api.get("/store/collections", storeHeaders)
 
@@ -83,6 +102,7 @@ medusaIntegrationTestRunner({
               }),
               expect.objectContaining({
                 id: baseCollection.id,
+                external_id: "ext-collection-01",
                 created_at: expect.any(String),
                 updated_at: expect.any(String),
               }),

--- a/integration-tests/http/__tests__/product-tag/admin/product-tag.spec.ts
+++ b/integration-tests/http/__tests__/product-tag/admin/product-tag.spec.ts
@@ -21,6 +21,7 @@ medusaIntegrationTestRunner({
           "/admin/product-tags",
           {
             value: "test1",
+            external_id: "ext-test-01",
           },
           adminHeaders
         )
@@ -46,6 +47,7 @@ medusaIntegrationTestRunner({
           expect.arrayContaining([
             expect.objectContaining({
               value: "test1",
+              external_id: "ext-test-01",
             }),
             expect.objectContaining({
               value: "test2",
@@ -63,6 +65,17 @@ medusaIntegrationTestRunner({
           expect.arrayContaining([expect.objectContaining({ value: "test1" })])
         )
       })
+
+
+      it("returns a list of product tags matching external_id search param", async () => {
+        const res = await api.get("/admin/product-tags?external_id[]=ext-test-01", adminHeaders)
+
+        expect(res.status).toEqual(200)
+        expect(res.data.product_tags.length).toEqual(1)
+        expect(res.data.product_tags).toEqual(
+          expect.arrayContaining([expect.objectContaining({ value: "test1", external_id: "ext-test-01" })])
+        )
+      })      
     })
     // BREAKING: Removed a test that filtered tags by discount condition id, which is no longer supported
   },

--- a/integration-tests/http/__tests__/product-tag/store/product-tag.spec.ts
+++ b/integration-tests/http/__tests__/product-tag/store/product-tag.spec.ts
@@ -25,34 +25,36 @@ medusaIntegrationTestRunner({
 
       tag1 = (
         await api.post(
-          "/admin/product-types",
+          "/admin/product-tags",
           {
             value: "test1",
+            external_id: "ext-test-01",
           },
           adminHeaders
         )
-      ).data.product_type
+      ).data.product_tag
 
       tag2 = (
         await api.post(
-          "/admin/product-types",
+          "/admin/product-tags",
           {
             value: "test2",
           },
           adminHeaders
         )
-      ).data.product_type
+      ).data.product_tag
     })
 
-    describe("GET /store/product-types", () => {
-      it("returns a list of product types", async () => {
-        const res = await api.get("/store/product-types", storeHeaders)
+    describe("GET /store/product-tags", () => {
+      it("returns a list of product tags", async () => {
+        const res = await api.get("/store/product-tags", storeHeaders)
 
         expect(res.status).toEqual(200)
-        expect(res.data.product_types).toEqual(
+        expect(res.data.product_tags).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
               value: "test1",
+              external_id: "ext-test-01",
             }),
             expect.objectContaining({
               value: "test2",
@@ -61,13 +63,23 @@ medusaIntegrationTestRunner({
         )
       })
 
-      it("returns a list of product types matching free text search param", async () => {
-        const res = await api.get("/store/product-types?q=1", storeHeaders)
+      it('returns a list of product tags matching external_id search param', async () => {
+        const res = await api.get("/store/product-tags?external_id=ext-test-01", storeHeaders)
 
         expect(res.status).toEqual(200)
-        expect(res.data.product_types.length).toEqual(1)
-        expect(res.data.product_types).toEqual(
-          expect.arrayContaining([expect.objectContaining({ value: "test1" })])
+        expect(res.data.product_tags.length).toEqual(1)
+        expect(res.data.product_tags).toEqual(
+          expect.arrayContaining([expect.objectContaining({ value: "test1", external_id: "ext-test-01" })])
+        )
+      });
+
+      it("returns a list of product tags matching free text search param", async () => {
+        const res = await api.get("/store/product-tags?q=1", storeHeaders)
+
+        expect(res.status).toEqual(200)
+        expect(res.data.product_tags.length).toEqual(1)
+        expect(res.data.product_tags).toEqual(
+          expect.arrayContaining([expect.objectContaining({ value: "test1", external_id: "ext-test-01" })])
         )
       })
     })

--- a/integration-tests/http/__tests__/product-type/admin/product-type.spec.ts
+++ b/integration-tests/http/__tests__/product-type/admin/product-type.spec.ts
@@ -21,6 +21,7 @@ medusaIntegrationTestRunner({
           "/admin/product-types",
           {
             value: "test1",
+            external_id: "ext-test-01",
           },
           adminHeaders
         )
@@ -47,6 +48,7 @@ medusaIntegrationTestRunner({
             {
               id: expect.stringMatching(/ptyp_.{24}/),
               value: "test1",
+              external_id: "ext-test-01",
               created_at: expect.any(String),
               updated_at: expect.any(String),
               metadata: null,
@@ -54,6 +56,7 @@ medusaIntegrationTestRunner({
             {
               id: expect.stringMatching(/ptyp_.{24}/),
               value: "test2",
+              external_id: null,
               created_at: expect.any(String),
               updated_at: expect.any(String),
               metadata: null,
@@ -61,6 +64,16 @@ medusaIntegrationTestRunner({
           ])
         )
       })
+
+      it('returns a list of product types matching external_id search param', async () => {
+        const res = await api.get("/admin/product-types?external_id=ext-test-01", adminHeaders)
+        
+        expect(res.status).toEqual(200) 
+        expect(res.data.product_types.length).toEqual(1)
+        expect(res.data.product_types).toEqual(
+          expect.arrayContaining([expect.objectContaining({ value: "test1", external_id: "ext-test-01" })])
+        )
+      });
 
       it("returns a list of product types matching free text search param", async () => {
         const res = await api.get("/admin/product-types?q=test1", adminHeaders)
@@ -72,6 +85,7 @@ medusaIntegrationTestRunner({
           {
             id: expect.stringMatching(/ptyp_.{24}/),
             value: "test1",
+            external_id: "ext-test-01",
             created_at: expect.any(String),
             updated_at: expect.any(String),
             metadata: null,
@@ -93,6 +107,7 @@ medusaIntegrationTestRunner({
         expect(res.data.product_type).toEqual({
           id: expect.stringMatching(/ptyp_.{24}/),
           value: "test1",
+          external_id: "ext-test-01",
           created_at: expect.any(String),
           updated_at: expect.any(String),
           metadata: null,

--- a/integration-tests/http/__tests__/product-type/store/product-type.spec.ts
+++ b/integration-tests/http/__tests__/product-type/store/product-type.spec.ts
@@ -25,34 +25,36 @@ medusaIntegrationTestRunner({
 
       tag1 = (
         await api.post(
-          "/admin/product-tags",
+          "/admin/product-types",
           {
             value: "test1",
+            external_id: "ext-test-01",
           },
           adminHeaders
         )
-      ).data.product_tag
+      ).data.product_type
 
       tag2 = (
         await api.post(
-          "/admin/product-tags",
+          "/admin/product-types",
           {
             value: "test2",
           },
           adminHeaders
         )
-      ).data.product_tag
+      ).data.product_type
     })
 
-    describe("GET /store/product-tags", () => {
-      it("returns a list of product tags", async () => {
-        const res = await api.get("/store/product-tags", storeHeaders)
+    describe("GET /store/product-types", () => {
+      it("returns a list of product types", async () => {
+        const res = await api.get("/store/product-types", storeHeaders)
 
         expect(res.status).toEqual(200)
-        expect(res.data.product_tags).toEqual(
+        expect(res.data.product_types).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
               value: "test1",
+              external_id: "ext-test-01",
             }),
             expect.objectContaining({
               value: "test2",
@@ -61,13 +63,23 @@ medusaIntegrationTestRunner({
         )
       })
 
-      it("returns a list of product tags matching free text search param", async () => {
-        const res = await api.get("/admin/product-tags?q=1", adminHeaders)
+      it('returns a list of product types matching external_id search param', async () => {
+        const res = await api.get("/store/product-types?external_id=ext-test-01", storeHeaders)
+        
+        expect(res.status).toEqual(200) 
+        expect(res.data.product_types.length).toEqual(1)
+        expect(res.data.product_types).toEqual(
+          expect.arrayContaining([expect.objectContaining({ value: "test1", external_id: "ext-test-01" })])
+        )
+      });
+
+      it("returns a list of product types matching free text search param", async () => {
+        const res = await api.get("/store/product-types?q=1", storeHeaders)
 
         expect(res.status).toEqual(200)
-        expect(res.data.product_tags.length).toEqual(1)
-        expect(res.data.product_tags).toEqual(
-          expect.arrayContaining([expect.objectContaining({ value: "test1" })])
+        expect(res.data.product_types.length).toEqual(1)
+        expect(res.data.product_types).toEqual(
+          expect.arrayContaining([expect.objectContaining({ value: "test1", external_id: "ext-test-01" })])
         )
       })
     })

--- a/packages/core/types/src/http/collection/admin/payloads.ts
+++ b/packages/core/types/src/http/collection/admin/payloads.ts
@@ -8,6 +8,10 @@ export interface AdminCreateCollection {
    */
   handle?: string
   /**
+   * An external ID for the collection.
+   */
+  external_id?: string | null
+  /**
    * Key-value pairs of custom data.
    */
   metadata?: Record<string, any>
@@ -22,6 +26,10 @@ export interface AdminUpdateCollection {
    * The collection's handle.
    */
   handle?: string
+  /**
+   * An external ID for the collection.
+   */
+  external_id?: string | null
   /**
    * Key-value pairs of custom data.
    */

--- a/packages/core/types/src/http/collection/common.ts
+++ b/packages/core/types/src/http/collection/common.ts
@@ -32,6 +32,10 @@ export interface BaseCollection {
    */
   products?: BaseProduct[]
   /**
+   * An external ID for the collection.
+   */
+  external_id?: string | null
+  /**
    * Key-value pairs of custom data.
    */
   metadata: Record<string, unknown> | null
@@ -58,6 +62,10 @@ export interface BaseCollectionListParams
    * Filter by collection title(s).
    */
   title?: string | string[]
+  /**
+   * Filter by external ID(s).
+   */
+  external_id?: string | string[]
   /**
    * Apply filters on collection creation dates.
    */

--- a/packages/core/types/src/http/product-tag/admin/payloads.ts
+++ b/packages/core/types/src/http/product-tag/admin/payloads.ts
@@ -4,6 +4,10 @@ export interface AdminCreateProductTag {
    */
   value: string
   /**
+   * An external ID for the tag.
+   */
+  external_id?: string | null
+  /**
    * Key-value pairs of custom data.
    */
   metadata?: Record<string, unknown> | null
@@ -14,6 +18,10 @@ export interface AdminUpdateProductTag {
    * The tag's value.
    */
   value?: string
+  /**
+   * An external ID for the tag.
+   */
+  external_id?: string | null
   /**
    * Key-value pairs of custom data.
    */

--- a/packages/core/types/src/http/product-tag/common.ts
+++ b/packages/core/types/src/http/product-tag/common.ts
@@ -23,6 +23,10 @@ export interface BaseProductTag {
    */
   deleted_at?: string | null
   /**
+   * An external ID for the tag.
+   */
+  external_id?: string | null
+  /**
    * Key-value pairs of custom data.
    */
   metadata?: Record<string, unknown> | null
@@ -41,6 +45,10 @@ export interface BaseProductTagListParams extends FindParams {
    * Filter by value(s).
    */
   value?: string | string[]
+  /**
+   * Filter by external ID(s).
+   */
+  external_id?: string | string[]
   /**
    * Apply filters on the creation date.
    */

--- a/packages/core/types/src/http/product-type/admin/payloads.ts
+++ b/packages/core/types/src/http/product-type/admin/payloads.ts
@@ -4,6 +4,10 @@ export interface AdminCreateProductType {
    */
   value: string
   /**
+   * An external ID for the product type.
+   */
+  external_id?: string | null
+  /**
    * Key-value pairs of custom data.
    */
   metadata?: Record<string, unknown> | null
@@ -14,6 +18,10 @@ export interface AdminUpdateProductType {
    * The type's value.
    */
   value?: string
+  /**
+   * An external ID for the product type.
+   */
+  external_id?: string | null
   /**
    * Key-value pairs of custom data.
    */

--- a/packages/core/types/src/http/product-type/admin/queries.ts
+++ b/packages/core/types/src/http/product-type/admin/queries.ts
@@ -17,6 +17,10 @@ export interface AdminProductTypeListParams
    */
   value?: string | string[]
   /**
+   * Filter by external ID(s).
+   */
+  external_id?: string | string[]
+  /**
    * Apply filters on the creation date.
    */
   created_at?: OperatorMap<string>

--- a/packages/core/types/src/http/product-type/common.ts
+++ b/packages/core/types/src/http/product-type/common.ts
@@ -23,6 +23,10 @@ export interface BaseProductType {
    */
   deleted_at?: string | null
   /**
+   * An external ID for the product type.
+   */
+  external_id?: string | null
+  /**
    * Key-value pairs of custom data.
    */
   metadata?: Record<string, unknown> | null
@@ -41,6 +45,10 @@ export interface BaseProductTypeListParams extends FindParams {
    * Filter by value(s).
    */
   value?: string | string[]
+  /**
+   * Filter by external ID(s).
+   */
+  external_id?: string | string[]
   /**
    * Apply filters on the creation date.
    */

--- a/packages/medusa/src/api/admin/collections/query-config.ts
+++ b/packages/medusa/src/api/admin/collections/query-config.ts
@@ -6,6 +6,7 @@ export const defaultAdminCollectionFields = [
   "id",
   "title",
   "handle",
+  "external_id",
   "created_at",
   "updated_at",
   "metadata",

--- a/packages/medusa/src/api/admin/collections/validators.ts
+++ b/packages/medusa/src/api/admin/collections/validators.ts
@@ -14,6 +14,7 @@ export const AdminGetCollectionsParamsFields = z.object({
   id: z.union([z.string(), z.array(z.string())]).optional(),
   title: z.union([z.string(), z.array(z.string())]).optional(),
   handle: z.union([z.string(), z.array(z.string())]).optional(),
+  external_id: z.union([z.string(), z.array(z.string())]).optional(),
   created_at: createOperatorMap().optional(),
   updated_at: createOperatorMap().optional(),
   deleted_at: createOperatorMap().optional(),
@@ -33,6 +34,7 @@ export type AdminCreateCollectionType = z.infer<typeof CreateCollection>
 export const CreateCollection = z.object({
   title: z.string(),
   handle: z.string().optional(),
+  external_id: z.string().nullish(),
   metadata: z.record(z.string(), z.unknown()).nullish(),
 })
 
@@ -42,6 +44,7 @@ export type AdminUpdateCollectionType = z.infer<typeof UpdateCollection>
 export const UpdateCollection = z.object({
   title: z.string().optional(),
   handle: z.string().optional(),
+  external_id: z.string().nullish(),
   metadata: z.record(z.string(), z.unknown()).nullish(),
 })
 

--- a/packages/medusa/src/api/admin/product-tags/query-config.ts
+++ b/packages/medusa/src/api/admin/product-tags/query-config.ts
@@ -5,6 +5,7 @@ export enum Entities {
 export const defaultAdminProductTagFields = [
   "id",
   "value",
+  "external_id",
   "created_at",
   "updated_at",
   "metadata",

--- a/packages/medusa/src/api/admin/product-tags/validators.ts
+++ b/packages/medusa/src/api/admin/product-tags/validators.ts
@@ -15,6 +15,7 @@ export const AdminGetProductTagsParamsFields = z.object({
   q: z.string().optional(),
   id: z.union([z.string(), z.array(z.string())]).optional(),
   value: z.union([z.string(), z.array(z.string())]).optional(),
+  external_id: z.union([z.string(), z.array(z.string())]).optional(),
   created_at: createOperatorMap().optional(),
   updated_at: createOperatorMap().optional(),
   deleted_at: createOperatorMap().optional(),
@@ -34,6 +35,7 @@ export type AdminCreateProductTagType = z.infer<typeof AdminCreateProductTag>
 export const AdminCreateProductTag = z
   .object({
     value: z.string(),
+    external_id: z.string().nullish(),
     metadata: z.record(z.string(), z.unknown()).nullish(),
   })
   .strict()
@@ -42,6 +44,7 @@ export type AdminUpdateProductTagType = z.infer<typeof AdminUpdateProductTag>
 export const AdminUpdateProductTag = z
   .object({
     value: z.string().optional(),
+    external_id: z.string().nullish(),
     metadata: z.record(z.string(), z.unknown()).nullish(),
   })
   .strict()

--- a/packages/medusa/src/api/admin/product-types/query-config.ts
+++ b/packages/medusa/src/api/admin/product-types/query-config.ts
@@ -5,6 +5,7 @@ export enum Entities {
 export const defaultAdminProductTypeFields = [
   "id",
   "value",
+  "external_id",
   "created_at",
   "updated_at",
   "metadata",

--- a/packages/medusa/src/api/admin/product-types/validators.ts
+++ b/packages/medusa/src/api/admin/product-types/validators.ts
@@ -15,6 +15,7 @@ export const AdminGetProductTypesParamsFields = z.object({
   q: z.string().optional(),
   id: z.union([z.string(), z.array(z.string())]).optional(),
   value: z.union([z.string(), z.array(z.string())]).optional(),
+  external_id: z.union([z.string(), z.array(z.string())]).optional(),
   // TODO: To be added in next iteration, when coming from a different module, it should be separated from the direct fields
   // discount_condition_id: z.string().nullish(),
   created_at: createOperatorMap().optional(),
@@ -36,6 +37,7 @@ export type AdminCreateProductTypeType = z.infer<typeof AdminCreateProductType>
 export const AdminCreateProductType = z
   .object({
     value: z.string(),
+    external_id: z.string().nullish(),
     metadata: z.record(z.string(), z.unknown()).nullish(),
   })
   .strict()
@@ -44,6 +46,7 @@ export type AdminUpdateProductTypeType = z.infer<typeof AdminUpdateProductType>
 export const AdminUpdateProductType = z
   .object({
     value: z.string().optional(),
+    external_id: z.string().nullish(),
     metadata: z.record(z.string(), z.unknown()).nullish(),
   })
   .strict()

--- a/packages/medusa/src/api/store/collections/query-config.ts
+++ b/packages/medusa/src/api/store/collections/query-config.ts
@@ -2,6 +2,7 @@ export const defaultStoreCollectionFields = [
   "id",
   "title",
   "handle",
+  "external_id",
   "created_at",
   "updated_at",
 ]

--- a/packages/medusa/src/api/store/collections/validators.ts
+++ b/packages/medusa/src/api/store/collections/validators.ts
@@ -13,6 +13,7 @@ export const StoreGetCollectionsParamsFields = z.object({
   id: z.union([z.string(), z.array(z.string())]).optional(),
   title: z.union([z.string(), z.array(z.string())]).optional(),
   handle: z.union([z.string(), z.array(z.string())]).optional(),
+  external_id: z.union([z.string(), z.array(z.string())]).optional(),
   created_at: createOperatorMap().optional(),
   updated_at: createOperatorMap().optional(),
 })

--- a/packages/medusa/src/api/store/product-tags/query-config.ts
+++ b/packages/medusa/src/api/store/product-tags/query-config.ts
@@ -1,6 +1,7 @@
 export const defaults = [
   "id",
   "value",
+  "external_id",
   "created_at",
   "updated_at",
   "metadata",

--- a/packages/medusa/src/api/store/product-tags/validators.ts
+++ b/packages/medusa/src/api/store/product-tags/validators.ts
@@ -14,6 +14,7 @@ export const StoreProductTagsParamsFields = z.object({
   q: z.string().optional(),
   id: z.union([z.string(), z.array(z.string())]).optional(),
   value: z.union([z.string(), z.array(z.string())]).optional(),
+  external_id: z.union([z.string(), z.array(z.string())]).optional(),
   created_at: createOperatorMap().optional(),
   updated_at: createOperatorMap().optional(),
   deleted_at: createOperatorMap().optional(),

--- a/packages/medusa/src/api/store/product-types/query-config.ts
+++ b/packages/medusa/src/api/store/product-types/query-config.ts
@@ -1,6 +1,7 @@
 export const defaults = [
   "id",
   "value",
+  "external_id",
   "created_at",
   "updated_at",
   "metadata",

--- a/packages/medusa/src/api/store/product-types/validators.ts
+++ b/packages/medusa/src/api/store/product-types/validators.ts
@@ -14,6 +14,7 @@ export const StoreProductTypesParamsFields = z.object({
   q: z.string().optional(),
   id: z.union([z.string(), z.array(z.string())]).optional(),
   value: z.union([z.string(), z.array(z.string())]).optional(),
+  external_id: z.union([z.string(), z.array(z.string())]).optional(),
   created_at: createOperatorMap().optional(),
   updated_at: createOperatorMap().optional(),
   deleted_at: createOperatorMap().optional(),

--- a/packages/modules/product/src/migrations/.snapshot-medusa-product.json
+++ b/packages/modules/product/src/migrations/.snapshot-medusa-product.json
@@ -239,6 +239,15 @@
           "nullable": false,
           "mappedType": "text"
         },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
         "metadata": {
           "name": "metadata",
           "type": "jsonb",
@@ -337,6 +346,15 @@
           "nullable": false,
           "mappedType": "text"
         },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
         "metadata": {
           "name": "metadata",
           "type": "jsonb",
@@ -433,6 +451,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "mappedType": "text"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
           "mappedType": "text"
         },
         "metadata": {

--- a/packages/modules/product/src/migrations/Migration20260306120000.ts
+++ b/packages/modules/product/src/migrations/Migration20260306120000.ts
@@ -1,0 +1,27 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations"
+
+export class Migration20260306120000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "product_tag" add column if not exists "external_id" text null;`
+    )
+    this.addSql(
+      `alter table if exists "product_collection" add column if not exists "external_id" text null;`
+    )
+    this.addSql(
+      `alter table if exists "product_type" add column if not exists "external_id" text null;`
+    )
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "product_tag" drop column if exists "external_id";`
+    )
+    this.addSql(
+      `alter table if exists "product_collection" drop column if exists "external_id";`
+    )
+    this.addSql(
+      `alter table if exists "product_type" drop column if exists "external_id";`
+    )
+  }
+}

--- a/packages/modules/product/src/models/product-collection.ts
+++ b/packages/modules/product/src/models/product-collection.ts
@@ -6,6 +6,7 @@ const ProductCollection = model
     id: model.id({ prefix: "pcol" }).primaryKey(),
     title: model.text().searchable().translatable(),
     handle: model.text(),
+    external_id: model.text().nullable(),
     metadata: model.json().nullable(),
     products: model.hasMany(() => Product, {
       mappedBy: "collection",

--- a/packages/modules/product/src/models/product-tag.ts
+++ b/packages/modules/product/src/models/product-tag.ts
@@ -7,6 +7,7 @@ const ProductTag = model
     {
       id: model.id({ prefix: "ptag" }).primaryKey(),
       value: model.text().searchable().translatable(),
+      external_id: model.text().nullable(),
       metadata: model.json().nullable(),
       products: model.manyToMany(() => Product, {
         mappedBy: "tags",

--- a/packages/modules/product/src/models/product-type.ts
+++ b/packages/modules/product/src/models/product-type.ts
@@ -5,6 +5,7 @@ const ProductType = model
   .define("ProductType", {
     id: model.id({ prefix: "ptyp" }).primaryKey(),
     value: model.text().searchable().translatable(),
+    external_id: model.text().nullable(),
     metadata: model.json().nullable(),
     products: model.hasMany(() => Product, {
       mappedBy: "type",


### PR DESCRIPTION
… both admin and store apis

## Summary

**What** — What changes are introduced in this PR?

Add `external_id` on product-tag, product-type and product-collection

**Why** — Why are these changes relevant or necessary?  

To allow external integration flows based on event based hooks, to correctly identify each of these. 
Also to make consistent for other product module entities.

**How** — How have these changes been implemented?

Added fields to database, and store and admin apis

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests included.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
    sdk.admin.productTag.create({
      value: "tag1",
       external_id: "ext-tag-01"
    });
```

```ts
   sdk.admin.productTag.list({
      external_id: "ext_tag_01",
    });
```

```ts
   sdk.admin.productTag.list({
      external_id: "ext_tag_01",
    });
```


```ts
    sdk.admin.productTag.create({
      value: "tag1",
       external_id: "ext-tag-01"
    });
```

```ts
    sdk.admin.productType.list({
          external_id: "ext-type-01"
    });
```

```ts
    sdk.admin.productCollection.create({
      name: "col1",
       handle: "col-handle",
       external_id: "ext-col-01"
    });
```

```ts
    sdk.admin.productCollection.list({
       external_id: "ext-col-01"
    });
```

For /store, its available on the API, but as neither tags or types are exposed in the js-sdk as seperate top-level entries, they are mostly available as expanded/included values in the product itself.

---

## Checklist

Please ensure the following before requesting a review:

- [X] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [X] The changes are covered by relevant **tests**
- [X] I have verified the code works as intended locally
- [X] I have linked the related issue(s) if applicable

---



## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
Closes #15070 
This relates to PRs #14826 and #14799 