### PR TITLE
fix(loyalty-plugin): remove delete gift cards action + cleanup

### DIFF
--- a/.changeset/late-stamps-battle.md
+++ b/.changeset/late-stamps-battle.md
@@ -2,4 +2,4 @@
 "@medusajs/loyalty-plugin": patch
 ---
 
-fix(loyalty-plugin): allow deleting gift cards + clean up
+fix(loyalty-plugin): remove delete gift cards action + cleanup

--- a/.changeset/late-stamps-battle.md
+++ b/.changeset/late-stamps-battle.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/loyalty-plugin": patch
+---
+
+fix(loyalty-plugin): allow deleting gift cards + clean up

--- a/packages/plugins/loyalty/src/admin/routes/gift-cards/[id]/components/gift-card-general-section.tsx
+++ b/packages/plugins/loyalty/src/admin/routes/gift-cards/[id]/components/gift-card-general-section.tsx
@@ -88,7 +88,7 @@ const GiftCardGeneralSection = ({ giftCard }: { giftCard: AdminGiftCard }) => {
                     icon: <Trash />,
                     label: "Delete",
                     onClick: handleDelete,
-                    disabled: isDeleting || true,
+                    disabled: isDeleting,
                   },
                 ],
               },

--- a/packages/plugins/loyalty/src/admin/routes/gift-cards/[id]/components/gift-card-general-section.tsx
+++ b/packages/plugins/loyalty/src/admin/routes/gift-cards/[id]/components/gift-card-general-section.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Calendar, Trash } from "@medusajs/icons";
+import { Calendar } from "@medusajs/icons";
 import {
   Badge,
   Container,
@@ -7,45 +7,17 @@ import {
   Heading,
   StatusBadge,
   Text,
-  toast,
-  usePrompt,
 } from "@medusajs/ui";
 import { Link } from "react-router-dom";
 import { AdminGiftCard } from "../../../../../types";
 import { ActionMenu } from "../../../../components/action-menu";
 import { SectionRow } from "../../../../components/section-row";
 import { Thumbnail } from "../../../../components/thumbnail";
-import { useDeleteGiftCard } from "../../../../hooks/api/gift-cards";
 import { getFullDate } from "../../../../utils/date-utils";
 import { formatAmount } from "../../../../utils/format-amount";
 import { formatDate, getRelativeDate } from "../../../../utils/format-date";
 
 const GiftCardGeneralSection = ({ giftCard }: { giftCard: AdminGiftCard }) => {
-  const prompt = usePrompt();
-
-  const { mutateAsync: deleteGiftCard, isPending: isDeleting } =
-    useDeleteGiftCard(giftCard.id!);
-
-  const handleDelete = async () => {
-    const res = await prompt({
-      title: "Delete gift card",
-      description: "Are you sure? This cannot be undone.",
-      verificationText: giftCard.value.toString(),
-      verificationInstruction: "Confirmation",
-      confirmText: "Delete",
-      cancelText: "Cancel",
-    });
-
-    if (!res) {
-      return;
-    }
-
-    await deleteGiftCard(undefined, {
-      onSuccess: () => toast.success("Gift card deleted successfully"),
-      onError: (error) => toast.error(error.message),
-    });
-  };
-
   const hasGiftCardExpired = useMemo(() => {
     return giftCard.expires_at && new Date(giftCard.expires_at) < new Date();
   }, [giftCard.expires_at]);
@@ -79,16 +51,6 @@ const GiftCardGeneralSection = ({ giftCard }: { giftCard: AdminGiftCard }) => {
                     icon: <Calendar />,
                     label: "Edit expiration date",
                     to: "expiration",
-                  },
-                ],
-              },
-              {
-                actions: [
-                  {
-                    icon: <Trash />,
-                    label: "Delete",
-                    onClick: handleDelete,
-                    disabled: isDeleting,
                   },
                 ],
               },

--- a/packages/plugins/loyalty/src/workflows/carts/steps/validate-gift-card-balances.ts
+++ b/packages/plugins/loyalty/src/workflows/carts/steps/validate-gift-card-balances.ts
@@ -1,6 +1,6 @@
 import { MathBN, MedusaError } from "@medusajs/framework/utils";
 import { createStep } from "@medusajs/framework/workflows-sdk";
