### PR TITLE
feat: add support for custom arguments in Twilio Sendgrid email notifications

### DIFF
--- a/.changeset/forty-states-invent.md
+++ b/.changeset/forty-states-invent.md
@@ -1,5 +1,5 @@
 ---
-"@medusajs/notification-sendgrid": minor
+"@medusajs/notification-sendgrid": patch
 ---
 
-Add support for custom_args to sendgrid
+feat(notification-sendgrid): add support for custom_args

--- a/.changeset/forty-states-invent.md
+++ b/.changeset/forty-states-invent.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/notification-sendgrid": minor
+---
+
+Add support for custom_args to sendgrid

--- a/.changeset/forty-states-invent.md
+++ b/.changeset/forty-states-invent.md
@@ -2,4 +2,4 @@
 "@medusajs/notification-sendgrid": patch
 ---
 
-feat(notification-sendgrid): add support for custom_args
+feat(notification-sendgrid): add support for personalizations via provider_data

--- a/packages/modules/providers/notification-sendgrid/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/notification-sendgrid/integration-tests/__tests__/services.spec.ts
@@ -1,5 +1,100 @@
+import sendgrid from "@sendgrid/mail"
 import { SendgridNotificationService } from "../../src/services/sendgrid"
+
+jest.mock("@sendgrid/mail", () => ({
+  __esModule: true,
+  default: {
+    setApiKey: jest.fn(),
+    send: jest.fn().mockResolvedValue([{ statusCode: 202 }, {}]),
+  },
+}))
+
+jest.mock("@medusajs/framework/utils", () => ({
+  AbstractNotificationProviderService: class {},
+  MedusaError: class MedusaError extends Error {
+    static Types = {
+      INVALID_DATA: "invalid_data",
+      UNEXPECTED_STATE: "unexpected_state",
+    }
+    type: string
+    constructor(type: string, message: string) {
+      super(message)
+      this.type = type
+    }
+  },
+  isString: (v: unknown): v is string => typeof v === "string",
+}), { virtual: true })
+
+const mockSend = sendgrid.send as jest.MockedFunction<typeof sendgrid.send>
+
 jest.setTimeout(100000)
+
+describe("SendgridNotificationService - customArgs", () => {
+  let service: SendgridNotificationService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = new SendgridNotificationService(
+      { logger: console as any },
+      { api_key: "test-api-key", from: "sender@example.com" }
+    )
+  })
+
+  it("includes customArgs in personalizations when provider_data.custom_args contains string values", async () => {
+    await service.send({
+      to: "recipient@example.com",
+      channel: "email",
+      template: "some-template",
+      provider_data: {
+        custom_args: {
+          campaign_id: "abc123",
+          source: "welcome-flow",
+        },
+      },
+    })
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    const message = mockSend.mock.calls[0][0] as any
+    expect(message.personalizations[0].customArgs).toEqual({
+      campaign_id: "abc123",
+      source: "welcome-flow",
+    })
+  })
+
+  it("omits customArgs from personalizations when provider_data.custom_args is absent", async () => {
+    await service.send({
+      to: "recipient@example.com",
+      channel: "email",
+      template: "some-template",
+    })
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    const message = mockSend.mock.calls[0][0] as any
+    expect(message.personalizations[0]).not.toHaveProperty("customArgs")
+  })
+
+  it("filters out non-string values from custom_args", async () => {
+    await service.send({
+      to: "recipient@example.com",
+      channel: "email",
+      template: "some-template",
+      provider_data: {
+        custom_args: {
+          valid_key: "valid-string",
+          number_key: 42,
+          object_key: { nested: true },
+          null_key: null,
+        } as Record<string, unknown>,
+      },
+    })
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    const message = mockSend.mock.calls[0][0] as any
+    expect(message.personalizations[0].customArgs).toEqual({
+      valid_key: "valid-string",
+    })
+  })
+})
 
 // Note: This test hits the sendgrid service, and it is mainly meant to be run manually after setting all the envvars below.
 // We could also setup a sink email service to test this automatically, but it is not necessary for the time being.

--- a/packages/modules/providers/notification-sendgrid/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/notification-sendgrid/integration-tests/__tests__/services.spec.ts
@@ -77,6 +77,22 @@ describe("SendgridNotificationService - personalizations", () => {
     expect(message.to).toEqual("recipient@example.com")
     expect(message).not.toHaveProperty("personalizations")
   })
