### PR TITLE
fix(core-flows): keep payment authorization on order edit for partial capture

### DIFF
--- a/packages/core/core-flows/src/order/workflows/create-or-update-order-payment-collection.ts
+++ b/packages/core/core-flows/src/order/workflows/create-or-update-order-payment-collection.ts
@@ -84,15 +84,12 @@ export const createOrUpdateOrderPaymentCollectionWorkflow = createWorkflow(
 
     const { data: existingPaymentCollection } = useQueryGraphStep({
       entity: "payment_collection",
-      fields: ["id", "status"],
+      fields: ["id", "status", "amount"],
       filters: {
         id: orderPaymentCollectionIds,
         status: [
           PaymentCollectionStatus.NOT_PAID,
           PaymentCollectionStatus.AWAITING,
-          // Keep authorized collections alive for partial capture instead of
-          // canceling them. Most payment providers (Stripe, Adyen, etc.)
-          // support capturing an amount ≤ the authorized amount.
           PaymentCollectionStatus.AUTHORIZED,
           PaymentCollectionStatus.PARTIALLY_AUTHORIZED,
         ],
@@ -100,12 +97,34 @@ export const createOrUpdateOrderPaymentCollectionWorkflow = createWorkflow(
       options: { isList: false },
     }).config({ name: "payment-collection-query" })
 
-    // Authorized collections are updated in place (amount change only).
-    // At capture time, the merchant captures the new amount and the
-    // provider releases the remaining hold automatically (partial capture).
+    // Determine whether to cancel+recreate or update in place.
+    //
+    // AUTHORIZED + amount decreased/same: keep the authorization alive
+    // for partial capture. Most providers (Stripe, Adyen, PayPal) support
+    // capturing an amount ≤ the authorized amount.
+    //
+    // AUTHORIZED + amount increased: must cancel and recreate since
+    // providers can't capture more than the authorized amount.
+    //
+    // PARTIALLY_AUTHORIZED: intermediate state — always recreate.
     const shouldRecreate = transform(
-      { existingPaymentCollection },
-      ({ existingPaymentCollection }) => false
+      { existingPaymentCollection, amountPending },
+      ({ existingPaymentCollection, amountPending }) => {
+        if (!existingPaymentCollection) return false
+
+        const status = existingPaymentCollection.status
+
+        if (status === PaymentCollectionStatus.PARTIALLY_AUTHORIZED) {
+          return true
+        }
+
+        if (status === PaymentCollectionStatus.AUTHORIZED) {
+          const authorizedAmount = existingPaymentCollection.amount ?? 0
+          return MathBN.gt(amountPending, authorizedAmount)
+        }
+
+        return false
+      }
     )
 
     const amountPending = transform({ order, input }, ({ order, input }) => {

--- a/packages/core/core-flows/src/order/workflows/create-or-update-order-payment-collection.ts
+++ b/packages/core/core-flows/src/order/workflows/create-or-update-order-payment-collection.ts
@@ -88,10 +88,11 @@ export const createOrUpdateOrderPaymentCollectionWorkflow = createWorkflow(
       filters: {
         id: orderPaymentCollectionIds,
         status: [
-          // To update the collection amoun
           PaymentCollectionStatus.NOT_PAID,
           PaymentCollectionStatus.AWAITING,
-          // To cancel the authorized payments and create a new collection
+          // Keep authorized collections alive for partial capture instead of
+          // canceling them. Most payment providers (Stripe, Adyen, etc.)
+          // support capturing an amount ≤ the authorized amount.
           PaymentCollectionStatus.AUTHORIZED,
           PaymentCollectionStatus.PARTIALLY_AUTHORIZED,
         ],
@@ -99,13 +100,12 @@ export const createOrUpdateOrderPaymentCollectionWorkflow = createWorkflow(
       options: { isList: false },
     }).config({ name: "payment-collection-query" })
 
+    // Authorized collections are updated in place (amount change only).
+    // At capture time, the merchant captures the new amount and the
+    // provider releases the remaining hold automatically (partial capture).
     const shouldRecreate = transform(
       { existingPaymentCollection },
-      ({ existingPaymentCollection }) =>
-        existingPaymentCollection?.status ===
-          PaymentCollectionStatus.AUTHORIZED ||
-        existingPaymentCollection?.status ===
-          PaymentCollectionStatus.PARTIALLY_AUTHORIZED
+      ({ existingPaymentCollection }) => false
     )
 
     const amountPending = transform({ order, input }, ({ order, input }) => {


### PR DESCRIPTION
## Summary

- Fixes order edit workflow canceling payment authorization instead of keeping it alive for partial capture
- Updates `createOrUpdateOrderPaymentCollectionWorkflow` to update collection amount in place when status is AUTHORIZED
- Payment providers (Stripe, Adyen, PayPal) natively support capturing ≤ authorized amount — the remaining hold releases automatically

## What changed

In `create-or-update-order-payment-collection.ts`, the `shouldRecreate` flag previously triggered cancel+recreate for AUTHORIZED payment collections. Now AUTHORIZED collections follow the "update amount" path instead, preserving the authorization for partial capture.

**Before:** Edit order → cancel Stripe PaymentIntent → create empty collection → merchant can't collect payment  
**After:** Edit order → update collection amount → merchant captures new amount → Stripe releases remaining hold

## References

- Fixes #14984
- [Stripe: Capture part of a payment](https://docs.stripe.com/payments/capture-later#capture-part-of-a-payment)

## Test plan

- [ ] Create order with Stripe manual capture (`capture: false`)
- [ ] Confirm Stripe authorizes the full amount
- [ ] Edit the order (remove an item, lowering the total)
- [ ] Confirm the edit
- [ ] Verify the original Stripe PaymentIntent is NOT voided
- [ ] Capture payment from admin — verify only the new (lower) amount is charged
- [ ] Verify the remaining hold is released on the customer's card

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment-collection lifecycle behavior during order edits, which can impact charging/capture flows if edge cases (provider limitations, amount decreases/increases) aren’t handled as expected.
> 
> **Overview**
> Order edits no longer trigger cancel+recreate behavior for `AUTHORIZED` / `PARTIALLY_AUTHORIZED` payment collections; the workflow now always keeps the existing authorization and updates the collection `amount` in place to support partial capture.
> 
> This effectively disables the `shouldRecreate` path for authorized collections while keeping them eligible in the payment-collection query, preventing voided authorizations when the order total changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2582e9d343c882c7157d1a5ab784b9091f4d9d8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->