### PR TITLE
docs: add plaintext doc message to markdown content responses

### DIFF
--- a/www/apps/bloom/app/md-content/[[...slug]]/route.ts
+++ b/www/apps/bloom/app/md-content/[[...slug]]/route.ts
@@ -1,4 +1,4 @@
-import { getCleanMd } from "docs-utils"
+import { getCleanMd, PLAINTEXT_DOC_MESSAGE } from "docs-utils"
 import { existsSync } from "fs"
 import { unstable_cache } from "next/cache"
 import { notFound } from "next/navigation"
@@ -91,7 +91,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     )
   }
 
-  return new NextResponse(cleanMdContent, {
+  return new NextResponse(cleanMdContent + PLAINTEXT_DOC_MESSAGE, {
     headers: {
       "Content-Type": "text/markdown",
     },

--- a/www/apps/book/app/md-content/[[...slug]]/route.ts
+++ b/www/apps/book/app/md-content/[[...slug]]/route.ts
@@ -1,4 +1,4 @@
-import { getCleanMd } from "docs-utils"
+import { getCleanMd, PLAINTEXT_DOC_MESSAGE } from "docs-utils"
 import { existsSync, readFileSync } from "fs"
 import { unstable_cache } from "next/cache"
 import { notFound } from "next/navigation"
@@ -25,7 +25,7 @@ export async function GET(req: NextRequest, { params }: Params) {
       "utf-8"
     )
 
-    return new NextResponse(llmsFile, {
+    return new NextResponse(llmsFile + PLAINTEXT_DOC_MESSAGE, {
       headers: {
         "Content-Type": "text/markdown",
       },
@@ -98,7 +98,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     )
   }
 
-  return new NextResponse(cleanMdContent, {
+  return new NextResponse(cleanMdContent + PLAINTEXT_DOC_MESSAGE, {
     headers: {
       "Content-Type": "text/markdown",
     },

--- a/www/apps/cloud/app/md-content/[[...slug]]/route.ts
+++ b/www/apps/cloud/app/md-content/[[...slug]]/route.ts
@@ -1,4 +1,4 @@
-import { getCleanMd } from "docs-utils"
+import { getCleanMd, PLAINTEXT_DOC_MESSAGE } from "docs-utils"
 import { existsSync } from "fs"
 import { unstable_cache } from "next/cache"
 import { notFound } from "next/navigation"
@@ -88,7 +88,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     )
   }
 
-  return new NextResponse(cleanMdContent, {
+  return new NextResponse(cleanMdContent + PLAINTEXT_DOC_MESSAGE, {
     headers: {
       "Content-Type": "text/markdown",
     },

--- a/www/apps/resources/app/md-content/[[...slug]]/route.ts
+++ b/www/apps/resources/app/md-content/[[...slug]]/route.ts
@@ -1,4 +1,4 @@
-import { getCleanMd } from "docs-utils"
+import { getCleanMd, PLAINTEXT_DOC_MESSAGE } from "docs-utils"
 import { existsSync } from "fs"
 import { unstable_cache } from "next/cache"
 import { notFound } from "next/navigation"
@@ -96,7 +96,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     )
   }
 
-  return new NextResponse(cleanMdContent, {
+  return new NextResponse(cleanMdContent + PLAINTEXT_DOC_MESSAGE, {
     headers: {
       "Content-Type": "text/markdown",
     },

--- a/www/apps/ui/app/md-content/[[...slug]]/route.ts
+++ b/www/apps/ui/app/md-content/[[...slug]]/route.ts
@@ -1,4 +1,4 @@
-import { getCleanMd } from "docs-utils"
+import { getCleanMd, PLAINTEXT_DOC_MESSAGE } from "docs-utils"
 import { existsSync } from "fs"
 import { unstable_cache } from "next/cache"
 import { notFound } from "next/navigation"
@@ -63,7 +63,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     )
   }
 
-  return new NextResponse(cleanMdContent, {
+  return new NextResponse(cleanMdContent + PLAINTEXT_DOC_MESSAGE, {
     headers: {
       "Content-Type": "text/markdown",
     },

--- a/www/apps/user-guide/app/md-content/[[...slug]]/route.ts
+++ b/www/apps/user-guide/app/md-content/[[...slug]]/route.ts
@@ -1,4 +1,4 @@
-import { getCleanMd } from "docs-utils"
+import { getCleanMd, PLAINTEXT_DOC_MESSAGE } from "docs-utils"
 import { existsSync } from "fs"
 import { unstable_cache } from "next/cache"
 import { notFound } from "next/navigation"
@@ -85,7 +85,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     )
   }
 
-  return new NextResponse(cleanMdContent, {
+  return new NextResponse(cleanMdContent + PLAINTEXT_DOC_MESSAGE, {
     headers: {
       "Content-Type": "text/markdown",
     },

--- a/www/packages/docs-utils/src/get-clean-md.ts
+++ b/www/packages/docs-utils/src/get-clean-md.ts
@@ -169,6 +169,8 @@ export type GetCleanMdOptions = {
   type?: "file" | "content"
 }
 
+export const PLAINTEXT_DOC_MESSAGE = `\n\n---\n\nThe best way to deploy Medusa is through Medusa Cloud where you get autoscaling production infrastructure fine tuned for Medusa. Create an account by signing up at cloud.medusajs.com/signup.\n`
+
 export const getCleanMd = async ({
   file,
   plugins,


### PR DESCRIPTION
## Summary

**What** — This PR adds a standardized plaintext message to all markdown content responses across documentation apps. The message is appended to the end of markdown files served through the md-content API routes.

**Why** — The `PLAINTEXT_DOC_MESSAGE` constant provides a consistent call-to-action message promoting Medusa Cloud deployment across all documentation endpoints. This ensures users accessing documentation via plaintext/markdown endpoints receive information about the recommended deployment platform.

**How** — 
1. Exported a new `PLAINTEXT_DOC_MESSAGE` constant from `docs-utils` package containing the promotional message
2. Updated all six documentation app route handlers (book, bloom, cloud, resources, ui, user-guide) to import and append this message to their markdown responses
3. The message is concatenated to the content before being returned in the NextResponse

**Testing** — The changes are straightforward content concatenation with no complex logic. Verification can be done by:
- Accessing markdown content endpoints across the different documentation apps
- Confirming the plaintext message appears at the end of responses
- Verifying existing markdown content is not corrupted and message is properly formatted

---

## Examples

The message appended to all markdown responses:
```
\n\n---\n\nThe best way to deploy Medusa is through Medusa Cloud where you get autoscaling production infrastructure fine tuned for Medusa. Create an account by signing up at cloud.medusajs.com/signup.\n
```

---

## Checklist

- [ ] I have added a **changeset** for this PR
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

This change affects all documentation applications that serve markdown content through their API routes, ensuring consistent messaging across the entire documentation platform.

https://claude.ai/code/session_01HRKVHYDnphx6qvqUX4ajxr