### PR TITLE
perf: deduplicate region fetch in store product middleware

### DIFF
--- a/packages/medusa/src/api/utils/middlewares/products/set-pricing-context.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/set-pricing-context.ts
@@ -26,17 +26,22 @@ export function setPricingContext(options: PricingContextOptions = {}) {
     }
 
     // We validate the region ID in the previous middleware
+    // Also fetch automatic_taxes so setTaxContext can reuse this region
+    // instead of making a duplicate DB query
     const region = await refetchEntity({
       entity: "region",
       idOrFilter: req.filterableFields.region_id!,
       scope: req.scope,
-      fields: ["id", "currency_code"],
+      fields: ["id", "currency_code", "automatic_taxes"],
       options: {
         cache: {
           enable: true,
         },
       },
     })
+
+    // Store region on the request so setTaxContext can reuse it
+    ;(req as any).__region = region
 
     if (!region) {
       try {

--- a/packages/medusa/src/api/utils/middlewares/products/set-tax-context.ts
+++ b/packages/medusa/src/api/utils/middlewares/products/set-tax-context.ts
@@ -47,6 +47,15 @@ export function setTaxContext(options: TaxContextOptions = {}) {
 }
 
 const getTaxInclusivityInfo = async (req: MedusaRequest) => {
+  // Reuse the region already fetched by setPricingContext if available,
+  // avoiding a duplicate DB query for the same region
+  const cachedRegion = (req as any).__region
+  if (cachedRegion && cachedRegion.automatic_taxes !== undefined) {
+    return {
+      automaticTaxes: cachedRegion.automatic_taxes,
+    }
+  }
+
   const region = await refetchEntity({
     entity: "region",
     idOrFilter: req.filterableFields.region_id as string,


### PR DESCRIPTION
## Summary
- `setPricingContext` and `setTaxContext` both query the same region on every store product request with calculated prices — two DB round-trips for the same row
- Now `setPricingContext` fetches `automatic_taxes` alongside `currency_code` and stores the region on `req.__region`
- `setTaxContext` reads from the cached region first, falling back to its own fetch only if unavailable

## Impact
Eliminates 1 DB round-trip per store product request with calculated prices.

## Test plan
- [ ] Store product list with `region_id` + `currency_code` query params returns correct prices
- [ ] Store product list with `region_id` where `automatic_taxes=true` still applies tax context
- [ ] Store product list without pricing fields skips both middleware (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk perf change that only alters how the region is fetched/cached for store product requests; main risk is unintended coupling via `req.__region` if other middleware relies on the request shape or ordering.
> 
> **Overview**
> **Deduplicates region fetching** for store product requests that require calculated pricing.
> 
> `setPricingContext` now fetches `automatic_taxes` along with currency info and caches the region on `req.__region`; `setTaxContext` reuses this cached region to determine tax inclusivity, falling back to its own `refetchEntity` call only when the cache is unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa72e838b93c296d48ba819a697966f1c39268f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->