### PR TITLE
fix(core-flows): scope calculated shipping provider items to the option's shipping profile

### DIFF
--- a/.changeset/short-terms-thank.md
+++ b/.changeset/short-terms-thank.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): scope calculated shipping provider items to the option's shipping profile

--- a/integration-tests/http/__tests__/shipping-option/store/shipping-option-calculated.spec.ts
+++ b/integration-tests/http/__tests__/shipping-option/store/shipping-option-calculated.spec.ts
@@ -624,11 +624,9 @@ medusaIntegrationTestRunner({
           ).data.cart
 
           // Methods for different shipping profiles stack on the cart.
-          // Under the fix, each calculated provider call sees only the
+          // Each calculated provider call sees only the
           // items for that option's profile/location:
           //   optionA: 2 * 1.5 = 3     optionB: 1 * 1.5 = 1.5
-          // Under the bug, each provider call receives the full cart
-          // (3 units total) and both amounts collapse to 4.5.
           const respA = await api.post(
             `/store/carts/${cart.id}/shipping-methods?fields=*shipping_methods`,
             { option_id: shippingOptionCalculated.id, data: {} },
@@ -654,9 +652,7 @@ medusaIntegrationTestRunner({
           expect(methodB.amount).toBe(1.5)
 
           // Method A stacks alongside method B and keeps its profile-scoped
-          // price after the refresh that follows adding method B. Under the
-          // bug the refresh reprices it against the full cart, turning it
-          // into 4.5.
+          // price after the refresh that follows adding method B
           const methodAAfterB = respB.data.cart.shipping_methods.find(
             (m) => m.shipping_option_id === shippingOptionCalculated.id
           )

--- a/integration-tests/http/__tests__/shipping-option/store/shipping-option-calculated.spec.ts
+++ b/integration-tests/http/__tests__/shipping-option/store/shipping-option-calculated.spec.ts
@@ -505,6 +505,188 @@ medusaIntegrationTestRunner({
           )
         })
       })
+
+      describe("with cart spanning multiple shipping profiles", () => {
+        let shippingProfileB
+        let productB
+        let stockLocationB
+        let fulfillmentSetB
+        let shippingOptionCalculatedB
+
+        beforeEach(async () => {
+          shippingProfileB = (
+            await api.post(
+              `/admin/shipping-profiles`,
+              { name: "Profile B", type: "default" },
+              adminHeaders
+            )
+          ).data.shipping_profile
+
+          productB = (
+            await api.post(
+              "/admin/products",
+              {
+                title: "Test fixture B",
+                shipping_profile_id: shippingProfileB.id,
+                status: ProductStatus.PUBLISHED,
+                options: [{ title: "size", values: ["large"] }],
+                variants: [
+                  {
+                    title: "Variant B",
+                    manage_inventory: false,
+                    prices: [{ currency_code: "usd", amount: 100 }],
+                    options: { size: "large" },
+                  },
+                ],
+              },
+              adminHeaders
+            )
+          ).data.product
+
+          stockLocationB = (
+            await api.post(
+              `/admin/stock-locations`,
+              { name: "test location B" },
+              adminHeaders
+            )
+          ).data.stock_location
+
+          await api.post(
+            `/admin/stock-locations/${stockLocationB.id}/sales-channels`,
+            { add: [salesChannel.id] },
+            adminHeaders
+          )
+
+          const fulfillmentSetsB = (
+            await api.post(
+              `/admin/stock-locations/${stockLocationB.id}/fulfillment-sets?fields=*fulfillment_sets`,
+              { name: "Test B", type: "test-type" },
+              adminHeaders
+            )
+          ).data.stock_location.fulfillment_sets
+
+          fulfillmentSetB = (
+            await api.post(
+              `/admin/fulfillment-sets/${fulfillmentSetsB[0].id}/service-zones`,
+              {
+                name: "Test B",
+                geo_zones: [{ type: "country", country_code: "us" }],
+              },
+              adminHeaders
+            )
+          ).data.fulfillment_set
+
+          await api.post(
+            `/admin/stock-locations/${stockLocationB.id}/fulfillment-providers`,
+            { add: ["manual-calculated_test-provider-calculated"] },
+            adminHeaders
+          )
+
+          shippingOptionCalculatedB = (
+            await api.post(
+              `/admin/shipping-options`,
+              {
+                name: "Calculated shipping option B",
+                service_zone_id: fulfillmentSetB.service_zones[0].id,
+                shipping_profile_id: shippingProfileB.id,
+                provider_id: "manual-calculated_test-provider-calculated",
+                price_type: "calculated",
+                type: {
+                  label: "Test type",
+                  description: "Test description",
+                  code: "test-code",
+                },
+                prices: [],
+                rules: [],
+              },
+              adminHeaders
+            )
+          ).data.shipping_option
+        })
+
+        it("POST /store/carts/:id/shipping-methods prices each calculated option from only its own location's items", async () => {
+          cart = (
+            await api.post(
+              `/store/carts`,
+              {
+                region_id: region.id,
+                sales_channel_id: salesChannel.id,
+                currency_code: "usd",
+                email: "test@admin.com",
+                shipping_address: { country_code: "us" },
+                items: [
+                  { variant_id: product.variants[0].id, quantity: 2 },
+                  { variant_id: productB.variants[0].id, quantity: 1 },
+                ],
+              },
+              storeHeaders
+            )
+          ).data.cart
+
+          // Each POST replaces the cart's shipping methods with a single
+          // method for the chosen option. Under the fix, the calculated
+          // provider sees only the items for that option's profile/location:
+          //   optionA: 2 * 1.5 = 3     optionB: 1 * 1.5 = 1.5
+          // Under the bug, each provider call receives the full cart
+          // (3 units total) and both amounts collapse to 4.5.
+          const respA = await api.post(
+            `/store/carts/${cart.id}/shipping-methods?fields=*shipping_methods`,
+            { option_id: shippingOptionCalculated.id, data: {} },
+            storeHeaders
+          )
+          const methodA = respA.data.cart.shipping_methods.find(
+            (m) => m.shipping_option_id === shippingOptionCalculated.id
+          )
+          expect(methodA).toBeDefined()
+          expect(methodA.amount).toBe(3)
+
+          const respB = await api.post(
+            `/store/carts/${cart.id}/shipping-methods?fields=*shipping_methods`,
+            { option_id: shippingOptionCalculatedB.id, data: {} },
+            storeHeaders
+          )
+          const methodB = respB.data.cart.shipping_methods.find(
+            (m) => m.shipping_option_id === shippingOptionCalculatedB.id
+          )
+          expect(methodB).toBeDefined()
+          expect(methodB.amount).toBe(1.5)
+        })
+
+        it("POST /store/shipping-options/:id/calculate prices each option from only its own location's items", async () => {
+          cart = (
+            await api.post(
+              `/store/carts`,
+              {
+                region_id: region.id,
+                sales_channel_id: salesChannel.id,
+                currency_code: "usd",
+                email: "test@admin.com",
+                shipping_address: { country_code: "us" },
+                items: [
+                  { variant_id: product.variants[0].id, quantity: 2 },
+                  { variant_id: productB.variants[0].id, quantity: 1 },
+                ],
+              },
+              storeHeaders
+            )
+          ).data.cart
+
+          const respA = await api.post(
+            `/store/shipping-options/${shippingOptionCalculated.id}/calculate`,
+            { cart_id: cart.id, data: {} },
+            storeHeaders
+          )
+          const respB = await api.post(
+            `/store/shipping-options/${shippingOptionCalculatedB.id}/calculate`,
+            { cart_id: cart.id, data: {} },
+            storeHeaders
+          )
+
+          // Same arithmetic as the GET case, via the single-option endpoint.
+          expect(respA.data.shipping_option.amount).toBe(3)
+          expect(respB.data.shipping_option.amount).toBe(1.5)
+        })
+      })
     })
   },
 })

