### PR TITLE
fix(core-flows): emit order.placed event after payment is authorized

### DIFF
--- a/.changeset/fix-order-placed-event-timing.md
+++ b/.changeset/fix-order-placed-event-timing.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): emit order.placed event after payment is authorized

--- a/integration-tests/http/__tests__/cart/store/cart.spec.ts
+++ b/integration-tests/http/__tests__/cart/store/cart.spec.ts
@@ -6,6 +6,7 @@ import {
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
 import {
   Modules,
+  OrderWorkflowEvents,
   PaymentSessionStatus,
   PriceListStatus,
   PriceListType,
@@ -3062,6 +3063,52 @@ medusaIntegrationTestRunner({
                 ])
               )
             })
+          })
+
+          it("should emit the order.placed event only after payment is authorized (not before)", async () => {
+            // Regression test for https://github.com/medusajs/medusa/issues/15122
+            // The order.placed event was previously emitted inside a parallelize() block
+            // alongside (and before) the payment authorization step. This meant the event
+            // could fire even if payment authorization failed and the order was rolled back.
+            // The fix moves emitEventStep to after authorizePaymentSessionStep and
+            // addOrderTransactionStep so the event only fires on a fully completed order.
+            const emittedEvents: string[] = []
+
+            const eventBus = appContainer.resolve(Modules.EVENT_BUS)
+            const subscriber = async ({ data }: { data: any }) => {
+              emittedEvents.push(OrderWorkflowEvents.PLACED)
+            }
+
+            await eventBus.subscribe(OrderWorkflowEvents.PLACED, subscriber)
+
+            const paymentCollection = (
+              await api.post(
+                `/store/payment-collections`,
+                { cart_id: cart.id },
+                storeHeaders
+              )
+            ).data.payment_collection
+
+            await api.post(
+              `/store/payment-collections/${paymentCollection.id}/payment-sessions`,
+              { provider_id: "pp_system_default" },
+              storeHeaders
+            )
+
+            const response = await api.post(
+              `/store/carts/${cart.id}/complete`,
+              {},
+              storeHeaders
+            )
+
+            expect(response.status).toEqual(200)
+            expect(response.data.order.id).toBeDefined()
+
+            // After successful cart completion, the event MUST have fired exactly once
+            expect(emittedEvents).toHaveLength(1)
+            expect(emittedEvents[0]).toEqual(OrderWorkflowEvents.PLACED)
+
+            await eventBus.unsubscribe(OrderWorkflowEvents.PLACED, subscriber)
           })
         })
 

--- a/integration-tests/http/__tests__/cart/store/cart.spec.ts
+++ b/integration-tests/http/__tests__/cart/store/cart.spec.ts
@@ -3081,34 +3081,36 @@ medusaIntegrationTestRunner({
 
             await eventBus.subscribe(OrderWorkflowEvents.PLACED, subscriber)
 
-            const paymentCollection = (
+            try {
+              const paymentCollection = (
+                await api.post(
+                  `/store/payment-collections`,
+                  { cart_id: cart.id },
+                  storeHeaders
+                )
+              ).data.payment_collection
+
               await api.post(
-                `/store/payment-collections`,
-                { cart_id: cart.id },
+                `/store/payment-collections/${paymentCollection.id}/payment-sessions`,
+                { provider_id: "pp_system_default" },
                 storeHeaders
               )
-            ).data.payment_collection
 
-            await api.post(
-              `/store/payment-collections/${paymentCollection.id}/payment-sessions`,
-              { provider_id: "pp_system_default" },
-              storeHeaders
-            )
+              const response = await api.post(
+                `/store/carts/${cart.id}/complete`,
+                {},
+                storeHeaders
+              )
 
-            const response = await api.post(
-              `/store/carts/${cart.id}/complete`,
-              {},
-              storeHeaders
-            )
+              expect(response.status).toEqual(200)
+              expect(response.data.order.id).toBeDefined()
 
-            expect(response.status).toEqual(200)
-            expect(response.data.order.id).toBeDefined()
-
-            // After successful cart completion, the event MUST have fired exactly once
-            expect(emittedEvents).toHaveLength(1)
-            expect(emittedEvents[0]).toEqual(OrderWorkflowEvents.PLACED)
-
-            await eventBus.unsubscribe(OrderWorkflowEvents.PLACED, subscriber)
+              // After successful cart completion, the event MUST have fired exactly once
+              expect(emittedEvents).toHaveLength(1)
+              expect(emittedEvents[0]).toEqual(OrderWorkflowEvents.PLACED)
+            } finally {
+              await eventBus.unsubscribe(OrderWorkflowEvents.PLACED, subscriber)
+            }
           })
         })
 

--- a/packages/core/core-flows/src/cart/workflows/complete-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/complete-cart.ts
@@ -595,14 +595,7 @@ export const completeCartWorkflow = createWorkflow(
         createRemoteLinkStep(linksToCreate),
         updateCartsStep([updateCompletedAt]),
         reserveInventoryStep(formatedInventoryItems),
-        registerUsageStep(promotionUsage),
-        emitEventStep({
-          eventName: OrderWorkflowEvents.PLACED,
-          data: { id: createdOrder.id },
-          options: {
-            priority: EventPriority.CRITICAL,
-          },
-        })
+        registerUsageStep(promotionUsage)
       )
 
       /**
@@ -642,6 +635,19 @@ export const completeCartWorkflow = createWorkflow(
       )
 
       addOrderTransactionStep(orderTransactions)
+
+      // Emit the order.placed event AFTER payment is authorized and transaction is recorded.
+      // Previously this was inside the parallelize block above, which meant the event could
+      // fire before payment authorization — causing listeners (e.g. sending confirmation emails,
+      // syncing to external systems) to act on an order that could still be rolled back.
+      // See: https://github.com/medusajs/medusa/issues/15122
+      emitEventStep({
+        eventName: OrderWorkflowEvents.PLACED,
+        data: { id: createdOrder.id },
+        options: {
+          priority: EventPriority.CRITICAL,
+        },
+      })
 
       /**
        * @ignore


### PR DESCRIPTION
## Summary

**What** — Moves the `order.placed` event emission to after payment authorization and transaction recording in the `completeCartWorkflow`.

**Why** — The `order.placed` event was previously emitted inside a `parallelize()` block, running concurrently with (and effectively before) `authorizePaymentSessionStep`. This meant external subscribers (e.g. sending confirmation emails, syncing orders to external systems) would receive the event for an order that could still be rolled back by the workflow's compensation function if payment failed.

Fixes #15122

**How** — Removed `emitEventStep` from the `parallelize()` block and placed it sequentially after `addOrderTransactionStep`, ensuring the event only fires once the order is fully committed — payment captured and transaction recorded.

**Testing** — Added a regression test to `cart.spec.ts` that subscribes to the `order.placed` event via the event bus and verifies it fires exactly once after a successful cart completion:

```
yarn test:integration:http -- --testPathPattern="cart/store/cart.spec.ts" --testNamePattern="should emit the order.placed event only after payment"
```

---

## Checklist

- [x] I have added a **changeset** for this PR
  - Every non-breaking change should be marked as a **patch**
  - To add a changeset, run `yarn changeset` and follow the prompts
  - The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s), if applicable

---

## Additions: Context

The event is now emitted after `addOrderTransactionStep`, right before the `orderCreated` hook, which is the last logical step of the workflow. This guarantees that any listener on `order.placed` will only receive the event after the order is fully persisted, payment is authorized, and all inventory reservations and links are created.
