### PR TITLE
chore: fix example in tsdocs of translations js sdk

### DIFF
--- a/packages/core/js-sdk/src/admin/translation.ts
+++ b/packages/core/js-sdk/src/admin/translation.ts
@@ -214,7 +214,6 @@ export class Translation {
    * .then(({ created, updated, deleted }) => {
    *   console.log(created, updated, deleted)
    * })
-   * ```
    */
   async batchSettings(
     body: HttpTypes.AdminBatchTranslationSettings,


### PR DESCRIPTION
Remove backticks from tsdoc comment in translations