### PR TITLE
chore: update mikro-orm to 6.6.12

### DIFF
--- a/.changeset/rare-snakes-itch.md
+++ b/.changeset/rare-snakes-itch.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/utils": patch
+"@medusajs/deps": patch
+---
+
+chore: update mikro-orm to 6.6.10

--- a/packages/core/utils/src/dal/mikro-orm/mikro-orm-create-connection.ts
+++ b/packages/core/utils/src/dal/mikro-orm/mikro-orm-create-connection.ts
@@ -113,6 +113,13 @@ export async function mikroOrmCreateConnection(
     useBatchUpdates: true,
     implicitTransactions: false,
     ignoreUndefinedInQuery: true,
+    // Introduced in MikroORM 6.5.0: when enabled, MikroORM auto-joins referenced entities
+    // (e.g. INNER JOINs PaymentSession when querying Payment) to apply their global filters
+    // (e.g. softDeletable). For non-nullable FKs this uses INNER JOIN, silently excluding
+    // owning entities (e.g. Payment) when the referenced entity (e.g. PaymentSession) is
+    // soft-deleted. Medusa was designed around MikroORM 6.4.x where this didn't exist, so
+    // we disable it to preserve the expected behavior.
+    autoJoinRefsForFilters: false,
     batchSize: 100,
     metadataCache: {
       enabled: true,

--- a/packages/core/utils/src/modules-sdk/medusa-internal-service.ts
+++ b/packages/core/utils/src/modules-sdk/medusa-internal-service.ts
@@ -55,12 +55,9 @@ export function registerInternalServiceEventSubscriber(
     context.manager) as EntityManager
   if (manager && subscriber) {
     const subscriberInstance = new subscriber(context)
-    // There is no public API to unregister subscribers or check if a subscriber is already
-    // registered. This means that we need to manually check if the subscriber is already
-    // registered, otherwise we will register the same subscriber twice.
-    const hasListeners = (manager.getEventManager() as any).subscribers.some(
-      (s) => s.constructor.name === subscriberInstance.constructor.name
-    )
+    const hasListeners = Array.from(
+      manager.getEventManager().getSubscribers()
+    ).some((s) => s.constructor.name === subscriberInstance.constructor.name)
     if (!hasListeners) {
       manager.getEventManager().registerSubscriber(subscriberInstance)
     }

--- a/packages/deps/package.json
+++ b/packages/deps/package.json
@@ -39,11 +39,11 @@
     "build": "yarn run -T rimraf dist && yarn run -T tsc --build"
   },
   "dependencies": {
-    "@mikro-orm/cli": "6.4.16",
-    "@mikro-orm/core": "6.4.16",
-    "@mikro-orm/knex": "6.4.16",
-    "@mikro-orm/migrations": "6.4.16",
-    "@mikro-orm/postgresql": "6.4.16",
+    "@mikro-orm/cli": "6.6.10",
+    "@mikro-orm/core": "6.6.10",
+    "@mikro-orm/knex": "6.6.10",
+    "@mikro-orm/migrations": "6.6.10",
+    "@mikro-orm/postgresql": "6.6.10",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/instrumentation-pg": "^0.52.0",
     "@opentelemetry/resources": "^2.0.0",

--- a/packages/deps/package.json
+++ b/packages/deps/package.json
@@ -39,11 +39,11 @@
     "build": "yarn run -T rimraf dist && yarn run -T tsc --build"
   },
   "dependencies": {
-    "@mikro-orm/cli": "6.6.10",
-    "@mikro-orm/core": "6.6.10",
-    "@mikro-orm/knex": "6.6.10",
-    "@mikro-orm/migrations": "6.6.10",
-    "@mikro-orm/postgresql": "6.6.10",
+    "@mikro-orm/cli": "6.6.12",
+    "@mikro-orm/core": "6.6.12",
+    "@mikro-orm/knex": "6.6.12",
+    "@mikro-orm/migrations": "6.6.12",
+    "@mikro-orm/postgresql": "6.6.12",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/instrumentation-pg": "^0.52.0",
     "@opentelemetry/resources": "^2.0.0",

--- a/packages/modules/order/src/utils/base-repository-find.ts
+++ b/packages/modules/order/src/utils/base-repository-find.ts
@@ -1,5 +1,5 @@
 import { Constructor, Context, DAL } from "@medusajs/framework/types"
-import { MikroOrmBaseRepository, toMikroORMEntity } from "@medusajs/framework/utils"
+import { MikroOrmBaseRepository } from "@medusajs/framework/utils"
 import { LoadStrategy } from "@medusajs/framework/mikro-orm/core"
 import { Order, OrderClaim, OrderLineItemAdjustment } from "@models"
 
@@ -100,18 +100,7 @@ export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
       orderAlias = "o1"
     }
 
-    let defaultVersion = knex.raw(`"${orderAlias}"."version"`)
-
-    if (strategy === LoadStrategy.SELECT_IN) {
-      const sql = manager
-        .qb(toMikroORMEntity(Order), "_sub0")
-        .select("version")
-        .where({ id: knex.raw(`"${orderAlias}"."order_id"`) })
-        .getKnexQuery()
-        .toString()
-
-      defaultVersion = knex.raw(`(${sql})`)
-    }
+    const defaultVersion = knex.raw(`"${orderAlias}"."version"`)
 
     const version = config.where?.version ?? defaultVersion
     delete config.where?.version
@@ -206,11 +195,8 @@ export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
       orderAlias = "o1"
     }
 
-    let defaultVersion = knex.raw(`"${orderAlias}"."version"`)
+    const defaultVersion = knex.raw(`"${orderAlias}"."version"`)
     const strategy = config.options.strategy ?? LoadStrategy.JOINED
-    if (strategy === LoadStrategy.SELECT_IN) {
-      defaultVersion = getVersionSubQuery(manager, orderAlias)
-    }
 
     const version = config.where.version ?? defaultVersion
     delete config.where.version
@@ -234,13 +220,7 @@ export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
       }
     }
 
