### PR TITLE
test: add test case to reproduce REDIS_URL config inconsistency bug (#14962)

### DIFF
--- a/packages/core/utils/src/common/__tests__/define-config.issue-14962.spec.ts
+++ b/packages/core/utils/src/common/__tests__/define-config.issue-14962.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Issue #14962: REDIS_URL missing from medusa_config.ts
+ *
+ * Bug Report Summary:
+ * The CLI adds REDIS_URL to the .env file when creating a new project,
+ * but the defineConfig() function does not automatically include redisUrl
+ * from process.env.REDIS_URL in non-cloud mode.
+ *
+ * This creates an inconsistency:
+ * - .env contains: REDIS_URL=redis://localhost:6379
+ * - medusa-config.ts does NOT contain: redisUrl: process.env.REDIS_URL
+ *
+ * Expected behavior: Either defineConfig() should automatically read REDIS_URL
+ * OR the CLI should not add REDIS_URL to .env
+ */
+
+import { defineConfig } from "../define-config"
+
+describe("Issue #14962: REDIS_URL missing from medusa_config.ts", () => {
+  let originalExecContext: string | undefined
+  let originalRedisUrl: string | undefined
+
+  beforeEach(() => {
+    originalExecContext = process.env.EXECUTION_CONTEXT
+    originalRedisUrl = process.env.REDIS_URL
+    delete process.env.EXECUTION_CONTEXT
+  })
+
+  afterEach(() => {
+    if (originalExecContext === undefined) {
+      delete process.env.EXECUTION_CONTEXT
+    } else {
+      process.env.EXECUTION_CONTEXT = originalExecContext
+    }
+
+    if (originalRedisUrl === undefined) {
+      delete process.env.REDIS_URL
+    } else {
+      process.env.REDIS_URL = originalRedisUrl
+    }
+  })
+
+  it("should demonstrate BUG: defineConfig does not automatically add redisUrl from REDIS_URL in non-cloud mode", () => {
+    // Setup: This simulates what the CLI does in prepare-project.ts line 188
+    // The CLI adds REDIS_URL to the .env file
+    process.env.REDIS_URL = "redis://localhost:6379"
+
+    // Reproduce: Call defineConfig() WITHOUT explicitly passing redisUrl
+    // This simulates the default medusa-config.ts template that users get
+    const config = defineConfig({
+      projectConfig: {
+        databaseUrl: "postgres://localhost/medusa",
+        http: {
+          storeCors: "http://localhost:8000",
+          adminCors: "http://localhost:7000",
+          authCors: "http://localhost:7000",
+          jwtSecret: "supersecret",
+          cookieSecret: "supersecret",
+        },
+      },
+    })
+
+    // BUG: Even though REDIS_URL is set in the environment,
+    // defineConfig() does NOT automatically add redisUrl to the config
+    // This creates an inconsistency with the .env file
+    expect(config.projectConfig.redisUrl).toBeUndefined()
+
+    // After the bug is fixed, this assertion should pass instead:
+    // expect(config.projectConfig.redisUrl).toBe("redis://localhost:6379")
+  })
+})


### PR DESCRIPTION
## Summary
**What** — Add test case to reproduce the inconsistency between CLI behavior and `defineConfig()` regarding `REDIS_URL`.

**Why** — The CLI adds `REDIS_URL` to the `.env` file when creating a new project, but the `defineConfig()` function does not automatically read `REDIS_URL` in non-cloud mode. This creates confusion as users expect the configuration to work automatically.

**How** — Added a unit test `define-config.issue-14962.spec.ts` that simulates the default `medusa-config.ts` template with `REDIS_URL` set in the environment, and verifies that `redisUrl` remains `undefined` in the config.

**Testing** — Run the test to verify the bug:

\`\`\`bash
cd packages/core/utils
npx jest src/common/__tests__/define-config.issue-14962.spec.ts
\`\`\`

---

## Root Cause

The issue is in `packages/core/utils/src/common/define-config.ts:417`:

\`\`\`typescript
...(isCloud ? { redisUrl: process.env.REDIS_URL } : {}),
\`\`\`

The `REDIS_URL` is only read when `isCloud` is true. For regular projects, it's ignored.

---

## Suggested Fix

**Option A**: Make `defineConfig()` always read `REDIS_URL` (recommended)

\`\`\`typescript
redisUrl: process.env.REDIS_URL,
\`\`\`

**Option B**: Remove `REDIS_URL` from CLI's `.env` template

---

**Related Issue**: #14962

---

Would you like me to submit a separate PR with the fix for this issue?