### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/www/apps/resources/app/storefront-development/guides/react-native-expo/page.mdx
+++ b/www/apps/resources/app/storefront-development/guides/react-native-expo/page.mdx
@@ -1250,7 +1250,7 @@ export const ProductCard = React.memo(function ProductCard({ product }: ProductC
       activeOpacity={0.7}
     >
       <Image
-        source={{ uri: thumbnail || "https://via.placeholder.com/200" }}
+        source={{ uri: thumbnail || "https://placehold.co/200" }}
         style={[styles.image, { backgroundColor: colors.imagePlaceholder }]}
         contentFit="cover"
       />
@@ -2860,7 +2860,7 @@ export const CartItem = React.memo(function CartItem({ item, currencyCode, onUpd
   return (
     <View style={[styles.container, { borderBottomColor: colors.icon + "30" }]}>
       <Image
-        source={{ uri: thumbnail || "https://via.placeholder.com/80" }}
+        source={{ uri: thumbnail || "https://placehold.co/80" }}
         style={[styles.image, { backgroundColor: colors.imagePlaceholder }]}
         contentFit="cover"
       />
@@ -5148,7 +5148,7 @@ return (
             ]}
           >
             <Image
-              source={{ uri: item.thumbnail || "https://via.placeholder.com/60" }}
+              source={{ uri: item.thumbnail || "https://placehold.co/60" }}
               style={[styles.itemImage, { backgroundColor: colors.imagePlaceholder }]}
               contentFit="cover"
             />


### PR DESCRIPTION
`www/apps/resources/app/storefront-development/guides/react-native-expo/page.mdx` references `via.placeholder.com/...` URLs. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Browsers render a broken-image icon in place of the intended placeholder.

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo 'connection refused / DNS gone'
```

#### What this PR changes

Updates the react-native-expo storefront guide MDX so the 3 `<Image>` thumbnail fallbacks render a real placeholder when a product thumbnail is missing. Affected: Product Card, Line Item Card, Cart Item Card examples.

#### Replacement details

`placehold.co` is the canonical working drop-in for `via.placeholder.com` — it accepts the identical path shape (`/<W>x<H>` or `/<size>`), needs no auth, and serves a 200 PNG. No behaviour change beyond the working URL.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** introduced as a dependency by this PR — the diff uses the dependency-free canonical replacement domain. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering the broader broken-placeholder landscape: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only URL swap for image placeholders; no runtime or backend logic changes.
> 
> **Overview**
> Updates the React Native Expo storefront guide to use `placehold.co` for fallback product images instead of the now-defunct `via.placeholder.com`.
> 
> This changes the placeholder URLs in three example components (`ProductCard`, `CartItem`, and order item rendering) so missing thumbnails no longer show broken images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8147fac15332bc673aef86a3e30c55ce50e509b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->