-    configurePopulateWhere(
-      config,
-      isRelatedEntity,
-      version,
-      strategy === LoadStrategy.SELECT_IN,
-      manager
-    )
+    configurePopulateWhere(config, isRelatedEntity, version)
 
     if (!config.options.orderBy) {
       config.options.orderBy = { id: "ASC" }
@@ -311,24 +291,10 @@ async function loadItemAdjustments(manager, orders) {
   }
 }
 
-function getVersionSubQuery(manager, alias, field = "order_id") {
-  const knex = manager.getKnex()
-  const sql = manager
-    .qb(toMikroORMEntity(Order), "_sub0")
-    .select("version")
-    .where({ id: knex.raw(`"${alias}"."${field}"`) })
-    .getKnexQuery()
-    .toString()
-
-  return knex.raw(`(${sql})`)
-}
-
 function configurePopulateWhere(
   config: any,
   isRelatedEntity: boolean,
-  version: any,
-  isSelectIn = false,
-  manager?
+  version: any
 ) {
   const requestedPopulate = config.options?.populate ?? []
   const hasRelation = (relation: string) =>
@@ -339,43 +305,30 @@ function configurePopulateWhere(
   config.options.populateWhere ??= {}
   const popWhere = config.options.populateWhere
 
-  // isSelectIn && isRelatedEntity - Order is always the FROM clause (field o0.id)
   if (isRelatedEntity) {
     popWhere.order ??= {}
 
     const popWhereOrder = popWhere.order
 
-    popWhereOrder.version = isSelectIn
-      ? getVersionSubQuery(manager, "o0", "id")
-      : version
+    popWhereOrder.version = version
 
     // related entity shipping method
     if (hasRelation("shipping_methods")) {
       popWhere.shipping_methods ??= {}
-      popWhere.shipping_methods.version = isSelectIn
-        ? getVersionSubQuery(manager, "s0")
-        : version
+      popWhere.shipping_methods.version = version
     }
 
     if (hasRelation("items") || hasRelation("order.items")) {
       popWhereOrder.items ??= {}
-      popWhereOrder.items.version = isSelectIn
-        ? getVersionSubQuery(manager, "o0", "id")
-        : version
+      popWhereOrder.items.version = version
     }
 
     if (hasRelation("shipping_methods")) {
       popWhereOrder.shipping_methods ??= {}
-      popWhereOrder.shipping_methods.version = isSelectIn
-        ? getVersionSubQuery(manager, "o0", "id")
-        : version
+      popWhereOrder.shipping_methods.version = version
     }
 
     return
-  }
-
-  if (isSelectIn) {
-    version = getVersionSubQuery(manager, "o0")
   }
 
   if (hasRelation("summary")) {

--- a/packages/modules/order/src/utils/base-repository-find.ts
+++ b/packages/modules/order/src/utils/base-repository-find.ts
@@ -1,5 +1,5 @@
 import { Constructor, Context, DAL } from "@medusajs/framework/types"
-import { MikroOrmBaseRepository } from "@medusajs/framework/utils"
+import { MikroOrmBaseRepository, toMikroORMEntity } from "@medusajs/framework/utils"
 import { LoadStrategy } from "@medusajs/framework/mikro-orm/core"
 import { Order, OrderClaim, OrderLineItemAdjustment } from "@models"
 
@@ -100,12 +100,29 @@ export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
       orderAlias = "o1"
     }
 
-    const defaultVersion = knex.raw(`"${orderAlias}"."version"`)
+    let defaultVersion = knex.raw(`"${orderAlias}"."version"`)
+
+    if (strategy === LoadStrategy.SELECT_IN) {
+      const sql = manager
+        .qb(toMikroORMEntity(Order), "_sub0")
+        .select("version")
+        .where({ id: knex.raw(`"${orderAlias}"."order_id"`) })
+        .getKnexQuery()
+        .toString()
+
+      defaultVersion = knex.raw(`(${sql})`)
+    }
 
     const version = config.where?.version ?? defaultVersion
     delete config.where?.version
 
-    configurePopulateWhere(config, isRelatedEntity, version)
+    configurePopulateWhere(
+      config,
+      isRelatedEntity,
+      version,
+      strategy === LoadStrategy.SELECT_IN,
+      manager
+    )
 
     let loadAdjustments = false
     if (config.options.populate.includes("items.item.adjustments")) {
@@ -195,8 +212,11 @@ export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
       orderAlias = "o1"
     }
 
-    const defaultVersion = knex.raw(`"${orderAlias}"."version"`)
+    let defaultVersion = knex.raw(`"${orderAlias}"."version"`)
     const strategy = config.options.strategy ?? LoadStrategy.JOINED
+    if (strategy === LoadStrategy.SELECT_IN) {
+      defaultVersion = getVersionSubQuery(manager, orderAlias)
+    }
 
     const version = config.where.version ?? defaultVersion
     delete config.where.version
@@ -220,7 +240,13 @@ export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
       }
     }
 
