### PR TITLE
Update import path for DeliveryStatus in delivery.ts

### DIFF
--- a/www/apps/resources/app/recipes/marketplace/examples/restaurant-delivery/page.mdx
+++ b/www/apps/resources/app/recipes/marketplace/examples/restaurant-delivery/page.mdx
@@ -267,7 +267,7 @@ Create the file `src/modules/delivery/models/delivery.ts` with the following con
 
 ```ts title="src/modules/delivery/models/delivery.ts"
 import { model } from "@medusajs/framework/utils"
-import { DeliveryStatus } from "../types/common"
+import { DeliveryStatus } from "../types"
 import { Driver } from "./driver"
 
 export const Delivery = model.define("delivery", {


### PR DESCRIPTION
Fix: Directory mismatch

## Summary
A small mismatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects a TypeScript import path; no runtime code paths are affected.
> 
> **Overview**
> Updates the restaurant-delivery marketplace recipe to import `DeliveryStatus` from `../types` (instead of `../types/common`) in the `src/modules/delivery/models/delivery.ts` snippet, fixing a directory mismatch in the example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67c0e8ab6090487b82baae621fd82416fff86756. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->