### PR TITLE
fix(core-flows): ensure full pricing context when adding items to draft order

### DIFF
--- a/.changeset/eight-banks-nail.md
+++ b/.changeset/eight-banks-nail.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): ensure full pricing context when adding items to draft order

--- a/integration-tests/http/__tests__/draft-order/admin/draft-order.spec.ts
+++ b/integration-tests/http/__tests__/draft-order/admin/draft-order.spec.ts
@@ -3,6 +3,8 @@ import { HttpTypes } from "@medusajs/types"
 import {
   ApiKeyType,
   ModuleRegistrationName,
+  PriceListStatus,
+  PriceListType,
   ProductStatus,
   PromotionStatus,
   PromotionType,
@@ -776,7 +778,8 @@ medusaIntegrationTestRunner({
 
         // Remove item
         await api.post(
-          `/admin/draft-orders/${testDraftOrder.id}/edit/items/item/${edit.items.find((i) => i.subtitle === "M shirt").id
+          `/admin/draft-orders/${testDraftOrder.id}/edit/items/item/${
+            edit.items.find((i) => i.subtitle === "M shirt").id
           }`,
           { quantity: 0 },
           adminHeaders
@@ -784,7 +787,8 @@ medusaIntegrationTestRunner({
 
         // Update item
         await api.post(
-          `/admin/draft-orders/${testDraftOrder.id}/edit/items/item/${edit.items.find((i) => i.subtitle === "L shirt").id
+          `/admin/draft-orders/${testDraftOrder.id}/edit/items/item/${
+            edit.items.find((i) => i.subtitle === "L shirt").id
           }`,
           { quantity: 2 },
           adminHeaders
@@ -1383,10 +1387,12 @@ medusaIntegrationTestRunner({
         ).data.draft_order_preview
 
         const response = await api.delete(
-          `/admin/draft-orders/${testDraftOrder.id
-          }/edit/shipping-methods/method/${edit.shipping_methods.find(
-            (sm) => sm.shipping_option_id === shippingOptionHeavy.id
-          ).id
+          `/admin/draft-orders/${
+            testDraftOrder.id
+          }/edit/shipping-methods/method/${
+            edit.shipping_methods.find(
+              (sm) => sm.shipping_option_id === shippingOptionHeavy.id
+            ).id
           }`,
           adminHeaders
         )
@@ -1437,6 +1443,164 @@ medusaIntegrationTestRunner({
               }),
             ]),
           })
+        )
+      })
+    })
+
+    describe("POST /draft-orders/:id/edit/items", () => {
+      let customer
+      let customerGroup
+      let draftOrder
+      let product
+
+      beforeEach(async () => {
+        const inventoryItem = (
+          await api.post(
+            `/admin/inventory-items`,
+            { sku: "shirt" },
+            adminHeaders
+          )
+        ).data.inventory_item
+
+        await api.post(
+          `/admin/inventory-items/${inventoryItem.id}/location-levels`,
+          {
+            location_id: stockLocation.id,
+            stocked_quantity: 10,
+          },
+          adminHeaders
+        )
+
+        product = (
+          await api.post(
+            "/admin/products",
+            {
+              title: "Shirt",
+              status: ProductStatus.PUBLISHED,
+              options: [{ title: "size", values: ["large"] }],
+              variants: [
+                {
+                  title: "L shirt",
+                  options: { size: "large" },
+                  manage_inventory: true,
+                  inventory_items: [
+                    {
+                      inventory_item_id: inventoryItem.id,
+                      required_quantity: 1,
+                    },
+                  ],
+                  prices: [
+                    {
+                      currency_code: "usd",
+                      amount: 10,
+                    },
+                  ],
+                },
+              ],
+            },
+            adminHeaders
+          )
+        ).data.product
+
+        customer = (
+          await api.post(
+            "/admin/customers",
+            {
+              first_name: "Tony",
+              last_name: "Stark",
+              email: "tony@stark-industries.com",
+            },
+            adminHeaders
+          )
+        ).data.customer
+
+        customerGroup = (
+          await api.post(
+            "/admin/customer-groups",
+            { name: "VIP" },
+            adminHeaders
+          )
+        ).data.customer_group
+
+        await api.post(
+          `/admin/customer-groups/${customerGroup.id}/customers`,
+          { add: [customer.id] },
+          adminHeaders
+        )
+
+        await api.post(
+          `/admin/price-lists`,
+          {
+            title: "VIP price list",
+            description: "test",
+            status: PriceListStatus.ACTIVE,
+            type: PriceListType.SALE,
+            prices: [
+              {
+                amount: 2,
+                currency_code: "usd",
+                variant_id: product.variants[0].id,
+              },
+            ],
+            rules: {
+              "customer.groups.id": [customerGroup.id],
+            },
+          },
+          adminHeaders
+        )
+
+        draftOrder = (
+          await api.post(
+            "/admin/draft-orders",
+            {
+              customer_id: customer.id,
+              region_id: region.id,
+              sales_channel_id: salesChannel.id,
+              shipping_address: {
+                address_1: "123 Main St",
+                city: "Anytown",
+                country_code: "US",
+                postal_code: "12345",
+                first_name: "Tony",
+              },
+            },
+            adminHeaders
+          )
+        ).data.draft_order
+      })
+
+      it("should apply price from price list associated to a customer group when customer rules match", async () => {
+        await api.post(
+          `/admin/draft-orders/${draftOrder.id}/edit`,
+          {},
+          adminHeaders
+        )
+
+        const response = await api.post(
+          `/admin/draft-orders/${draftOrder.id}/edit/items`,
+          {
+            items: [
+              {
+                variant_id: product.variants[0].id,
+                quantity: 1,
+              },
+            ],
+          },
+          adminHeaders
+        )
+
+        const preview = response.data.draft_order_preview
+
+        expect(response.status).toBe(200)
+        expect(preview.items).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              variant_id: product.variants[0].id,
+              unit_price: 2,
+              compare_at_unit_price: 10,
+              quantity: 1,
+            }),
+          ])
         )
       })
     })

--- a/packages/core/core-flows/src/cart/utils/fields.ts
+++ b/packages/core/core-flows/src/cart/utils/fields.ts
@@ -1,4 +1,7 @@
 // Always ensure that cartFieldsForPricingContext is present in cartFieldsForRefreshSteps
+
+import { fieldsForPricingContext } from "../../common/utils/fields"
+
 // Always ensure that cartFieldsForCalculateShippingOptionsPrices is present in cartFieldsForRefreshSteps
 export const cartFieldsForRefreshSteps = [
   "id",
@@ -134,22 +137,7 @@ export const completeCartFields = [
   "items.variant.inventory_items.inventory.location_levels.stock_locations.sales_channels.name",
 ]
 
-export const cartFieldsForPricingContext = [
-  "id",
-  "sales_channel_id",
-  "currency_code",
-  "region_id",
-  "shipping_address.city",
-  "shipping_address.country_code",
-  "shipping_address.province",
-  "shipping_address.postal_code",
-  "item_total",
-  "total",
-  "locale",
-  "customer.id",
-  "email",
-  "customer.groups.id",
-]
+export const cartFieldsForPricingContext = [...fieldsForPricingContext]
 
 export const productVariantsFields = [
   "id",

--- a/packages/core/core-flows/src/common/utils/fields.ts
+++ b/packages/core/core-flows/src/common/utils/fields.ts
@@ -1,0 +1,16 @@
+export const fieldsForPricingContext = [
+  "id",
+  "sales_channel_id",
+  "currency_code",
+  "region_id",
+  "shipping_address.city",
+  "shipping_address.country_code",
+  "shipping_address.province",
+  "shipping_address.postal_code",
+  "item_total",
+  "total",
+  "locale",
+  "customer.id",
+  "email",
+  "customer.groups.id",
+]

--- a/packages/core/core-flows/src/order/workflows/add-line-items.ts
+++ b/packages/core/core-flows/src/order/workflows/add-line-items.ts
@@ -24,6 +24,7 @@ import { getVariantsAndItemsWithPrices } from "../../cart/workflows/get-variants
 import { getTranslatedLineItemsStep, useQueryGraphStep } from "../../common"
 import { createOrderLineItemsStep } from "../steps"
 import { productVariantsFields } from "../utils/fields"
+import { fieldsForPricingContext } from "../../common/utils/fields"
 
 /**
  * The created order line items.
@@ -101,15 +102,7 @@ export const addOrderLineItemsWorkflow = createWorkflow(
     const { data: order } = useQueryGraphStep({
       entity: "order",
       filters: { id: input.order_id },
-      fields: [
-        "id",
-        "sales_channel_id",
-        "region_id",
-        "customer_id",
-        "email",
-        "currency_code",
-        "locale",
-      ],
+      fields: [...fieldsForPricingContext],
       options: { throwIfKeyNotFound: true, isList: false },
     }).config({ name: "order-query" })
 
@@ -127,7 +120,7 @@ export const addOrderLineItemsWorkflow = createWorkflow(
         regionId: order.region_id,
       }),
       findOrCreateCustomerStep({
-        customerId: order.customer_id,
+        customerId: order.customer?.id,
         email: order.email,
       })
     )


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Ensure the complete price context is passed when adding items to draft orders the same way we do when adding items to a cart.

**Why** — Why are these changes relevant or necessary?  

Not passing the full context will make price rules targeting properties not present in said context to not execute.

**How** — How have these changes been implemented?

Pass the same fields for the pricing context when adding items to draft orders in the same way we do for the analog operation in carts.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

closes CORE-1395