### PR TITLE
feat(draft-order): auto-select region and sales channel when only one…

### DIFF
--- a/.changeset/auto-select-single-options.md
+++ b/.changeset/auto-select-single-options.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/draft-order": patch
+---
+
+feat(draft-order): auto-select region and sales channel when only one option exists

--- a/packages/plugins/draft-order/src/admin/hooks/common/use-combobox-data.tsx
+++ b/packages/plugins/draft-order/src/admin/hooks/common/use-combobox-data.tsx
@@ -88,11 +88,14 @@ export const useComboboxData = <
     })
   }
 
+  const count = data?.pages[0]?.count ?? 0
+
   return {
     options,
     searchValue,
     onSearchValueChange,
     disabled,
+    count,
     ...rest,
   }
 }

--- a/packages/plugins/draft-order/src/admin/routes/draft-orders/@create/page.tsx
+++ b/packages/plugins/draft-order/src/admin/routes/draft-orders/@create/page.tsx
@@ -10,7 +10,7 @@ import {
   Switch,
   toast,
 } from "@medusajs/ui"
-import { Fragment, useCallback } from "react"
+import { Fragment, useCallback, useMemo } from "react"
 import { Control, useForm, UseFormSetValue, useWatch } from "react-hook-form"
 import { z } from "zod"
 import { AddressCard } from "../../../components/common/address-card"
@@ -39,21 +39,6 @@ const Create = () => {
 const CreateForm = () => {
   const { handleSuccess } = useRouteModal()
 
-  const form = useForm<z.infer<typeof schema>>({
-    defaultValues: {
-      region_id: "",
-      sales_channel_id: "",
-      customer_id: "",
-      email: "",
-      shipping_address_id: "",
-      shipping_address: initialAddress,
-      billing_address_id: "",
-      billing_address: null,
-      same_as_shipping: true,
-    },
-    resolver: zodResolver(schema),
-  })
-
   const regions = useComboboxData({
     queryFn: async (params) => {
       return await sdk.admin.region.list(params)
@@ -78,6 +63,34 @@ const CreateForm = () => {
         value: salesChannel.id,
       }))
     },
+  })
+
+  const formValues = useMemo(
+    () => ({
+      region_id:
+        regions.count === 1 && regions.options?.[0]
+          ? regions.options?.[0].value
+          : "",
+      sales_channel_id:
+        salesChannels.count === 1 && salesChannels.options?.[0]
+          ? salesChannels.options?.[0].value
+          : "",
+      customer_id: "",
+      email: "",
+      shipping_address_id: "",
+      shipping_address: initialAddress,
+      billing_address_id: "",
+      billing_address: null,
+      same_as_shipping: true,
+    }),
+    [regions.count, regions.options, salesChannels.count, salesChannels.options]
+  )
+
+  const form = useForm<z.infer<typeof schema>>({
+    defaultValues: formValues,
+    values: formValues,
+    resetOptions: { keepDirtyValues: true },
+    resolver: zodResolver(schema),
   })
 
   const { mutateAsync } = useCreateDraftOrder()


### PR DESCRIPTION
## Summary

**What** — Auto-select Region and Sales Channel dropdowns in the Create Draft Order form when only one option exists.

**Why** — Most Medusa merchants operate with a single sales channel and a single region. Currently they must manually select these from dropdowns every time they create a draft order, even when there's only one choice. This removes unnecessary clicks and speeds up the workflow.

**How** — Exposes `count` from `useComboboxData`'s existing infinite query response (matching the pattern already used in `packages/admin/dashboard/src/hooks/api/translations.tsx`). Uses `useMemo` to derive form defaults from the loaded combobox data, then syncs them into the form via react-hook-form's `values` prop with `resetOptions: { keepDirtyValues: true }`. This means:
- Zero extra API calls — reads from data already fetched by the combobox
- Zero `useEffect` — declarative sync through react-hook-form's built-in mechanism
- Non-destructive — user can still change the auto-selected value, and any manually edited fields are preserved

**Testing** — Manual testing on a Medusa instance:
1. Configure a store with a single region and a single sales channel
2. Navigate to Draft Orders → Create
3. Verify Region and Sales Channel are pre-selected
4. Verify you can still change them if needed
5. Add a second region/sales channel and confirm the dropdowns revert to placeholder behavior

No automated tests added — the admin dashboard has zero component/hook tests across the entire codebase (only build-tool utility tests exist).

---

## Examples

```ts
// useComboboxData now exposes count from the already-fetched infinite query
const regions = useComboboxData({
  queryKey: ["regions"],
  queryFn: (params) => sdk.admin.region.list(params),
  getOptions: (data) => data.regions.map((r) => ({ label: r.name, value: r.id })),
})

// regions.count === total items from the API (e.g., 1 if single region)
// regions.options === loaded items for the combobox dropdown

// Form values auto-derive from count
const formValues = useMemo(() => ({
  region_id: regions.count === 1 && regions.options?.[0]
    ? regions.options?.[0].value
    : "",
  // ...
}), [regions.count, regions.options])

// react-hook-form syncs without useEffect
const form = useForm({
  defaultValues: formValues,
  values: formValues,
  resetOptions: { keepDirtyValues: true },
})
```

---

## Checklist

- [x] I have added a **changeset** for this PR
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

- Related discussion: https://github.com/medusajs/medusa/discussions/15087
- The `count` exposure pattern matches the existing precedent in `packages/admin/dashboard/src/hooks/api/translations.tsx:92`
- Only 2 files changed, +32/-16 lines
