### PR TITLE
fix(cli): close leaked file descriptor in clearProject

### DIFF
--- a/.changeset/fix-clear-project-fd.md
+++ b/.changeset/fix-clear-project-fd.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/cli": patch
+---
+
+fix(cli): close leaked file descriptor in clearProject

--- a/packages/cli/medusa-cli/src/util/clear-project.ts
+++ b/packages/cli/medusa-cli/src/util/clear-project.ts
@@ -21,5 +21,6 @@ export function clearProject(directory: string) {
     })
   )
   // add empty typescript file to avoid build errors
-  fs.openSync(path.join(directory, "src", "index.ts"), "w")
+  // writeFileSync creates, writes, and closes in one call -- no fd leak.
+  fs.writeFileSync(path.join(directory, "src", "index.ts"), "")
 }


### PR DESCRIPTION
## Summary

`packages/cli/medusa-cli/src/util/clear-project.ts` uses `fs.openSync(path, "w")` to create an empty TypeScript file, but `openSync` returns a file descriptor that is never closed. The fd leaks until the process exits.

## Fix

Replaced `fs.openSync(path, "w")` with `fs.writeFileSync(path, "")` which creates, writes, and closes the file in a single call.

## Context

The intent was to create an empty `src/index.ts` after clearing the project to avoid build errors. `writeFileSync` with an empty string achieves the same result without leaking a file descriptor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: replaces a file-creation call with an equivalent API to avoid leaking a file descriptor; behavior should remain the same aside from improved resource handling.
> 
> **Overview**
> Fixes an fd leak in the CLI’s `clearProject` utility by replacing `fs.openSync(..., "w")` with `fs.writeFileSync(..., "")` when recreating an empty `src/index.ts` after cleanup.
> 
> Adds a changeset to ship this as a patch release for `@medusajs/cli`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e14b90915a9d3def11a03b558f384dad8eebd72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->