### PR TITLE
docs(resources): fix venue schema import in ticket booking guide

### DIFF
--- a/www/apps/resources/app/recipes/ticket-booking/example/page.mdx
+++ b/www/apps/resources/app/recipes/ticket-booking/example/page.mdx
@@ -888,7 +888,7 @@ import {
   defineMiddlewares, 
   validateAndTransformBody,
 } from "@medusajs/framework/http"
-import { CreateTicketProductSchema } from "./admin/ticket-products/route"
+import { CreateVenueSchema } from "./admin/venues/route"
 
 export default defineMiddlewares({
   routes: [

--- a/www/apps/resources/generated/edit-dates.mjs
+++ b/www/apps/resources/generated/edit-dates.mjs
@@ -6564,7 +6564,7 @@ export const generatedEditDates = {
   "app/storefront-development/cart/manage-promotions/page.mdx": "2025-09-11T14:11:40.904Z",
   "app/recipes/ticket-booking/examples/page.mdx": "2025-09-10T14:11:55.063Z",
   "app/recipes/ticket-booking/examples/storefront/page.mdx": "2025-09-10T14:14:44.005Z",
-  "app/recipes/ticket-booking/example/page.mdx": "2026-01-12T12:29:49.591Z",
+  "app/recipes/ticket-booking/example/page.mdx": "2026-03-10T05:02:47.682Z",
   "app/recipes/ticket-booking/example/storefront/page.mdx": "2025-09-10T15:26:04.084Z",
   "app/recipes/ticket-booking/page.mdx": "2025-09-11T06:53:21.071Z",
   "references/js_sdk/admin/Views/methods/js_sdk.admin.Views.columns/page.mdx": "2025-10-21T08:10:57.659Z",


### PR DESCRIPTION
## What
- fix the venue middleware snippet in the ticket-booking guide to import `CreateVenueSchema` from `./admin/venues/route`
- update the generated edit date for the page

## Why
- the current snippet imports `CreateTicketProductSchema` while validating `/admin/venues` requests with `CreateVenueSchema`
- copying the example as written produces a broken import setup for readers

## How
- replace the incorrect schema import in the `src/api/middlewares.ts` example
- run the docs prep workflow for `resources` to regenerate the page edit date

## Testing
- verified the snippet now imports the schema it uses for `validateAndTransformBody(CreateVenueSchema)`
- ran `yarn turbo run prep --filter=resources --filter=book` from `www` during validation; only the `resources` generated edit-date artifact is included in this PR

Closes #14838

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change plus a regenerated timestamp artifact; no runtime code paths are affected.
> 
> **Overview**
> Fixes the ticket-booking backend tutorial snippet so `src/api/middlewares.ts` imports `CreateVenueSchema` from `./admin/venues/route` (instead of the unrelated ticket-product schema), matching the middleware usage for `POST /admin/venues`.
> 
> Regenerates the `resources` docs edit-date artifact to reflect the updated page content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e23edc57d0c37bbf869dfbed9592598dd42dd20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->