### PR TITLE
feat(core-flows,medusa,types): add no_notification to markOrderFulfillmentAsDeliveredWorkflow

### DIFF
--- a/.changeset/beige-llamas-drive.md
+++ b/.changeset/beige-llamas-drive.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/core-flows": patch
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+feat(core-flows,medusa,types): add no_notification to markOrderFulfillmentAsDeliveredWorkflow

--- a/packages/admin/dashboard/src/hooks/api/orders.tsx
+++ b/packages/admin/dashboard/src/hooks/api/orders.tsx
@@ -296,11 +296,12 @@ export const useMarkOrderFulfillmentAsDelivered = (
   options?: UseMutationOptions<
     { order: HttpTypes.AdminOrder },
     FetchError,
-    void
+    HttpTypes.AdminMarkOrderFulfillmentAsDelivered
   >
 ) => {
   return useMutation({
-    mutationFn: () => sdk.admin.order.markAsDelivered(orderId, fulfillmentId),
+    mutationFn: (payload: HttpTypes.AdminMarkOrderFulfillmentAsDelivered) =>
+      sdk.admin.order.markAsDelivered(orderId, fulfillmentId, payload),
     onSuccess: (data: any, variables: any, context: any) => {
       queryClient.invalidateQueries({
         queryKey: ordersQueryKeys.all,

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -11,13 +11,17 @@ import {
   Container,
   Copy,
   Heading,
+  Label,
+  Prompt,
   StatusBadge,
+  Switch,
   Text,
   Tooltip,
   toast,
   usePrompt,
 } from "@medusajs/ui"
 import { format } from "date-fns"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useNavigate } from "react-router-dom"
 import { ActionMenu } from "../../../../../components/common/action-menu"
@@ -264,17 +268,24 @@ const Fulfillment = ({
   const showDeliveryButton =
     !fulfillment.canceled_at && !fulfillment.delivered_at
 
-  const handleMarkAsDelivered = async () => {
-    const res = await prompt({
-      title: t("general.areYouSure"),
-      description: t("orders.fulfillment.markAsDeliveredWarning"),
-      confirmText: t("actions.continue"),
-      cancelText: t("actions.cancel"),
-      variant: "confirmation",
-    })
+  const [sendNotification, setSendNotification] = useState(
+    !order.no_notification
+  )
+  const [showDeliveredPrompt, setShowDeliveredPrompt] = useState(false)
 
-    if (res) {
-      await markAsDelivered(undefined, {
+  const handleMarkAsDelivered = () => {
+    setShowDeliveredPrompt(true)
+  }
+
+  const handleCancelDeliveredPrompt = () => {
+    setShowDeliveredPrompt(false)
+  }
+
+  const handleConfirmDelivered = async () => {
+    setShowDeliveredPrompt(false)
+    await markAsDelivered(
+      { no_notification: !sendNotification },
+      {
         onSuccess: () => {
           toast.success(
             t(
@@ -287,8 +298,8 @@ const Fulfillment = ({
         onError: (e) => {
           toast.error(e.message)
         },
-      })
-    }
+      }
+    )
   }
 
   const handleCancel = async () => {
@@ -484,6 +495,40 @@ const Fulfillment = ({
           )}
         </div>
       )}
+
+      <Prompt open={showDeliveredPrompt} variant="confirmation">
+        <Prompt.Content>
+          <Prompt.Header>
+            <Prompt.Title>{t("general.areYouSure")}</Prompt.Title>
+            <Prompt.Description>
+              {t("orders.fulfillment.markAsDeliveredWarning")}
+            </Prompt.Description>
+          </Prompt.Header>
+          <div className="border-ui-border-base mt-6 flex items-center justify-between border-y border-dotted p-6">
+            <Label
+              htmlFor={`send-notification-${fulfillment.id}`}
+              className="txt-compact-small text-ui-fg-subtle"
+            >
+              {t("orders.returns.sendNotification")}
+            </Label>
+            <Switch
+              id={`send-notification-${fulfillment.id}`}
+              dir="ltr"
+              className="rtl:rotate-180"
+              checked={sendNotification}
+              onCheckedChange={setSendNotification}
+            />
+          </div>
+          <Prompt.Footer>
+            <Prompt.Cancel onClick={handleCancelDeliveredPrompt}>
+              {t("actions.cancel")}
+            </Prompt.Cancel>
+            <Prompt.Action onClick={handleConfirmDelivered}>
+              {t("actions.continue")}
+            </Prompt.Action>
+          </Prompt.Footer>
+        </Prompt.Content>
+      </Prompt>
     </Container>
   )
 }

--- a/packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts
+++ b/packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts
@@ -169,8 +169,7 @@ function prepareRegisterDeliveryData({
         const iitem = iitems.find(
           (i) => i.inventory.id === fitem.inventory_item_id
         )
-        if(iitem)
-          quantity = MathBN.div(quantity, iitem.required_quantity)
+        if (iitem) quantity = MathBN.div(quantity, iitem.required_quantity)
       }
 
       return {
@@ -193,6 +192,10 @@ export type MarkOrderFulfillmentAsDeliveredWorkflowInput = {
    * The ID of the fulfillment to mark as delivered.
    */
   fulfillmentId: string
+  /**
+   * Whether to notify the customer about the delivery.
+   */
+  no_notification?: boolean
 }
 
 export const markOrderFulfillmentAsDeliveredWorkflowId =
@@ -277,7 +280,10 @@ export const markOrderFulfillmentAsDeliveredWorkflow = createWorkflow(
 
     emitEventStep({
       eventName: FulfillmentWorkflowEvents.DELIVERY_CREATED,
-      data: { id: deliveredFulfillment.id },
+      data: {
+        id: deliveredFulfillment.id,
+        no_notification: input.no_notification,
+      },
     })
 
     return new WorkflowResponse(void 0)

--- a/packages/core/js-sdk/src/admin/order.ts
+++ b/packages/core/js-sdk/src/admin/order.ts
@@ -491,6 +491,7 @@ export class Order {
   async markAsDelivered(
     id: string,
     fulfillmentId: string,
+    body?: HttpTypes.AdminMarkOrderFulfillmentAsDelivered,
     query?: SelectParams,
     headers?: ClientHeaders
   ) {
@@ -499,6 +500,7 @@ export class Order {
       {
         method: "POST",
         headers,
+        body,
         query,
       }
     )

--- a/packages/core/types/src/http/order/admin/payloads.ts
+++ b/packages/core/types/src/http/order/admin/payloads.ts
@@ -100,6 +100,13 @@ export interface AdminCreateOrderShipment {
   metadata?: Record<string, unknown> | null
 }
 
+export interface AdminMarkOrderFulfillmentAsDelivered {
+  /**
+   * Whether to notify the customer about the delivery.
+   */
+  no_notification?: boolean
+}
+
 export interface AdminCancelOrderFulfillment {
   /**
    * Whether to notify the customer about this change.

--- a/packages/medusa/src/api/admin/orders/[id]/fulfillments/[fulfillment_id]/mark-as-delivered/route.ts
+++ b/packages/medusa/src/api/admin/orders/[id]/fulfillments/[fulfillment_id]/mark-as-delivered/route.ts
@@ -7,13 +7,20 @@ import {
 } from "@medusajs/framework/http"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest<{}, HttpTypes.AdminGetOrderParams>,
+  req: AuthenticatedMedusaRequest<
+    HttpTypes.AdminMarkOrderFulfillmentAsDelivered,
+    HttpTypes.AdminGetOrderParams
+  >,
   res: MedusaResponse<HttpTypes.AdminOrderResponse>
 ) => {
   const { id: orderId, fulfillment_id: fulfillmentId } = req.params
 
   await markOrderFulfillmentAsDeliveredWorkflow(req.scope).run({
-    input: { orderId, fulfillmentId },
+    input: {
+      orderId,
+      fulfillmentId,
+      no_notification: req.validatedBody.no_notification,
+    },
   })
 
   const order = await refetchEntity({

--- a/packages/medusa/src/api/admin/orders/middlewares.ts
+++ b/packages/medusa/src/api/admin/orders/middlewares.ts
@@ -13,6 +13,7 @@ import {
   AdminGetOrdersOrderItemsParams,
   AdminGetOrdersOrderParams,
   AdminGetOrdersParams,
+  AdminMarkOrderFulfillmentAsDelivered,
   AdminOrderCancelFulfillment,
   AdminOrderChangesParams,
   AdminOrderCreateFulfillment,
@@ -256,6 +257,7 @@ export const adminOrderRoutesMiddlewares: MiddlewareRoute[] = [
         AdminGetOrdersOrderParams,
         QueryConfig.retrieveTransformQueryConfig
       ),
+      validateAndTransformBody(AdminMarkOrderFulfillmentAsDelivered),
     ],
     policies: [
       {

--- a/packages/medusa/src/api/admin/orders/validators.ts
+++ b/packages/medusa/src/api/admin/orders/validators.ts
@@ -120,6 +120,10 @@ export const OrderCreateShipment = z.object({
 })
 export const AdminOrderCreateShipment = WithAdditionalData(OrderCreateShipment)
 
+export const AdminMarkOrderFulfillmentAsDelivered = z.object({
+  no_notification: z.boolean().optional(),
+})
+
 export type AdminOrderCancelFulfillmentType = z.infer<
   typeof OrderCancelFulfillment
 >


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Add `no_notification` to the `markOrderFulfillmentAsDeliveredWorkflow`.

<img width="416" height="271" alt="CleanShot 2026-04-14 at 20 08 46" src="https://github.com/user-attachments/assets/3089b89a-0c90-48fb-a5d5-afa3fdb18634" />

**Why** — Why are these changes relevant or necessary?  

No way to express wether a notification should be sent or not.

**How** — How have these changes been implemented?

Added the `no_notification` property to the workflow and its executing API route so the merchant can specify.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

fixes #15056