### PR TITLE
fix(product): batch variant image queries to fix N+1 in list endpoints

### DIFF
--- a/.changeset/batch-variant-images.md
+++ b/.changeset/batch-variant-images.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/product": patch
+---
+
+fix: batch variant image queries in listProducts and listAndCountProducts to fix N+1

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -251,15 +251,7 @@ export default class ProductModuleService
     )
 
     if (shouldLoadVariantImages) {
-      for (const product of products) {
-        if (product.variants && product.images) {
-          await this.buildVariantImagesFromProduct(
-            product.variants,
-            product.images,
-            sharedContext
-          )
-        }
-      }
+      await this.batchBuildVariantImagesFromProducts(products, sharedContext)
     }
 
     return this.baseRepository_.serialize<ProductTypes.ProductDTO[]>(products)
@@ -293,15 +285,7 @@ export default class ProductModuleService
     )
 
     if (shouldLoadVariantImages) {
-      for (const product of products) {
-        if (product.variants && product.images) {
-          await this.buildVariantImagesFromProduct(
-            product.variants,
-            product.images,
-            sharedContext
-          )
-        }
-      }
+      await this.batchBuildVariantImagesFromProducts(products, sharedContext)
     }
 
     const serializedProducts = await this.baseRepository_.serialize<
@@ -2520,6 +2504,71 @@ export default class ProductModuleService
     }
 
     return result
+  }
+
+  private async batchBuildVariantImagesFromProducts(
+    products: InferEntityType<typeof Product>[],
+    sharedContext: Context = {}
+  ): Promise<void> {
+    const allVariantIds: string[] = []
+
+    for (const product of products) {
+      if (!product.variants || !product.images) {
+        continue
+      }
+      for (const variant of product.variants) {
+        allVariantIds.push(variant.id)
+      }
+    }
+
+    if (allVariantIds.length === 0) {
+      return
+    }
+
+    const variantImageRelations =
+      await this.productVariantProductImageService_.list(
+        { variant_id: allVariantIds },
+        { select: ["variant_id", "image_id"] },
+        sharedContext
+      )
+
+    const variantIdImageIdsMap = new Map<string, string[]>()
+    const imageIdVariantIdsMap = new Map<string, Set<string>>()
+
+    for (const relation of variantImageRelations) {
+      if (!variantIdImageIdsMap.has(relation.variant_id)) {
+        variantIdImageIdsMap.set(relation.variant_id, [])
+      }
+      variantIdImageIdsMap.get(relation.variant_id)!.push(relation.image_id)
+
+      if (!imageIdVariantIdsMap.has(relation.image_id)) {
+        imageIdVariantIdsMap.set(relation.image_id, new Set())
+      }
+      imageIdVariantIdsMap.get(relation.image_id)!.add(relation.variant_id)
+    }
+
+    for (const product of products) {
+      if (!product.variants || !product.images) {
+        continue
+      }
+
+      const [generalImages, variantImages] = partitionArray(
+        product.images,
+        (img) => !imageIdVariantIdsMap.has(img.id)
+      )
+
+      for (const variant of product.variants) {
+        const variantImageIds = variantIdImageIdsMap.get(variant.id) || []
+
+        variant.images = [...generalImages]
+
+        for (const image of variantImages) {
+          if (variantImageIds.includes(image.id)) {
+            variant.images.push(image)
+          }
+        }
+      }
+    }
   }
 
   private async buildVariantImagesFromProduct(


### PR DESCRIPTION
## Summary

- **Problem**: `listProducts` and `listAndCountProducts` issued a separate DB query per product to resolve variant↔image associations via `buildVariantImagesFromProduct`. With 20 products per page, this meant **20 sequential round-trips** to the `product_variant_product_image` table on every request that includes `variants.images` in the fields.

- **Fix**: Replace the per-product loop with a single `batchBuildVariantImagesFromProducts` method that fetches all variant-image relations in **one query**, then distributes them in-memory using maps.

- The original `buildVariantImagesFromProduct` method is preserved since it's used by `retrieveProduct` for single-product retrieval.

## Benchmark results

Setup: 50 products (3 variants each), 20 per page, 10 concurrent connections, 15s per run, same machine for before/after.

### Store products (`?fields=*variants,*variants.images`)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Avg latency | 312 ms | 234 ms | **-25%** |
| p99 latency | 593 ms | 358 ms | **-40%** |
| Throughput | 31.7 req/s | 42.5 req/s | **+34%** |

### Admin products (`?fields=*variants,*variants.images`)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Avg latency | 393 ms | 337 ms | **-14%** |
| p99 latency | 593 ms | 561 ms | **-5%** |
| Throughput | 25.2 req/s | 29.3 req/s | **+16%** |

Default endpoints (without `variants.images`) are unaffected, as expected.

## Test plan

- [x] All 206 product module unit/integration tests pass
- [x] `variants.images` relation correctly resolved in list and listAndCount paths
- [x] Benchmark confirms latency reduction on affected endpoints
- [x] No regression on endpoints that don't request `variants.images`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `variants.images` are assembled for `listProducts`/`listAndCountProducts`, replacing per-product DB lookups with a batched query; risk is mainly around correctness/order of variant image assignment across multiple products.
> 
> **Overview**
> Fixes an N+1 in `listProducts` and `listAndCountProducts` when `variants.images` is requested by replacing per-product `buildVariantImagesFromProduct` calls with a new `batchBuildVariantImagesFromProducts` that fetches all `product_variant_product_image` relations in one query and distributes them in-memory.
> 
> Adds a changeset bumping `@medusajs/product` with a patch-level fix note; single-product retrieval (`retrieveProduct`) continues to use the existing per-product variant image builder.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0b6639416555918c2f7964a8c1c718497505507. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->