### PR TITLE
fix: prevent URL encoding of path separators in S3 file prefix

### DIFF
--- a/packages/modules/providers/file-s3/src/services/s3-file.ts
+++ b/packages/modules/providers/file-s3/src/services/s3-file.ts
@@ -163,7 +163,7 @@ export class S3FileService extends AbstractFileProviderService {
     }
 
     return {
-      url: `${this.config_.fileUrl}/${encodeURIComponent(fileKey)}`,
+      url: `${this.config_.fileUrl}/${fileKey.split("/").map(encodeURIComponent).join("/")}`,
       key: fileKey,
     }
   }


### PR DESCRIPTION
## Summary

Fixes #14756

- Replaces `encodeURIComponent(fileKey)` with `fileKey.split("/").map(encodeURIComponent).join("/")` in the S3 file service upload method, so path separators in the prefix (e.g. `public/`) are preserved while non-ASCII and special characters in filenames remain properly encoded.

## What changed

**File:** `packages/modules/providers/file-s3/src/services/s3-file.ts`

The bug was introduced in PR #14209 which added `encodeURIComponent(fileKey)` to handle non-ASCII characters in filenames. However, `encodeURIComponent` also encodes `/` to `%2F`, breaking any file key that includes a path prefix like `public/`.

**Before (broken):**
```typescript
url: `${this.config_.fileUrl}/${encodeURIComponent(fileKey)}`
// "public/thumbnail.jpg" → "public%2Fthumbnail.jpg"
```

**After (fixed):**
```typescript
url: `${this.config_.fileUrl}/${fileKey.split("/").map(encodeURIComponent).join("/")}`
// "public/thumbnail.jpg" → "public/thumbnail.jpg"
// "public/文档.pdf" → "public/%E6%96%87%E6%A1%A3.pdf"
// "public/cat?photo.jpg" → "public/cat%3Fphoto.jpg"
```

This approach encodes each path segment individually, preserving `/` separators while still encoding non-ASCII and special URL characters within each segment.

## Test plan

- [x] Verify that uploading a file with a prefix (e.g. `prefix: "public/"`) returns a URL with unencoded path separators
- [x] Verify that uploading a file with non-ASCII characters in the name (e.g. `文档.pdf`) still properly encodes those characters
- [x] Verify that uploading a file with special URL characters (e.g. `?`) still properly encodes those characters
- [x] Verify that uploading without a prefix still works correctly