--- a/packages/core/core-flows/src/cart/utils/fields.ts
+++ b/packages/core/core-flows/src/cart/utils/fields.ts
@@ -198,6 +198,7 @@ export const cartFieldsForCalculateShippingOptionsPrices = [
   "items.*",
   "items.variant.id",
   "items.variant.product.id",
+  "items.variant.product.shipping_profile.id",
   "items.variant.weight",
   "items.variant.length",
   "items.variant.height",

--- a/packages/core/core-flows/src/cart/utils/filter-items-by-shipping-profile.ts
+++ b/packages/core/core-flows/src/cart/utils/filter-items-by-shipping-profile.ts
@@ -1,0 +1,30 @@
+type ItemWithShippingProfile = {
+  variant?:
+    | {
+        product?: { shipping_profile?: { id?: string } | null } | null
+      }
+    | null
+}
+
+/**
+ * Returns the subset of cart/order items whose product is linked to the given
+ * shipping profile. Used to project an item list to the items that actually
+ * ship under a specific shipping option, so calculated-price providers only
+ * see the items they will price.
+ *
+ * Items with no linked shipping profile are excluded (unprofiled products
+ * aren't shippable in Medusa's link-module model). A falsy `shippingProfileId`
+ * returns `[]` rather than the full list to fail closed.
+ */
+export const filterCartItemsByShippingProfile = <T extends ItemWithShippingProfile>(
+  items: T[] | undefined | null,
+  shippingProfileId: string | undefined | null
+): T[] => {
+  if (!items?.length || !shippingProfileId) {
+    return []
+  }
+
+  return items.filter(
+    (item) => item.variant?.product?.shipping_profile?.id === shippingProfileId
+  )
+}

--- a/packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart-with-pricing.ts
+++ b/packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart-with-pricing.ts
@@ -22,6 +22,7 @@ import { useQueryGraphStep, validatePresenceOfStep } from "../../common"
 import { useRemoteQueryStep } from "../../common/steps/use-remote-query"
 import { calculateShippingOptionsPricesStep } from "../../fulfillment"
 import { cartFieldsForCalculateShippingOptionsPrices } from "../utils/fields"
+import { filterCartItemsByShippingProfile } from "../utils/filter-items-by-shipping-profile"
 import { shippingOptionsContextResult } from "../utils/schemas"
 import { getTranslatedShippingOptionsStep } from "../../common/steps/get-translated-shipping-option"
 
@@ -344,6 +345,10 @@ export const listShippingOptionsForCartWithPricingWorkflow = createWorkflow(
               optionData: so.data,
               context: {
                 ...cart,
+                items: filterCartItemsByShippingProfile(
+                  cart.items,
+                  so.shipping_profile_id
+                ),
                 from_location:
                   fulfillmentSetLocationMap[so.service_zone.fulfillment_set_id],
               },

--- a/packages/core/core-flows/src/fulfillment/workflows/calculate-shipping-options-prices.ts
+++ b/packages/core/core-flows/src/fulfillment/workflows/calculate-shipping-options-prices.ts
@@ -8,6 +8,7 @@ import {
 import { calculateShippingOptionsPricesStep } from "../steps"
 import { useQueryGraphStep } from "../../common"
 import { cartFieldsForCalculateShippingOptionsPrices } from "../../cart/utils/fields"
+import { filterCartItemsByShippingProfile } from "../../cart/utils/filter-items-by-shipping-profile"
 
 export const calculateShippingOptionsPricesWorkflowId =
   "calculate-shipping-options-prices-workflow"
@@ -58,7 +59,13 @@ export const calculateShippingOptionsPricesWorkflow = createWorkflow(
     const shippingOptionsQuery = useQueryGraphStep({
       entity: "shipping_option",
       filters: { id: ids },
-      fields: ["id", "provider_id", "data", "service_zone.fulfillment_set_id"],
+      fields: [
+        "id",
+        "provider_id",
+        "data",
+        "shipping_profile_id",
+        "service_zone.fulfillment_set_id",
+      ],
     }).config({ name: "shipping-options-query" })
 
     const cartQuery = useQueryGraphStep({
@@ -130,6 +137,10 @@ export const calculateShippingOptionsPricesWorkflow = createWorkflow(
           data: shippingOptionDataMap.get(shippingOption.id) ?? {},
           context: {
             ...cart,
+            items: filterCartItemsByShippingProfile(
+              cart.items,
+              shippingOption.shipping_profile_id
+            ),
             from_location: locations.find(
               (l) =>
                 l.id ===


### PR DESCRIPTION
## Summary

**What**

Fixes a bug where calculated-shipping fulfillment providers receive the full cart's items paired with only one `from_location`, regardless of which items actually ship from that location. Each calculated option now receives `context.items` filtered to the items whose `variant.product.shipping_profile.id` matches the option's `shipping_profile_id`.

Touches two cart-side workflows (`list-shipping-options-for-cart-with-pricing`, `calculate-shipping-options-prices`), adds one small reusable helper, and lands an integration test that documents the bug.

**Why**

When a cart spans items from multiple shipping profiles fulfilled from different stock locations (e.g. a default-profile item at Warehouse A + a fragile-goods item at Warehouse B), providers that price by weight / quantity / subtotal over-count: each option's provider call sees *all* cart units paired with *one* location. End-user symptom: every shipping option returns the same price even though each option ships a different subset of the cart.

`from_location` was already being narrowed per option, so items were the only half of the context still inconsistent with the per-option semantics.

**How**

1. New pure helper `filterCartItemsByShippingProfile` at `packages/core/core-flows/src/cart/utils/filter-items-by-shipping-profile.ts`. Returns the subset of items whose `variant.product.shipping_profile.id === shippingProfileId`; fails closed (returns `[]`) when either input is missing.
2. Added `"items.variant.product.shipping_profile.id"` to the shared `cartFieldsForCalculateShippingOptionsPrices` array in `packages/core/core-flows/src/cart/utils/fields.ts`, so both affected workflows receive the profile path through the same cart query. Matches the existing traversal pattern in `completeCartFields`.
3. `list-shipping-options-for-cart-with-pricing.ts` — the context transform injects `items: filterCartItemsByShippingProfile(cart.items, so.shipping_profile_id)` after the `...cart` spread.
4. `calculate-shipping-options-prices.ts` — same transform change, plus added `"shipping_profile_id"` to the shipping-options query fields (which previously only fetched `id, provider_id, data, service_zone.fulfillment_set_id`).

**Testing**

Three cases in `integration-tests/http/__tests__/shipping-option/store/shipping-option-calculated.spec.ts` under a `"with cart spanning multiple shipping profiles"` describe block. Each seeds two shipping profiles, two products, two stock locations with their own fulfillment sets and calculated shipping options, then asserts pricing per option (updated for the stacking semantics introduced in #15407):

- `POST /store/carts/:id/shipping-methods` (two sequential adds) — methods for different profiles now stack; asserts both methods coexist with their profile-scoped amounts (`3` and `1.5`, combined `shipping_total` of `4.5`). Notably, method A keeps its amount after the refresh that follows adding method B — `refreshCartShippingMethodsWorkflow` reprices all existing methods, so without the fix method A would be repriced to the collapsed `4.5` at that point. Covers `list-shipping-options-for-cart-with-pricing` (via `addShippingMethodToCartWorkflow.runAsStep`).
- `POST /store/carts/:id/shipping-methods` (single call, array payload from #15407) — both options added in one request, priced in one workflow run, same per-profile amounts.
- `POST /store/shipping-options/:id/calculate` — covers `calculateShippingOptionsPricesWorkflow` directly.

Before the fix each provider call saw `amount = 4.5` (the collapsed value). After the fix it sees the per-profile-scoped `3` and `1.5`. The 4 pre-existing single-profile cases in the same file remain green because the filter degenerates to the full item list when all items share the option's profile.

---

## Checklist

- [x] I have added a **changeset** for this PR (`.changeset/short-terms-thank.md`, `@medusajs/core-flows: patch`)
- [x] The changes are covered by relevant **tests** (`shipping-option-calculated.spec.ts`, new describe block)
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable
