### PR TITLE
Fix product list crash with orphaned sales channel references

### DIFF
--- a/.changeset/fix-product-list-null-sales-channel.md
+++ b/.changeset/fix-product-list-null-sales-channel.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(@medusajs/dashboard): handle null sales channel entries in product list and detail views

--- a/packages/admin/dashboard/src/components/table/table-cells/product/sales-channels-cell/sales-channels-cell.tsx
+++ b/packages/admin/dashboard/src/components/table/table-cells/product/sales-channels-cell/sales-channels-cell.tsx
@@ -13,8 +13,6 @@ export const SalesChannelsCell = ({
 }: SalesChannelsCellProps) => {
   const { t } = useTranslation()
 
-  // Filter out null/undefined entries that can occur when a sales channel
-  // is deleted but the product association is not cleaned up
   const validChannels = salesChannels?.filter(
     (sc): sc is SalesChannelDTO => sc != null
   )

--- a/packages/admin/dashboard/src/routes/products/product-detail/components/product-sales-channel-section/product-sales-channel-section.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-detail/components/product-sales-channel-section/product-sales-channel-section.tsx
@@ -20,7 +20,7 @@ export const ProductSalesChannelSection = ({
   // is deleted but the product association is not cleaned up
   const availableInSalesChannels =
     product.sales_channels
-      ?.filter((sc) => sc != null)
+      ?.filter((sc): sc is HttpTypes.AdminProductSalesChannel => sc != null)
       .map((sc) => ({
         id: sc.id,
         name: sc.name,


### PR DESCRIPTION
Fixes #14945

## Summary

**What** — Filters out null/orphaned sales channel entries in the product list table and product detail views.

**Why** — When a sales channel is deleted without cleaning up the product-to-sales-channel join table, the API returns `null` entries in `product.sales_channels`. The dashboard crashes with `TypeError: Cannot read properties of null (reading 'name')` when rendering these entries.

**How** — Replaced unguarded `.map()` calls with a type-safe filter predicate that narrows `(SalesChannelDTO | null)[]` to `SalesChannelDTO[]` before accessing `.name` or `.id`. Applied in both `SalesChannelsCell` (product list table) and `ProductSalesChannelSection` (product detail page).

**Testing** — To reproduce:
1. Create a product and assign it to a sales channel
2. Delete the sales channel directly from the database (or via API) without removing the join-table entry
3. Navigate to the product list — the page crashes
4. With this fix, the product list renders normally, skipping the orphaned channel references. Tooltip counts and "available in X of Y" text reflect only valid channels.

---

## Checklist

- [x] Added a changeset (`yarn changeset` — `@medusajs/dashboard` patch)
- [x] Verified locally that the product list and detail views render without crash
- [x] Linked related issue (#14945)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk UI robustness change that filters out `null` sales channel entries to prevent runtime crashes when orphaned associations are returned by the API.
> 
> **Overview**
> Prevents product list/detail rendering crashes when `product.sales_channels` contains orphaned `null` entries by filtering them out with type-guard predicates before mapping/printing channel `name`/`id`.
> 
> Adds a patch changeset for `@medusajs/dashboard` to release the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d71df85411664271230b19ea4ef407757e47ce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->