### PR TITLE
fix(core-flows): partial fulfillment failing when no available inventory

### DIFF
--- a/.changeset/fix-partial-fulfillment-inventory.md
+++ b/.changeset/fix-partial-fulfillment-inventory.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): partial fulfillment failing when no unreserved stock available

--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -1708,6 +1708,97 @@ medusaIntegrationTestRunner({
         expect(iitem.reserved_quantity).toBe(0)
       })
 
+      it("should handle partial fulfillment when stocked equals reserved (available = 0)", async () => {
+        const orderItemId = order.items.find(
+          (i) => i.variant_id === productOverride3.variants[0].id
+        ).id
+
+        // Reduce stocked_quantity to match reserved (3) so available = 0
+        await api.post(
+          `/admin/inventory-items/${inventoryItemOverride3.id}/location-levels/${stockChannelOverride.id}`,
+          { stocked_quantity: 3 },
+          adminHeaders
+        )
+
+        let iitem = (
+          await api.get(
+            `/admin/inventory-items/${inventoryItemOverride3.id}?fields=stocked_quantity,reserved_quantity`,
+            adminHeaders
+          )
+        ).data.inventory_item
+
+        expect(iitem.stocked_quantity).toBe(3)
+        expect(iitem.reserved_quantity).toBe(3)
+
+        // Partial fulfillment: fulfill 1 of 3 — this triggers the bug when
+        // adjustInventoryLevelsStep runs before updateReservationsStep
+        await api.post(
+          `/admin/orders/${order.id}/fulfillments`,
+          {
+            shipping_option_id: seeder.shippingOption.id,
+            location_id: seeder.stockLocation.id,
+            items: [{ id: orderItemId, quantity: 1 }],
+          },
+          adminHeaders
+        )
+
+        iitem = (
+          await api.get(
+            `/admin/inventory-items/${inventoryItemOverride3.id}?fields=stocked_quantity,reserved_quantity`,
+            adminHeaders
+          )
+        ).data.inventory_item
+
+        expect(iitem.stocked_quantity).toBe(2)
+        expect(iitem.reserved_quantity).toBe(2)
+
+        // Fulfill another 1
+        await api.post(
+          `/admin/orders/${order.id}/fulfillments`,
+          {
+            shipping_option_id: seeder.shippingOption.id,
+            location_id: seeder.stockLocation.id,
+            items: [{ id: orderItemId, quantity: 1 }],
+          },
+          adminHeaders
+        )
+
+        iitem = (
+          await api.get(
+            `/admin/inventory-items/${inventoryItemOverride3.id}?fields=stocked_quantity,reserved_quantity`,
+            adminHeaders
+          )
+        ).data.inventory_item
+
+        expect(iitem.stocked_quantity).toBe(1)
+        expect(iitem.reserved_quantity).toBe(1)
+
+        // Fulfill remaining 1
+        const {
+          data: { order: fulfilledOrder },
+        } = await api.post(
+          `/admin/orders/${order.id}/fulfillments?fields=fulfillments.id`,
+          {
+            shipping_option_id: seeder.shippingOption.id,
+            location_id: seeder.stockLocation.id,
+            items: [{ id: orderItemId, quantity: 1 }],
+          },
+          adminHeaders
+        )
+
+        expect(fulfilledOrder.fulfillments).toHaveLength(3)
+
+        iitem = (
+          await api.get(
+            `/admin/inventory-items/${inventoryItemOverride3.id}?fields=stocked_quantity,reserved_quantity`,
+            adminHeaders
+          )
+        ).data.inventory_item
+
+        expect(iitem.stocked_quantity).toBe(0)
+        expect(iitem.reserved_quantity).toBe(0)
+      })
+
       it("should throw if trying to fulfillment more items than it is reserved", async () => {
         const orderItemId = order.items.find(
           (i) => i.variant_id === productOverride3.variants[0].id

--- a/packages/core/core-flows/src/order/steps/adjust-fulfillment-inventory.ts
+++ b/packages/core/core-flows/src/order/steps/adjust-fulfillment-inventory.ts
@@ -1,0 +1,244 @@
+import type {
+  BigNumberInput,
+  IInventoryService,
+  InventoryTypes,
+} from "@medusajs/framework/types"
+import {
+  convertItemResponseToUpdateRequest,
+  getSelectsAndRelationsFromObjectArray,
+  MathBN,
+  Modules,
+} from "@medusajs/framework/utils"
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+
+type UpdateReservationItemInput = {
+  id: string
+  quantity: BigNumberInput
+  location_id: string
+}
+
+type AdjustInventoryItemInput = {
+  inventory_item_id: string
+  location_id: string
+  adjustment: BigNumberInput
+}
+
+type AdjustFulfillmentInventoryStepCompensationInput = {
+  dataBeforeUpdate: InventoryTypes.ReservationItemDTO[]
+  selects: string[]
+  relations: string[]
+  toDelete: string[]
+  revertAdjustment: AdjustInventoryItemInput[]
+  lockingKeys: string[]
+}
+
+/**
+ * The details to adjust inventory when creating a fulfillment.
+ */
+export type AdjustFulfillmentInventoryStepInput = {
+  /**
+   * Reservation items to update with remaining quantity.
+   */
+  toUpdate: UpdateReservationItemInput[]
+  /**
+   * Reservation item IDs to delete.
+   */
+  toDelete: string[]
+  /**
+   * Inventory level adjustments to apply.
+   */
+  inventoryAdjustment: AdjustInventoryItemInput[]
+}
+
+export const adjustFulfillmentInventoryStepId =
+  "adjust-fulfillment-inventory-step"
+/**
+ * This step atomically updates/deletes reservations and adjusts inventory
+ * levels for a fulfillment.
+ *
+ * @example
+ * const data = adjustFulfillmentInventoryStep({
+ *   toUpdate: [
+ *     {
+ *       id: "res_123",
+ *       quantity: 1,
+ *       location_id: "sloc_123",
+ *     },
+ *   ],
+ *   toDelete: ["res_456"],
+ *   inventoryAdjustment: [
+ *     {
+ *       inventory_item_id: "iitem_123",
+ *       location_id: "sloc_123",
+ *       adjustment: -1,
+ *     },
+ *   ],
+ * })
+ */
+export const adjustFulfillmentInventoryStep = createStep(
+  adjustFulfillmentInventoryStepId,
+  async (input: AdjustFulfillmentInventoryStepInput, { container }) => {
+    const inventoryService = container.resolve<IInventoryService>(Modules.INVENTORY)
+    const locking = container.resolve(Modules.LOCKING)
+
+    const toUpdate = input.toUpdate ?? []
+    const toDelete = Array.from(new Set(input.toDelete ?? []))
+    const inventoryAdjustment = input.inventoryAdjustment ?? []
+
+    const reservationIds = Array.from(
+      new Set([...toUpdate.map((reservation) => reservation.id), ...toDelete])
+    )
+
+    const reservations = reservationIds.length
+      ? await inventoryService.listReservationItems(
+          {
+            id: reservationIds,
+          },
+          {
+            select: ["inventory_item_id"],
+          }
+        )
+      : []
+
+    const lockingKeys = Array.from(
+      new Set([
+        ...inventoryAdjustment.map((item) => item.inventory_item_id),
+        ...reservations.map((reservation) => reservation.inventory_item_id),
+      ])
+    )
+
+    const { selects, relations } = getSelectsAndRelationsFromObjectArray(toUpdate)
+
+    const run = async (): Promise<AdjustFulfillmentInventoryStepCompensationInput> => {
+      const dataBeforeUpdate = toUpdate.length
+        ? await inventoryService.listReservationItems(
+            {
+              id: toUpdate.map((item) => item.id),
+            },
+            { relations, select: selects }
+          )
+        : []
+
+      let updatedReservations = false
+      let deletedReservations = false
+      const adjustedInventoryLevels: AdjustInventoryItemInput[] = []
+
+      try {
+        if (toUpdate.length) {
+          await inventoryService.updateReservationItems(toUpdate)
+          updatedReservations = true
+        }
+
+        if (toDelete.length) {
+          await inventoryService.softDeleteReservationItems(toDelete)
+          deletedReservations = true
+        }
+
+        if (inventoryAdjustment.length) {
+          for (const item of inventoryAdjustment) {
+            await inventoryService.adjustInventory(
+              item.inventory_item_id,
+              item.location_id,
+              item.adjustment
+            )
+            adjustedInventoryLevels.push(item)
+          }
+        }
+      } catch (e) {
+        // Roll back completed mutations before propagating the error,
+        // since a throw here prevents StepResponse from being returned
+        // and the workflow compensation would have no data to work with.
+        if (adjustedInventoryLevels.length) {
+          await inventoryService.adjustInventory(
+            adjustedInventoryLevels
+              .slice()
+              .reverse()
+              .map((item) => ({
+                inventoryItemId: item.inventory_item_id,
+                locationId: item.location_id,
+                adjustment: MathBN.mult(item.adjustment, -1),
+              }))
+          )
+        }
+
+        if (deletedReservations) {
+          await inventoryService.restoreReservationItems(toDelete)
+        }
+
+        if (updatedReservations && dataBeforeUpdate.length) {
+          await inventoryService.updateReservationItems(
+            dataBeforeUpdate.map((data) =>
+              convertItemResponseToUpdateRequest(data, selects, relations)
+            )
+          )
+        }
+
+        throw e
+      }
+
+      return {
+        dataBeforeUpdate,
+        selects,
+        relations,
+        toDelete,
+        revertAdjustment: inventoryAdjustment.map((item) => ({
+          ...item,
+          adjustment: MathBN.mult(item.adjustment, -1),
+        })),
+        lockingKeys,
+      }
+    }
+
+    const compensationData = lockingKeys.length
+      ? await locking.execute(lockingKeys, run)
+      : await run()
+
+    return new StepResponse(void 0, compensationData)
+  },
+  async (
+    revertInput: AdjustFulfillmentInventoryStepCompensationInput | undefined,
+    { container }
+  ) => {
+    if (!revertInput) {
+      return
+    }
+
+    const inventoryService = container.resolve<IInventoryService>(Modules.INVENTORY)
+    const locking = container.resolve(Modules.LOCKING)
+
+    const run = async () => {
+      if (revertInput.revertAdjustment.length) {
+        await inventoryService.adjustInventory(
+          revertInput.revertAdjustment.map((item) => ({
+            inventoryItemId: item.inventory_item_id,
+            locationId: item.location_id,
+            adjustment: item.adjustment,
+          }))
+        )
+      }
+
+      if (revertInput.toDelete.length) {
+        await inventoryService.restoreReservationItems(revertInput.toDelete)
+      }
+
+      if (revertInput.dataBeforeUpdate.length) {
+        await inventoryService.updateReservationItems(
+          revertInput.dataBeforeUpdate.map((data) =>
+            convertItemResponseToUpdateRequest(
+              data,
+              revertInput.selects,
+              revertInput.relations
+            )
+          )
+        )
+      }
+    }
+
+    if (revertInput.lockingKeys.length) {
+      await locking.execute(revertInput.lockingKeys, run)
+      return
+    }
+
+    await run()
+  }
+)

--- a/packages/core/core-flows/src/order/steps/index.ts
+++ b/packages/core/core-flows/src/order/steps/index.ts
@@ -1,3 +1,4 @@
+export * from "./adjust-fulfillment-inventory"
 export * from "./add-order-transaction"
 export * from "./archive-orders"
 export * from "./cancel-fulfillment"

--- a/packages/core/core-flows/src/order/workflows/create-fulfillment.ts
+++ b/packages/core/core-flows/src/order/workflows/create-fulfillment.ts
@@ -33,12 +33,10 @@ import {
   useRemoteQueryStep,
 } from "../../common"
 import { createFulfillmentWorkflow } from "../../fulfillment"
-import { adjustInventoryLevelsStep } from "../../inventory"
 import {
-  deleteReservationsStep,
-  updateReservationsStep,
-} from "../../reservation"
-import { registerOrderFulfillmentStep } from "../steps"
+  adjustFulfillmentInventoryStep,
+  registerOrderFulfillmentStep,
+} from "../steps"
 import { buildReservationsMap } from "../utils/build-reservations-map"
 import {
   throwIfItemsAreNotGroupedByShippingRequirement,
@@ -563,12 +561,15 @@ export const createOrderFulfillmentWorkflow = createWorkflow(
       prepareInventoryUpdate
     )
 
-    adjustInventoryLevelsStep(inventoryAdjustment)
+    adjustFulfillmentInventoryStep({
+      toUpdate,
+      toDelete,
+      inventoryAdjustment,
+    })
+
     parallelize(
       registerOrderFulfillmentStep(registerOrderFulfillmentData),
       createRemoteLinkStep(link),
-      updateReservationsStep(toUpdate),
-      deleteReservationsStep(toDelete),
       emitEventStep({
         eventName: OrderWorkflowEvents.FULFILLMENT_CREATED,
         data: {


### PR DESCRIPTION
  What — _Replaces three separate inventory/reservation workflow steps
  (adjustInventoryLevelsStep, updateReservationsStep, deleteReservationsStep) with a
   single atomic adjustFulfillmentInventoryStep in createOrderFulfillmentWorkflow._  

  Why — _Partial fulfillment fails when all stocked inventory is reserved (e.g., 5   
  ordered, 5 reserved, 0 available, fulfilling 3). The previous code adjusted       
  stocked_quantity before reducing reserved_quantity, causing the inventory module  
  to reject the operation due to negative availability. Additionally, the
  reservation steps ran without distributed locking, creating a race window where   
  concurrent requests could reserve against phantom availability._

  How — _The new composite step runs all three operations under a single distributed 
  lock in the correct order: reduce reservations first (update/delete), then adjust 
  inventory levels. An in-place try/catch rollback tracks completed mutations and   
  reverses them if a later operation fails, since a throw before StepResponse means 
  the workflow compensation has no data to work with._

  Testing — _Added integration test should handle partial fulfillment when stocked   
  equals reserved (available = 0) that sets up a scenario with stocked_quantity ==  
  reserved_quantity and verifies partial fulfillment succeeds._


 `yarn test:integration:http -- --testPathPattern="order/admin/order.spec"
  --testNamePattern="should handle partial fulfillment when stocked equals reserved"`

  ---
  Examples

```ts
  // Before: inventory adjusted before reservations — fails with 0 available        
  adjustInventoryLevelsStep(inventoryAdjustment) // stocked 5→2, reserved still 5 → 
  available -3 ✗
  parallelize(
    updateReservationsStep(toUpdate),   // no locking
    deleteReservationsStep(toDelete),   // no locking
  )

 // After: all operations atomic under one lock, reservations reduced first        
 adjustFulfillmentInventoryStep({
    toUpdate,              // reserved 5→2
    toDelete,              // remove exhausted reservations
    inventoryAdjustment,   // stocked 5→2, available = 2-2 = 0 ✓
  })
```
  ---
  Checklist

- [x] I have added a **changeset** for this PR
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

  ---
  Additional Context

  - cancel-order-fulfillment.ts has the inverse pattern (restore inventory before   
  reservations) and could benefit from a similar consolidation in a follow-up.      
  - The pre-lock reservation query to derive locking keys is architecturally        
  necessary and safe since inventory_item_id on reservations is immutable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fulfillment creation to mutate reservations and inventory under a single distributed lock, which affects core order/inventory correctness and could surface edge cases in rollback/compensation paths.
> 
> **Overview**
> Fixes a partial-fulfillment failure when *available inventory is 0* (stocked equals reserved) by replacing the separate `adjustInventoryLevelsStep` + reservation update/delete steps with a single atomic `adjustFulfillmentInventoryStep` in `create-order-fulfillment`.
> 
> Adds the new step to update/soft-delete reservations **before** adjusting inventory levels, runs the whole sequence under locking keys derived from involved inventory items, and includes explicit in-step rollback/compensation data to avoid leaving partial mutations on errors. An integration test is added to reproduce the 0-available partial fulfillment scenario and assert stocked/reserved quantities decrement correctly across multiple partial fulfillments, along with a patch changeset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bc6a2a150c3115455a76967ad7d7c14a7eae3d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->