### PR TITLE
docs(ui): fix content menu position

### DIFF
--- a/www/packages/docs-ui/src/components/ContentMenu/index.tsx
+++ b/www/packages/docs-ui/src/components/ContentMenu/index.tsx
@@ -19,7 +19,7 @@ export const ContentMenu = () => {
       className={clsx(
         "hidden lg:flex w-full max-w-sidebar-lg",
         "flex-col gap-docs_2 pb-docs_1.5",
-        "fixed top-[57px] right-docs_0.25 z-10",
+        "fixed top-[57px] right-[21px] z-10",
         "border-l border-medusa-border-base h-full",
         showCollapsedNavbar && "max-h-[calc(100%-112px)]",
         !showCollapsedNavbar && "max-h-[calc(100%-56px)]"

--- a/www/packages/docs-ui/src/layouts/main-content.tsx
+++ b/www/packages/docs-ui/src/layouts/main-content.tsx
@@ -134,7 +134,7 @@ export const MainContentLayout = ({
         {showContentMenu && (
           <>
             {sidebarCollapser(
-              desktopSidebarOpen ? "right-[225px]" : "right-docs_0.25"
+              desktopSidebarOpen ? "right-[242px]" : "right-docs_0.25"
             )}
             {desktopSidebarOpen && <ContentMenu />}
           </>


### PR DESCRIPTION
## Summary

Currently the content menu covers the main scrollbar which makes it hard to interact with it.

<img width="326" height="712" alt="Screenshot 2026-04-07 at 18 21 50" src="https://github.com/user-attachments/assets/b4d4c334-aa01-4345-9124-a38f486a913d" />

This PR fixes this issue by slightly changing the content menu position (and the collapse button) to account for the scrollbar width (which is usually 17px).

<img width="326" height="712" alt="Screenshot 2026-04-07 at 18 22 29" src="https://github.com/user-attachments/assets/b93f3444-f1a9-488a-ba4c-991390605f85" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, CSS-only positioning tweaks to the docs UI with no logic, data, or security impact.
> 
> **Overview**
> Fixes an issue where the right-side content menu could cover the main scrollbar by nudging the menu’s fixed `right` offset.
> 
> Also shifts the right-side sidebar collapse handle when the desktop sidebar is open to keep alignment consistent with the updated menu position.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80932d177213994db94a9ad801b48a98acf2f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->