### PR TITLE
fix(docs): update link for Upgrade Guides in medusa/medusa README.md

### DIFF
--- a/packages/medusa/README.md
+++ b/packages/medusa/README.md
@@ -52,7 +52,7 @@ Learn more about [Medusa’s architecture](https://docs.medusajs.com/learn/advan
 
 You can view the planned, started and completed features in the [Roadmap discussion](https://github.com/medusajs/medusa/discussions/categories/roadmap).
 
-Follow the [Upgrade Guides](https://docs.medusajs.com/upgrade-guides/) to keep your Medusa project up-to-date.
+Follow the [Upgrade Guides](https://docs.medusajs.com/learn/update) to keep your Medusa project up-to-date.
 
 ## Community & Contributions
 


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

I noticed the [Upgrade Guide link](https://npmx.dev/package/@medusajs/medusa#user-content-roadmap-upgrades) in the @medusajs/medusa package was broken, I updated it to the proper documentation link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; updates a single URL with no runtime or behavior impact.
> 
> **Overview**
> Fixes a broken documentation reference in `packages/medusa/README.md` by updating the **Upgrade Guides** link to the current `docs.medusajs.com/learn/update` URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ccc0dfa1272cdfab65e2d92df8ff31d29dd2e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->