### PR TITLE
fix: use in-memory modules if REDIS_URL unset

### DIFF
--- a/.changeset/four-memes-relax.md
+++ b/.changeset/four-memes-relax.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+use in-memory modules if REDIS_URL unset

--- a/packages/core/utils/src/common/__tests__/define-config.spec.ts
+++ b/packages/core/utils/src/common/__tests__/define-config.spec.ts
@@ -1332,6 +1332,200 @@ describe("defineConfig", function () {
     `)
   })
 
+  it("should use inmemory modules in cloud environment if REDIS_URL is not set", function () {
+    const originalEnv = { ...process.env }
+
+    process.env.EXECUTION_CONTEXT = "medusa-cloud"
+    delete process.env.REDIS_URL
+    delete process.env.CACHE_REDIS_URL
+    process.env.S3_FILE_URL = "https://s3.amazonaws.com/medusa-cloud-test"
+    process.env.S3_PREFIX = "test"
+    process.env.S3_REGION = "us-east-1"
+    process.env.S3_BUCKET = "medusa-cloud-test"
+    process.env.S3_ENDPOINT = "https://s3.amazonaws.com"
+    const res = defineConfig({})
+
+    process.env = { ...originalEnv }
+
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "admin": {
+          "backendUrl": "/",
+          "maxUploadFileSize": 1048576,
+          "path": "/app",
+        },
+        "featureFlags": {},
+        "logger": undefined,
+        "modules": {
+          "api_key": {
+            "resolve": "@medusajs/medusa/api-key",
+          },
+          "auth": {
+            "options": {
+              "providers": [
+                {
+                  "id": "emailpass",
+                  "resolve": "@medusajs/medusa/auth-emailpass",
+                },
+              ],
+            },
+            "resolve": "@medusajs/medusa/auth",
+          },
+          "cache": {
+            "resolve": "@medusajs/medusa/cache-inmemory",
+          },
+          "cart": {
+            "resolve": "@medusajs/medusa/cart",
+          },
+          "currency": {
+            "resolve": "@medusajs/medusa/currency",
+          },
+          "customer": {
+            "resolve": "@medusajs/medusa/customer",
+          },
+          "event_bus": {
+            "resolve": "@medusajs/medusa/event-bus-local",
+          },
+          "file": {
+            "options": {
+              "providers": [
+                {
+                  "id": "s3",
+                  "options": {
+                    "authentication_method": "s3-iam-role",
+                    "bucket": "medusa-cloud-test",
+                    "endpoint": "https://s3.amazonaws.com",
+                    "file_url": "https://s3.amazonaws.com/medusa-cloud-test",
+                    "prefix": "test",
+                    "region": "us-east-1",
+                  },
+                  "resolve": "@medusajs/medusa/file-s3",
+                },
+              ],
+            },
+            "resolve": "@medusajs/medusa/file",
+          },
+          "fulfillment": {
+            "options": {
+              "providers": [
+                {
+                  "id": "manual",
+                  "resolve": "@medusajs/medusa/fulfillment-manual",
+                },
+              ],
+            },
+            "resolve": "@medusajs/medusa/fulfillment",
+          },
+          "inventory": {
+            "resolve": "@medusajs/medusa/inventory",
+          },
+          "locking": {
+            "resolve": "@medusajs/medusa/locking",
+          },
+          "notification": {
+            "options": {
+              "providers": [
+                {
+                  "id": "local",
+                  "options": {
+                    "channels": [
+                      "feed",
+                    ],
+                    "name": "Local Notification Provider",
+                  },
+                  "resolve": "@medusajs/medusa/notification-local",
+                },
+              ],
+            },
+            "resolve": "@medusajs/medusa/notification",
+          },
+          "order": {
+            "resolve": "@medusajs/medusa/order",
+          },
+          "payment": {
+            "resolve": "@medusajs/medusa/payment",
+          },
+          "pricing": {
+            "resolve": "@medusajs/medusa/pricing",
+          },
+          "product": {
+            "resolve": "@medusajs/medusa/product",
+          },
+          "promotion": {
+            "resolve": "@medusajs/medusa/promotion",
+          },
+          "rbac": {
+            "disable": true,
+            "resolve": "@medusajs/medusa/rbac",
+          },
+          "region": {
+            "resolve": "@medusajs/medusa/region",
+          },
+          "sales_channel": {
+            "resolve": "@medusajs/medusa/sales-channel",
+          },
+          "settings": {
+            "resolve": "@medusajs/medusa/settings",
+          },
+          "stock_location": {
+            "resolve": "@medusajs/medusa/stock-location",
+          },
+          "store": {
+            "resolve": "@medusajs/medusa/store",
+          },
+          "tax": {
+            "resolve": "@medusajs/medusa/tax",
+          },
+          "translation": {
+            "disable": true,
+            "resolve": "@medusajs/medusa/translation",
+          },
+          "user": {
+            "options": {
+              "jwt_options": undefined,
+              "jwt_public_key": undefined,
+              "jwt_secret": "supersecret",
+              "jwt_verify_options": undefined,
+            },
+            "resolve": "@medusajs/medusa/user",
+          },
+          "workflows": {
+            "resolve": "@medusajs/medusa/workflow-engine-inmemory",
+          },
+        },
+        "plugins": [
+          {
+            "options": {},
+            "resolve": "@medusajs/draft-order",
+          },
+        ],
+        "projectConfig": {
+          "databaseUrl": "postgres://localhost/medusa-starter-default",
+          "http": {
+            "adminCors": "http://localhost:7000,http://localhost:7001,http://localhost:5173",
+            "authCors": "http://localhost:7000,http://localhost:7001,http://localhost:5173",
+            "cookieSecret": "supersecret",
+            "jwtPublicKey": undefined,
+            "jwtSecret": "supersecret",
+            "restrictedFields": {
+              "store": [
+                ${DEFAULT_STORE_RESTRICTED_FIELDS.map((v) => `"${v}"`).join(
+                  ",\n                "
+                )},
+              ],
+            },
+            "storeCors": "http://localhost:8000",
+          },
+          "redisOptions": {
+            "retryStrategy": [Function],
+          },
+          "redisUrl": undefined,
+          "sessionOptions": {},
+        },
+      }
+    `)
+  })
+
   it("should include cloud-based config with dynamo db", function () {
     const originalEnv = { ...process.env }
 

--- a/packages/core/utils/src/common/define-config.ts
+++ b/packages/core/utils/src/common/define-config.ts
@@ -273,40 +273,8 @@ function resolveModules(
     },
   ]
 
-  const cloudModules = [
+  const cloudModules: InputConfig["modules"] = [
     ...sharedModules,
-    {
-      resolve: TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.WORKFLOW_ENGINE],
-      options: {
-        redis: { url: process.env.REDIS_URL },
-      },
-    },
-    {
-      resolve: TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.CACHE],
-      options: { redisUrl: process.env.REDIS_URL },
-    },
-    {
-      resolve: TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.EVENT_BUS],
-      options: {
-        redisUrl: process.env.REDIS_URL,
-        workerOptions: { concurrency: 1 },
-      },
-    },
-    {
-      resolve: MODULE_PACKAGE_NAMES[Modules.LOCKING],
-      options: {
-        providers: [
-          {
-            id: "locking-redis",
-            resolve: TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.LOCKING],
-            is_default: true,
-            options: {
-              redisUrl: process.env.REDIS_URL,
-            },
-          },
-        ],
-      },
-    },
     {
       resolve: MODULE_PACKAGE_NAMES[Modules.FILE],
       options: {
@@ -327,6 +295,55 @@ function resolveModules(
       },
     },
   ]