-    configurePopulateWhere(config, isRelatedEntity, version)
+    configurePopulateWhere(
+      config,
+      isRelatedEntity,
+      version,
+      strategy === LoadStrategy.SELECT_IN,
+      manager
+    )
 
     if (!config.options.orderBy) {
       config.options.orderBy = { id: "ASC" }
@@ -291,10 +317,24 @@ async function loadItemAdjustments(manager, orders) {
   }
 }
 
+function getVersionSubQuery(manager, alias, field = "order_id") {
+  const knex = manager.getKnex()
+  const sql = manager
+    .qb(toMikroORMEntity(Order), "_sub0")
+    .select("version")
+    .where({ id: knex.raw(`"${alias}"."${field}"`) })
+    .getKnexQuery()
+    .toString()
+
+  return knex.raw(`(${sql})`)
+}
+
 function configurePopulateWhere(
   config: any,
   isRelatedEntity: boolean,
-  version: any
+  version: any,
+  isSelectIn = false,
+  manager?
 ) {
   const requestedPopulate = config.options?.populate ?? []
   const hasRelation = (relation: string) =>
@@ -305,30 +345,43 @@ function configurePopulateWhere(
   config.options.populateWhere ??= {}
   const popWhere = config.options.populateWhere
 
+  // isSelectIn && isRelatedEntity - Order is always the FROM clause (field o0.id)
   if (isRelatedEntity) {
     popWhere.order ??= {}
 
     const popWhereOrder = popWhere.order
 
-    popWhereOrder.version = version
+    popWhereOrder.version = isSelectIn
+      ? getVersionSubQuery(manager, "o0", "id")
+      : version
 
     // related entity shipping method
     if (hasRelation("shipping_methods")) {
       popWhere.shipping_methods ??= {}
-      popWhere.shipping_methods.version = version
+      popWhere.shipping_methods.version = isSelectIn
+        ? getVersionSubQuery(manager, "s0")
+        : version
     }
 
     if (hasRelation("items") || hasRelation("order.items")) {
       popWhereOrder.items ??= {}
-      popWhereOrder.items.version = version
+      popWhereOrder.items.version = isSelectIn
+        ? getVersionSubQuery(manager, "o0", "id")
+        : version
     }
 
     if (hasRelation("shipping_methods")) {
       popWhereOrder.shipping_methods ??= {}
-      popWhereOrder.shipping_methods.version = version
+      popWhereOrder.shipping_methods.version = isSelectIn
+        ? getVersionSubQuery(manager, "o0", "id")
+        : version
     }
 
     return
+  }
+
+  if (isSelectIn) {
+    version = getVersionSubQuery(manager, "o0")
   }
 
   if (hasRelation("summary")) {

--- a/packages/modules/order/src/utils/base-repository-find.ts
+++ b/packages/modules/order/src/utils/base-repository-find.ts
@@ -1,6 +1,6 @@
 import { Constructor, Context, DAL } from "@medusajs/framework/types"
 import { MikroOrmBaseRepository, toMikroORMEntity } from "@medusajs/framework/utils"
-import { LoadStrategy } from "@medusajs/framework/mikro-orm/core"
+import { LoadStrategy, raw } from "@medusajs/framework/mikro-orm/core"
 import { Order, OrderClaim, OrderLineItemAdjustment } from "@models"
 
 import { mapRepositoryToOrderModel } from "."
@@ -259,11 +259,16 @@ export function setFindMethods<T>(klass: Constructor<T>, entity: any) {
       })
     }
 
-    const [result, count] = await manager.findAndCount(
-      this.entity,
-      config.where,
-      config.options
-    )
+    // The count query uses JOINED strategy internally (MikroORM 6.6+), but
+    // populateWhere version subqueries reference SELECT_IN aliases (e.g. "o0")
+    // that don't exist in the JOINED count context. Since version filters only
+    // control which items to load (not which root entities to count), we run
+    // find and count separately with different populateWhere options.
+    const countOptions = { ...config.options, populateWhere: undefined }
+    const [result, count] = await Promise.all([
+      manager.find(this.entity, config.where, config.options),
+      manager.count(this.entity, config.where, countOptions),
+    ])
 
     if (loadAdjustments) {
       const orders = !isRelatedEntity
@@ -345,36 +350,65 @@ function configurePopulateWhere(
   config.options.populateWhere ??= {}
   const popWhere = config.options.populateWhere
 
-  // isSelectIn && isRelatedEntity - Order is always the FROM clause (field o0.id)
   if (isRelatedEntity) {
     popWhere.order ??= {}
 
     const popWhereOrder = popWhere.order
 
-    popWhereOrder.version = isSelectIn
-      ? getVersionSubQuery(manager, "o0", "id")
-      : version
+    if (!isSelectIn) {
+      // For JOINED strategy, version is a reference to the order alias (e.g. "o1"."version")
+      // This is trivially true since Order has one row per id, but kept for consistency
+      popWhereOrder.version = version
+    }
+    // For SELECT_IN strategy, the order.version condition is always trivially true
+    // (Order has one row per id) so we skip it entirely
 
     // related entity shipping method
     if (hasRelation("shipping_methods")) {
       popWhere.shipping_methods ??= {}
-      popWhere.shipping_methods.version = isSelectIn
-        ? getVersionSubQuery(manager, "s0")
-        : version
+      if (isSelectIn) {
+        // For MikroORM 6.6.x+, populateWhere conditions for force-joined relations are
+        // embedded as inline JOIN conditions. Use alias callback so [::alias::] gets
+        // replaced with the actual shipping_method alias at query-build time.
+        const fragment = raw(
+          (alias) =>
+            `"${alias}"."version" = (select "_sub0"."version" from "order" as "_sub0" where "_sub0"."id" = "${alias}"."order_id")`
+        )
+        ;(popWhere.shipping_methods as any)[fragment.toString()] = []
+      } else {
+        popWhere.shipping_methods.version = version
+      }
     }
 
     if (hasRelation("items") || hasRelation("order.items")) {
       popWhereOrder.items ??= {}
-      popWhereOrder.items.version = isSelectIn
-        ? getVersionSubQuery(manager, "o0", "id")
-        : version
+      if (isSelectIn) {
+        // In MikroORM 6.6.x+, the global alias counter changed (no longer per-entity-type),
+        // so "o0" no longer exists in the query context for related entity queries.
+        // Instead, use a self-referential raw fragment: the [::alias::] placeholder is
+        // replaced with the order_item's own JOIN alias, and order_item.order_id is used
+        // to look up the order's current version.
+        const fragment = raw(
+          (alias) =>
+            `"${alias}"."version" = (select "_sub0"."version" from "order" as "_sub0" where "_sub0"."id" = "${alias}"."order_id")`
+        )
+        ;(popWhereOrder.items as any)[fragment.toString()] = []
+      } else {
+        popWhereOrder.items.version = version
+      }
     }
 
     if (hasRelation("shipping_methods")) {
       popWhereOrder.shipping_methods ??= {}
-      popWhereOrder.shipping_methods.version = isSelectIn
-        ? getVersionSubQuery(manager, "o0", "id")
-        : version
+      if (isSelectIn) {
+        const fragment = raw(
+          (alias) =>
+            `"${alias}"."version" = (select "_sub0"."version" from "order" as "_sub0" where "_sub0"."id" = "${alias}"."order_id")`
+        )
+        ;(popWhereOrder.shipping_methods as any)[fragment.toString()] = []
+      } else {
+        popWhereOrder.shipping_methods.version = version
+      }
     }
 
     return

--- a/packages/modules/pricing/src/repositories/pricing.ts
+++ b/packages/modules/pricing/src/repositories/pricing.ts
@@ -51,7 +51,7 @@ export class PricingRepository
     `
     )
     this.#availableAttributes.clear()
-    rows.forEach(({ attribute }) => {
+    rows.forEach(({ attribute }: { attribute: string }) => {
       this.#availableAttributes.add(attribute)
     })
   }
@@ -72,11 +72,11 @@ export class PricingRepository
     const context = { ...(pricingContext.context || {}) }
 
     // Extract quantity and currency from context
-    const quantity = context.quantity
+    const quantity = context.quantity as number | undefined
     delete context.quantity
 
     // Currency code is required
-    const currencyCode = context.currency_code
+    const currencyCode = context.currency_code as string | undefined
     delete context.currency_code
 
     if (!currencyCode) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,11 +3490,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@medusajs/deps@workspace:packages/deps"
   dependencies:
-    "@mikro-orm/cli": 6.6.10
-    "@mikro-orm/core": 6.6.10
-    "@mikro-orm/knex": 6.6.10
-    "@mikro-orm/migrations": 6.6.10
-    "@mikro-orm/postgresql": 6.6.10
+    "@mikro-orm/cli": 6.6.12
+    "@mikro-orm/core": 6.6.12
+    "@mikro-orm/knex": 6.6.12
+    "@mikro-orm/migrations": 6.6.12
+    "@mikro-orm/postgresql": 6.6.12
     "@opentelemetry/api": ^1.9.0
     "@opentelemetry/instrumentation-pg": ^0.52.0
     "@opentelemetry/resources": ^2.0.0
@@ -4313,44 +4313,44 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@mikro-orm/cli@npm:6.6.10":
-  version: 6.6.10
-  resolution: "@mikro-orm/cli@npm:6.6.10"
+"@mikro-orm/cli@npm:6.6.12":
+  version: 6.6.12
+  resolution: "@mikro-orm/cli@npm:6.6.12"
   dependencies:
     "@jercle/yargonaut": 1.1.5
-    "@mikro-orm/core": 6.6.10
-    "@mikro-orm/knex": 6.6.10
+    "@mikro-orm/core": 6.6.12
+    "@mikro-orm/knex": 6.6.12
     fs-extra: 11.3.3
     tsconfig-paths: 4.2.0
     yargs: 17.7.2
   bin:
     mikro-orm: cli
     mikro-orm-esm: esm
-  checksum: fd473d20b54eeef9e039708aadbbd4c2ee0c193f3ec11c6ea256e2d6f7297dbc8acda3470012b75f6130318dabfc6cc0a466162bbaf214872a9b55ab222d0940
+  checksum: 2ad744258d22a692fdce8af2fd21b0ff7a7a3adadea9e26725b6a377bc8c727592234272db973818bb0119530a998621bb173faa621aaff2da20fba7ecdf4a52
   languageName: node
   linkType: hard
 
-"@mikro-orm/core@npm:6.6.10":
-  version: 6.6.10
-  resolution: "@mikro-orm/core@npm:6.6.10"
+"@mikro-orm/core@npm:6.6.12":
+  version: 6.6.12
+  resolution: "@mikro-orm/core@npm:6.6.12"
   dependencies:
     dataloader: 2.2.3
     dotenv: 17.3.1
     esprima: 4.0.1
     fs-extra: 11.3.3
     globby: 11.1.0
-    mikro-orm: 6.6.10
+    mikro-orm: 6.6.12
     reflect-metadata: 0.2.2
-  checksum: 13fc37fa35d96f00ca7f3dc58545befb70ceffa5370cb4eff73e561cbd61c13c3c0e9aa3855e61a92334241a9fe0c8f279ce86969e109b51bd694bf8c1b77bbc
+  checksum: 899411e5bd6caab065d10a09dd0a67b5bfedc25e2fbebe16830e9a0b39564f28df94ddbd9ce759b7cf87c6a0c64d49e21b889d1d331f76ea8fc2673601479beb
   languageName: node
   linkType: hard
 
-"@mikro-orm/knex@npm:6.6.10":
-  version: 6.6.10
-  resolution: "@mikro-orm/knex@npm:6.6.10"
+"@mikro-orm/knex@npm:6.6.12":
+  version: 6.6.12
+  resolution: "@mikro-orm/knex@npm:6.6.12"
   dependencies:
     fs-extra: 11.3.3
-    knex: 3.1.0
+    knex: 3.2.8
     sqlstring: 2.3.3
   peerDependencies:
     "@mikro-orm/core": ^6.0.0
@@ -4364,35 +4364,35 @@ __metadata:
       optional: true
     mariadb:
       optional: true
-  checksum: f72ed424491c166ad9691d9c023893f98b932387b761f114085f0ca6b59fe1ed4282dbba704b3224fdd3d2bd6641299d86418faf2e0d98160213b5c40ff3bac1
+  checksum: beb5c1ea222f50f36d0e88bf5313dc5a643d9646508e5da15eaaea3e9d71cca63db80976fc1dd2dc89e5e47c7b01ef73a0a635b14c64df19d2877c23bc13625e
   languageName: node
   linkType: hard
 
-"@mikro-orm/migrations@npm:6.6.10":
-  version: 6.6.10
-  resolution: "@mikro-orm/migrations@npm:6.6.10"
+"@mikro-orm/migrations@npm:6.6.12":
+  version: 6.6.12
+  resolution: "@mikro-orm/migrations@npm:6.6.12"
   dependencies:
-    "@mikro-orm/knex": 6.6.10
+    "@mikro-orm/knex": 6.6.12
     fs-extra: 11.3.3
     umzug: 3.8.2
   peerDependencies:
     "@mikro-orm/core": ^6.0.0
-  checksum: 545a8a12cb58ca2791b0bd8fd27327837a32ba42ff6e7f31e92f7969114d1cf6a2928588f8abfbb1846c5fee7b3f9ded0a2b4b2a2ecc1287222411e28ea89dcc
+  checksum: 76bbb1417a8138835cc26b2af253007085ea3daf10bac1d12f633d354d658db19406113e10555dc9d48a1d1026be3dbfab6f2badbb0ceedf70b6363804f2b626
   languageName: node
   linkType: hard
 
-"@mikro-orm/postgresql@npm:6.6.10":
-  version: 6.6.10
-  resolution: "@mikro-orm/postgresql@npm:6.6.10"
+"@mikro-orm/postgresql@npm:6.6.12":
+  version: 6.6.12
+  resolution: "@mikro-orm/postgresql@npm:6.6.12"
   dependencies:
-    "@mikro-orm/knex": 6.6.10
-    pg: 8.19.0
+    "@mikro-orm/knex": 6.6.12
+    pg: 8.20.0
     postgres-array: 3.0.4
     postgres-date: 2.1.0
     postgres-interval: 4.0.2
   peerDependencies:
     "@mikro-orm/core": ^6.0.0
-  checksum: 0756e14eb75f1b3661e888f9270c54fb0bc841a1485f5b717235e622d322a0355e57442adba78bdbf09f7a3cabbe73c612397d3004e721cffd8cf09033eb38e4
+  checksum: 20be101e19d39b8939a454819c1a1b73f6b5bde2605f089d5836ec7ac50a0472aeefc43de9b8cf3084af731c9067732dda07d6c5c57754e29e0cad6957d7913a
   languageName: node
   linkType: hard
 
@@ -20304,9 +20304,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"knex@npm:3.1.0":
-  version: 3.1.0
-  resolution: "knex@npm:3.1.0"
+"knex@npm:3.2.8":
+  version: 3.2.8
+  resolution: "knex@npm:3.2.8"
   dependencies:
     colorette: 2.0.19
     commander: ^10.0.0
@@ -20322,6 +20322,8 @@ __metadata:
     resolve-from: ^5.0.0
     tarn: ^3.0.2
     tildify: 2.0.0
+  peerDependencies:
+    pg-query-stream: ^4.14.0
   peerDependenciesMeta:
     better-sqlite3:
       optional: true
@@ -20333,13 +20335,15 @@ __metadata:
       optional: true
     pg-native:
       optional: true
+    pg-query-stream:
+      optional: true
     sqlite3:
       optional: true
     tedious:
       optional: true
   bin:
     knex: bin/cli.js
-  checksum: d8a1f99fad143c6057e94759b2ae700ae661a0b0b2385f643011962ef501dcc7b32cfdb5bda66ef81283ca56f13630f47691c579ce66ad0e8128e209533c3785
+  checksum: f6035da7e7793620b7313b548786e6f0db361ad68981560ff099975b289cdc459eb04f7a68a3cc87d2279578c16b7ed3b7c0814e5e540f1825fa2d8a6772a0bb
   languageName: node
   linkType: hard
 
@@ -21060,10 +21064,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mikro-orm@npm:6.6.10":
-  version: 6.6.10
-  resolution: "mikro-orm@npm:6.6.10"
-  checksum: 9358f44ec20ec6e1dcb8189475e7c1f5ea4c059349a0069118f2a1578392e930bab751977d179198d08c9d83b2e6f14e0626818f6be2b24e135932296ec94f34
+"mikro-orm@npm:6.6.12":
+  version: 6.6.12
+  resolution: "mikro-orm@npm:6.6.12"
+  checksum: 917a0f8cafce5a6c8d69985bbd2c9611ad9d1e55d4791fbc4e006e10788d00cf04eda50e5c6d692ba62ff321df5283f15b97a1813709da6f966e95dccd6f0920
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,11 +3490,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@medusajs/deps@workspace:packages/deps"
   dependencies:
-    "@mikro-orm/cli": 6.4.16
-    "@mikro-orm/core": 6.4.16
-    "@mikro-orm/knex": 6.4.16
-    "@mikro-orm/migrations": 6.4.16
-    "@mikro-orm/postgresql": 6.4.16
+    "@mikro-orm/cli": 6.6.10
+    "@mikro-orm/core": 6.6.10
+    "@mikro-orm/knex": 6.6.10
+    "@mikro-orm/migrations": 6.6.10
+    "@mikro-orm/postgresql": 6.6.10
     "@opentelemetry/api": ^1.9.0
     "@opentelemetry/instrumentation-pg": ^0.52.0
     "@opentelemetry/resources": ^2.0.0
@@ -4313,43 +4313,43 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@mikro-orm/cli@npm:6.4.16":
-  version: 6.4.16
-  resolution: "@mikro-orm/cli@npm:6.4.16"
+"@mikro-orm/cli@npm:6.6.10":
+  version: 6.6.10
+  resolution: "@mikro-orm/cli@npm:6.6.10"
   dependencies:
     "@jercle/yargonaut": 1.1.5
-    "@mikro-orm/core": 6.4.16
-    "@mikro-orm/knex": 6.4.16
-    fs-extra: 11.3.0
+    "@mikro-orm/core": 6.6.10
+    "@mikro-orm/knex": 6.6.10
+    fs-extra: 11.3.3
     tsconfig-paths: 4.2.0
     yargs: 17.7.2
   bin:
-    mikro-orm: ./cli
-    mikro-orm-esm: ./esm
-  checksum: c58cfc6a89a4770671c58e3c40a60c8a38229a74e1722d1fb6c14a8d19a43303aa26557ec6a0000ac1d494270f3cfd98e32e38c69163f6b9cafb7c3ef6804b00
+    mikro-orm: cli
+    mikro-orm-esm: esm
+  checksum: fd473d20b54eeef9e039708aadbbd4c2ee0c193f3ec11c6ea256e2d6f7297dbc8acda3470012b75f6130318dabfc6cc0a466162bbaf214872a9b55ab222d0940
   languageName: node
   linkType: hard
 
-"@mikro-orm/core@npm:6.4.16":
-  version: 6.4.16
-  resolution: "@mikro-orm/core@npm:6.4.16"
+"@mikro-orm/core@npm:6.6.10":
+  version: 6.6.10
+  resolution: "@mikro-orm/core@npm:6.6.10"
   dependencies:
     dataloader: 2.2.3
-    dotenv: 16.5.0
+    dotenv: 17.3.1
     esprima: 4.0.1
-    fs-extra: 11.3.0
+    fs-extra: 11.3.3
     globby: 11.1.0
-    mikro-orm: 6.4.16
+    mikro-orm: 6.6.10
     reflect-metadata: 0.2.2
-  checksum: beeb614134d908674916105326c4846fe80fb9a7adc1251a8b9bd70f4db1115256a1bdaa08107fab1577986bbca46dd24b0ff24d87753925f382d1ef216bea18
+  checksum: 13fc37fa35d96f00ca7f3dc58545befb70ceffa5370cb4eff73e561cbd61c13c3c0e9aa3855e61a92334241a9fe0c8f279ce86969e109b51bd694bf8c1b77bbc
   languageName: node
   linkType: hard
 
-"@mikro-orm/knex@npm:6.4.16":
-  version: 6.4.16
-  resolution: "@mikro-orm/knex@npm:6.4.16"
+"@mikro-orm/knex@npm:6.6.10":
+  version: 6.6.10
+  resolution: "@mikro-orm/knex@npm:6.6.10"
   dependencies:
-    fs-extra: 11.3.0
+    fs-extra: 11.3.3
     knex: 3.1.0
     sqlstring: 2.3.3
   peerDependencies:
@@ -4364,35 +4364,35 @@ __metadata:
       optional: true
     mariadb:
       optional: true
-  checksum: b0584fe3bd79b131512712ec9e31a1b76e272dcff519d5607daebfd5b3dd856116d9aae836c86baa006abc58e0331926aa3bd4ef4bba1a7ced4781d8c6fd3d21
+  checksum: f72ed424491c166ad9691d9c023893f98b932387b761f114085f0ca6b59fe1ed4282dbba704b3224fdd3d2bd6641299d86418faf2e0d98160213b5c40ff3bac1
   languageName: node
   linkType: hard
 
-"@mikro-orm/migrations@npm:6.4.16":
-  version: 6.4.16
-  resolution: "@mikro-orm/migrations@npm:6.4.16"
+"@mikro-orm/migrations@npm:6.6.10":
+  version: 6.6.10
+  resolution: "@mikro-orm/migrations@npm:6.6.10"
   dependencies:
-    "@mikro-orm/knex": 6.4.16
-    fs-extra: 11.3.0
+    "@mikro-orm/knex": 6.6.10
+    fs-extra: 11.3.3
     umzug: 3.8.2
   peerDependencies:
     "@mikro-orm/core": ^6.0.0
-  checksum: 1d5beb2423c20879cffc9c51f035b2f24b963997bea4d69445f1686616686a3bd8d7b34c2081fcb421df24c0f14ee2c51b4ed01299b5c9dbf2af4fc4cbc22de5
+  checksum: 545a8a12cb58ca2791b0bd8fd27327837a32ba42ff6e7f31e92f7969114d1cf6a2928588f8abfbb1846c5fee7b3f9ded0a2b4b2a2ecc1287222411e28ea89dcc
   languageName: node
   linkType: hard
 
-"@mikro-orm/postgresql@npm:6.4.16":
-  version: 6.4.16
-  resolution: "@mikro-orm/postgresql@npm:6.4.16"
+"@mikro-orm/postgresql@npm:6.6.10":
+  version: 6.6.10
+  resolution: "@mikro-orm/postgresql@npm:6.6.10"
   dependencies:
-    "@mikro-orm/knex": 6.4.16
-    pg: 8.16.0
+    "@mikro-orm/knex": 6.6.10
+    pg: 8.19.0
     postgres-array: 3.0.4
     postgres-date: 2.1.0
     postgres-interval: 4.0.2
   peerDependencies:
     "@mikro-orm/core": ^6.0.0
-  checksum: 0d7b6dd04f9c476d445fd31b5544be88d38da9b3c5c3666c2c84c1fb35db55de27a98e23b62ba26528f9056bb28966cc8dc5673418bf4b2da6bf6bfeb6af0264
+  checksum: 0756e14eb75f1b3661e888f9270c54fb0bc841a1485f5b717235e622d322a0355e57442adba78bdbf09f7a3cabbe73c612397d3004e721cffd8cf09033eb38e4
   languageName: node
   linkType: hard
 
@@ -15844,10 +15844,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:16.5.0":
-  version: 16.5.0
-  resolution: "dotenv@npm:16.5.0"
-  checksum: 5bc94c919fbd955bf0ba44d33922a1e93d1078e64a1db5c30faeded1d996e7a83c55332cb8ea4fae5a9ca4d0be44cbceb95c5811e70f9f095298df09d1997dd9
+"dotenv@npm:17.3.1":
+  version: 17.3.1
+  resolution: "dotenv@npm:17.3.1"
+  checksum: c78e0c2d5a549c751e544cc60e2b95e7cb67e0c551f42e094d161c6b297aa44b630a3c2dcacf5569e529a6c2a6b84e2ab9be8d37b299d425df5a18b81ce4a35f
   languageName: node
   linkType: hard
 
@@ -17479,14 +17479,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:11.3.0":
-  version: 11.3.0
-  resolution: "fs-extra@npm:11.3.0"
+"fs-extra@npm:11.3.3":
+  version: 11.3.3
+  resolution: "fs-extra@npm:11.3.3"
   dependencies:
     graceful-fs: ^4.2.0
     jsonfile: ^6.0.1
     universalify: ^2.0.0
-  checksum: 5f95e996186ff45463059feb115a22fb048bdaf7e487ecee8a8646c78ed8fdca63630e3077d4c16ce677051f5e60d3355a06f3cd61f3ca43f48cc58822a44d0a
+  checksum: 984924ff4104e3e9f351b658a864bf3b354b2c90429f57aec0acd12d92c4e6b762cbacacdffb4e745b280adce882e1f980c485d9f02c453f769ab4e7fc646ce3
   languageName: node
   linkType: hard
 
@@ -21060,10 +21060,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mikro-orm@npm:6.4.16":
-  version: 6.4.16
-  resolution: "mikro-orm@npm:6.4.16"
-  checksum: 6a7d6ad717503433eba0372f890fc66c8f0f80927b40ae8666bc0795006b0a5a089e662a7a5fc121d3e0fbdb1350c1878dc3bee2c1c6bc4028c729b2c4a45f7a
+"mikro-orm@npm:6.6.10":
+  version: 6.6.10
+  resolution: "mikro-orm@npm:6.6.10"
+  checksum: 9358f44ec20ec6e1dcb8189475e7c1f5ea4c059349a0069118f2a1578392e930bab751977d179198d08c9d83b2e6f14e0626818f6be2b24e135932296ec94f34
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update MikroORM dependencies as a mitigation to the following vulnerabilities:

- https://github.com/advisories/GHSA-gwhv-j974-6fxm
- https://github.com/advisories/GHSA-qpfv-44f3-qqx6

Issues fixed following the update:

- We previously accessed `subscribers` on the entity manager that wasn't publicly accessible, and following the update this caused an error. Latest version has a `getSubscribers` API to access it. 
- v6.5.0 of Mikro ORM automatically INNER JOINs referenced entities. This causes issues in our code when a referenced entity is soft-deleted, as the INNER JOIN with WHERE deleted_at  IS NULL silently excludes the owning entity from query results. For example, a Payment becomes invisible after its PaymentSession is soft-deleted.
  - We fix this by disabling the new `autoJoinRefsForFilters` option, which reverts the behavior to the v6.4.16 behavior that our code is built on
- v6.6.0 of MikroORM switched from per-entity-type alias counters to a global sequential counter. This causes issues in our code when hardcoded entity aliases (e.g. "o0") are used in populateWhere raw fragments for SELECT_IN queries, as those aliases no longer reliably refer to the expected entity.
  - The fix uses MikroORM's `raw` callback in `populateWhere` conditions,  where the alias parameter is resolved to the correct entity alias at query-build time instead of being hardcoded. Additionally, `findAndCount` was updated to run   find and count as separate queries, since the count query uses JOINED strategy internally (with a different alias context) but the version subqueries were built for `SELECT_IN` aliases.