### PR TITLE
docs: add TSDocs for "allow filtering on variant sku/barcode/ean/upc on both /stor"

### DIFF
--- a/packages/core/types/src/http/product/admin/queries.ts
+++ b/packages/core/types/src/http/product/admin/queries.ts
@@ -2,8 +2,14 @@ import { BaseFilterable, OperatorMap } from "../../../dal"
 import { FindParams } from "../../common"
 import { BaseProductListParams, BaseProductOptionParams } from "../common"
 
+/**
+ * The product option's details.
+ */
 export interface AdminProductOptionParams
   extends Omit<BaseProductOptionParams, "product_id"> {}
+/**
+ * The filters to apply on the retrieved product variants.
+ */
 export interface AdminProductVariantParams
   extends FindParams,
     BaseFilterable<AdminProductVariantParams> {
@@ -53,6 +59,9 @@ export interface AdminProductVariantParams
    */
   deleted_at?: OperatorMap<string>
 }
+/**
+ * The filters to apply on the retrieved products.
+ */
 export interface AdminProductListParams
   extends Omit<BaseProductListParams, "categories"> {
   /**
@@ -65,20 +74,62 @@ export interface AdminProductListParams
   variants?: Omit<AdminProductVariantParams, "q">
 }
 
+/**
+ * The filters to apply on the retrieved products to export.
+ */
 export interface AdminProductExportParams extends Omit<AdminProductListParams, "tags" | "variants"> {
+  /**
+   * Filter by tag ID(s).
+   */
   tags?: {
+    /**
+     * The tag ID(s) to filter by.
+     */
     id?: string[]
   }
+  /**
+   * Apply filters on the product variants.
+   */
   variants?: { 
-
+    /**
+     * Filter by variant sku(s).
+     *
+     * @since 2.13.7
+     */
     sku?: string | string[] | OperatorMap<string | string[]>
+    /**
+     * Filter by variant ean(s).
+     *
+     * @since 2.13.7
+     */
     ean?: string | string[] | OperatorMap<string | string[]>
+    /**
+     * Filter by variant upc(s).
+     *
+     * @since 2.13.7
+     */
     upc?: string | string[] | OperatorMap<string | string[]>
+    /**
+     * Filter by variant barcode(s).
+     *
+     * @since 2.13.7
+     */
     barcode?: string | string[] | OperatorMap<string | string[]>
-    
+    /**
+     * Apply filters on the product variant's options.
+     */
     options?: { 
+      /**
+       * Filter by option value(s).
+       */
       value?: string
+      /**
+       * Filter by option ID(s).
+       */
       option_id?: string
+      /**
+       * Apply filters on the option.
+       */
       option?: Record<string, any>
     }
   }

--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -6,7 +6,13 @@ import { BaseProductCategory } from "../product-category/common"
 import { BaseProductTag } from "../product-tag/common"
 import { BaseProductType } from "../product-type/common"
 
+/**
+ * The product's status.
+ */
 export type ProductStatus = "draft" | "proposed" | "published" | "rejected"
+/**
+ * The product's details.
+ */
 export interface BaseProduct {
   /**
    * The product's ID.
@@ -134,6 +140,9 @@ export interface BaseProduct {
   metadata?: Record<string, unknown> | null
 }
 
+/**
+ * The product variant's details.
+ */
 export interface BaseProductVariant {
   /**
    * The variant's ID.
@@ -255,6 +264,9 @@ export interface BaseProductVariant {
   metadata?: Record<string, unknown> | null
 }
 
+/**
+ * The product option's details.
+ */
 export interface BaseProductOption {
   /**
    * The option's ID.
@@ -294,6 +306,9 @@ export interface BaseProductOption {
   deleted_at?: string | null
 }
 
+/**
+ * The product image's details.
+ */
 export interface BaseProductImage {
   /**
    * The image's ID.
@@ -325,6 +340,9 @@ export interface BaseProductImage {
   metadata?: Record<string, unknown> | null
 }
 
+/**
+ * The product option value's details.
+ */
 export interface BaseProductOptionValue {
   /**
    * The option value's ID.
@@ -360,6 +378,9 @@ export interface BaseProductOptionValue {
   deleted_at?: string | null
 }
 
+/**
+ * The filters to apply on the retrieved products.
+ */
 export interface BaseProductListParams
   extends FindParams,
     BaseFilterable<BaseProductListParams> {
@@ -429,29 +450,91 @@ export interface BaseProductListParams
   deleted_at?: OperatorMap<string>
 }
 
+/**
+ * The filters to apply on the retrieved product options.
+ */
 export interface BaseProductOptionParams
   extends FindParams,
     BaseFilterable<BaseProductOptionParams> {
+  /**
+   * Query or keywords to filter the option's searchable fields.
+   */
   q?: string
+  /**
+   * Filter by option ID(s).
+   */
   id?: string | string[]
+  /**
+   * Filter by option title(s).
+   */
   title?: string | string[]
+  /**
+   * Filter by product ID(s).
+   */
   product_id?: string | string[]
 }
 
+/**
+ * The filters to apply on the retrieved product variants.
+ */
 export interface BaseProductVariantParams
   extends FindParams,
     BaseFilterable<BaseProductVariantParams> {
+  /**
+   * Query or keywords to filter the variant's searchable fields.
+   */
   q?: string
+  /**
+   * Filter by variant ID(s).
+   */
   id?: string | string[]
+  /**
+   * Apply filters on the variant's options.
+   */
   options?: {
+    /**
+     * Filter by option value.
+     */
     value: string
+    /**
+     * Filter by option ID.
+     */
     option_id: string
   },
+  /**
+   * Filter by variant sku(s).
+   *
+   * @since 2.13.7
+   */
   sku?: string | string[]
+  /**
+   * Filter by variant ean(s).
+   *
+   * @since 2.13.7
+   */
   ean?: string | string[]
+  /**
+   * Filter by variant upc(s).
+   *
+   * @since 2.13.7
+   */
   upc?: string | string[]
+  /**
+   * Filter by variant barcode(s).
+   *
+   * @since 2.13.7
+   */
   barcode?: string | string[]
+  /**
+   * Apply filters on the variant's creation date.
+   */
   created_at?: OperatorMap<string>
+  /**
+   * Apply filters on the variant's update date.
+   */
   updated_at?: OperatorMap<string>
+  /**
+   * Apply filters on the variant's deletion date.
+   */
   deleted_at?: OperatorMap<string>
 }

--- a/packages/core/types/src/http/product/store/queries.ts
+++ b/packages/core/types/src/http/product/store/queries.ts
@@ -5,7 +5,13 @@ import {
   BaseProductVariantParams,
 } from "../common"
 
+/**
+ * The product option's details.
+ */
 export interface StoreProductOptionParams extends BaseProductOptionParams {}
+/**
+ * The filters to apply on the retrieved product variants.
+ */
 export interface StoreProductVariantParams extends BaseProductVariantParams {}
 export interface StoreProductPricingContext {
   /**


### PR DESCRIPTION
## Automated TSDoc Additions

This PR adds TSDoc comments to TypeScript source files changed in commit [`923a869`](https://github.com/medusajs/medusa/commit/923a869a7d462c2e0399619ac2b35c16132e079c).

**Triggered by:** chore(api,types): allow filtering on variant sku/barcode/ean/upc on both /store and /admin apis (#14826)

**Files updated:**
- `packages/core/types/src/http/product/admin/queries.ts`
- `packages/core/types/src/http/product/common.ts`
- `packages/core/types/src/http/product/store/queries.ts`
- `packages/core/types/src/product/common.ts`
- `packages/medusa/src/api/admin/product-variants/validators.ts`
- `packages/medusa/src/api/store/products/validators.ts`

> Review carefully before merging. Claude may have missed context or used incorrect descriptions.