### PR TITLE
feat(create-medusa-app,medusa): ask to install claude code plugin

### DIFF
--- a/.changeset/sparkly-streets-wait.md
+++ b/.changeset/sparkly-streets-wait.md
@@ -1,0 +1,6 @@
+---
+"create-medusa-app": patch
+"@medusajs/medusa": patch
+---
+
+feat(create-medusa-app,medusa): ask to install claude code plugin

--- a/packages/cli/create-medusa-app/package.json
+++ b/packages/cli/create-medusa-app/package.json
@@ -19,6 +19,7 @@
     "boxen": "^5.0.1",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",
+    "configstore": "^8.0.0",
     "inquirer": "^8.0.0",
     "nanoid": "^4.0.2",
     "node-emoji": "^2.0.2",

--- a/packages/cli/create-medusa-app/package.json
+++ b/packages/cli/create-medusa-app/package.json
@@ -19,7 +19,6 @@
     "boxen": "^5.0.1",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",
-    "configstore": "^8.0.0",
     "inquirer": "^8.0.0",
     "nanoid": "^4.0.2",
     "node-emoji": "^2.0.2",

--- a/packages/cli/create-medusa-app/src/utils/__tests__/claude-code-plugin.test.ts
+++ b/packages/cli/create-medusa-app/src/utils/__tests__/claude-code-plugin.test.ts
@@ -1,0 +1,292 @@
+import { promptClaudeCodePlugin } from "../claude-code-plugin"
+import { spawnSync } from "child_process"
+import fs from "fs"
+import inquirer from "inquirer"
+import logMessage from "../log-message"
+
+jest.mock("child_process")
+jest.mock("fs")
+jest.mock("inquirer", () => ({ prompt: jest.fn() }))
+jest.mock("../log-message")
+jest.mock("os", () => ({
+  homedir: jest.fn().mockReturnValue("/mock/home"),
+}))
+jest.mock("@medusajs/telemetry", () => ({
+  Store: jest.fn(),
+  track: jest.fn(),
+}))
+
+const mockSpawnSync = spawnSync as jest.MockedFunction<typeof spawnSync>
+const mockExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>
+const mockReadFileSync = fs.readFileSync as jest.Mock
+const mockInquirerPrompt = (inquirer as any).prompt as jest.Mock
+const mockLogMessage = logMessage as jest.MockedFunction<typeof logMessage>
+
+const CLAUDE_DIR = "/mock/home/.claude"
+const PLUGIN_ID = "medusa-dev@medusa"
+const CONFIG_KEY = "claude-code-plugin.prompted"
+
+describe("promptClaudeCodePlugin", () => {
+  let originalEnv: NodeJS.ProcessEnv
+  let mockGetConfig: jest.Mock
+  let mockSetConfig: jest.Mock
+  let MockStore: jest.Mock
+  let mockTrack: jest.Mock
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+    jest.clearAllMocks()
+    jest.spyOn(console, "log").mockImplementation()
+
+    // Default: interactive, not CI, no CLAUDE_CODE env
+    delete process.env.CI
+    delete process.env.CLAUDE_CODE
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    })
+
+    // Set up Store mock
+    mockGetConfig = jest.fn().mockReturnValue(false)
+    mockSetConfig = jest.fn()
+    const telemetry = jest.requireMock("@medusajs/telemetry")
+    MockStore = telemetry.Store
+    mockTrack = telemetry.track
+    MockStore.mockImplementation(() => ({
+      getConfig: mockGetConfig,
+      setConfig: mockSetConfig,
+      config_: { path: "/mock/config/path" },
+    }))
+
+    // Default: ~/.claude exists (Claude Code present), plugin not installed
+    mockExistsSync.mockImplementation((filePath: unknown) => {
+      return filePath === CLAUDE_DIR
+    })
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ version: 2, plugins: {} })
+    )
+
+    // Default: user says yes
+    mockInquirerPrompt.mockResolvedValue({ install: true })
+
+    // Default: both install commands succeed
+    mockSpawnSync.mockReturnValue({ error: undefined } as any)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    jest.restoreAllMocks()
+  })
+
+  describe("non-interactive environments", () => {
+    it("skips when CI=true", async () => {
+      process.env.CI = "true"
+
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).not.toHaveBeenCalled()
+    })
+
+    it("skips when stdout is not a TTY", async () => {
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: false,
+        writable: true,
+        configurable: true,
+      })
+
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("Claude Code detection", () => {
+    it("skips when ~/.claude does not exist and CLAUDE_CODE env is not set", async () => {
+      mockExistsSync.mockReturnValue(false)
+
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).not.toHaveBeenCalled()
+    })
+
+    it("proceeds when ~/.claude exists", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).toHaveBeenCalled()
+    })
+
+    it("proceeds when CLAUDE_CODE env var is set even without ~/.claude dir", async () => {
+      mockExistsSync.mockReturnValue(false)
+      process.env.CLAUDE_CODE = "1"
+
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).toHaveBeenCalled()
+    })
+  })
+
+  describe("plugin installation detection", () => {
+    it("skips when installed_plugins.json contains the plugin", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ version: 2, plugins: { [PLUGIN_ID]: [{}] } })
+      )
+
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).not.toHaveBeenCalled()
+    })
+
+    it("proceeds when installed_plugins.json exists but does not contain the plugin", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ version: 2, plugins: { "other-plugin@other": [{}] } })
+      )
+
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).toHaveBeenCalled()
+    })
+
+    it("proceeds when installed_plugins.json does not exist", async () => {
+      mockExistsSync.mockImplementation((filePath: unknown) => {
+        return filePath === CLAUDE_DIR
+      })
+
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).toHaveBeenCalled()
+    })
+
+    it("proceeds when installed_plugins.json contains malformed JSON", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue("not valid json")
+
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).toHaveBeenCalled()
+    })
+  })
+
+  describe("already prompted", () => {
+    it("skips when configStore already has the prompted flag set", async () => {
+      mockGetConfig.mockReturnValue(true)
+
+      await promptClaudeCodePlugin()
+
+      expect(mockInquirerPrompt).not.toHaveBeenCalled()
+    })
+
+    it("checks the correct config key", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockGetConfig).toHaveBeenCalledWith(CONFIG_KEY)
+    })
+
+    it("marks as prompted before showing the prompt", async () => {
+      let setConfigCalledBeforePrompt = false
+      mockInquirerPrompt.mockImplementation(async () => {
+        setConfigCalledBeforePrompt = mockSetConfig.mock.calls.length > 0
+        return { install: false }
+      })
+
+      await promptClaudeCodePlugin()
+
+      expect(setConfigCalledBeforePrompt).toBe(true)
+      expect(mockSetConfig).toHaveBeenCalledWith(CONFIG_KEY, true)
+    })
+  })
+
+  describe("user says yes", () => {
+    beforeEach(() => {
+      mockInquirerPrompt.mockResolvedValue({ install: true })
+    })
+
+    it("runs marketplace add command", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        "claude",
+        ["plugin", "marketplace", "add", "medusajs/medusa-agent-skills"],
+        { stdio: "inherit" }
+      )
+    })
+
+    it("runs plugin install command", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        "claude",
+        ["plugin", "install", PLUGIN_ID],
+        { stdio: "inherit" }
+      )
+    })
+
+    it("tracks telemetry with install=true", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockTrack).toHaveBeenCalledWith("CMA_CLAUDE_CODE_PLUGIN_PROMPT", {
+        install: true,
+      })
+    })
+
+    it("does not show fallback message when both commands succeed", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockLogMessage).not.toHaveBeenCalled()
+    })
+
+    it("shows fallback message when marketplace command fails", async () => {
+      mockSpawnSync.mockReturnValue({ error: new Error("not found") } as any)
+
+      await promptClaudeCodePlugin()
+
+      expect(mockLogMessage).toHaveBeenCalledWith({
+        message: expect.stringContaining(
+          "/plugin marketplace add medusajs/medusa-agent-skills"
+        ),
+      })
+    })
+
+    it("shows fallback message when plugin install command fails", async () => {
+      mockSpawnSync
+        .mockReturnValueOnce({ error: undefined } as any)
+        .mockReturnValueOnce({ error: new Error("not found") } as any)
+
+      await promptClaudeCodePlugin()
+
+      expect(mockLogMessage).toHaveBeenCalledWith({
+        message: expect.stringContaining(
+          "/plugin marketplace add medusajs/medusa-agent-skills"
+        ),
+      })
+    })
+  })
+
+  describe("user says no", () => {
+    beforeEach(() => {
+      mockInquirerPrompt.mockResolvedValue({ install: false })
+    })
+
+    it("does not run any install commands", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockSpawnSync).not.toHaveBeenCalled()
+    })
+
+    it("does not show fallback message", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockLogMessage).not.toHaveBeenCalled()
+    })
+
+    it("tracks telemetry with install=false", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockTrack).toHaveBeenCalledWith("CMA_CLAUDE_CODE_PLUGIN_PROMPT", {
+        install: false,
+      })
+    })
+  })
+})

