### PR TITLE
fix(loyalty-plugin): show gift card products section + error message for expiration date

### DIFF
--- a/.changeset/curly-trains-poke.md
+++ b/.changeset/curly-trains-poke.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/loyalty-plugin": patch
+---
+
+fix(loyalty-plugin): show gift card products section + error message for expiration date

--- a/packages/plugins/loyalty/src/admin/routes/gift-cards/[id]/@expiration/page.tsx
+++ b/packages/plugins/loyalty/src/admin/routes/gift-cards/[id]/@expiration/page.tsx
@@ -68,12 +68,22 @@ const GiftCardExpirationForm = ({ giftCard }: GiftCardExpirationFormProps) => {
   )
 
   const onSubmit = form.handleSubmit(async (data) => {
+    if (isSettingExpiration && !data.expires_at) {
+      form.setError("expires_at", {
+        message: "Please select an expiration date and time",
+      })
+      return
+    }
+
     await mutateAsync(
       {
-        expires_at: isSettingExpiration ? data.expires_at?.toISOString() : null,
+        expires_at: isSettingExpiration
+          ? data.expires_at!.toISOString()
+          : null,
       },
       {
         onSuccess: () => {
+          toast.success("Expiration date updated successfully")
           handleSuccess()
         },
         onError: (error) => {

--- a/packages/plugins/loyalty/src/admin/routes/gift-cards/components/gift-card-products-section.tsx
+++ b/packages/plugins/loyalty/src/admin/routes/gift-cards/components/gift-card-products-section.tsx
@@ -11,11 +11,7 @@ const GiftCardProductsSection = () => {
     is_giftcard: true,
   });
 
-  if (!giftCardProducts?.length) {
-    return;
-  }
-
-  const slicedProducts = giftCardProducts.slice(0, 3);
+  const slicedProducts = giftCardProducts?.slice(0, 3) ?? [];
 
   return (
     <Container className="p-0">


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

- Show the gift card products section in a gift card's page even when there are no gift card products
- Show an error message when the expiration date isn't fully set

**Why** — Why are these changes relevant or necessary?  

- When there are no gift card products, the section isn't shown in the gift cards page but the table of gift cards doesn't span full width.
- When updating the expiration date of a gift card and you don't specify the time, the form is submitted on save but the expiration date isn't saved.

**How** — How have these changes been implemented?

- Show the gift card products section with an empty message if there are no gift crd products
- Show an error when updating the expiration date without setting a time

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
