### PR TITLE
fix(utils): error clearly when defineLink properties read before bootstrap

### DIFF
--- a/.changeset/define-link-lazy-property-errors.md
+++ b/.changeset/define-link-lazy-property-errors.md
@@ -1,0 +1,15 @@
+---
+"@medusajs/utils": patch
+---
+
+fix(utils): surface clear error when `defineLink()` properties are read before app bootstrap
+
+`defineLink()` returns an object whose `serviceName`, `entity`, and `entryPoint`
+are populated asynchronously during `MedusaModule.bootstrapAll()`. Capturing
+any of them as a primitive at import time (e.g. `const ep = MyLink.entryPoint`)
+used to silently freeze the empty string and later surface as an opaque
+`Service "undefined" was not found` at runtime. These properties are now
+exposed through getters that throw a descriptive error pointing at the real
+cause when read before registration. The setters used by the internal
+`register` callback flip an `_registered` flag, so normal usage after
+bootstrap is unchanged.

--- a/packages/core/utils/src/modules-sdk/__tests__/define-link.spec.ts
+++ b/packages/core/utils/src/modules-sdk/__tests__/define-link.spec.ts
@@ -1,0 +1,77 @@
+import { defineLink, DefineLinkSymbol } from "../define-link"
+
+describe("defineLink", () => {
+  const originalMedusaModule = (global as any).MedusaModule
+  let registered: Array<(modules: any[]) => any>
+
+  beforeEach(() => {
+    registered = []
+    ;(global as any).MedusaModule = {
+      setCustomLink: (cb: (modules: any[]) => any) => {
+        registered.push(cb)
+      },
+    }
+  })
+
+  afterEach(() => {
+    ;(global as any).MedusaModule = originalMedusaModule
+  })
+
+  const fakeLinkable = (serviceName: string, key: string, alias: string) => ({
+    serviceName,
+    field: alias,
+    linkable: key,
+    primaryKey: "id",
+  })
+
+  const buildModules = () => [
+    {
+      serviceName: "store",
+      primaryKeys: ["id"],
+      alias: [{ name: "store", entity: "Store" }],
+      linkableKeys: { store_id: "Store" },
+    },
+    {
+      serviceName: "region",
+      primaryKeys: ["id"],
+      alias: [{ name: "region", entity: "Region" }],
+      linkableKeys: { region_id: "Region" },
+    },
+  ]
+
+  it("exposes the DefineLink marker symbol before registration", () => {
+    const link = defineLink(
+      fakeLinkable("store", "store_id", "store"),
+      fakeLinkable("region", "region_id", "region")
+    )
+
+    // The marker symbol is always readable — only the lazy properties throw.
+    expect((link as any)[DefineLinkSymbol]).toBe(true)
+  })
+
+  it("throws a descriptive error when a lazy property is read before registration", () => {
+    const link = defineLink(
+      fakeLinkable("store", "store_id", "store"),
+      fakeLinkable("region", "region_id", "region")
+    )
+
+    expect(() => link.entryPoint).toThrow(/not available until the app bootstraps/)
+    expect(() => link.serviceName).toThrow(/entryPoint|serviceName/)
+    expect(() => link.entity as any).toThrow(/not available until the app bootstraps/)
+  })
+
+  it("populates the properties after the register callback runs", () => {
+    const link = defineLink(
+      fakeLinkable("store", "store_id", "store"),
+      fakeLinkable("region", "region_id", "region")
+    )
+
+    // Simulate MedusaModule.bootstrapAll() invoking the registered callback.
+    expect(registered).toHaveLength(1)
+    registered[0](buildModules())
+
+    expect(link.entryPoint).toBe("store_region")
+    expect(link.serviceName.length).toBeGreaterThan(0)
+    expect(link.entity!.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/core/utils/src/modules-sdk/define-link.ts
+++ b/packages/core/utils/src/modules-sdk/define-link.ts
@@ -228,12 +228,76 @@ export function defineLink(
     ) as unknown as DefineLinkExport
   }
 
-  const output = {
-    [DefineLinkSymbol]: true,
-    serviceName: "",
-    entity: "",
-    entryPoint: "",
-  }
+  // The `register` callback below mutates this object's properties during
+  // `MedusaModule.bootstrapAll()`. Callers who capture the primitive value
+  // of one of these properties at import time (e.g.
+  // `const entryPoint = MyLink.entryPoint`) would previously get an empty
+  // string with no error, and later hit an opaque `Service "undefined" was
+  // not found` at runtime. To surface that mistake at the point it happens,
+  // the three lazily-populated properties are exposed through getters that
+  // throw a descriptive error when read before registration. The `register`
+  // callback writes to them through the corresponding setters, which flip
+  // `_registered` so subsequent reads return the actual value.
+  const defineLinkOutput = (() => {
+    let _serviceName = ""
+    let _entity = ""
+    let _entryPoint = ""
+    let _registered = false
+
+    const notRegisteredError = (prop: string) =>
+      new Error(
+        `defineLink: "${prop}" is not available until the app bootstraps. ` +
+          `This happens when you capture the primitive value at import time, e.g.\n` +
+          `  const entryPoint = MyLink.entryPoint // "" — frozen at import time\n` +
+          `Instead, pass the link object and read the property at runtime:\n` +
+          `  function handler() { const entryPoint = MyLink.entryPoint /* populated */ }`
+      )
+
+    return Object.defineProperties(
+      { [DefineLinkSymbol]: true } as DefineLinkExport & {
+        [DefineLinkSymbol]: boolean
+      },
+      {
+        serviceName: {
+          enumerable: true,
+          configurable: true,
+          get() {
+            if (!_registered) throw notRegisteredError("serviceName")
+            return _serviceName
+          },
+          set(v: string) {
+            _serviceName = v
+            _registered = true
+          },
+        },
+        entity: {
+          enumerable: true,
+          configurable: true,
+          get() {
+            if (!_registered) throw notRegisteredError("entity")
+            return _entity
+          },
+          set(v: string) {
+            _entity = v
+            _registered = true
+          },
+        },
+        entryPoint: {
+          enumerable: true,
+          configurable: true,
+          get() {
+            if (!_registered) throw notRegisteredError("entryPoint")
+            return _entryPoint
+          },
+          set(v: string) {
+            _entryPoint = v
+            _registered = true
+          },
+        },
+      }
+    )
+  })()
+  const output = defineLinkOutput
 
   const register = function (
     modules: ModuleJoinerConfig[]


### PR DESCRIPTION
## Summary

- `defineLink()` previously returned an object with empty-string `serviceName` / `entity` / `entryPoint`, only populated during `MedusaModule.bootstrapAll()`. Capturing a primitive at import time (e.g. `const entryPoint = MyLink.entryPoint`) silently froze the empty string and later produced an opaque `Service \"undefined\" was not found` error with no pointer back to `defineLink`.
- The three properties are now exposed through getter/setter pairs backed by private fields and a `_registered` flag. Reading any of them before the register callback runs throws a descriptive error that names the mistake and shows the recommended fix.
- Behaviour after bootstrap is unchanged — the existing internal `register` callback just assigns through the setters, which flip `_registered` so normal reads succeed.

Closes #14843.

## Test plan

- [x] New unit test `packages/core/utils/src/modules-sdk/__tests__/define-link.spec.ts` covering:
  - `DefineLinkSymbol` is always readable before registration
  - Each lazy property throws a descriptive error before registration
  - Properties return real values after the registered callback runs
- [ ] CI monorepo test suite passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to earlier failure with clearer messaging when `defineLink()` output properties are accessed before registration; post-bootstrap behavior should remain the same. Main risk is any code that intentionally read these values early will now throw.
> 
> **Overview**
> Prevents silent empty-string reads from `defineLink()` output by replacing `serviceName`/`entity`/`entryPoint` with lazy getters that **throw a descriptive error** until the internal registration callback runs, while setters populate the values during bootstrap as before.
> 
> Adds unit tests to assert the marker symbol remains readable pre-registration, the lazy properties throw before bootstrap, and the properties are populated after simulating `MedusaModule.bootstrapAll()` registration. Includes a patch changeset for `@medusajs/utils` documenting the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9618d70609e481878aca303330acd2ca828ceee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->