### PR TITLE
fix(dashboard): use i18n for hardcoded "Providers" in region edit

### DIFF
--- a/.changeset/fix-providers-i18n.md
+++ b/.changeset/fix-providers-i18n.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix: replace hardcoded "Providers" string in region edit form with i18n translation key

--- a/packages/admin/dashboard/src/routes/regions/region-edit/components/edit-region-form/edit-region-form.tsx
+++ b/packages/admin/dashboard/src/routes/regions/region-edit/components/edit-region-form/edit-region-form.tsx
@@ -204,7 +204,7 @@ export const EditRegionForm = ({
             <div className="flex flex-col gap-y-4">
               <div>
                 <Text size="small" leading="compact" weight="plus">
-                  Providers
+                  {t("fields.providers")}
                 </Text>
                 <Text size="small" className="text-ui-fg-subtle">
                   {t("regions.providersHint")}


### PR DESCRIPTION
## Summary

**What** — Replaces the hardcoded English string "Providers" with `t("fields.providers")` in the region edit form.

**Why** — The heading always displays in English regardless of the user's language setting, breaking i18n. The translation key `fields.providers` already exists in all language files.

**How** — One-line change in `edit-region-form.tsx` (line 207): `Providers` → `{t("fields.providers")}`.

**Testing** — Set the admin dashboard to a non-English language (e.g., Spanish), navigate to Settings → Regions → Edit a region, and confirm the "Providers" heading now displays in the selected language.

Fixes #14811

---

## Checklist

- [ ] I have added a **changeset** for this PR
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

The `t("fields.providers")` key is already translated across all locale files (e.g., "Proveedores" in Spanish, "提供商" in Chinese). This is a minimal fix consistent with how the rest of the form uses `t()`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a simple UI text change replacing a hardcoded label with an existing i18n key, plus a patch changeset; no business logic or data handling is modified.
> 
> **Overview**
> Updates the region edit form to use `t("fields.providers")` instead of a hardcoded **"Providers"** label so the heading is localized.
> 
> Adds a patch changeset for `@medusajs/dashboard` documenting the i18n fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beb8814b67fb5527405d3c29c455d3db5925018a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->