### PR TITLE
fix(dashboard): use product default fields on Admin dashboard exports

### DIFF
--- a/.changeset/polite-cougars-tickle.md
+++ b/.changeset/polite-cougars-tickle.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): use product default fields on Admin dashboard exports

--- a/packages/admin/dashboard/src/routes/products/product-export/product-export.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-export/product-export.tsx
@@ -26,6 +26,7 @@ export const ProductExport = () => {
 const ProductExportContent = () => {
   const { t } = useTranslation()
   const { searchParams } = useProductTableQuery({})
+  delete searchParams.fields
 
   const { mutateAsync } = useExportProducts({ ...searchParams })
   const { handleSuccess } = useRouteModal()


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Avoid passing a defined set of fields on Admin dashboard product exports, allowing the query config default fields to be used, which include everything that is needed to construct the expected CSV. This aligns with what we assert in tests.

**Why** — Why are these changes relevant or necessary?  

Passing defined fields like we were doing was causing the prepare query config middleware to replace the default fields of the query config, causing the generated CSV to include fewer information than expected.

**How** — How have these changes been implemented?

Avoid passing fields altogether when requesting the export from the Admin dashboard and allowing the information to be resolved from the query config defaults.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Now the request in the Admin dashboard matches the existing expectations of the tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
