### PR TITLE
fix(auth-emailpass): allow email update in updateProvider method

### DIFF
--- a/.changeset/good-balloons-flow.md
+++ b/.changeset/good-balloons-flow.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/auth-emailpass": patch
+---
+
+fix(auth-emailpass): allow email update in updateProvider method

--- a/packages/modules/providers/auth-emailpass/integration-tests/__tests__/services.spec.ts
+++ b/packages/modules/providers/auth-emailpass/integration-tests/__tests__/services.spec.ts
@@ -271,5 +271,81 @@ describe("Email password auth provider", () => {
     expect(authServiceSpies.retrieve).toHaveBeenCalled()
 
     expect(resp.error).toEqual("Invalid email or password")
+  
+    })
+
+  it("returns error if entity_id is not passed to update", async () => {
+    const resp = await emailpassService.update(
+      { entity_id: "" },
+      {} as any
+    )
+
+    expect(resp).toEqual({
+      success: false,
+      error: "Cannot update emailpass provider identity without entity_id",
+    })
+  })
+
+  it("updates password if password is passed", async () => {
+    const authServiceSpies = {
+      update: jest.fn().mockImplementation(() => {
+        return {
+          provider_identities: [
+            {
+              entity_id: "test@admin.com",
+              provider: "emailpass",
+              provider_metadata: {},
+            },
+          ],
+        }
+      }),
+    }
+
+    const resp = await emailpassService.update(
+      { entity_id: "test@admin.com", password: "newpassword" },
+      authServiceSpies as any
+    )
+
+    expect(authServiceSpies.update).toHaveBeenCalledWith(
+      "test@admin.com",
+      expect.objectContaining({
+        provider_metadata: expect.objectContaining({
+          password: expect.any(String),
+        }),
+      })
+    )
+    expect(resp.success).toBe(true)
+  })
+
+  it("updates email if email is passed", async () => {
+    const authServiceSpies = {
+      update: jest.fn().mockImplementation(() => {
+        return {
+          provider_identities: [
+            {
+              entity_id: "test@admin.com",
+              provider: "emailpass",
+              provider_metadata: {},
+            },
+          ],
+        }
+      }),
+    }
+
+    const resp = await emailpassService.update(
+      { entity_id: "test@admin.com", email: "newemail@admin.com" },
+      authServiceSpies as any
+    )
+
+    expect(authServiceSpies.update).toHaveBeenCalledWith(
+      "test@admin.com",
+      expect.objectContaining({
+        user_metadata: expect.objectContaining({
+          email: "newemail@admin.com",
+        }),
+      })
+    )
+    expect(resp.success).toBe(true)
   })
 })
+

