### PR TITLE
test: add test case to reproduce URL encoding inconsistency bug (#14957)

### DIFF
--- a/packages/modules/providers/file-s3/src/__tests__/issue-14957-url-encoding-bug-reproduction.test.ts
+++ b/packages/modules/providers/file-s3/src/__tests__/issue-14957-url-encoding-bug-reproduction.test.ts
@@ -1,0 +1,99 @@
+/**
+ * ISSUE #14957: Inconsistent URL Encoding Bug Reproduction
+ *
+ * BUG: S3FileService constructs file URLs inconsistently:
+ * 1. upload() uses encodeURIComponent(fileKey) - encodes '/' as '%2F'
+ * 2. getUploadStream() uses NO encoding - leaves spaces raw
+ *
+ * EXPECTED: Both methods should encode path segments separately, preserving '/' separators
+ *
+ * REPRODUCTION: Upload a file with spaces in name and a prefix containing '/'
+ */
+
+import { S3FileService } from "../services/s3-file"
+
+// Mock the S3 client
+const mockSend = jest.fn()
+jest.mock("@aws-sdk/client-s3", () => {
+  const originalModule = jest.requireActual("@aws-sdk/client-s3")
+  return {
+    ...originalModule,
+    S3Client: jest.fn().mockImplementation(() => ({
+      send: mockSend,
+    })),
+  }
+})
+
+// Mock @aws-sdk/lib-storage Upload
+jest.mock("@aws-sdk/lib-storage", () => {
+  return {
+    Upload: jest.fn().mockImplementation(() => ({
+      done: jest.fn().mockResolvedValue({
+        url: "https://test.s3.amazonaws.com/test-key",
+        key: "test-key",
+      }),
+    })),
+  }
+})
+
+describe("ISSUE #14957: Inconsistent URL Encoding", () => {
+  const mockLogger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }
+
+  const s3Service = new S3FileService(
+    { logger: mockLogger as any },
+    {
+      file_url: "https://cdn.example.com",
+      access_key_id: "test-key",
+      secret_access_key: "test-secret",
+      region: "us-east-1",
+      bucket: "test-bucket",
+      prefix: "uploads/products/", // Prefix contains '/' - key to reproducing the bug
+    }
+  )
+
+  beforeEach(() => {
+    mockSend.mockClear()
+  })
+
+  it("should reproduce ISSUE #14957: inconsistent URL encoding between upload() and getUploadStream()", async () => {
+    // Arrange
+    mockSend.mockResolvedValueOnce({
+      $metadata: { httpStatusCode: 200 },
+    })
+    const filename = "my product.jpg" // Contains space to trigger encoding bugs
+
+    // Act: Use both methods with identical configuration
+    const uploadResult = await s3Service.upload({
+      filename,
+      mimeType: "image/jpeg",
+      content: "test",
+      access: "public",
+    })
+
+    const streamResult = await s3Service.getUploadStream({
+      filename,
+      mimeType: "image/jpeg",
+      access: "public",
+    })
+
+    // Assert: Verify the inconsistency bug
+    console.log("── ISSUE #14957: URL Encoding Inconsistency ──")
+    console.log("upload() URL:         ", uploadResult.url)
+    console.log("getUploadStream() URL:", streamResult.url)
+    console.log("─────────────────────────────────────────────")
+
+    // BUG #1: upload() uses encodeURIComponent() which encodes '/' as '%2F'
+    expect(uploadResult.url).toContain("%2F")
+
+    // BUG #2: getUploadStream() uses NO encoding, leaving spaces raw
+    expect(streamResult.url).toContain(" ")
+
+    // BUG #3: Inconsistency - two different encoding schemes for the same file
+    expect(uploadResult.url).not.toEqual(streamResult.url)
+  })
+})


### PR DESCRIPTION
## Summary
**What** — Add test case to reproduce the inconsistent URL encoding bug between `upload()` and `getUploadStream()` methods in `S3FileService`.

**Why** — The two methods use different URL encoding strategies:
- `upload()` uses `encodeURIComponent(fileKey)` which encodes `/` as `%2F`, creating broken links
- `getUploadStream()` uses no encoding, leaving special characters (like spaces) unencoded, creating invalid URLs

This inconsistency causes different URL formats for the same file and breaks functionality depending on which method is used.

**How** — Added a unit test `issue-14957-url-encoding-bug-reproduction.test.ts` that calls both methods with identical input (filename with spaces, prefix with `/`) and asserts that:
1. `upload()` URL contains `%2F` (proves over-encoding)
2. `getUploadStream()` URL contains raw spaces (proves no encoding)
3. The two URLs are not equal (proves inconsistency)

**Testing** — Run the test to verify the bug is reproduced:

```bash
cd packages/modules/providers/file-s3
npm test -- issue-14957-url-encoding-bug-reproduction
```

---

## Examples
The test demonstrates the inconsistency:

```typescript
const s3Service = new S3FileService(
  { logger: mockLogger },
  {
    file_url: "https://cdn.example.com",
    prefix: "uploads/products/",  // Contains '/'
    // ... other config
  }
)

const filename = "my product.jpg"  // Contains space

const uploadResult = await s3Service.upload({ filename, /* ... */ })
const streamResult = await s3Service.getUploadStream({ filename, /* ... */ })

// BUG: Two different URL formats for the same file
uploadResult.url   // https://cdn.example.com/uploads%2Fproducts%2Fmy%20product.jpg
streamResult.url   // https://cdn.example.com/uploads/products/my product.jpg
```

---

## Additional Context

**Suggested Fix**: Add a private helper method that encodes path segments while preserving separators:

```typescript
private buildFileUrl_(fileKey: string): string {
  const encoded = fileKey
    .split("/")
    .map((segment) => encodeURIComponent(segment))
    .join("/");
  return `${this.config_.fileUrl}/${encoded}`;
}
```

This would produce a correctly encoded URL: `https://cdn.example.com/uploads/products/my%20product.jpg`

**Related Issue**: #14957

---

Would you like me to submit a separate PR with the fix for this issue?