### PR TITLE
fix(core-flows): fix incorrect stock location picked for item with backorder in a sales channel with multiple locations

### DIFF
--- a/.changeset/silly-worms-stand.md
+++ b/.changeset/silly-worms-stand.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): fix incorrect stock location picked for item with backorder in a sales channel with multiple locations

--- a/packages/core/core-flows/src/cart/utils/__tests__/prepare-confirm-inventory-input.spec.ts
+++ b/packages/core/core-flows/src/cart/utils/__tests__/prepare-confirm-inventory-input.spec.ts
@@ -463,6 +463,103 @@ describe("prepareConfirmInventoryInput", () => {
     })
   })
 
+  it("should only return locations where the inventory item has a level when falling back (backorder item stocked at a different location than another item in the same channel)", () => {
+    const input = {
+      sales_channel_id: "sc_1",
+      variants: [
+        {
+          id: "pv_1",
+          manage_inventory: true,
+          allow_backorder: false,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_1",
+              variant_id: "pv_1",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stocked_quantity: 5,
+                    reserved_quantity: 0, // available=5 >= 1
+                    location_id: "sl_A",
+                    stock_locations: [
+                      {
+                        id: "sl_A",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: "pv_2",
+          manage_inventory: true,
+          allow_backorder: true,
+          inventory_items: [
+            {
+              inventory_item_id: "ii_2",
+              variant_id: "pv_2",
+              required_quantity: 1,
+              inventory: [
+                {
+                  location_levels: {
+                    stocked_quantity: 6,
+                    reserved_quantity: 19, // available=-13 < 1: no availability
+                    location_id: "sl_B",
+                    stock_locations: [
+                      {
+                        id: "sl_B",
+                        sales_channels: [{ id: "sc_1" }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      items: [
+        {
+          variant_id: "pv_1",
+          quantity: 1,
+          id: "item_1",
+        },
+        {
+          variant_id: "pv_2",
+          quantity: 1,
+          id: "item_2",
+        },
+      ],
+    }
+
+    const result = prepareConfirmInventoryInput({ input })
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: "item_1",
+          inventory_item_id: "ii_1",
+          required_quantity: 1,
+          quantity: 1,
+          allow_backorder: false,
+          location_ids: ["sl_A"], // has availability at sl_A
+        },
+        {
+          id: "item_2",
+          inventory_item_id: "ii_2",
+          required_quantity: 1,
+          quantity: 1,
+          allow_backorder: true,
+          location_ids: ["sl_B"], // no availability, but only has a level at sl_B — must not pick sl_A
+        },
+      ],
+    })
+  })
+
   it("should throw an error if any variant has no inventory items", () => {
     const input = {
       sales_channel_id: "sc_1",

--- a/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
+++ b/packages/core/core-flows/src/cart/utils/prepare-confirm-inventory-input.ts
@@ -259,6 +259,12 @@ const formatInventoryInput = ({
         )
       )
 
+      const locationsWithLevel = location_ids.filter((locId) =>
+        stockAvailability
+          .get(locId)
+          ?.has(variantInventoryItem.inventory_item_id)
+      )
+
       itemsToConfirm.push({
         id: item.id,
         inventory_item_id: variantInventoryItem.inventory_item_id,
@@ -267,6 +273,8 @@ const formatInventoryInput = ({
         quantity: item.quantity,
         location_ids: locationsWithAvailability.length
           ? locationsWithAvailability
+          : locationsWithLevel.length
+          ? locationsWithLevel
           : location_ids,
       })
     })


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix use cases where incorrect stock location is picked, causing an error for unavailable quantity on checkout

Closes #15132

**Why** — Why are these changes relevant or necessary?  

Consider you have:

1. Sales Channel with locations A and B
2. Product A that has inventory in location A
3. Product B that has allowed backorder = true and negative availability in B

Then, as a customer, when you add product A to the cart, then product B to the cart, and choose shipping option from location A, then proceed to checkout, you'll get an error when completing the order that product B doesn't have stock in location A

This occurred because:

1. When retrieving the item's stock and inventory details, we try to retrieve the locations where the item has quantity greater than the required quantity. However, we don't take into account that the item may have allowed_backorder = true
2. If there is no location that has availability greater than the required quantity, we return all locations (including locations where other items in the cart has levels, but not this item)
3. When confirming the inventory, we look at the first location only. In the case where we return all locations, the item may not have levels at the chosen location, resulting in an error (even though allowed backorder is enabled) 

**How** — How have these changes been implemented?

In this fix, if an item doesn't have available quantity, we only return the locations where the item has levels in. That way, when confirming the quantity availability, we're not comparing against a location where the item doesn't have levels in.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Added necessary test for this use case. Tested locally as well

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable
