### PR TITLE
fix: add no_notification parameter to delivery workflow

### DIFF
--- a/packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts
+++ b/packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts
@@ -193,6 +193,10 @@ export type MarkOrderFulfillmentAsDeliveredWorkflowInput = {
    * The ID of the fulfillment to mark as delivered.
    */
   fulfillmentId: string
+  /**
+   * Whether to notify the customer about the delivery.
+   */
+  no_notification?: boolean
 }
 
 export const markOrderFulfillmentAsDeliveredWorkflowId =
@@ -277,7 +281,10 @@ export const markOrderFulfillmentAsDeliveredWorkflow = createWorkflow(
 
     emitEventStep({
       eventName: FulfillmentWorkflowEvents.DELIVERY_CREATED,
-      data: { id: deliveredFulfillment.id },
+      data: {
+        id: deliveredFulfillment.id,
+        no_notification: input.no_notification,
+      },
     })
 
     return new WorkflowResponse(void 0)

--- a/packages/core/types/src/http/order/admin/payloads.ts
+++ b/packages/core/types/src/http/order/admin/payloads.ts
@@ -107,6 +107,13 @@ export interface AdminCancelOrderFulfillment {
   no_notification?: boolean
 }
 
+export interface AdminMarkOrderFulfillmentAsDelivered {
+  /**
+   * Whether to notify the customer about this change.
+   */
+  no_notification?: boolean
+}
+
 export interface AdminRequestOrderTransfer {
   /**
    * The ID of the customer to transfer the order to.

--- a/packages/medusa/src/api/admin/orders/[id]/fulfillments/[fulfillment_id]/mark-as-delivered/route.ts
+++ b/packages/medusa/src/api/admin/orders/[id]/fulfillments/[fulfillment_id]/mark-as-delivered/route.ts
@@ -7,13 +7,20 @@ import {
 } from "@medusajs/framework/http"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest<{}, HttpTypes.AdminGetOrderParams>,
+  req: AuthenticatedMedusaRequest<
+    HttpTypes.AdminMarkOrderFulfillmentAsDelivered,
+    HttpTypes.AdminGetOrderParams
+  >,
   res: MedusaResponse<HttpTypes.AdminOrderResponse>
 ) => {
   const { id: orderId, fulfillment_id: fulfillmentId } = req.params
 
   await markOrderFulfillmentAsDeliveredWorkflow(req.scope).run({
-    input: { orderId, fulfillmentId },
+    input: {
+      orderId,
+      fulfillmentId,
+      no_notification: req.validatedBody?.no_notification,
+    },
   })
 
   const order = await refetchEntity({

--- a/packages/medusa/src/api/admin/orders/middlewares.ts
+++ b/packages/medusa/src/api/admin/orders/middlewares.ts
@@ -17,6 +17,7 @@ import {
   AdminOrderChangesParams,
   AdminOrderCreateFulfillment,
   AdminOrderCreateShipment,
+  AdminOrderMarkAsDelivered,
   AdminTransferOrder,
   AdminUpdateOrder,
 } from "./validators"
@@ -252,6 +253,7 @@ export const adminOrderRoutesMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/admin/orders/:id/fulfillments/:fulfillment_id/mark-as-delivered",
     middlewares: [
+      validateAndTransformBody(AdminOrderMarkAsDelivered),
       validateAndTransformQuery(
         AdminGetOrdersOrderParams,
         QueryConfig.retrieveTransformQueryConfig

--- a/packages/medusa/src/api/admin/orders/validators.ts
+++ b/packages/medusa/src/api/admin/orders/validators.ts
@@ -130,6 +130,16 @@ export const AdminOrderCancelFulfillment = WithAdditionalData(
   OrderCancelFulfillment
 )
 
+export type AdminOrderMarkAsDeliveredType = z.infer<
+  typeof OrderMarkAsDelivered
+>
+export const OrderMarkAsDelivered = z.object({
+  no_notification: z.boolean().optional(),
+})
+export const AdminOrderMarkAsDelivered = WithAdditionalData(
+  OrderMarkAsDelivered
+)
+
 export const AdminOrderChangesParams = createSelectParams().merge(
   z.object({
     id: z.union([z.string(), z.array(z.string())]).optional(),


### PR DESCRIPTION
## Summary

Fixes #15056

The `markOrderFulfillmentAsDeliveredWorkflow` was missing the `no_notification` parameter that other fulfillment workflows (`create-fulfillment`, `create-shipment`, `cancel-fulfillment`) already support. This prevented users from marking orders as delivered without triggering customer notifications.

### Changes

- **Workflow input type**: Added `no_notification?: boolean` to `MarkOrderFulfillmentAsDeliveredWorkflowInput`
- **Workflow event emission**: Passes `no_notification` through the `DELIVERY_CREATED` event data (matching `SHIPMENT_CREATED` and `FULFILLMENT_CREATED` patterns)
- **HTTP type**: Added `AdminMarkOrderFulfillmentAsDelivered` interface to `@medusajs/framework/types`
- **Validator**: Added `AdminOrderMarkAsDelivered` Zod validator with `no_notification: z.boolean().optional()`
- **Middleware**: Added `validateAndTransformBody(AdminOrderMarkAsDelivered)` to the mark-as-delivered route
- **Route handler**: Updated to accept body payload and forward `no_notification` to the workflow

### Files changed

| File | Change |
|------|--------|
| `packages/core/core-flows/src/order/workflows/mark-order-fulfillment-as-delivered.ts` | Added `no_notification` to input type and event data |
| `packages/core/types/src/http/order/admin/payloads.ts` | Added `AdminMarkOrderFulfillmentAsDelivered` interface |
| `packages/medusa/src/api/admin/orders/validators.ts` | Added `AdminOrderMarkAsDelivered` Zod schema |
| `packages/medusa/src/api/admin/orders/middlewares.ts` | Added body validation to mark-as-delivered route |
| `packages/medusa/src/api/admin/orders/[id]/fulfillments/[fulfillment_id]/mark-as-delivered/route.ts` | Updated handler to pass `no_notification` |

## Test plan

- [x] Verify calling `POST /admin/orders/:id/fulfillments/:fulfillment_id/mark-as-delivered` without body still works (backward compatible)
- [x] Verify calling with `{ "no_notification": true }` passes the flag through the `delivery.created` event
- [x] Verify calling with `{ "no_notification": false }` passes `false` through the event
- [x] Confirm the pattern matches existing `create-shipment` and `create-fulfillment` workflows