### PR TITLE
perf: batch variant image queries across all products

### DIFF
--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -251,15 +251,7 @@ export default class ProductModuleService
     )
 
     if (shouldLoadVariantImages) {
-      for (const product of products) {
-        if (product.variants && product.images) {
-          await this.buildVariantImagesFromProduct(
-            product.variants,
-            product.images,
-            sharedContext
-          )
-        }
-      }
+      await this.buildVariantImagesFromProducts(products, sharedContext)
     }
 
     return this.baseRepository_.serialize<ProductTypes.ProductDTO[]>(products)
@@ -293,15 +285,7 @@ export default class ProductModuleService
     )
 
     if (shouldLoadVariantImages) {
-      for (const product of products) {
-        if (product.variants && product.images) {
-          await this.buildVariantImagesFromProduct(
-            product.variants,
-            product.images,
-            sharedContext
-          )
-        }
-      }
+      await this.buildVariantImagesFromProducts(products, sharedContext)
     }
 
     const serializedProducts = await this.baseRepository_.serialize<
@@ -2520,6 +2504,74 @@ export default class ProductModuleService
     }
 
     return result
+  }
+
+  private async buildVariantImagesFromProducts(
+    products: InferEntityType<typeof Product>[],
+    sharedContext: Context = {}
+  ): Promise<void> {
+    // Collect all variant IDs across all products in a single batch
+    const allVariantIds: string[] = []
+    const productsWithVariantImages: InferEntityType<typeof Product>[] = []
+
+    for (const product of products) {
+      if (product.variants && product.images) {
+        productsWithVariantImages.push(product)
+        for (const variant of product.variants) {
+          allVariantIds.push(variant.id)
+        }
+      }
+    }
+
+    if (!allVariantIds.length) {
+      return
+    }
+
+    // Single batch query for all variant-image relations across all products
+    const allVariantImageRelations =
+      await this.productVariantProductImageService_.list(
+        { variant_id: allVariantIds },
+        { select: ["variant_id", "image_id"] },
+        sharedContext
+      )
+
+    // Build a global variant_id -> image_ids lookup
+    const variantIdImageIdsMap = new Map<string, string[]>()
+    for (const relation of allVariantImageRelations) {
+      if (!variantIdImageIdsMap.has(relation.variant_id)) {
+        variantIdImageIdsMap.set(relation.variant_id, [])
+      }
+      variantIdImageIdsMap.get(relation.variant_id)!.push(relation.image_id)
+    }
+
+    // Assign images to variants per product
+    for (const product of productsWithVariantImages) {
+      const imageIdVariantIdsMap = new Map<string, string[]>()
+      for (const variant of product.variants) {
+        const imageIds = variantIdImageIdsMap.get(variant.id) || []
+        for (const imageId of imageIds) {
+          if (!imageIdVariantIdsMap.has(imageId)) {
+            imageIdVariantIdsMap.set(imageId, [])
+          }
+          imageIdVariantIdsMap.get(imageId)!.push(variant.id)
+        }
+      }
+
+      const [generalImages, variantImages] = partitionArray(
+        product.images,
+        (img) => !imageIdVariantIdsMap.has(img.id)
+      )
+
+      for (const variant of product.variants) {
+        const variantImageIds = variantIdImageIdsMap.get(variant.id) || []
+        variant.images = [...generalImages]
+        for (const image of variantImages) {
+          if (variantImageIds.includes(image.id)) {
+            variant.images.push(image)
+          }
+        }
+      }
+    }
   }
 
   private async buildVariantImagesFromProduct(


### PR DESCRIPTION
## Summary
- `buildVariantImagesFromProduct` was called once per product in a loop — 1 DB query per product to the `product_variant_product_image` table
- With 50 products, this meant 50 sequential queries where 1 suffices
- New `buildVariantImagesFromProducts` method collects all variant IDs across the entire product list, makes a single batch query, then distributes results per product in memory
- Affects `listProducts` and `listAndCountProducts`; single-product `retrieveProduct` is unchanged

## Impact
Replaces N queries with 1 when `variants.images` is requested (50 products → 50x fewer queries).

## Test plan
- [ ] Product list with `variants.images` in fields returns correct variant-specific and general images
- [ ] Product list without `variants.images` is unaffected (no regression)
- [ ] Single product retrieve still works correctly with variant images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `variants.images` are assembled for product lists by batching DB reads and rehydrating in memory, which could affect correctness or ordering of variant/general images. Scope is limited to `listProducts`/`listAndCountProducts`; single-product retrieval path is unchanged.
> 
> **Overview**
> Improves performance when requesting `variants.images` on product list endpoints by replacing per-product `product_variant_product_image` lookups with a **single batched query** across all returned products/variants, then distributing the results back onto each variant in memory.
> 
> Updates `listProducts` and `listAndCountProducts` to call the new `buildVariantImagesFromProducts` helper; `retrieveProduct` continues to use the existing per-product implementation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19170ca03362221ca7c4df3269b603ede73805bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->