### PR TITLE
feat(medusa-oas-cli, oas-github-ci): support versioning for outputted oas

### DIFF
--- a/.changeset/green-ways-mate.md
+++ b/.changeset/green-ways-mate.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/medusa-oas-cli": patch
+"@medusajs/oas-github-ci": patch
+---
+
+feat(medusa-oas-cli, oas-github-ci): support versioning for outputted oas

--- a/.github/workflows/generate-public-references.yml
+++ b/.github/workflows/generate-public-references.yml
@@ -167,8 +167,24 @@ jobs:
           GIT_OWNER: ${{ github.repository_owner }}
           GIT_REPO: medusa
 
+      - name: Get Previous Release Version
+        id: prev-release
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREV_TAG=$(gh release list --repo ${{ github.repository }} --limit 2 --json tagName | jq -r '.[1].tagName')
+          PREV_VERSION="${PREV_TAG#v}"
+          echo "version=$PREV_VERSION" >> $GITHUB_OUTPUT
+
       - name: Generate API Reference
-        run: yarn openapi:generate
+        run: |
+          PREV_VERSION="${{ steps.prev-release.outputs.version }}"
+          if [ -n "$PREV_VERSION" ]; then
+            yarn openapi:generate --archive-version=$PREV_VERSION
+          else
+            yarn openapi:generate
+          fi
 
       - name: Run prep script
         run: yarn prep

--- a/packages/cli/oas/medusa-oas-cli/src/__tests__/command-docs.test.ts
+++ b/packages/cli/oas/medusa-oas-cli/src/__tests__/command-docs.test.ts
@@ -288,6 +288,108 @@ describe("command docs", () => {
     })
   })
 
