### PR TITLE
fix(core-flows): update cart.updated_at on cart item and shipping met…

### DIFF
--- a/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
@@ -1320,8 +1320,16 @@ medusaIntegrationTestRunner({
           ])
 
           cart = await cartModuleService.retrieveCart(cart.id, {
-            select: ["id", "region_id", "currency_code", "sales_channel_id"],
+            select: [
+              "id",
+              "region_id",
+              "currency_code",
+              "sales_channel_id",
+              "updated_at",
+            ],
           })
+
+          const previousUpdatedAt = cart.updated_at
 
           const wfInput = {
             items: [
@@ -1420,6 +1428,10 @@ medusaIntegrationTestRunner({
           cart = await cartModuleService.retrieveCart(cart.id, {
             relations: ["items"],
           })
+
+          expect(new Date(cart.updated_at).getTime()).toBeGreaterThan(
+            new Date(previousUpdatedAt).getTime()
+          )
 
           expect(cart).toEqual(
             expect.objectContaining({
@@ -2976,9 +2988,11 @@ medusaIntegrationTestRunner({
           })
 
           cart = await cartModuleService.retrieveCart(cart.id, {
-            select: ["id", "region_id", "currency_code"],
+            select: ["id", "region_id", "currency_code", "updated_at"],
             relations: ["items", "items.variant_id", "items.metadata"],
           })
+
+          const previousUpdatedAt = cart.updated_at
 
           const item = cart.items?.[0]!
 
@@ -2997,6 +3011,14 @@ medusaIntegrationTestRunner({
           })
 
           const updatedItem = await cartModuleService.retrieveLineItem(item.id)
+
+          cart = await cartModuleService.retrieveCart(cart.id, {
+            select: ["id", "updated_at"],
+          })
+
+          expect(new Date(cart.updated_at).getTime()).toBeGreaterThan(
+            new Date(previousUpdatedAt).getTime()
+          )
 
           expect(updatedItem).toEqual(
             expect.objectContaining({
@@ -4181,6 +4203,8 @@ medusaIntegrationTestRunner({
         })
 
         it("should add shipping method to cart", async () => {
+          const previousUpdatedAt = cart.updated_at
+
           const shippingOption = (
             await api.post(
               `/admin/shipping-options`,
@@ -4222,6 +4246,10 @@ medusaIntegrationTestRunner({
 
           cart = (await api.get(`/store/carts/${cart.id}`, storeHeaders)).data
             .cart
+
+          expect(new Date(cart.updated_at).getTime()).toBeGreaterThan(
+            new Date(previousUpdatedAt).getTime()
+          )
 
           expect(cart).toEqual(
             expect.objectContaining({

--- a/packages/core/core-flows/src/cart/workflows/add-shipping-method-to-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/add-shipping-method-to-cart.ts
@@ -14,6 +14,7 @@ import { acquireLockStep, releaseLockStep } from "../../locking"
 import {
   addShippingMethodToCartStep,
   removeShippingMethodFromCartStep,
+  updateCartsStep,
   validateCartShippingOptionsStep,
 } from "../steps"
 import { validateCartStep } from "../steps/validate-cart"
@@ -212,6 +213,8 @@ export const addShippingMethodToCartWorkflow = createWorkflow(
         additional_data: input.additional_data,
       },
     })
+
+    updateCartsStep([{ id: cart.id }])
 
     parallelize(
       emitEventStep({

--- a/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/add-to-cart.ts
@@ -23,6 +23,7 @@ import { acquireLockStep, releaseLockStep } from "../../locking"
 import {
   createLineItemsStep,
   getLineItemActionsStep,
+  updateCartsStep,
   updateLineItemsStep,
 } from "../steps"
 import { validateCartStep } from "../steps/validate-cart"
@@ -342,6 +343,8 @@ export const addToCartWorkflow = createWorkflow(
         additional_data: input.additional_data,
       },
     })
+
+    updateCartsStep([{ id: cart.id }])
 
     parallelize(
       emitEventStep({

--- a/packages/core/core-flows/src/cart/workflows/update-line-item-in-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-line-item-in-cart.ts
@@ -28,6 +28,7 @@ import { emitEventStep } from "../../common/steps/emit-event"
 import { deleteLineItemsWorkflow } from "../../line-item"
 import { updateLineItemsStepWithSelector } from "../../line-item/steps"
 import { acquireLockStep, releaseLockStep } from "../../locking"
+import { updateCartsStep } from "../steps"
 import { validateCartStep } from "../steps/validate-cart"
 import { validateVariantPricesStep } from "../steps/validate-variant-prices"
 import {
@@ -309,6 +310,8 @@ export const updateLineItemInCartWorkflow = createWorkflow(
         },
       })
     })
+
+    updateCartsStep([{ id: input.cart_id }])
 
     parallelize(
       releaseLockStep({


### PR DESCRIPTION
## Summary
**What** — Fixes `cart.updated_at` timestamp behavior so it is refreshed when cart content changes through these workflows:
- `add-to-cart`
- `update-line-item-in-cart`
- `add-shipping-method-to-cart`

Also adds integration-test assertions to prevent regressions for this behavior.

**Why** — The current behavior makes abandoned-cart handling unreliable, because `cart.updated_at` does not reflect real cart activity unless the Update Cart endpoint is used. This change ensures `cart.updated_at` represents meaningful customer actions such as adding items, changing quantities, and selecting shipping methods.

**How** — The fix explicitly touches the cart record after cart mutations by calling `updateCartsStep` with the cart id in each affected workflow. Regression coverage was added in existing cart integration tests by asserting that `updated_at` increases after each of the above operations.

**Testing** — Added integration assertions in cart workflow tests for:
- `should add item to cart`
- `should update item in cart`
- `should add shipping method to cart`

Reviewer validation steps:
1. Run the cart workflow integration suite.
2. Verify each of the above tests asserts `updated_at` moves forward after mutation.
3. Optionally validate manually through Store API by comparing `cart.updated_at` before and after each mutation request.

---

## Examples

```ts
// 1) Read cart
// cart.updated_at = T1

// 2) Add item to cart (or update item quantity / add shipping method)

// 3) Read cart again
// cart.updated_at = T2
// Expect: T2 > T1
```

---

## Checklist
Please ensure the following before requesting a review:
- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context
Targeted fix only — does not change cart business totals logic. Only ensures `cart.updated_at` is bumped for cart mutation workflows that previously did not touch the cart row directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cart workflows to add an explicit cart update after item/shipping mutations, which could affect downstream behavior and adds extra write operations. Coverage is improved via integration assertions that `updated_at` advances after these mutations.
> 
> **Overview**
> Ensures `cart.updated_at` is refreshed when cart contents change via the `add-to-cart`, `update-line-item-in-cart`, and `add-shipping-method-to-cart` workflows by explicitly calling `updateCartsStep` after the mutation/refresh steps.
> 
> Adds integration-test assertions in `cart.workflows.spec.ts` to verify `updated_at` increases after adding items, updating a line item, and adding a shipping method, preventing regressions in abandoned-cart/activity tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f7ac169e2190fa03ad62b9843dd090e282ba99b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->