-import { ModuleAccountStats, ModuleGiftCard } from "src/types";
+import { ModuleAccountStats, ModuleGiftCard } from "../../../types";
 
 /**
  * Input to validate that all gift cards in a collection have a positive balance.

--- a/packages/plugins/loyalty/src/workflows/carts/workflows/add-store-credits-to-cart.ts
+++ b/packages/plugins/loyalty/src/workflows/carts/workflows/add-store-credits-to-cart.ts
@@ -13,7 +13,7 @@ import {
   transform,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
-import { PluginCartDTO } from "src/types/cart";
+import { PluginCartDTO } from "../../../../src/types/cart";
 import { ModuleStoreCreditAccount } from "../../../types/store-credit";
 
 /**

--- a/packages/plugins/loyalty/src/workflows/carts/workflows/confirm-cart-credit-lines.ts
+++ b/packages/plugins/loyalty/src/workflows/carts/workflows/confirm-cart-credit-lines.ts
@@ -122,16 +122,6 @@ export const confirmCartCreditLinesWorkflow = createWorkflow(
       return cart.gift_cards.map((gc) => gc.id);
     });
 
-    const giftCardQuery = useQueryGraphStep({
-      entity: "gift_card",
-      filters: { id: giftCardIds },
-      fields: ["id", "code", "status", "currency_code"],
-    }).config({ name: "get-gift-card-query" });
-
-    const giftCards = transform({ giftCardQuery }, ({ giftCardQuery }) => {
-      return giftCardQuery.data;
-    });
-
     const storeCreditAccountsQuery = useQueryGraphStep({
       entity: "gift_card_store_credit_account",
       filters: { gift_card_id: giftCardIds },

--- a/packages/plugins/loyalty/src/workflows/gift-cards/steps/create-gift-cards.ts
+++ b/packages/plugins/loyalty/src/workflows/gift-cards/steps/create-gift-cards.ts
@@ -46,7 +46,7 @@ export const createGiftCardsStep = createStep(
       giftCards.map((gc) => gc.id)
     );
   },
-  async (ids: string[], { container }) => {
+  async (ids, { container }) => {
     if (!ids?.length) {
       return;
     }

--- a/packages/plugins/loyalty/src/workflows/gift-cards/workflows/claim-gift-card.ts
+++ b/packages/plugins/loyalty/src/workflows/gift-cards/workflows/claim-gift-card.ts
@@ -1,5 +1,3 @@
-import crypto from "crypto"
-
 import { MedusaError } from "@medusajs/framework/utils"
 import { useQueryGraphStep } from "@medusajs/medusa/core-flows"
 import {

--- a/packages/plugins/loyalty/src/workflows/gift-cards/workflows/redeem-gift-card.ts
+++ b/packages/plugins/loyalty/src/workflows/gift-cards/workflows/redeem-gift-card.ts
@@ -7,7 +7,6 @@ import {
   createStep,
   createWorkflow,
   transform,
-  when,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
 import {

--- a/packages/plugins/loyalty/src/workflows/orders/workflows/refund-credit-lines.ts
+++ b/packages/plugins/loyalty/src/workflows/orders/workflows/refund-credit-lines.ts
@@ -12,7 +12,6 @@ import {
   transform,
   when,
 } from "@medusajs/framework/workflows-sdk"
-import crypto from "crypto"
 import {
   IStoreCreditModuleService,
   ModuleStoreCreditAccount,

--- a/packages/plugins/loyalty/src/workflows/store-credit/steps/create-store-credit-accounts.ts
+++ b/packages/plugins/loyalty/src/workflows/store-credit/steps/create-store-credit-accounts.ts
@@ -1,4 +1,4 @@
-import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk";
+import { createStep, StepResponse, WorkflowData } from "@medusajs/framework/workflows-sdk";
 import {
   IStoreCreditModuleService,
   ModuleCreateStoreCreditAccount,
@@ -46,7 +46,7 @@ export const createStoreCreditAccountsStep = createStep(
       accounts.map((gc) => gc.id)
     );
   },
-  async (ids: string[], { container }) => {
+  async (ids, { container }) => {
     if (!ids?.length) {
       return;
     }

--- a/packages/plugins/loyalty/src/workflows/store-credit/steps/credit-account.ts
+++ b/packages/plugins/loyalty/src/workflows/store-credit/steps/credit-account.ts
@@ -38,7 +38,7 @@ export const creditAccountStep = createStep(
       transactions.map((t) => t.id)
     );
   },
-  async (ids: string[], { container }) => {
+  async (ids, { container }) => {
     if (!ids?.length) {
       return;
     }

--- a/packages/plugins/loyalty/src/workflows/store-credit/steps/debit-account.ts
+++ b/packages/plugins/loyalty/src/workflows/store-credit/steps/debit-account.ts
@@ -38,7 +38,7 @@ export const debitAccountStep = createStep(
       transactions.map((t) => t.id)
     );
   },
-  async (ids: string[], { container }) => {
+  async (ids, { container }) => {
     if (!ids?.length) {
       return;
     }

--- a/packages/plugins/loyalty/src/workflows/store-credit/workflows/claim-store-credit-account.ts
+++ b/packages/plugins/loyalty/src/workflows/store-credit/workflows/claim-store-credit-account.ts
@@ -1,5 +1,3 @@
-import crypto from "crypto";
-
 import { isPresent, MathBN, MedusaError } from "@medusajs/framework/utils";
 import { useQueryGraphStep } from "@medusajs/medusa/core-flows";
 import {

--- a/packages/plugins/loyalty/src/workflows/store-credit/workflows/create-store-credit-accounts.ts
+++ b/packages/plugins/loyalty/src/workflows/store-credit/workflows/create-store-credit-accounts.ts
@@ -6,7 +6,6 @@ import {
 } from "@medusajs/framework/workflows-sdk";
 import { ModuleCreateStoreCreditAccount } from "../../../types/store-credit";
 import { createStoreCreditAccountsStep } from "../steps/create-store-credit-accounts";
-import { generateCode } from "../../../utils/code-generator";
 
 /**
  * This step validates the input for creating store credit accounts. It throws an

--- a/packages/plugins/loyalty/src/workflows/store-credit/workflows/credit-store-credit-account.ts
+++ b/packages/plugins/loyalty/src/workflows/store-credit/workflows/credit-store-credit-account.ts
@@ -1,9 +1,8 @@
-import crypto from "crypto";
 import { MathBN, MedusaError } from "@medusajs/framework/utils";
 import { useQueryGraphStep } from "@medusajs/medusa/core-flows";
 import { createStep, createWorkflow, transform } from "@medusajs/framework/workflows-sdk";
 
-import { ModuleCreditStoreCreditAccount } from "src/types/store-credit";
+import { ModuleCreditStoreCreditAccount } from "../../../../src/types/store-credit";
 import { creditAccountStep } from "../steps/credit-account";
 
 /**


### PR DESCRIPTION
1. Remove delete gift card button from admin. we don't have API route for it.
2. Clean up of loyalty plugin workflows by removing unused imports, unused variables, and fixing type errors where compensation function inputs were cast incorrectly