### PR TITLE
fix(medusa): register project API middleware before core routes

### DIFF
--- a/.changeset/cool-lines-attend.md
+++ b/.changeset/cool-lines-attend.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): register project API middleware before core routes

--- a/integration-tests/http/__fixtures__/middlewares/medusa-config.js
+++ b/integration-tests/http/__fixtures__/middlewares/medusa-config.js
@@ -1,0 +1,10 @@
+const baseConfig = require("../../medusa-config")
+
+module.exports = {
+  ...baseConfig,
+  projectConfig: {
+    ...baseConfig.projectConfig,
+    databaseUrl: process.env.DB_TEMP_NAME || "postgres://localhost/medusa-test",
+    databaseType: "postgres",
+  },
+}

--- a/integration-tests/http/__fixtures__/middlewares/src/api/middlewares.ts
+++ b/integration-tests/http/__fixtures__/middlewares/src/api/middlewares.ts
@@ -1,0 +1,17 @@
+import { defineMiddlewares } from "@medusajs/framework/http"
+
+export default defineMiddlewares({
+  routes: [
+    {
+      matcher: "/admin/products",
+      methods: ["POST"],
+      middlewares: [
+        (req, res, next) => {
+          // If our bugfix works, this user middleware will hit first and we can intercept
+          // before the built-in validators throw a 400 Bad Request error.
+          res.status(200).json({ custom_middleware_hit: true })
+        },
+      ],
+    },
+  ],
+})

--- a/integration-tests/http/__tests__/middlewares/routing.spec.ts
+++ b/integration-tests/http/__tests__/middlewares/routing.spec.ts
@@ -1,0 +1,33 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+  adminHeaders,
+  createAdminUser,
+} from "../../../helpers/create-admin-user"
+import path from "path"
+
+jest.setTimeout(60000)
+
+medusaIntegrationTestRunner({
+  env: {},
+  cwd: path.resolve(__dirname, "../../__fixtures__/middlewares"),
+  testSuite: ({ getContainer, api, dbConnection }) => {
+    describe("API Middleware Routing", () => {
+      beforeEach(async () => {
+        await createAdminUser(dbConnection, adminHeaders, getContainer())
+      })
+
+      it("should run custom user middleware on exact path before Medusa built-in validation", async () => {
+        // We POST an empty body to /admin/products.
+        // With our fix, the user middleware in the fixture intercepts this before the Zod validator.
+        const response = await api.post(
+          "/admin/products",
+          {},
+          adminHeaders
+        ).catch((e) => e.response)
+
+        expect(response.status).toEqual(200)
+        expect(response.data.custom_middleware_hit).toEqual(true)
+      })
+    })
+  },
+})

--- a/packages/medusa/src/loaders/api.ts
+++ b/packages/medusa/src/loaders/api.ts
@@ -46,10 +46,10 @@ export default async ({ app, container, plugins }: Options) => {
    * "/products/:id" route.
    */
   sourcePaths.push(
-    join(__dirname, "../api"),
     ...plugins.map((pluginDetails) => {
       return join(pluginDetails.resolve, "api")
-    })
+    }),
+    join(__dirname, "../api")
   )
 
   const {

--- a/packages/medusa/src/loaders/api.ts
+++ b/packages/medusa/src/loaders/api.ts
@@ -34,11 +34,11 @@ export default async ({ app, container, plugins }: Options) => {
   const sourcePaths: string[] = []
 
   /**
-   * Always load plugin routes before the Medusa core routes, since it
-   * will allow the plugin to define routes with higher priority
-   * than Medusa. Here are couple of examples.
+   * Always load project and plugin routes before the Medusa core routes, since it
+   * will allow them to define routes and middlewares with higher priority
+   * than Medusa. Here are a couple of examples:
    *
-   * - Plugin registers a route called "/products/active"
+   * - A project registers a custom middleware or route on "/products/active"
    * - Medusa registers a route called "/products/:id"
    *
    * Now, if Medusa routes gets registered first, then the "/products/active"


### PR DESCRIPTION
## Summary

### What

This PR fixes exact-path project API middleware registration order.

Project middleware defined in `src/api/middlewares.ts` with an exact matcher like `/admin/products` is now registered before Medusa core API routes and route middleware.

### Why

Custom project middleware using exact route matchers could be skipped in practice because Medusa core routes were registered before project/plugin API resources.

For example, a project middleware on `POST /admin/products` would not run before Medusa's built-in product validation middleware. Wildcard matchers such as `/admin/*` worked as a workaround because they were sorted ahead of static core routes.

Fixes #15035.

### How

The API loader now scans plugin/project API source paths before Medusa core API paths. Since the project app is represented as the project plugin, its `src/api/middlewares.ts` is collected before core API middleware and routes.

A new HTTP integration regression test boots a fixture Medusa project with `src/api/middlewares.ts`, registers middleware on `POST /admin/products`, and verifies it runs before the built-in product validation middleware.

### Testing

```bash
yarn test:integration:http -- --testPathPattern="routing.spec.ts"
```

---

## Checklist

- [ ] I have added a changeset for this PR
- [x] The changes are covered by relevant tests
- [x] I have fixed the related issues if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes route/middleware registration order, which can alter request handling precedence for existing projects/plugins. Covered by a targeted integration test, but could surface unexpected overrides in custom setups.
> 
> **Overview**
> Fixes API routing precedence so **project/plugin-defined middlewares and routes are registered before Medusa core API routes**, ensuring exact-match middlewares (e.g. `POST /admin/products`) can intercept requests before built-in validators.
> 
> Adds an HTTP integration regression test fixture with a `src/api/middlewares.ts` override and a new `routing.spec.ts` to assert the custom middleware runs first, plus a patch changeset for the Medusa package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b1ae44635ba26b094f5b2301f73ecfd63108fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->