### PR TITLE
fix(payment): fix currency code unset when updating payment collection

### DIFF
--- a/.changeset/spotty-mails-fold.md
+++ b/.changeset/spotty-mails-fold.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/payment": patch
+---
+
+fix(payment): fix currency code unset when updating payment collection

--- a/packages/modules/payment/integration-tests/__tests__/services/payment-module/index.spec.ts
+++ b/packages/modules/payment/integration-tests/__tests__/services/payment-module/index.spec.ts
@@ -410,6 +410,24 @@ moduleIntegrationTestRunner<IPaymentModuleService>({
               })
             )
           })
+
+          it("should not reset currency_code to empty string when updating other fields", async () => {
+            await service.updatePaymentCollections("pay-col-id-2", {
+              amount: 9,
+            })
+
+            const collection = await service.retrievePaymentCollection(
+              "pay-col-id-2"
+            )
+
+            expect(collection).toEqual(
+              expect.objectContaining({
+                id: "pay-col-id-2",
+                amount: 9,
+                currency_code: "usd",
+              })
+            )
+          })
         })
 
         describe("complete", () => {

--- a/packages/modules/payment/src/services/payment-module.ts
+++ b/packages/modules/payment/src/services/payment-module.ts
@@ -249,7 +249,9 @@ export default class PaymentModuleService
         {
           id: idOrSelector,
           ...data,
-          currency_code: normalizeCurrencyCode(data.currency_code ?? ""),
+          ...(data.currency_code ? 
+            { currency_code: normalizeCurrencyCode(data.currency_code) } :
+            {}),
         },
       ]
     } else {
@@ -262,7 +264,10 @@ export default class PaymentModuleService
       updateData = collections.map((c) => ({
         id: c.id,
         ...data,
-        currency_code: normalizeCurrencyCode(data.currency_code ?? ""),
+        ...(data.currency_code ?
+          { currency_code: normalizeCurrencyCode(data.currency_code) } :
+          {}
+        ),
       }))
     }
 
@@ -319,7 +324,10 @@ export default class PaymentModuleService
       )
       .map((element) => ({
         ...element,
-        currency_code: normalizeCurrencyCode(element.currency_code ?? ""),
+        ...(element.currency_code ? 
+          { currency_code: normalizeCurrencyCode(element.currency_code) } :
+          {}
+        )
       }))
     const forCreate = input
       .filter(
@@ -327,7 +335,10 @@ export default class PaymentModuleService
       )
       .map((element) => ({
         ...element,
-        currency_code: normalizeCurrencyCode(element.currency_code ?? ""),
+        ...(element.currency_code ? 
+          { currency_code: normalizeCurrencyCode(element.currency_code) } :
+          {}
+        )
       }))
 
     const operations: Promise<InferEntityType<typeof PaymentCollection>[]>[] =
@@ -406,7 +417,7 @@ export default class PaymentModuleService
           },
           data: { ...input.data, session_id: paymentSession!.id },
           amount: input.amount,
-          currency_code: normalizeCurrencyCode(input.currency_code ?? ""),
+          currency_code: normalizeCurrencyCode(input.currency_code),
         }
       )
 
@@ -449,7 +460,7 @@ export default class PaymentModuleService
         payment_collection_id: paymentCollectionId,
         provider_id: data.provider_id,
         amount: data.amount,
-        currency_code: normalizeCurrencyCode(data.currency_code ?? ""),
+        currency_code: normalizeCurrencyCode(data.currency_code),
         context: data.context,
         data: data.data,
         metadata: data.metadata,
@@ -477,7 +488,7 @@ export default class PaymentModuleService
       {
         data: data.data,
         amount: data.amount,
-        currency_code: normalizeCurrencyCode(data.currency_code ?? ""),
+        currency_code: normalizeCurrencyCode(data.currency_code),
         context: data.context,
       }
     )
@@ -486,7 +497,7 @@ export default class PaymentModuleService
       {
         id: session.id,
         amount: data.amount,
-        currency_code: normalizeCurrencyCode(data.currency_code ?? ""),
+        currency_code: normalizeCurrencyCode(data.currency_code),
         data: providerData.data,
         // Allow the caller to explicitly set the status (eg. due to a webhook), fallback to the update response, and finally to the existing status.
         status: data.status ?? providerData.status ?? session.status,
@@ -631,7 +642,7 @@ export default class PaymentModuleService
     const payment = await this.paymentService_.create(
       {
         amount: session.amount,
-        currency_code: normalizeCurrencyCode(session.currency_code ?? ""),
+        currency_code: normalizeCurrencyCode(session.currency_code),
         payment_session: session.id,
         payment_collection_id: session.payment_collection_id,
         provider_id: session.provider_id,


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix currency code being set to empty string when updating a payment collection.

**Why** — Why are these changes relevant or necessary?  

A recent change caused the payment collection's currency code to always be changed when updating the payment collection, even when the currency code isn't being updated. This causes a bug where the payment collection's currency is unset when an order change is made, which breaks orders and any payment operation on them.

**How** — How have these changes been implemented?

Only normalize the currency code when it's being updated

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Added a test to validate the fix

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