+
+  it("falls back to top-level to when provider_data.personalizations is an empty array", async () => {
+    await service.send({
+      to: "recipient@example.com",
+      channel: "email",
+      template: "some-template",
+      provider_data: {
+        personalizations: [],
+      },
+    })
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    const message = mockSend.mock.calls[0][0] as any
+    expect(message.to).toEqual("recipient@example.com")
+    expect(message).not.toHaveProperty("personalizations")
+  })
 })
 
 // Note: This test hits the sendgrid service, and it is mainly meant to be run manually after setting all the envvars below.

--- a/packages/modules/providers/notification-sendgrid/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/notification-sendgrid/integration-tests/__tests__/services.spec.ts
@@ -40,7 +40,7 @@ describe("SendgridNotificationService - customArgs", () => {
     )
   })
 
-  it("includes customArgs in personalizations when provider_data.custom_args contains string values", async () => {
+  it("includes customArgs in personalizations and omits top-level to when provider_data.custom_args contains string values", async () => {
     await service.send({
       to: "recipient@example.com",
       channel: "email",
@@ -55,13 +55,14 @@ describe("SendgridNotificationService - customArgs", () => {
 
     expect(mockSend).toHaveBeenCalledTimes(1)
     const message = mockSend.mock.calls[0][0] as any
+    expect(message).not.toHaveProperty("to")
     expect(message.personalizations[0].customArgs).toEqual({
       campaign_id: "abc123",
       source: "welcome-flow",
     })
   })
 
-  it("omits customArgs from personalizations when provider_data.custom_args is absent", async () => {
+  it("omits personalizations entirely when provider_data.custom_args is absent", async () => {
     await service.send({
       to: "recipient@example.com",
       channel: "email",
@@ -70,7 +71,7 @@ describe("SendgridNotificationService - customArgs", () => {
 
     expect(mockSend).toHaveBeenCalledTimes(1)
     const message = mockSend.mock.calls[0][0] as any
-    expect(message.personalizations[0]).not.toHaveProperty("customArgs")
+    expect(message).not.toHaveProperty("personalizations")
   })
 
   it("filters out non-string values from custom_args", async () => {
@@ -93,6 +94,24 @@ describe("SendgridNotificationService - customArgs", () => {
     expect(message.personalizations[0].customArgs).toEqual({
       valid_key: "valid-string",
     })
+  })
+
+  it("omits personalizations when all custom_args values are non-strings", async () => {
+    await service.send({
+      to: "recipient@example.com",
+      channel: "email",
+      template: "some-template",
+      provider_data: {
+        custom_args: {
+          number_key: 42,
+          object_key: { nested: true },
+        } as Record<string, unknown>,
+      },
+    })
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    const message = mockSend.mock.calls[0][0] as any
+    expect(message).not.toHaveProperty("personalizations")
   })
 })
 

--- a/packages/modules/providers/notification-sendgrid/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/notification-sendgrid/integration-tests/__tests__/services.spec.ts
@@ -22,14 +22,13 @@ jest.mock("@medusajs/framework/utils", () => ({
       this.type = type
     }
   },
-  isString: (v: unknown): v is string => typeof v === "string",
 }), { virtual: true })
 
 const mockSend = sendgrid.send as jest.MockedFunction<typeof sendgrid.send>
 
 jest.setTimeout(100000)
 
-describe("SendgridNotificationService - customArgs", () => {
+describe("SendgridNotificationService - personalizations", () => {
   let service: SendgridNotificationService
 
   beforeEach(() => {
@@ -40,77 +39,42 @@ describe("SendgridNotificationService - customArgs", () => {
     )
   })
 
-  it("includes customArgs in personalizations and omits top-level to when provider_data.custom_args contains string values", async () => {
+  it("passes provider_data.personalizations directly to sendgrid and omits top-level to", async () => {
     await service.send({
       to: "recipient@example.com",
       channel: "email",
       template: "some-template",
       provider_data: {
-        custom_args: {
-          campaign_id: "abc123",
-          source: "welcome-flow",
-        },
+        personalizations: [
+          {
+            to: [{ email: "recipient@example.com" }],
+            customArgs: { campaign_id: "abc123", source: "welcome-flow" },
+          },
+        ],
       },
     })
 
     expect(mockSend).toHaveBeenCalledTimes(1)
     const message = mockSend.mock.calls[0][0] as any
     expect(message).not.toHaveProperty("to")
-    expect(message.personalizations[0].customArgs).toEqual({
-      campaign_id: "abc123",
-      source: "welcome-flow",
-    })
-  })
-
-  it("omits personalizations entirely when provider_data.custom_args is absent", async () => {
-    await service.send({
-      to: "recipient@example.com",
-      channel: "email",
-      template: "some-template",
-    })
-
-    expect(mockSend).toHaveBeenCalledTimes(1)
-    const message = mockSend.mock.calls[0][0] as any
-    expect(message).not.toHaveProperty("personalizations")
-  })
-
-  it("filters out non-string values from custom_args", async () => {
-    await service.send({
-      to: "recipient@example.com",
-      channel: "email",
-      template: "some-template",
-      provider_data: {
-        custom_args: {
-          valid_key: "valid-string",
-          number_key: 42,
-          object_key: { nested: true },
-          null_key: null,
-        } as Record<string, unknown>,
+    expect(message.personalizations).toEqual([
+      {
+        to: [{ email: "recipient@example.com" }],
+        customArgs: { campaign_id: "abc123", source: "welcome-flow" },
       },
-    })
-
-    expect(mockSend).toHaveBeenCalledTimes(1)
-    const message = mockSend.mock.calls[0][0] as any
-    expect(message.personalizations[0].customArgs).toEqual({
-      valid_key: "valid-string",
-    })
+    ])
   })
 
-  it("omits personalizations when all custom_args values are non-strings", async () => {
+  it("uses top-level to and omits personalizations when provider_data.personalizations is absent", async () => {
     await service.send({
       to: "recipient@example.com",
       channel: "email",
       template: "some-template",
-      provider_data: {
-        custom_args: {
-          number_key: 42,
-          object_key: { nested: true },
-        } as Record<string, unknown>,
-      },
     })
 
     expect(mockSend).toHaveBeenCalledTimes(1)
     const message = mockSend.mock.calls[0][0] as any
+    expect(message.to).toEqual("recipient@example.com")
     expect(message).not.toHaveProperty("personalizations")
   })
 })

--- a/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
+++ b/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
@@ -82,29 +82,33 @@ export class SendgridNotificationService extends AbstractNotificationProviderSer
 
     const rawCustomArgs = notification.provider_data?.custom_args as
       | Record<string, unknown>
-      | undefined;
-    const customArgs = rawCustomArgs
-      ? Object.fromEntries(
-          Object.entries(rawCustomArgs).filter(([, v]) => isString(v)) as [
-            string,
-            string,
-          ][]
-        )
+      | undefined
+    const filteredCustomArgs = rawCustomArgs
+      ? (Object.fromEntries(
+          Object.entries(rawCustomArgs).filter(([, v]) => isString(v))
+        ) as Record<string, string>)
       : undefined
+    const customArgs =
+      filteredCustomArgs && Object.keys(filteredCustomArgs).length > 0
+        ? filteredCustomArgs
+        : undefined
 
     const message: sendgrid.MailDataRequired = {
-      to: notification.to,
       from: from,
       dynamicTemplateData: notification.data as
         | { [key: string]: any }
         | undefined,
       attachments: attachments,
-      personalizations: [
-        {
-          to: [{ email: notification.to as string }],
-          ...(customArgs && { customArgs }),
-        },
-      ],
+      ...(customArgs
+        ? {
+            personalizations: [
+              {
+                to: [{ email: notification.to as string }],
+                customArgs,
+              },
+            ],
+          }
+        : { to: notification.to }),
       ...mailContent,
     }
 

--- a/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
+++ b/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
@@ -6,6 +6,7 @@ import {
 import {
   AbstractNotificationProviderService,
   MedusaError,
+  isString,
 } from "@medusajs/framework/utils"
 import sendgrid from "@sendgrid/mail"
 
@@ -84,9 +85,10 @@ export class SendgridNotificationService extends AbstractNotificationProviderSer
       | undefined;
     const customArgs = rawCustomArgs
       ? Object.fromEntries(
-          Object.entries(rawCustomArgs)
-            .filter(([, v]) => v != null)
-            .map(([k, v]) => [k, String(v)]),
+          Object.entries(rawCustomArgs).filter(([, v]) => isString(v)) as [
+            string,
+            string,
+          ][]
         )
       : undefined
 

--- a/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
+++ b/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
@@ -6,7 +6,6 @@ import {
 import {
   AbstractNotificationProviderService,
   MedusaError,
-  isString,
 } from "@medusajs/framework/utils"
 import sendgrid from "@sendgrid/mail"
 
@@ -80,18 +79,9 @@ export class SendgridNotificationService extends AbstractNotificationProviderSer
       }
     }
 
-    const rawCustomArgs = notification.provider_data?.custom_args as
-      | Record<string, unknown>
+    const personalizations = notification.provider_data?.personalizations as
+      | sendgrid.MailDataRequired["personalizations"]
       | undefined
-    const filteredCustomArgs = rawCustomArgs
-      ? (Object.fromEntries(
-          Object.entries(rawCustomArgs).filter(([, v]) => isString(v))
-        ) as Record<string, string>)
-      : undefined
-    const customArgs =
-      filteredCustomArgs && Object.keys(filteredCustomArgs).length > 0
-        ? filteredCustomArgs
-        : undefined
 
     const message: sendgrid.MailDataRequired = {
       from: from,
@@ -99,16 +89,7 @@ export class SendgridNotificationService extends AbstractNotificationProviderSer
         | { [key: string]: any }
         | undefined,
       attachments: attachments,
-      ...(customArgs
-        ? {
-            personalizations: [
-              {
-                to: [{ email: notification.to as string }],
-                customArgs,
-              },
-            ],
-          }
-        : { to: notification.to }),
+      ...(personalizations ? { personalizations } : { to: notification.to }),
       ...mailContent,
     }
 

--- a/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
+++ b/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
@@ -79,6 +79,17 @@ export class SendgridNotificationService extends AbstractNotificationProviderSer
       }
     }
 
+    const rawCustomArgs = notification.provider_data?.custom_args as
+      | Record<string, unknown>
+      | undefined;
+    const customArgs = rawCustomArgs
+      ? Object.fromEntries(
+          Object.entries(rawCustomArgs)
+            .filter(([, v]) => v != null)
+            .map(([k, v]) => [k, String(v)]),
+        )
+      : undefined
+
     const message: sendgrid.MailDataRequired = {
       to: notification.to,
       from: from,
@@ -86,6 +97,12 @@ export class SendgridNotificationService extends AbstractNotificationProviderSer
         | { [key: string]: any }
         | undefined,
       attachments: attachments,
+      personalizations: [
+        {
+          to: [{ email: notification.to as string }],
+          ...(customArgs && { customArgs }),
+        },
+      ],
       ...mailContent,
     }
 

--- a/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
+++ b/packages/modules/providers/notification-sendgrid/src/services/sendgrid.ts
@@ -89,7 +89,7 @@ export class SendgridNotificationService extends AbstractNotificationProviderSer
         | { [key: string]: any }
         | undefined,
       attachments: attachments,
-      ...(personalizations ? { personalizations } : { to: notification.to }),
+      ...(personalizations?.length ? { personalizations } : { to: notification.to }),
       ...mailContent,
     }
 


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

*Added support for passing SendGrid personalizations directly via provider_data in the notification payload.*

**Why** — Why are these changes relevant or necessary?  

*This allows callers to pass any SendGrid-native personalization data (e.g. customArgs for analytics/event tracking, per-recipient overrides, dynamic template data per recipient) without the provider needing to know about each specific field.*

**How** — How have these changes been implemented?

*Modified the SendgridNotificationService.send() method to check notification.provider_data.personalizations. When present and non-empty, it is forwarded directly to the SendGrid send() call and the top-level to field is omitted (since personalizations handles recipient routing). When absent or empty, the existing behavior using the top-level to field is preserved unchanged.*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Unit tests added in integration-tests/__tests__/services.spec.ts using a mocked @sendgrid/mail. Three cases are covered: personalizations present and forwarded, absent (falls back to top-level to), and empty array (also falls back to top-level to).*

resolves #15115 
---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
import { Modules } from "@medusajs/framework/utils"
import { INotificationModuleService } from "@medusajs/framework/types"

export default async function productCreateHandler({
  event: { data },
  container,
}: SubscriberArgs<{ id: string }>) {
  const notificationModuleService: INotificationModuleService =
    container.resolve(Modules.NOTIFICATION)

  const emailData = {
    name: "Sample Product",
    message: `New product created with id ${data.id}`,
  }

  const email = await notificationModuleService.createNotifications({
    to: "xxxxx@xxxx.com",
    channel: "email",
    template: "xxxxxxxxxx",
    data: emailData,
    provider_data: {
      personalizations: [
        {
          to: [{ email: "xxxxx@xxxx.com" }],
          customArgs: {
            customer_id: "cust_abc",
            ga4_id: "GA1.2.xxxxx",
            notification_type: "order_confirmation",
          },
        },
      ],
    },
  })
}

export const config: SubscriberConfig = {
  event: "product.created",
}
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, additive change to the SendGrid payload; main risk is passing unexpected `provider_data.custom_args` values, mitigated by coercing all values to strings.
> 
> **Overview**
> Adds support for SendGrid `customArgs` by reading `notification.provider_data.custom_args`, coercing values to strings, and including the result in the outgoing `sendgrid.send()` message payload.
> 
> Includes a changeset bumping `@medusajs/notification-sendgrid` as a minor release to document the new capability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69b1ef0c09846ff94a2ccc374014526b19c63a97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->