--- a/packages/modules/providers/auth-emailpass/src/services/emailpass.ts
+++ b/packages/modules/providers/auth-emailpass/src/services/emailpass.ts
@@ -46,40 +46,47 @@ export class EmailPassAuthService extends AbstractAuthModuleProvider {
   }
 
   async update(
-    data: { password: string; entity_id: string },
-    authIdentityService: AuthIdentityProviderService
-  ) {
-    const { password, entity_id } = data ?? {}
+  data: { password?: string; email?: string; entity_id: string },
+  authIdentityService: AuthIdentityProviderService
+) {
+  const { password, email, entity_id } = data ?? {}
 
-    if (!entity_id) {
-      return {
-        success: false,
-        error: `Cannot update ${this.provider} provider identity without entity_id`,
-      }
-    }
-
-    if (!password || !isString(password)) {
-      return { success: true }
-    }
-
-    let authIdentity
-
-    try {
-      const passwordHash = await this.hashPassword(password)
-
-      authIdentity = await authIdentityService.update(entity_id, {
-        provider_metadata: {
-          password: passwordHash,
-        },
-      })
-    } catch (error) {
-      return { success: false, error: error.message }
-    }
-
+  if (!entity_id) {
     return {
-      success: true,
-      authIdentity,
+      success: false,
+      error: `Cannot update ${this.provider} provider identity without entity_id`,
     }
+  }
+
+  let authIdentity
+  const providerMetadataUpdate: Record<string, unknown> = {}
+  const userMetadataUpdate: Record<string, unknown> = {}
+
+  if (password && isString(password)) {
+    providerMetadataUpdate.password = await this.hashPassword(password)
+  }
+
+  if (email && isString(email)) {
+    userMetadataUpdate.email = email
+  }
+
+  try {
+    const updateData: {
+      provider_metadata?: Record<string, unknown>
+      user_metadata?: Record<string, unknown>
+    } = {}
+
+    if (Object.keys(providerMetadataUpdate).length > 0) {
+      updateData.provider_metadata = providerMetadataUpdate
+    }
+
+    if (Object.keys(userMetadataUpdate).length > 0) {
+      updateData.user_metadata = userMetadataUpdate
+    }
+
+    authIdentity = await authIdentityService.update(entity_id, updateData)
+  } catch (error) {
+    return { success: false, error: error.message }
   }
 
   async authenticate(

--- a/packages/modules/providers/auth-emailpass/src/services/emailpass.ts
+++ b/packages/modules/providers/auth-emailpass/src/services/emailpass.ts
@@ -6,7 +6,7 @@ import {
   EmailPassAuthProviderOptions,
   Logger,
 } from "@medusajs/framework/types"
-import { AbstractAuthModuleProvider, isString, MedusaError, } from "@medusajs/framework/utils"
+import { AbstractAuthModuleProvider, isString, MedusaError } from "@medusajs/framework/utils"
 import Scrypt from "scrypt-kdf"
 import { isPresent } from "@medusajs/utils"
 
@@ -15,8 +15,8 @@ type InjectedDependencies = {
 }
 
 type AuthIdentityParams = {
-  email: string;
-  password: string;
+  email: string
+  password: string
   authIdentityService: AuthIdentityProviderService
 }
 
@@ -46,47 +46,50 @@ export class EmailPassAuthService extends AbstractAuthModuleProvider {
   }
 
   async update(
-  data: { password?: string; email?: string; entity_id: string },
-  authIdentityService: AuthIdentityProviderService
-) {
-  const { password, email, entity_id } = data ?? {}
+    data: { password?: string; email?: string; entity_id: string },
+    authIdentityService: AuthIdentityProviderService
+  ) {
+    const { password, email, entity_id } = data ?? {}
 
-  if (!entity_id) {
-    return {
-      success: false,
-      error: `Cannot update ${this.provider} provider identity without entity_id`,
-    }
-  }
-
-  let authIdentity
-  const providerMetadataUpdate: Record<string, unknown> = {}
-  const userMetadataUpdate: Record<string, unknown> = {}
-
-  if (password && isString(password)) {
-    providerMetadataUpdate.password = await this.hashPassword(password)
-  }
-
-  if (email && isString(email)) {
-    userMetadataUpdate.email = email
-  }
-
-  try {
-    const updateData: {
-      provider_metadata?: Record<string, unknown>
-      user_metadata?: Record<string, unknown>
-    } = {}
-
-    if (Object.keys(providerMetadataUpdate).length > 0) {
-      updateData.provider_metadata = providerMetadataUpdate
+    if (!entity_id) {
+      return {
+        success: false,
+        error: `Cannot update ${this.provider} provider identity without entity_id`,
+      }
     }
 
-    if (Object.keys(userMetadataUpdate).length > 0) {
-      updateData.user_metadata = userMetadataUpdate
+    const providerMetadataUpdate: Record<string, unknown> = {}
+    const userMetadataUpdate: Record<string, unknown> = {}
+
+    if (password && isString(password)) {
+      providerMetadataUpdate.password = await this.hashPassword(password)
     }
 
-    authIdentity = await authIdentityService.update(entity_id, updateData)
-  } catch (error) {
-    return { success: false, error: error.message }
+    if (email && isString(email)) {
+      userMetadataUpdate.email = email
+    }
+
+    let authIdentity
+    try {
+      const updateData: {
+        provider_metadata?: Record<string, unknown>
+        user_metadata?: Record<string, unknown>
+      } = {}
+
+      if (Object.keys(providerMetadataUpdate).length > 0) {
+        updateData.provider_metadata = providerMetadataUpdate
+      }
+
+      if (Object.keys(userMetadataUpdate).length > 0) {
+        updateData.user_metadata = userMetadataUpdate
+      }
+
+      authIdentity = await authIdentityService.update(entity_id, updateData)
+    } catch (error) {
+      return { success: false, error: error.message }
+    }
+
+    return { success: true, authIdentity }
   }
 
   async authenticate(
@@ -180,7 +183,6 @@ export class EmailPassAuthService extends AbstractAuthModuleProvider {
         entity_id: email,
       })
 
-      // If app_metadata is not defined or empty, it means no actor was assigned to the auth_identity yet (still "claimable")
       if (!isPresent(identity.app_metadata)) {
         const updatedAuthIdentity = await this.upsertAuthIdentity('update', {
           email,
@@ -216,19 +218,25 @@ export class EmailPassAuthService extends AbstractAuthModuleProvider {
     }
   }
 
-  private async upsertAuthIdentity(type: 'update' | 'create', { email, password, authIdentityService }: AuthIdentityParams) {
+  private async upsertAuthIdentity(
+    type: 'update' | 'create',
+    { email, password, authIdentityService }: AuthIdentityParams
+  ) {
     const passwordHash = await this.hashPassword(password)
 
-    const authIdentity = type === 'create' ? await authIdentityService.create({
-        entity_id: email,
-        provider_metadata: {
-          password: passwordHash,
-        },
-      }) : await authIdentityService.update(email, {
-      provider_metadata: {
-        password: passwordHash,
-      },
-    })
+    const authIdentity =
+      type === 'create'
+        ? await authIdentityService.create({
+            entity_id: email,
+            provider_metadata: {
+              password: passwordHash,
+            },
+          })
+        : await authIdentityService.update(email, {
+            provider_metadata: {
+              password: passwordHash,
+            },
+          })
 
     const copy = JSON.parse(JSON.stringify(authIdentity))
     const providerIdentity = copy.provider_identities?.find(


### PR DESCRIPTION
## What
Fixes #14921

`authModuleService.updateProvider` was not allowing email updates for 
emailpass provider. Only password updates were supported despite the 
docs stating email can also be updated.

## Why
In `EmailPassAuthService.update()`, the `email` field was completely 
absent from the type signature and never destructured or saved. 
Only `password` was handled.

## How
- Added `email?` to the `update` method type signature
- Email is now saved to `user_metadata` when passed
- Password remains optional and independent of email update
- Added 3 integration tests covering the new behavior

## Testing

**To reproduce the bug (before fix):**
1. Create a user with emailpass provider
2. Call `authModuleService.updateProvider` with a new email
3. Check `user_metadata` — email is not updated (silently ignored)

**To verify the fix (after fix):**
1. Create a user with emailpass provider
2. Call `authModuleService.updateProvider` with a new email
3. Check `user_metadata` — email is now correctly updated
4. Verify password update still works independently
5. Verify login still works with original email (entity_id unchanged)

**Test cases added:**
- Update email only → `user_metadata.email` is updated
- Update password only → `provider_metadata` is updated
- Missing `entity_id` → returns error correctly