### PR TITLE
chore(core-flows): Fix comments for removePriceListPricesWorkflow input ids

### DIFF
--- a/.changeset/fresh-lands-bet.md
+++ b/.changeset/fresh-lands-bet.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+chore(core-flows): Fix comments for removePriceListPricesWorkflow input ids

--- a/packages/core/core-flows/src/price-list/steps/remove-price-list-prices.ts
+++ b/packages/core/core-flows/src/price-list/steps/remove-price-list-prices.ts
@@ -3,13 +3,13 @@ import { Modules } from "@medusajs/framework/utils"
 import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
 
 /**
- * The IDs of price lists to remove their prices.
+ * The IDs of prices to remove.
  */
 export type RemovePriceListPricesStepInput = string[]
 
 export const removePriceListPricesStepId = "remove-price-list-prices"
 /**
- * This step removes prices from a price list.
+ * This step removes prices.
  */
 export const removePriceListPricesStep = createStep(
   removePriceListPricesStepId,

--- a/packages/core/core-flows/src/price-list/workflows/remove-price-list-prices.ts
+++ b/packages/core/core-flows/src/price-list/workflows/remove-price-list-prices.ts
@@ -6,38 +6,40 @@ import {
 import { removePriceListPricesStep } from "../steps/remove-price-list-prices"
 
 /**
- * The data to remove prices from price lists.
+ * The data to remove prices.
  */
 export type RemovePriceListPricesWorkflowInput = {
   /**
-   * The IDs of the price lists to remove their prices.
+   * The IDs of the prices to remove.
    */
   ids: string[]
 }
 
 export const removePriceListPricesWorkflowId = "remove-price-list-prices"
 /**
- * This workflow removes price lists' prices. It's used by other workflows, such
+ * This workflow removes prices. It's used by other workflows, such
  * as {@link batchPriceListPricesWorkflow}.
- * 
+ *
  * You can use this workflow within your customizations or your own custom workflows, allowing you to
- * remove prices in price lists in your custom flows.
- * 
+ * remove prices in your custom flows.
+ *
  * @example
  * const { result } = await removePriceListPricesWorkflow(container)
  * .run({
  *   input: {
- *     ids: ["plist_123"]
+ *     ids: ["price_123"]
  *   }
  * })
- * 
+ *
  * @summary
- * 
- * Remove prices in price lists.
+ *
+ * Remove prices.
  */
 export const removePriceListPricesWorkflow = createWorkflow(
   removePriceListPricesWorkflowId,
-  (input: WorkflowData<RemovePriceListPricesWorkflowInput>): WorkflowResponse<string[]> => {
+  (
+    input: WorkflowData<RemovePriceListPricesWorkflowInput>
+  ): WorkflowResponse<string[]> => {
     return new WorkflowResponse(removePriceListPricesStep(input.ids))
   }
 )


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

The comments in the `removePriceListPricesWorkflow` would make you think one should pass price list ids, to clear prices from a price list, but in fact the workflow expects these ids to belong to `prices` since it soft deletes prices directly, without matching against a price list.

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
