### PR TITLE
fix(medusa): prevent plugin:db:generate crash when model files export enums

### DIFF
--- a/.changeset/cyan-mice-kick.md
+++ b/.changeset/cyan-mice-kick.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): prevent plugin:db:generate crash when model files export enums - adds test coverage

--- a/packages/medusa/src/commands/plugin/db/generate.ts
+++ b/packages/medusa/src/commands/plugin/db/generate.ts
@@ -77,7 +77,7 @@ async function getEntitiesForModule(path: string) {
       (potentialEntity) => {
         return (
           DmlEntity.isDmlEntity(potentialEntity) ||
-          !!MetadataStorage.getMetadataFromDecorator(potentialEntity as any)
+          typeof potentialEntity === "function"
         )
       }
     )

--- a/packages/medusa/src/commands/plugin/db/integration-tests/__fixtures__/plugins-1-with-enum/src/modules/module-1/index.ts
+++ b/packages/medusa/src/commands/plugin/db/integration-tests/__fixtures__/plugins-1-with-enum/src/modules/module-1/index.ts
@@ -1,0 +1,4 @@
+import { MedusaService, Module } from "@medusajs/framework/utils"
+export default Module("module1_with_enum", {
+  service: class Module1Service extends MedusaService({}) {},
+})

--- a/packages/medusa/src/commands/plugin/db/integration-tests/__fixtures__/plugins-1-with-enum/src/modules/module-1/models/module-model-1.ts
+++ b/packages/medusa/src/commands/plugin/db/integration-tests/__fixtures__/plugins-1-with-enum/src/modules/module-1/models/module-model-1.ts
@@ -1,0 +1,14 @@
+import { model } from "@medusajs/framework/utils"
+
+// This enum export previously caused plugin:db:generate to crash
+export enum MyStatus {
+  ACTIVE = "active",
+  INACTIVE = "inactive",
+}
+
+const model1 = model.define("module_model_1_with_enum", {
+  id: model.id().primaryKey(),
+  name: model.text(),
+})
+
+export default model1

--- a/packages/medusa/src/commands/plugin/db/integration-tests/__tests__/plugin-generate.spec.ts
+++ b/packages/medusa/src/commands/plugin/db/integration-tests/__tests__/plugin-generate.spec.ts
@@ -28,6 +28,19 @@ describe("plugin-generate", () => {
       )
     )
     await module1.remove("migrations")
+
+    const module1WithEnum = new FileSystem(
+      join(
+        __dirname,
+        "..",
+        "__fixtures__",
+        "plugins-1-with-enum",
+        "src",
+        "modules",
+        "module-1"
+      )
+    )
+    await module1WithEnum.remove("migrations")
   })
 
   describe("main function", () => {
@@ -88,6 +101,22 @@ describe("plugin-generate", () => {
       )
 
       expect(process.exit).toHaveBeenCalledWith(1)
+    })
+    it("should successfully generate migrations when model files export enums alongside entities", async () => {
+      await main({
+        directory: join(__dirname, "..", "__fixtures__", "plugins-1-with-enum"),
+      })
+      expect(logger.info).toHaveBeenNthCalledWith(1, "Generating migrations...")
+      expect(logger.info).toHaveBeenNthCalledWith(
+        2,
+        "Generating migrations for module module1_with_enum..."
+      )
+      expect(logger.info).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining("Migration created")
+      )
+      expect(logger.info).toHaveBeenNthCalledWith(4, "Migrations generated")
+      expect(process.exit).toHaveBeenCalledWith()
     })
   })
 })


### PR DESCRIPTION
## What
Prevent `plugin:db:generate` from crashing when model files export 
TypeScript enums alongside MikroORM entities.

## Why
`MetadataStorage.getMetadataFromDecorator()` returns truthy for anything 
with a `.name` property — which compiled TypeScript enums have — so enums 
get misidentified as database entities, causing MikroORM to crash during 
migration generation.

## How
Replace the `MetadataStorage` check with `typeof potentialEntity === "function"` 
in `getEntitiesForModule()`. Class constructors are functions; enum objects 
are not. This aligns with the same pattern already used in `load-internal.ts`.

## Changes
- Fix entity detection in `packages/medusa/src/commands/plugin/db/generate.ts`
- Add integration test for enum + entity model files
- Add test fixture `plugins-1-with-enum` with enum and entity exports

Closes #15077