### PR TITLE
docs: add TSDocs for "Fix product export breaking when `sales_channel_id` filter i"

### DIFF
--- a/packages/core/core-flows/src/product/steps/export-products.ts
+++ b/packages/core/core-flows/src/product/steps/export-products.ts
@@ -8,10 +8,37 @@ import { WorkflowTypes } from "@medusajs/types"
 import { normalizeForExport } from "../helpers/normalize-for-export"
 import { json2csv } from "json-2-csv"
 
+/**
+ * The step ID for exporting products.
+ */
 export const exportProductsStepId = "export-products"
 
 const DEFAULT_BATCH_SIZE = 50
 
+/**
+ * This step exports products to a CSV file based on the provided filters.
+ * 
+ * @example
+ * To export all products:
+ * 
+ * ```ts
+ * const data = exportProductsStep({
+ *   select: ["id", "title", "handle"],
+ *   batch_size: 100
+ * })
+ * ```
+ * 
+ * To export products from a specific sales channel:
+ * 
+ * ```ts
+ * const data = exportProductsStep({
+ *   select: ["id", "title", "handle"],
+ *   filter: {
+ *     sales_channel_id: "sc_123"
+ *   }
+ * })
+ * ```
+ */
 export const exportProductsStep = createStep(
   exportProductsStepId,
   async (


### PR DESCRIPTION
## Automated TSDoc Additions

This PR adds TSDoc comments to TypeScript source files changed in commit [`c18e1f4`](https://github.com/medusajs/medusa/commit/c18e1f49a88c3b6a426171afeaf6f7691e8c5bde).

**Triggered by:** fix(core-flows,types): Fix product export breaking when `sales_channel_id` filter is passed (#14450)

**Files updated:**
- `packages/core/core-flows/src/product/steps/export-products.ts`
- `packages/core/core-flows/src/product/steps/get-all-products.ts`
- `packages/core/types/src/workflow/product/export-products.ts`

> Review carefully before merging. Claude may have missed context or used incorrect descriptions.