### PR TITLE
fix(workflows-sdk): fix excessive stack depth error

### DIFF
--- a/.changeset/good-lemons-stand.md
+++ b/.changeset/good-lemons-stand.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/workflows-sdk": patch
+---
+
+fix(workflows-sdk): fix excessive stack depth error

--- a/packages/core/workflows-sdk/src/utils/composer/type.ts
+++ b/packages/core/workflows-sdk/src/utils/composer/type.ts
@@ -88,9 +88,7 @@ export type WorkflowDataProperties<T = unknown> = {
 export type WorkflowData<T = unknown> = (T extends Array<infer Item>
   ? Array<Item | WorkflowData<Item>>
   : T extends object
-  ? {
-      [Key in keyof T]: T[Key] | WorkflowData<T[Key]>
-    }
+  ? T
   : T & WorkflowDataProperties<T>) &
   T &
   WorkflowDataProperties<T> & {


### PR DESCRIPTION
Fix excessive stack depth error that occurs when returning a cart in an object as part of WorkflowResponse