+  describe("--archive-out-file", () => {
+    let srcFile: string
+
+    beforeAll(async () => {
+      openApi = getBaseOpenApi()
+      openApi.components = {
+        schemas: {
+          Product: {
+            type: "object",
+          },
+        },
+      }
+      const outDir = path.resolve(tmpDir, uid())
+      await mkdir(outDir, { recursive: true })
+      srcFile = path.resolve(outDir, "admin.oas.json")
+      await writeJson(srcFile, openApi)
+    })
+
+    it("should copy the bundled YAML to the specified archive path", async () => {
+      const outDir = path.resolve(tmpDir, uid())
+      const archiveOutFile = path.resolve(tmpDir, uid(), "versions", "2.0.0", "admin", "openapi.full.yaml")
+      await runCLI("docs", [
+        "--src-file",
+        srcFile,
+        "--out-dir",
+        outDir,
+        "--archive-out-file",
+        archiveOutFile,
+      ])
+      const archiveExists = await exists(archiveOutFile)
+      expect(archiveExists).toBeTruthy()
+    })
+
+    it("should create intermediate directories for the archive path", async () => {
+      const outDir = path.resolve(tmpDir, uid())
+      const archiveOutFile = path.resolve(tmpDir, uid(), "versions", "1.0.0", "store", "openapi.full.yaml")
+      await runCLI("docs", [
+        "--src-file",
+        srcFile,
+        "--out-dir",
+        outDir,
+        "--archive-out-file",
+        archiveOutFile,
+      ])
+      const archiveExists = await exists(archiveOutFile)
+      expect(archiveExists).toBeTruthy()
+    })
+
+    it("should write valid YAML to the archive file", async () => {
+      const outDir = path.resolve(tmpDir, uid())
+      const archiveOutFile = path.resolve(tmpDir, uid(), "versions", "2.0.0", "admin", "openapi.full.yaml")
+      await runCLI("docs", [
+        "--src-file",
+        srcFile,
+        "--out-dir",
+        outDir,
+        "--archive-out-file",
+        archiveOutFile,
+      ])
+      const oas = (await readYaml(archiveOutFile)) as OpenAPIObject
+      expect(oas.openapi).toBeDefined()
+      expect(oas.components?.schemas?.Product).toBeDefined()
+    })
+
+    it("should write the same content to the archive as the main output file", async () => {
+      const outDir = path.resolve(tmpDir, uid())
+      const mainFileName = "openapi.full.yaml"
+      const archiveOutFile = path.resolve(tmpDir, uid(), "versions", "2.0.0", "admin", "openapi.full.yaml")
+      await runCLI("docs", [
+        "--src-file",
+        srcFile,
+        "--out-dir",
+        outDir,
+        "--main-file-name",
+        mainFileName,
+        "--archive-out-file",
+        archiveOutFile,
+      ])
+      const mainOas = (await readYaml(
+        path.resolve(outDir, mainFileName)
+      )) as OpenAPIObject
+      const archiveOas = (await readYaml(archiveOutFile)) as OpenAPIObject
+      expect(JSON.stringify(archiveOas)).toEqual(JSON.stringify(mainOas))
+    })
+
+    it("should not create the archive file when --dry-run is set", async () => {
+      const outDir = path.resolve(tmpDir, uid())
+      const archiveOutFile = path.resolve(tmpDir, uid(), "versions", "2.0.0", "admin", "openapi.full.yaml")
+      await runCLI("docs", [
+        "--src-file",
+        srcFile,
+        "--out-dir",
+        outDir,
+        "--dry-run",
+        "--archive-out-file",
+        archiveOutFile,
+      ])
+      const archiveExists = await exists(archiveOutFile)
+      expect(archiveExists).toBeFalsy()
+    })
+  })
+
   describe("circular references", () => {
     let srcFile: string
 

--- a/packages/cli/oas/medusa-oas-cli/src/command-docs.ts
+++ b/packages/cli/oas/medusa-oas-cli/src/command-docs.ts
@@ -74,6 +74,10 @@ export const commandOptions: Option[] = [
     "--main-file-name <mainFileName>",
     "The name of the main YAML file."
   ).default("openapi.yaml"),
+  new Option(
+    "--archive-out-file <archiveOutFile>",
+    "Path to copy the full bundled YAML to (e.g. for versioned storage). Creates intermediate directories as needed."
+  ),
 ]
 
 export function getCommand(): Command {
@@ -101,6 +105,9 @@ export async function execute(cliParams: OptionValues): Promise<void> {
   const dryRun = !!cliParams.dryRun
   const srcFile = path.resolve(cliParams.srcFile)
   const outDir = path.resolve(cliParams.outDir)
+  const archiveOutFile = cliParams.archiveOutFile
+    ? path.resolve(cliParams.archiveOutFile)
+    : undefined
 
   const configFileCustom = cliParams.config
     ? path.resolve(cliParams.config)
@@ -145,6 +152,12 @@ export async function execute(cliParams: OptionValues): Promise<void> {
   const srcFileSanitized = path.resolve(tmpDir, "tmp.oas.yaml")
   await sanitizeOAS(srcFile, srcFileSanitized, configTmpFile)
   await fixCirclularReferences(srcFileSanitized)
+
+  if (archiveOutFile && !dryRun) {
+    await mkdir(path.dirname(archiveOutFile), { recursive: true })
+    await fs.copyFile(srcFileSanitized, archiveOutFile)
+    console.log(`⚫️ Archived OAS to - ${archiveOutFile}`)
+  }
 
   if (dryRun) {
     console.log(`⚫️ Dry run - no files generated`)

--- a/packages/cli/oas/oas-github-ci/scripts/build-openapi.js
+++ b/packages/cli/oas/oas-github-ci/scripts/build-openapi.js
@@ -7,6 +7,8 @@ const execa = require("execa")
 
 const isDryRun = process.argv.indexOf("--dry-run") !== -1
 const withFullFile = process.argv.indexOf("--with-full-file") !== -1
+const archiveVersionArg = process.argv.find((a) => a.startsWith("--archive-version="))
+const archiveVersion = archiveVersionArg ? archiveVersionArg.split("=")[1] : undefined
 const basePath = path.resolve(__dirname, `../`)
 const repoRootPath = path.resolve(basePath, `../../../../`)
 const docsApiPath = path.resolve(repoRootPath, "www/apps/api-reference/specs")
@@ -17,7 +19,7 @@ const run = async () => {
     await generateOASSource(oasOutDir, apiType)
     const oasSrcFile = path.resolve(oasOutDir, `${apiType}.oas.json`)
     const docsOutDir = path.resolve(oasOutDir, apiType)
-    await generateDocs(oasSrcFile, docsOutDir, isDryRun)
+    await generateDocs(oasSrcFile, docsOutDir, apiType, isDryRun)
   }
 }
 
@@ -31,7 +33,7 @@ const generateOASSource = async (outDir, apiType) => {
   console.log(logs)
 }
 
-const generateDocs = async (srcFile, outDir, isDryRun) => {
+const generateDocs = async (srcFile, outDir, apiType, isDryRun) => {
   let params = [
     "docs",
     `--src-file=${srcFile}`,
@@ -51,6 +53,17 @@ const generateDocs = async (srcFile, outDir, isDryRun) => {
       `--out-dir=${outDir}`,
       `--main-file-name=openapi.full.yaml`
     ]
+    if (archiveVersion) {
+      const archiveOutFile = path.resolve(
+        docsApiPath,
+        "versions",
+        archiveVersion,
+        apiType,
+        "openapi.full.yaml"
+      )
+      params.push(`--archive-out-file=${archiveOutFile}`)
+      console.log(`Archiving version ${archiveVersion} to ${archiveOutFile}`)
+    }
     await runMedusaOasCommand(params)
     console.log("Finished generating full file.")
   }

--- a/www/apps/api-reference/app/download/[area]/route.ts
+++ b/www/apps/api-reference/app/download/[area]/route.ts
@@ -11,7 +11,27 @@ type DownloadParams = {
 export async function GET(request: Request, props: DownloadParams) {
   const params = await props.params
   const { area } = params
-  const filePath = path.join(process.cwd(), "specs", area, "openapi.full.yaml")
+  const { searchParams } = new URL(request.url)
+  const version = searchParams.get("version")
+
+  const defaultPath = path.join(
+    process.cwd(),
+    "specs",
+    area,
+    "openapi.full.yaml"
+  )
+  const versionedPath = version
+    ? path.join(
+        process.cwd(),
+        "specs",
+        "versions",
+        version,
+        area,
+        "openapi.full.yaml"
+      )
+    : null
+  const filePath =
+    versionedPath && existsSync(versionedPath) ? versionedPath : defaultPath
 
   if (!existsSync(filePath)) {
     return new NextResponse(null, {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Allow archiving old outputted OAS under a specific version, and allow downloading from the docs the OAS of a version

**Why** — Why are these changes relevant or necessary?  

This will allow us to keep OpenAPI specs across versions.

**How** — How have these changes been implemented?

- Add an option to copy previous version to an "archived" directory
- Update our pipeline on release to retrieve the previous version to move previous OAS into that version.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Run the following command in the root:

```bash
yarn openapi:generate --archive-version=2.13.5
```

This will copy previous OAS to the directory `www/apps/api-reference/specs/versions/2.13.5/admin/openapi.full.yaml` and `www/apps/api-reference/specs/versions/2.13.5/store/openapi.full.yaml`

In the docs:

- Send a request to `/api/download/admin?version=2.13.5` -> returns the OAS of that version.
- Send a request to `/api/download/admin` -> returns OAS of latest
- Send a request to `/api/download/admin?version=1` -> fallsback to latest OAS

---

## Examples

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
