### PR TITLE
fix(framework): fix plugin build not outputting server assets

### DIFF
--- a/.changeset/eighty-ravens-brush.md
+++ b/.changeset/eighty-ravens-brush.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/framework": patch
+---
+
+fix(framework): fix plugin build not outputting server assets

--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -190,7 +190,10 @@ export class Compiler {
   }> {
     const ts = await this.#loadTSCompiler()
     const filesToCompile = tsConfig.fileNames.filter((fileName) => {
-      return !chunksToIgnore.some((chunk) => fileName.includes(`${chunk}`))
+      const relativeFileName = path.relative(this.#projectRoot, fileName)
+      return !chunksToIgnore.some((chunk) =>
+        relativeFileName.includes(`${chunk}`)
+      )
     })
 
     /**
@@ -423,7 +426,7 @@ export class Compiler {
    */
   async buildPluginBackend(tsConfig: tsStatic.ParsedCommandLine) {
     const tracker = this.#trackDuration()
-    const dist = ".medusa/server"
+    const dist = this.#pluginsDistFolder
     this.#logger.info("Compiling plugin source...")
 
     /**


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fixes the plugin build command that wasn't picking up server assets

Closes #14904

**Why** — Why are these changes relevant or necessary?  

The `plugin:build` command wasn't correctly resolving the paths in the project due to incorrect file name check. So, it only outputted admin customizations in the build.

**How** — How have these changes been implemented?

Correctly resolve paths to project root and plugin dist directory.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Tested in a plugin project

---

## Examples

-

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

-