--- a/packages/cli/create-medusa-app/src/utils/claude-code-plugin.ts
+++ b/packages/cli/create-medusa-app/src/utils/claude-code-plugin.ts
@@ -1,0 +1,96 @@
+import { spawnSync } from "child_process"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import inquirer from "inquirer"
+import logMessage from "./log-message.js"
+import pkg from '@medusajs/telemetry';
+const { Store, track } = pkg
+
+const CLAUDE_DIR = path.join(os.homedir(), ".claude")
+const INSTALLED_PLUGINS_FILE = path.join(
+  CLAUDE_DIR,
+  "plugins",
+  "installed_plugins.json"
+)
+const PLUGIN_ID = "medusa-dev@medusa"
+const CONFIG_KEY = "claude-code-plugin.prompted"
+
+function isClaudeCodePresent(): boolean {
+  return !!process.env.CLAUDE_CODE || fs.existsSync(CLAUDE_DIR)
+}
+
+function isNonInteractive(): boolean {
+  return process.env.CI === "true" || !process.stdout.isTTY
+}
+
+function isPluginInstalled(): boolean {
+  if (!fs.existsSync(INSTALLED_PLUGINS_FILE)) {
+    return false
+  }
+  try {
+    const data = JSON.parse(fs.readFileSync(INSTALLED_PLUGINS_FILE, "utf-8"))
+    return !!data?.plugins?.[PLUGIN_ID]
+  } catch {
+    return false
+  }
+}
+
+function runInstall(): boolean {
+  try {
+    const marketplace = spawnSync(
+      "claude",
+      ["plugin", "marketplace", "add", "medusajs/medusa-agent-skills"],
+      { stdio: "inherit" }
+    )
+    if (marketplace.error) {
+      return false
+    }
+
+    const install = spawnSync("claude", ["plugin", "install", PLUGIN_ID], {
+      stdio: "inherit",
+    })
+    return !install.error
+  } catch {
+    return false
+  }
+}
+
+export async function promptClaudeCodePlugin(): Promise<void> {
+  if (isNonInteractive() || !isClaudeCodePresent() || isPluginInstalled()) {
+    return
+  }
+
+  const configStore = new Store()
+  console.log(configStore.config_.path)
+  if (configStore.getConfig(CONFIG_KEY)) {
+    return
+  }
+
+  configStore.setConfig(CONFIG_KEY, true)
+
+  const { install } = await inquirer.prompt([
+    {
+      type: "confirm",
+      name: "install",
+      message:
+        "Working with Medusa is easier with the Medusa Plugin for Claude Code. Would you like to install it?",
+      default: true,
+    },
+  ])
+
+  track("CMA_CLAUDE_CODE_PLUGIN_PROMPT", {
+    install,
+  })
+
+  if (!install) {
+    return
+  }
+
+  const success = runInstall()
+  if (!success) {
+    logMessage({
+      message: `Could not auto-install. To install manually, open Claude Code in your project and run:\n\n  /plugin marketplace add medusajs/medusa-agent-skills\n`,
+    })
+  }
+}

--- a/packages/cli/create-medusa-app/src/utils/project-creator/medusa-plugin-creator.ts
+++ b/packages/cli/create-medusa-app/src/utils/project-creator/medusa-plugin-creator.ts
@@ -14,6 +14,7 @@ import {
   ProjectOptions,
 } from "./creator.js"
 import terminalLink from "terminal-link"
+import { promptClaudeCodePlugin } from "../claude-code-plugin.js"
 
 // Plugin Project Creator
 export class PluginProjectCreator
@@ -27,6 +28,7 @@ export class PluginProjectCreator
 
   async create(): Promise<void> {
     track("CREATE_CLI_CMP")
+    await promptClaudeCodePlugin()
 
     logMessage({
       message: `${emojify(

--- a/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
+++ b/packages/cli/create-medusa-app/src/utils/project-creator/medusa-project-creator.ts
@@ -7,6 +7,7 @@ import open from "open"
 import { EOL } from "os"
 import slugifyType from "slugify"
 import waitOn from "wait-on"
+import { promptClaudeCodePlugin } from "../claude-code-plugin.js"
 import { runCloneRepo } from "../clone-repo.js"
 import { isAbortError } from "../create-abort-controller.js"
 import { getDbClientAndCredentials, runCreateDb } from "../create-db.js"
@@ -63,6 +64,7 @@ export class MedusaProjectCreator
   private async initializeProject(): Promise<void> {
     const installNextjs =
       this.options.withNextjsStarter || (await askForNextjsStarter())
+    await promptClaudeCodePlugin()
 
     if (!this.options.skipDb) {
       await this.setupDatabase()

--- a/packages/medusa/package.json
+++ b/packages/medusa/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@inquirer/checkbox": "^2.3.11",
+    "@inquirer/confirm": "^2.0.17",
     "@inquirer/input": "^2.2.9",
     "@medusajs/admin-bundler": "2.13.6",
     "@medusajs/analytics": "2.13.6",

--- a/packages/medusa/src/commands/develop.ts
+++ b/packages/medusa/src/commands/develop.ts
@@ -11,6 +11,7 @@ import { EOL } from "os"
 import path from "path"
 import BackendHmrFeatureFlag from "../feature-flags/backend-hmr"
 import { initializeContainer } from "../loaders"
+import { promptClaudeCodePlugin } from "../utils/claude-code-plugin"
 
 const defaultConfig = {
   padding: 5,
@@ -231,7 +232,7 @@ export default async function ({ types, directory }) {
     },
   }
 
-  process.on("SIGINT", () => {
+  process.on("SIGINT", async () => {
     const configStore = new Store()
     const hasPrompted = configStore.getConfig("star.prompted") ?? false
     if (!hasPrompted) {
@@ -247,6 +248,7 @@ export default async function ({ types, directory }) {
 
       configStore.setConfig("star.prompted", true)
     }
+    await promptClaudeCodePlugin()
     process.exit(0)
   })
 

--- a/packages/medusa/src/utils/__tests__/claude-code-plugin.spec.ts
+++ b/packages/medusa/src/utils/__tests__/claude-code-plugin.spec.ts
@@ -1,0 +1,288 @@
+import { promptClaudeCodePlugin } from "../claude-code-plugin"
+import { spawnSync } from "child_process"
+import fs from "fs"
+import confirm from "@inquirer/confirm"
+import { Store, track } from "@medusajs/telemetry"
+
+jest.mock("child_process")
+jest.mock("fs")
+jest.mock("@inquirer/confirm", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+jest.mock("os", () => ({
+  homedir: jest.fn().mockReturnValue("/mock/home"),
+}))
+jest.mock("@medusajs/telemetry", () => ({
+  Store: jest.fn(),
+  track: jest.fn(),
+}))
+
+const mockSpawnSync = spawnSync as jest.MockedFunction<typeof spawnSync>
+const mockExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>
+const mockReadFileSync = fs.readFileSync as jest.Mock
+const mockConfirm = confirm as jest.MockedFunction<typeof confirm>
+const MockStore = Store as jest.MockedClass<typeof Store>
+const mockTrack = track as jest.MockedFunction<typeof track>
+
+const CLAUDE_DIR = "/mock/home/.claude"
+const PLUGIN_ID = "medusa-dev@medusa"
+const CONFIG_KEY = "claude-code-plugin.prompted"
+
+describe("promptClaudeCodePlugin", () => {
+  let originalEnv: NodeJS.ProcessEnv
+  let mockGetConfig: jest.Mock
+  let mockSetConfig: jest.Mock
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+    jest.clearAllMocks()
+    jest.spyOn(console, "log").mockImplementation()
+
+    // Default: interactive, not CI, no CLAUDE_CODE env
+    delete process.env.CI
+    delete process.env.CLAUDE_CODE
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    })
+
+    // Set up Store mock instance
+    mockGetConfig = jest.fn().mockReturnValue(false)
+    mockSetConfig = jest.fn()
+    MockStore.mockImplementation(
+      () =>
+        ({
+          getConfig: mockGetConfig,
+          setConfig: mockSetConfig,
+        }) as any
+    )
+
+    // Default: ~/.claude exists (Claude Code present), plugin not installed
+    mockExistsSync.mockImplementation((filePath: unknown) => {
+      return filePath === CLAUDE_DIR
+    })
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ version: 2, plugins: {} })
+    )
+
+    // Default: user says yes
+    mockConfirm.mockResolvedValue(true)
+
+    // Default: both install commands succeed
+    mockSpawnSync.mockReturnValue({ error: undefined } as any)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    jest.restoreAllMocks()
+  })
+
+  describe("non-interactive environments", () => {
+    it("skips when CI=true", async () => {
+      process.env.CI = "true"
+
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).not.toHaveBeenCalled()
+    })
+
+    it("skips when stdout is not a TTY", async () => {
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: false,
+        writable: true,
+        configurable: true,
+      })
+
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("Claude Code detection", () => {
+    it("skips when ~/.claude does not exist and CLAUDE_CODE env is not set", async () => {
+      mockExistsSync.mockReturnValue(false)
+
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).not.toHaveBeenCalled()
+    })
+
+    it("proceeds when ~/.claude exists", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).toHaveBeenCalled()
+    })
+
+    it("proceeds when CLAUDE_CODE env var is set even without ~/.claude dir", async () => {
+      mockExistsSync.mockReturnValue(false)
+      process.env.CLAUDE_CODE = "1"
+
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).toHaveBeenCalled()
+    })
+  })
+
+  describe("plugin installation detection", () => {
+    it("skips when installed_plugins.json contains the plugin", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ version: 2, plugins: { [PLUGIN_ID]: [{}] } })
+      )
+
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).not.toHaveBeenCalled()
+    })
+
+    it("proceeds when installed_plugins.json exists but does not contain the plugin", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ version: 2, plugins: { "other-plugin@other": [{}] } })
+      )
+
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).toHaveBeenCalled()
+    })
+
+    it("proceeds when installed_plugins.json does not exist", async () => {
+      mockExistsSync.mockImplementation((filePath: unknown) => {
+        return filePath === CLAUDE_DIR
+      })
+
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).toHaveBeenCalled()
+    })
+
+    it("proceeds when installed_plugins.json contains malformed JSON", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue("not valid json")
+
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).toHaveBeenCalled()
+    })
+  })
+
+  describe("already prompted", () => {
+    it("skips when configStore already has the prompted flag set", async () => {
+      mockGetConfig.mockReturnValue(true)
+
+      await promptClaudeCodePlugin()
+
+      expect(mockConfirm).not.toHaveBeenCalled()
+    })
+
+    it("checks the correct config key", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockGetConfig).toHaveBeenCalledWith(CONFIG_KEY)
+    })
+
+    it("marks as prompted before showing the prompt", async () => {
+      let setConfigCalledBeforePrompt = false
+      ;(mockConfirm as jest.Mock).mockImplementation(async () => {
+        setConfigCalledBeforePrompt = mockSetConfig.mock.calls.length > 0
+        return false
+      })
+
+      await promptClaudeCodePlugin()
+
+      expect(setConfigCalledBeforePrompt).toBe(true)
+      expect(mockSetConfig).toHaveBeenCalledWith(CONFIG_KEY, true)
+    })
+  })
+
+  describe("user says yes", () => {
+    beforeEach(() => {
+      mockConfirm.mockResolvedValue(true)
+    })
+
+    it("runs marketplace add command", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        "claude",
+        ["plugin", "marketplace", "add", "medusajs/medusa-agent-skills"],
+        { stdio: "inherit" }
+      )
+    })
+
+    it("runs plugin install command", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        "claude",
+        ["plugin", "install", PLUGIN_ID],
+        { stdio: "inherit" }
+      )
+    })
+
+    it("tracks telemetry with install=true", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockTrack).toHaveBeenCalledWith("MEDUSA_CLAUDE_CODE_PLUGIN_PROMPT", {
+        install: true,
+      })
+    })
+
+    it("does not show fallback message when both commands succeed", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(console.log).not.toHaveBeenCalled()
+    })
+
+    it("shows fallback message when marketplace command fails", async () => {
+      mockSpawnSync.mockReturnValue({ error: new Error("not found") } as any)
+
+      await promptClaudeCodePlugin()
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining("/plugin marketplace add medusajs/medusa-agent-skills")
+      )
+    })
+
+    it("shows fallback message when plugin install command fails", async () => {
+      mockSpawnSync
+        .mockReturnValueOnce({ error: undefined } as any)
+        .mockReturnValueOnce({ error: new Error("not found") } as any)
+
+      await promptClaudeCodePlugin()
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining("/plugin marketplace add medusajs/medusa-agent-skills")
+      )
+    })
+  })
+
+  describe("user says no", () => {
+    beforeEach(() => {
+      mockConfirm.mockResolvedValue(false)
+    })
+
+    it("does not run any install commands", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockSpawnSync).not.toHaveBeenCalled()
+    })
+
+    it("does not show fallback message", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(console.log).not.toHaveBeenCalled()
+    })
+
+    it("tracks telemetry with install=false", async () => {
+      await promptClaudeCodePlugin()
+
+      expect(mockTrack).toHaveBeenCalledWith("MEDUSA_CLAUDE_CODE_PLUGIN_PROMPT", {
+        install: false,
+      })
+    })
+  })
+})

--- a/packages/medusa/src/utils/claude-code-plugin.ts
+++ b/packages/medusa/src/utils/claude-code-plugin.ts
@@ -1,0 +1,87 @@
+import { Store, track } from "@medusajs/telemetry"
+import { spawnSync } from "child_process"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import confirm from "@inquirer/confirm"
+
+const CLAUDE_DIR = path.join(os.homedir(), ".claude")
+const INSTALLED_PLUGINS_FILE = path.join(
+  CLAUDE_DIR,
+  "plugins",
+  "installed_plugins.json"
+)
+const PLUGIN_ID = "medusa-dev@medusa"
+const CONFIG_KEY = "claude-code-plugin.prompted"
+
+function isClaudeCodePresent(): boolean {
+  return !!process.env.CLAUDE_CODE || fs.existsSync(CLAUDE_DIR)
+}
+
+function isNonInteractive(): boolean {
+  return process.env.CI === "true" || !process.stdout.isTTY
+}
+
+function isPluginInstalled(): boolean {
+  if (!fs.existsSync(INSTALLED_PLUGINS_FILE)) {
+    return false
+  }
+  try {
+    const data = JSON.parse(fs.readFileSync(INSTALLED_PLUGINS_FILE, "utf-8"))
+    return !!data?.plugins?.[PLUGIN_ID]
+  } catch {
+    return false
+  }
+}
+
+function runInstall(): boolean {
+  try {
+    const marketplace = spawnSync(
+      "claude",
+      ["plugin", "marketplace", "add", "medusajs/medusa-agent-skills"],
+      { stdio: "inherit" }
+    )
+    if (marketplace.error) {
+      return false
+    }
+
+    const install = spawnSync("claude", ["plugin", "install", PLUGIN_ID], {
+      stdio: "inherit",
+    })
+    return !install.error
+  } catch {
+    return false
+  }
+}
+
+export async function promptClaudeCodePlugin(): Promise<void> {
+  if (isNonInteractive() || !isClaudeCodePresent() || isPluginInstalled()) {
+    return
+  }
+
+  const configStore = new Store()
+  if (configStore.getConfig(CONFIG_KEY)) {
+    return
+  }
+
+  configStore.setConfig(CONFIG_KEY, true)
+
+  const install = await confirm({
+    message:
+      "Working with Medusa is easier with the Medusa Plugin for Claude Code. Would you like to install it?",
+    default: true,
+  })
+
+  track("MEDUSA_CLAUDE_CODE_PLUGIN_PROMPT", { install })
+
+  if (!install) {
+    return
+  }
+
+  const success = runInstall()
+  if (!success) {
+    console.log(
+      "\nCould not auto-install. To install manually, open Claude Code in your project and run:\n\n  /plugin marketplace add medusajs/medusa-agent-skills\n"
+    )
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2519,6 +2519,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/confirm@npm:^2.0.17":
+  version: 2.0.17
+  resolution: "@inquirer/confirm@npm:2.0.17"
+  dependencies:
+    "@inquirer/core": ^6.0.0
+    "@inquirer/type": ^1.1.6
+    chalk: ^4.1.2
+  checksum: c5e3835f38f5d2f7f442a0dddf454b569e3b25bef5da4f17d4dde6e9cf89b6aa6019cc1f8c0dcfe5d48e8f3e4c35b5fba9a9a8fcd4fa40b3845c01465d0e2d64
+  languageName: node
+  linkType: hard
+
 "@inquirer/confirm@npm:^5.0.0":
   version: 5.1.21
   resolution: "@inquirer/confirm@npm:5.1.21"
@@ -2552,6 +2563,28 @@ __metadata:
     "@types/node":
       optional: true
   checksum: f0f27e07fe288e01e3949b4ad216c19751f025ce77c610366e08d8b0f7a135d064dc074732031d251584b454c576f1e5c849e4abe259186dd5d4974c8f85c13e
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@inquirer/core@npm:6.0.0"
+  dependencies:
+    "@inquirer/type": ^1.1.6
+    "@types/mute-stream": ^0.0.4
+    "@types/node": ^20.10.7
+    "@types/wrap-ansi": ^3.0.0
+    ansi-escapes: ^4.3.2
+    chalk: ^4.1.2
+    cli-spinners: ^2.9.2
+    cli-width: ^4.1.0
+    figures: ^3.2.0
+    mute-stream: ^1.0.0
+    run-async: ^3.0.0
+    signal-exit: ^4.1.0
+    strip-ansi: ^6.0.1
+    wrap-ansi: ^6.2.0
+  checksum: 0663330936c9baea58d8a10e93de6c3446ab84ed909c41d7b3f6762842473b8f88e10d776326d89a278abfb3c4083240d0f5876293908eb1005d0026aa2cfb7d
   languageName: node
   linkType: hard
 
@@ -2607,7 +2640,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/type@npm:^1.5.3":
+"@inquirer/type@npm:^1.1.6, @inquirer/type@npm:^1.5.3":
   version: 1.5.5
   resolution: "@inquirer/type@npm:1.5.5"
   dependencies:
@@ -3875,6 +3908,7 @@ __metadata:
   resolution: "@medusajs/medusa@workspace:packages/medusa"
   dependencies:
     "@inquirer/checkbox": ^2.3.11
+    "@inquirer/confirm": ^2.0.17
     "@inquirer/input": ^2.2.9
     "@medusajs/admin-bundler": 2.13.6
     "@medusajs/analytics": 2.13.6
@@ -11941,6 +11975,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^20.10.7":
+  version: 20.19.39
+  resolution: "@types/node@npm:20.19.39"
+  dependencies:
+    undici-types: ~6.21.0
+  checksum: 1d16da7b5f47a7415b827fcf3b94d279febf4c14671afec74a03e47856b5270023d9beb1b9aeab4d3b622fd97d61a60206cfc2cca588663181331bc592468289
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^20.12.11":
   version: 20.19.27
   resolution: "@types/node@npm:20.19.27"
@@ -14513,7 +14556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.5.0":
+"cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.9.2":
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
@@ -17424,7 +17467,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figures@npm:^3.0.0":
+"figures@npm:^3.0.0, figures@npm:^3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
   dependencies:
@@ -25237,6 +25280,13 @@ __metadata:
   version: 2.4.1
   resolution: "run-async@npm:2.4.1"
   checksum: 35a68c8f1d9664f6c7c2e153877ca1d6e4f886e5ca067c25cdd895a6891ff3a1466ee07c63d6a9be306e9619ff7d509494e6d9c129516a36b9fd82263d579ee1
+  languageName: node
+  linkType: hard
+
+"run-async@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "run-async@npm:3.0.0"
+  checksum: b18b562ae37c3020083dcaae29642e4cc360c824fbfb6b7d50d809a9d5227bb986152d09310255842c8dce40526e82ca768f02f00806c91ba92a8dfa6159cb85
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Ask to install Claude Code plugin on `create-medusa-app` and `medusa develop`

Closes DX-2590

**Why** — Why are these changes relevant or necessary?  

Increase awareness for the plugin

**How** — How have these changes been implemented?

- **create-medusa-app:** Show question as part of the setup questions if haven't asked before, claude is installed, and plugin isn't installed
- **medusa develop:** Show question on termination if haven't asked before, claude is installed, and plugin isn't installed

> Note: we can't re-use the logic in the packages by using it in `@medusajs/utils` as it has dependencies that mess up `create-medusa-app`.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

In `packages/cli/create-medusa-app`, run the following command:

(If you have the plugin installed, remove it temporarily or disable the line that checks it)

```
yarn dev
```

It will ask if you want to install the plugin:

```
? Working with Medusa is easier with the Medusa Plugin for Claude Code. Would you like to install it? (Y/n)
```

To re-run the test, make sure to remove the config: `.config/medusa/config.json`

For the Medusa CLI, run it in a project with resolutions and run `yarn dev`, then terminate the server. You'll see the prompt.

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

