### PR TITLE
fix: use exponential backoff in Redis lock acquisition retries

### DIFF
--- a/.changeset/thirty-months-draw.md
+++ b/.changeset/thirty-months-draw.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/locking-redis": patch
+---
+
+use exponential factor in Redis lock acquisition retries

--- a/packages/modules/providers/locking-redis/src/services/redis-lock.ts
+++ b/packages/modules/providers/locking-redis/src/services/redis-lock.ts
@@ -18,8 +18,9 @@ export class RedisLockingProvider implements ILockingProvider {
   }
   protected keyNamePrefix: string
   protected waitLockingTimeout: number = 5
-  protected defaultRetryInterval: number = 5
-  protected maximumRetryInterval: number = 200
+  protected defaultRetryInterval: number = 20
+  protected maximumRetryInterval: number = 1000
+  protected backoffFactor: number = 2
 
   constructor({ redisClient, prefix }, options: RedisCacheModuleOptions) {
     this.redisClient = redisClient
@@ -35,6 +36,10 @@ export class RedisLockingProvider implements ILockingProvider {
 
     if (!isNaN(+options?.maximumRetryInterval!)) {
       this.maximumRetryInterval = +options.maximumRetryInterval!
+    }
+
+    if (!isNaN(+options?.backoffFactor!)) {
+      this.backoffFactor = +options.backoffFactor!
     }
 
     // Define the custom command for acquiring locks
@@ -160,7 +165,7 @@ export class RedisLockingProvider implements ILockingProvider {
 
     const timeout = Math.max(args?.expire ?? this.waitLockingTimeout, 1)
     const timeoutSeconds = Number.isNaN(timeout) ? 1 : timeout
-    let retryTimes = 0
+    let retryDelay = this.defaultRetryInterval
 
     const ownerId = args?.ownerId ?? "*"
     const awaitQueue = args?.awaitQueue ?? false
@@ -186,15 +191,13 @@ export class RedisLockingProvider implements ILockingProvider {
             break
           } else {
             if (awaitQueue) {
-              // Wait for a short period before retrying
-              await setTimeout(
-                Math.min(
-                  this.defaultRetryInterval +
-                    (retryTimes / 10) * this.defaultRetryInterval,
-                  this.maximumRetryInterval
-                )
+              // Wait before retrying with exponential backoff
+              await setTimeout(retryDelay)
+
+              retryDelay = Math.min(
+                retryDelay * this.backoffFactor,
+                this.maximumRetryInterval
               )
-              retryTimes++
             } else {
               throw new Error(errMessage)
             }

--- a/packages/modules/providers/locking-redis/src/types/index.ts
+++ b/packages/modules/providers/locking-redis/src/types/index.ts
@@ -33,13 +33,19 @@ export type RedisCacheModuleOptions = {
 
   /**
    * Default retry interval (in milliseconds)
-   * @default 5
+   * @default 20
    */
   defaultRetryInterval?: number
 
   /**
    * Maximum retry interval (in milliseconds)
-   * @default 200
+   * @default 1000
    */
   maximumRetryInterval?: number
+
+  /**
+   * Backoff factor for retries
+   * @default 2
+   */
+  backoffFactor?: number
 }


### PR DESCRIPTION
## Summary

**What**

Use exponential backoff instead of linear when retrying acquisition of Redis locks

**Why**

In the current linear backoff, with 1/10 coefficient, the retry delay grows very slowly. With default settings, it goes like `5ms, 5.5ms , 6ms, 6.5ms...`. Since each retry executes a Lua script, this creates CPU contention in Redis, affecting other operations outside of locking, often reaching minutes to complete.

See this trace e.g., showing how frequent the retries are:
<img width="2840" height="1266" alt="image" src="https://github.com/user-attachments/assets/d0ac591e-2185-4836-8175-b1ac6f6ac5d2" />

**How**

Using an exponential backoff instead of linear, and increasing the base delay a bit too.

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---
