### PR TITLE
Fix/axios vulnerability

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -17,7 +17,7 @@
     "get-port": "^7.1.0",
     "@medusajs/medusa": "^1.20.10",
     "@medusajs/core-flows": "^0.0.10",
-    "axios": "^1.12.0",
+    "axios": "^1.13.1",
     "scrypt-kdf": "^2.0.1",
     "jsonwebtoken": "^9.0.2",
     "@medusajs/framework": "^1.0.1",


### PR DESCRIPTION
## Summary
Updated `axios` dependency in `integration-tests/package.json` from `^1.12.0` to `^1.13.1` for consistency with the rest of the monorepo.

## Context
Addresses #14603 - `@medusajs/medusa-js` (v1.x) has been replaced by `@medusajs/js-sdk` in v2.x which uses `fetch` instead of `axios`, eliminating the core vulnerability.

All remaining `axios` dependencies in the monorepo already use `^1.13.1` (resolving to `1.13.2`), which is well above the vulnerable `<=0.29.0` range. The root `package.json` also enforces `axios@^1.13.1` via Yarn resolutions monorepo-wide.

This change normalizes the only remaining outlier for consistency.

## Test Plan
- [x] Verify `yarn install` resolves successfully  
- [x] Verify `npm audit` / `yarn audit` shows no `axios` vulnerabilities  

## Examples
No code usage changes - this is a dependency version bump only.

## Checklist
- [x] I have verified the code works as intended locally  
- [x] I have linked the related issue(s) if applicable  