+
+  if (process.env.REDIS_URL) {
+    cloudModules.push(
+      ...[
+        {
+          resolve:
+            TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.WORKFLOW_ENGINE],
+          options: {
+            redis: { url: process.env.REDIS_URL },
+          },
+        },
+        {
+          resolve: TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.CACHE],
+          options: { redisUrl: process.env.REDIS_URL },
+        },
+        {
+          resolve: TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.EVENT_BUS],
+          options: {
+            redisUrl: process.env.REDIS_URL,
+            workerOptions: { concurrency: 1 },
+          },
+        },
+        {
+          resolve: MODULE_PACKAGE_NAMES[Modules.LOCKING],
+          options: {
+            providers: [
+              {
+                id: "locking-redis",
+                resolve: TEMPORARY_REDIS_MODULE_PACKAGE_NAMES[Modules.LOCKING],
+                is_default: true,
+                options: {
+                  redisUrl: process.env.REDIS_URL,
+                },
+              },
+            ],
+          },
+        },
+      ]
+    )
+  } else {
+    cloudModules.push(
+      ...[
+        { resolve: MODULE_PACKAGE_NAMES[Modules.CACHE] },
+        { resolve: MODULE_PACKAGE_NAMES[Modules.EVENT_BUS] },
+        { resolve: MODULE_PACKAGE_NAMES[Modules.WORKFLOW_ENGINE] },
+        { resolve: MODULE_PACKAGE_NAMES[Modules.LOCKING] },
+      ]
+    )
+  }
 
   if (process.env.CACHE_REDIS_URL) {
     cloudModules.push({


### PR DESCRIPTION
## Summary

**What**

Use in-memory modules if REDIS_URL unset in Cloud

**Why**

For the new Developer plan

**How**

Fallback to default in-memory modules

**Testing**

Unit tests

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable
