### PR TITLE
fix(medusa,types,loyalty-plugin): remove unused parameter + export step

### DIFF
--- a/.changeset/soft-pants-flash.md
+++ b/.changeset/soft-pants-flash.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/loyalty-plugin": patch
+"@medusajs/types": patch
+"@medusajs/medusa": patch
+---
+
+fix(medusa,types,loyalty-plugin): remove unused parameter + export step

--- a/packages/core/types/src/http/invite/admin/payloads.ts
+++ b/packages/core/types/src/http/invite/admin/payloads.ts
@@ -20,6 +20,8 @@ export type AdminCreateInvite = {
   email: string
   /**
    * The RBAC roles to assign to the user when the invite is accepted.
+   * 
+   * @featureFlag rbac
    */
   roles?: string[] | null
   /**

--- a/packages/core/types/src/http/order/admin/queries.ts
+++ b/packages/core/types/src/http/order/admin/queries.ts
@@ -8,10 +8,6 @@ export interface AdminOrderFilters extends FindParams, BaseOrderFilters {
    */
   id?: string[] | string
   /**
-   * Filter by name(s).
-   */
-  name?: string | string[]
-  /**
    * Filter by sales channel IDs to retrieve their associated orders.
    */
   sales_channel_id?: string[]

--- a/packages/medusa/src/api/admin/draft-orders/route.ts
+++ b/packages/medusa/src/api/admin/draft-orders/route.ts
@@ -21,7 +21,7 @@ import {
 import { refetchOrder } from "./helpers"
 
 export const GET = async (
-  req: MedusaRequest<HttpTypes.AdminOrderFilters>,
+  req: MedusaRequest<HttpTypes.AdminDraftOrderListParams>,
   res: MedusaResponse<HttpTypes.AdminDraftOrderListResponse>
 ) => {
   const variables = {

--- a/packages/medusa/src/api/admin/orders/validators.ts
+++ b/packages/medusa/src/api/admin/orders/validators.ts
@@ -57,7 +57,6 @@ const AdminGetOrdersParamsBase = createFindParams({
     status: z
       .union([z.string(), z.array(z.string()), createOperatorMap()])
       .optional(),
-    name: z.union([z.string(), z.array(z.string())]).optional(),
     sales_channel_id: z.array(z.string()).optional(),
     region_id: z.union([z.string(), z.array(z.string())]).optional(),
     customer_id: z.union([z.string(), z.array(z.string())]).optional(),

--- a/packages/medusa/src/api/admin/returns/route.ts
+++ b/packages/medusa/src/api/admin/returns/route.ts
@@ -12,7 +12,7 @@ import {
 } from "@medusajs/framework/http"
 
 export const GET = async (
-  req: AuthenticatedMedusaRequest<HttpTypes.AdminOrderFilters>,
+  req: AuthenticatedMedusaRequest<HttpTypes.AdminReturnFilters>,
   res: MedusaResponse<HttpTypes.AdminReturnsResponse>
 ) => {
   const remoteQuery = req.scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)

--- a/packages/plugins/loyalty/src/workflows/store-credit/workflows/claim-store-credit-account.ts
+++ b/packages/plugins/loyalty/src/workflows/store-credit/workflows/claim-store-credit-account.ts
@@ -84,7 +84,28 @@ export const validateClaimStoreCreditAccountInputStep = createStep(
   }
 );
 
-const validateSourceStoreCreditAccountsStep = createStep(
+/**
+ * This step validates that the source store credit account can be claimed by the customer. It checks that
+ * the source account is not already owned by the customer, that it does not belong to another customer, and
+ * that it has a balance greater than 0. It throws an error if any of these conditions are not met.
+ * 
+ * @example
+ * validateSourceStoreCreditAccountsStep({
+ *   sourceStoreCreditAccount: {
+ *     id: "sca_123",
+ *     customer_id: null,
+ *     balance: 1000,
+ *     // other store credit account properties...
+ *   },
+ *   targetStoreCreditAccount: {
+ *     id: "sca_456",
+ *     customer_id: "cust_123",
+ *     balance: 500,
+ *     // other store credit account properties...
+ *   },
+ * })
+ */
+export const validateSourceStoreCreditAccountsStep = createStep(
   "validate-source-store-credit-account",
   async function (args: {
     sourceStoreCreditAccount: ModuleStoreCreditAccount;


### PR DESCRIPTION
1. Remove `name` filter for orders (not sure what it was for and it's not used)
2. Export step in loyalty plugin for the workflow reference
3. Add missing feature flag for rbac property