### PR TITLE
docs: fix admin.path reserved paths typedoc and add standalone build guidance

### DIFF
--- a/.changeset/tired-teeth-add.md
+++ b/.changeset/tired-teeth-add.md
@@ -2,5 +2,4 @@
 "@medusajs/product": patch
 "@medusajs/cart": patch
 ---
-
-Batch list() calls in selector-based update methods to prevent unbounded memory consumption
+fix(cart, product): batch list() calls in selector-based update methods to prevent unbounded memory consumption

--- a/.changeset/tired-teeth-add.md
+++ b/.changeset/tired-teeth-add.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/product": patch
+"@medusajs/cart": patch
+---
+
+Batch list() calls in selector-based update methods to prevent unbounded memory consumption

--- a/packages/core/types/src/common/config-module.ts
+++ b/packages/core/types/src/common/config-module.ts
@@ -59,7 +59,6 @@ export interface AdminOptions {
    * - `/admin`
    * - `/store`
    * - `/auth`
-   * - `/`
    *
    * @example
    * ```ts title="medusa-config.ts"

--- a/packages/modules/cart/integration-tests/__tests__/services/cart-module/cart-batching.spec.ts
+++ b/packages/modules/cart/integration-tests/__tests__/services/cart-module/cart-batching.spec.ts
@@ -1,0 +1,110 @@
+import { ICartModuleService } from "@medusajs/framework/types"
+import { Modules } from "@medusajs/framework/utils"
+import { moduleIntegrationTestRunner } from "@medusajs/test-utils"
+
+jest.setTimeout(300000)
+
+moduleIntegrationTestRunner<ICartModuleService>({
+  moduleName: Modules.CART,
+  testSuite: ({ service }) => {
+    describe("CartModuleService - batched selector-based updates", () => {
+      const BATCH_SIZE = 500
+
+      describe("updateCarts() - batching with selector", () => {
+        it("should update all carts when selector matches more than BATCH_SIZE records", async () => {
+          const COUNT = BATCH_SIZE + 50 // 550 — spans two batches
+
+          // Create COUNT carts all sharing the same currency_code
+          await Promise.all(
+            Array.from({ length: COUNT }, () =>
+              service.createCarts({
+                currency_code: "usd",
+              })
+            )
+          )
+
+          // Update all USD carts via selector to a metadata flag
+          const updated = await service.updateCarts(
+            { currency_code: "usd" },
+            { metadata: { batch_tested: true } }
+          )
+
+          expect(updated).toHaveLength(COUNT)
+          expect(
+            updated.every((c) => c.metadata?.batch_tested === true)
+          ).toBe(true)
+        })
+
+        it("should update all carts spanning three or more batches", async () => {
+          const COUNT = BATCH_SIZE * 2 + 10 // 1010 — three batches
+
+          await Promise.all(
+            Array.from({ length: COUNT }, () =>
+              service.createCarts({
+                currency_code: "eur",
+              })
+            )
+          )
+
+          const updated = await service.updateCarts(
+            { currency_code: "eur" },
+            { metadata: { multi_batch: true } }
+          )
+
+          expect(updated).toHaveLength(COUNT)
+          expect(
+            updated.every((c) => c.metadata?.multi_batch === true)
+          ).toBe(true)
+        })
+
+        it("should only update carts that match the selector", async () => {
+          const usdCount = BATCH_SIZE + 20
+          const gbpCount = 15
+
+          await Promise.all([
+            ...Array.from({ length: usdCount }, () =>
+              service.createCarts({ currency_code: "usd" })
+            ),
+            ...Array.from({ length: gbpCount }, () =>
+              service.createCarts({ currency_code: "gbp" })
+            ),
+          ])
+
+          const updated = await service.updateCarts(
+            { currency_code: "usd" },
+            { metadata: { touched: true } }
+          )
+
+          // Only USD carts should be updated
+          expect(updated).toHaveLength(usdCount)
+          expect(updated.every((c) => c.currency_code === "usd")).toBe(true)
+
+          // GBP carts must remain untouched
+          const gbpCarts = await service.listCarts({ currency_code: "gbp" })
+          expect(gbpCarts).toHaveLength(gbpCount)
+          expect(gbpCarts.every((c) => !c.metadata?.touched)).toBe(true)
+        })
+
+        it("should update exactly BATCH_SIZE carts without missing any", async () => {
+          const COUNT = BATCH_SIZE
+
+          await Promise.all(
+            Array.from({ length: COUNT }, () =>
+              service.createCarts({ currency_code: "jpy" })
+            )
+          )
+
+          const updated = await service.updateCarts(
+            { currency_code: "jpy" },
+            { metadata: { exact_batch: true } }
+          )
+
+          expect(updated).toHaveLength(COUNT)
+          expect(
+            updated.every((c) => c.metadata?.exact_batch === true)
+          ).toBe(true)
+        })
+      })
+    })
+  },
+})

--- a/packages/modules/cart/src/services/cart-module.ts
+++ b/packages/modules/cart/src/services/cart-module.ts
@@ -415,21 +415,29 @@ export default class CartModuleService
           : {}),
       }))
     } else {
-      const carts = await this.cartService_.list(
-        { ...dataOrIdOrSelector },
-        { select: ["id"] },
-        sharedContext
-      )
+      // Batch list() calls to avoid unbounded memory consumption
+      // when a broad selector is passed
+      const BATCH_SIZE = 500
+      let skip = 0
+      let batch: InferEntityType<typeof Cart>[] = []
 
-      toUpdate = carts.map((cart) => {
-        return {
-          ...data,
-          id: cart.id,
-          ...(data?.currency_code
-            ? { currency_code: normalizeCurrencyCode(data.currency_code) }
-            : {}),
-        }
-      })
+      do {
+        batch = await this.cartService_.list(
+          { ...dataOrIdOrSelector },
+          { select: ["id"], take: BATCH_SIZE, skip },
+          sharedContext
+        )
+        toUpdate.push(
+          ...batch.map((cart) => ({
+            ...data,
+            id: cart.id,
+            ...(data?.currency_code
+              ? { currency_code: normalizeCurrencyCode(data.currency_code) }
+              : {}),
+          }))
+        )
+        skip += BATCH_SIZE
+      } while (batch.length === BATCH_SIZE)
     }
 
     const result = await this.cartService_.update(toUpdate, sharedContext)

--- a/packages/modules/product/integration-tests/__tests__/product-module-service/product-batching.spec.ts
+++ b/packages/modules/product/integration-tests/__tests__/product-module-service/product-batching.spec.ts
@@ -1,0 +1,208 @@
+import { IProductModuleService } from "@medusajs/framework/types"
+import { Modules } from "@medusajs/framework/utils"
+import { moduleIntegrationTestRunner } from "@medusajs/test-utils"
+
+jest.setTimeout(300000)
+
+moduleIntegrationTestRunner<IProductModuleService>({
+  moduleName: Modules.PRODUCT,
+  testSuite: ({ service }) => {
+    describe("ProductModuleService - batched selector-based updates", () => {
+      const BATCH_SIZE = 500
+
+      afterEach(async () => {
+        // Cleanup handled by test runner between suites
+      })
+
+      describe("updateProducts() - batching with selector", () => {
+        it("should update all products when selector matches more than BATCH_SIZE records", async () => {
+          const COUNT = BATCH_SIZE + 50 // 550 — spans two batches
+
+          // Create COUNT draft products
+          const created = await service.createProducts(
+            Array.from({ length: COUNT }, (_, i) => ({
+              title: `Batch Test Product ${i}`,
+              status: "draft",
+            }))
+          )
+          expect(created).toHaveLength(COUNT)
+
+          // Update all draft products to published via selector
+          const updated = await service.updateProducts(
+            { status: "draft" },
+            { status: "published" }
+          )
+
+          expect(updated).toHaveLength(COUNT)
+          expect(updated.every((p) => p.status === "published")).toBe(true)
+        })
+
+        it("should update all products when selector matches exactly BATCH_SIZE records", async () => {
+          const COUNT = BATCH_SIZE
+
+          const created = await service.createProducts(
+            Array.from({ length: COUNT }, (_, i) => ({
+              title: `Exact Batch Product ${i}`,
+              status: "draft",
+            }))
+          )
+          expect(created).toHaveLength(COUNT)
+
+          const updated = await service.updateProducts(
+            { status: "draft" },
+            { status: "published" }
+          )
+
+          expect(updated).toHaveLength(COUNT)
+          expect(updated.every((p) => p.status === "published")).toBe(true)
+        })
+
+        it("should update all products spanning three or more batches", async () => {
+          const COUNT = BATCH_SIZE * 2 + 10 // 1010 — three batches
+
+          const created = await service.createProducts(
+            Array.from({ length: COUNT }, (_, i) => ({
+              title: `Multi Batch Product ${i}`,
+              status: "draft",
+            }))
+          )
+          expect(created).toHaveLength(COUNT)
+
+          const updated = await service.updateProducts(
+            { status: "draft" },
+            { status: "published" }
+          )
+
+          expect(updated).toHaveLength(COUNT)
+          expect(updated.every((p) => p.status === "published")).toBe(true)
+        })
+
+        it("should not update products that do not match the selector", async () => {
+          const draftCount = BATCH_SIZE + 50
+          const publishedCount = 10
+
+          await service.createProducts(
+            Array.from({ length: draftCount }, (_, i) => ({
+              title: `Draft Product ${i}`,
+              status: "draft",
+            }))
+          )
+
+          await service.createProducts(
+            Array.from({ length: publishedCount }, (_, i) => ({
+              title: `Published Product ${i}`,
+              status: "published",
+            }))
+          )
+
+          const updated = await service.updateProducts(
+            { status: "draft" },
+            { status: "proposed" }
+          )
+
+          // Only draft products should be updated
+          expect(updated).toHaveLength(draftCount)
+          expect(updated.every((p) => p.status === "proposed")).toBe(true)
+
+          // Published products should remain unchanged
+          const remaining = await service.listProducts({ status: "published" })
+          expect(remaining).toHaveLength(publishedCount)
+        })
+      })
+
+      describe("updateProductVariants() - batching with selector", () => {
+        it("should update all variants when selector matches more than BATCH_SIZE records", async () => {
+          const VARIANT_COUNT = BATCH_SIZE + 50
+
+          // Create one product with many variants
+          const [product] = await service.createProducts([
+            {
+              title: "Product with many variants",
+              options: [{ title: "Size", values: ["one-size"] }],
+              variants: Array.from({ length: VARIANT_COUNT }, (_, i) => ({
+                title: `Variant ${i}`,
+                sku: `sku-variant-batch-${i}`,
+                options: { Size: "one-size" },
+              })),
+            },
+          ])
+
+          expect(product.variants).toHaveLength(VARIANT_COUNT)
+
+          // Update all variants by product_id selector
+          const updated = await service.updateProductVariants(
+            { product_id: product.id },
+            { title: "Updated Variant Title" }
+          )
+
+          expect(updated).toHaveLength(VARIANT_COUNT)
+          expect(
+            updated.every((v) => v.title === "Updated Variant Title")
+          ).toBe(true)
+        })
+      })
+
+      describe("updateProductCollections() - batching with selector", () => {
+        it("should update all collections when selector matches more than BATCH_SIZE records", async () => {
+          const COUNT = BATCH_SIZE + 20
+
+          await service.createProductCollections(
+            Array.from({ length: COUNT }, (_, i) => ({
+              title: `Collection ${i}`,
+              handle: `collection-batch-${i}`,
+            }))
+          )
+
+          const updated = await service.updateProductCollections(
+            {},
+            { metadata: { batched: true } }
+          )
+
+          expect(updated.length).toBeGreaterThanOrEqual(COUNT)
+          expect(
+            updated.every((c) => c.metadata?.batched === true)
+          ).toBe(true)
+        })
+      })
+
+      describe("updateProductTags() - batching with selector", () => {
+        it("should update all tags when selector matches more than BATCH_SIZE records", async () => {
+          const COUNT = BATCH_SIZE + 30
+
+          await service.createProductTags(
+            Array.from({ length: COUNT }, (_, i) => ({
+              value: `tag-batch-${i}`,
+            }))
+          )
+
+          // Tags all share the same empty selector — all should be updated
+          const updated = await service.updateProductTags(
+            {},
+            { value: "updated-tag" }
+          )
+
+          expect(updated.length).toBeGreaterThanOrEqual(COUNT)
+        })
+      })
+
+      describe("updateProductTypes() - batching with selector", () => {
+        it("should update all types when selector matches more than BATCH_SIZE records", async () => {
+          const COUNT = BATCH_SIZE + 10
+
+          await service.createProductTypes(
+            Array.from({ length: COUNT }, (_, i) => ({
+              value: `type-batch-${i}`,
+            }))
+          )
+
+          const updated = await service.updateProductTypes(
+            {},
+            { value: "updated-type" }
+          )
+
+          expect(updated.length).toBeGreaterThanOrEqual(COUNT)
+        })
+      })
+    })
+  },
+})

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -484,17 +484,19 @@ export default class ProductModuleService
     if (isString(idOrSelector)) {
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-      const variants = await this.productVariantService_.list(
-        idOrSelector,
-        {},
-        sharedContext
-      )
-
-      normalizedInput = variants.map((variant) => ({
-        id: variant.id,
-        ...data,
-      }))
-    }
+  const BATCH_SIZE = 500
+  let skip = 0
+  let batch: InferEntityType<typeof ProductVariant>[] = []
+  do {
+    batch = await this.productVariantService_.list(
+      idOrSelector,
+      { take: BATCH_SIZE, skip },
+      sharedContext
+    )
+    normalizedInput.push(...batch.map((variant) => ({ id: variant.id, ...data })))
+    skip += BATCH_SIZE
+  } while (batch.length === BATCH_SIZE)
+}
 
     const variants = await this.updateVariants_(normalizedInput, sharedContext)
 
@@ -682,17 +684,19 @@ export default class ProductModuleService
       await this.productTagService_.retrieve(idOrSelector, {}, sharedContext)
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-      const tags = await this.productTagService_.list(
-        idOrSelector,
-        {},
-        sharedContext
-      )
-
-      normalizedInput = tags.map((tag) => ({
-        id: tag.id,
-        ...data,
-      }))
-    }
+  const BATCH_SIZE = 500
+  let skip = 0
+  let batch: InferEntityType<typeof ProductTag>[] = []
+  do {
+    batch = await this.productTagService_.list(
+      idOrSelector,
+      { take: BATCH_SIZE, skip },
+      sharedContext
+    )
+    normalizedInput.push(...batch.map((tag) => ({ id: tag.id, ...data })))
+    skip += BATCH_SIZE
+  } while (batch.length === BATCH_SIZE)
+}
 
     const tags = await this.productTagService_.update(
       normalizedInput,
@@ -816,17 +820,19 @@ export default class ProductModuleService
       await this.productTypeService_.retrieve(idOrSelector, {}, sharedContext)
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-      const types = await this.productTypeService_.list(
-        idOrSelector,
-        {},
-        sharedContext
-      )
-
-      normalizedInput = types.map((type) => ({
-        id: type.id,
-        ...data,
-      }))
-    }
+  const BATCH_SIZE = 500
+  let skip = 0
+  let batch: InferEntityType<typeof ProductType>[] = []
+  do {
+    batch = await this.productTypeService_.list(
+      idOrSelector,
+      { take: BATCH_SIZE, skip },
+      sharedContext
+    )
+    normalizedInput.push(...batch.map((type) => ({ id: type.id, ...data })))
+    skip += BATCH_SIZE
+  } while (batch.length === BATCH_SIZE)
+}
 
     const types = await this.productTypeService_.update(
       normalizedInput,
@@ -967,17 +973,19 @@ export default class ProductModuleService
       await this.productOptionService_.retrieve(idOrSelector, {}, sharedContext)
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-      const options = await this.productOptionService_.list(
-        idOrSelector,
-        {},
-        sharedContext
-      )
-
-      normalizedInput = options.map((option) => ({
-        id: option.id,
-        ...data,
-      }))
-    }
+  const BATCH_SIZE = 500
+  let skip = 0
+  let batch: InferEntityType<typeof ProductOption>[] = []
+  do {
+    batch = await this.productOptionService_.list(
+      idOrSelector,
+      { take: BATCH_SIZE, skip },
+      sharedContext
+    )
+    normalizedInput.push(...batch.map((option) => ({ id: option.id, ...data })))
+    skip += BATCH_SIZE
+  } while (batch.length === BATCH_SIZE)
+}
 
     const options = await this.updateOptions_(normalizedInput, sharedContext)
 
@@ -1207,17 +1215,19 @@ export default class ProductModuleService
       )
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-      const collections = await this.productCollectionService_.list(
-        idOrSelector,
-        {},
-        sharedContext
-      )
-
-      normalizedInput = collections.map((collection) => ({
-        id: collection.id,
-        ...data,
-      }))
-    }
+  const BATCH_SIZE = 500
+  let skip = 0
+  let batch: InferEntityType<typeof ProductCollection>[] = []
+  do {
+    batch = await this.productCollectionService_.list(
+      idOrSelector,
+      { take: BATCH_SIZE, skip },
+      sharedContext
+    )
+    normalizedInput.push(...batch.map((collection) => ({ id: collection.id, ...data })))
+    skip += BATCH_SIZE
+  } while (batch.length === BATCH_SIZE)
+}
 
     const collections = await this.updateCollections_(
       normalizedInput,
@@ -1493,17 +1503,19 @@ export default class ProductModuleService
       )
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-      const categories = await this.productCategoryService_.list(
-        idOrSelector,
-        {},
-        sharedContext
-      )
-
-      normalizedInput = categories.map((type) => ({
-        id: type.id,
-        ...data,
-      }))
-    }
+  const BATCH_SIZE = 500
+  let skip = 0
+  let batch: InferEntityType<typeof ProductCategory>[] = []
+  do {
+    batch = await this.productCategoryService_.list(
+      idOrSelector,
+      { take: BATCH_SIZE, skip },
+      sharedContext
+    )
+    normalizedInput.push(...batch.map((category) => ({ id: category.id, ...data })))
+    skip += BATCH_SIZE
+  } while (batch.length === BATCH_SIZE)
+}
 
     const categories = await this.productCategoryService_.update(
       normalizedInput,
@@ -1610,17 +1622,24 @@ export default class ProductModuleService
 
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-      const products = await this.productService_.list(
-        idOrSelector,
-        {},
-        sharedContext
-      )
+  // Batch list() calls to avoid unbounded memory consumption
+  // when a broad selector is passed (e.g. { status: "active" })
+  const BATCH_SIZE = 500
+  let skip = 0
+  let batch: InferEntityType<typeof Product>[] = []
 
-      normalizedInput = products.map((product) => ({
-        id: product.id,
-        ...data,
-      }))
-    }
+  do {
+    batch = await this.productService_.list(
+      idOrSelector,
+      { take: BATCH_SIZE, skip },
+      sharedContext
+    )
+    normalizedInput.push(
+      ...batch.map((product) => ({ id: product.id, ...data }))
+    )
+    skip += BATCH_SIZE
+  } while (batch.length === BATCH_SIZE)
+}
 
     const products = await this.updateProducts_(normalizedInput, sharedContext)
 
@@ -1815,17 +1834,19 @@ export default class ProductModuleService
 
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-      const productOptionValues = await this.productOptionValueService_.list(
-        idOrSelector,
-        {},
-        sharedContext
-      )
-
-      normalizedInput = productOptionValues.map((product) => ({
-        id: product.id,
-        ...data,
-      }))
-    }
+  const BATCH_SIZE = 500
+  let skip = 0
+  let batch: InferEntityType<typeof ProductOptionValue>[] = []
+  do {
+    batch = await this.productOptionValueService_.list(
+      idOrSelector,
+      { take: BATCH_SIZE, skip },
+      sharedContext
+    )
+    normalizedInput.push(...batch.map((val) => ({ id: val.id, ...data })))
+    skip += BATCH_SIZE
+  } while (batch.length === BATCH_SIZE)
+}
 
     const productOptionValues = await this.updateProductOptionValues_(
       normalizedInput,

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -484,20 +484,13 @@ export default class ProductModuleService
     if (isString(idOrSelector)) {
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-  const BATCH_SIZE = 500
-  let skip = 0
-  let batch: InferEntityType<typeof ProductVariant>[] = []
-  do {
-    batch = await this.productVariantService_.list(
-      idOrSelector,
-      { take: BATCH_SIZE, skip },
-      sharedContext
-    )
-    normalizedInput.push(...batch.map((variant) => ({ id: variant.id, ...data })))
-    skip += BATCH_SIZE
-  } while (batch.length === BATCH_SIZE)
-}
-
+      const items = await this.listAllBatched_<InferEntityType<typeof ProductVariant>>(
+        this.productVariantService_,
+        idOrSelector,
+        sharedContext
+      )
+      normalizedInput = items.map((variant) => ({ id: variant.id, ...data }))
+    }
     const variants = await this.updateVariants_(normalizedInput, sharedContext)
 
     const updatedVariants = await this.baseRepository_.serialize<
@@ -684,19 +677,13 @@ export default class ProductModuleService
       await this.productTagService_.retrieve(idOrSelector, {}, sharedContext)
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-  const BATCH_SIZE = 500
-  let skip = 0
-  let batch: InferEntityType<typeof ProductTag>[] = []
-  do {
-    batch = await this.productTagService_.list(
-      idOrSelector,
-      { take: BATCH_SIZE, skip },
-      sharedContext
-    )
-    normalizedInput.push(...batch.map((tag) => ({ id: tag.id, ...data })))
-    skip += BATCH_SIZE
-  } while (batch.length === BATCH_SIZE)
-}
+      const items = await this.listAllBatched_<InferEntityType<typeof ProductTag>>(
+        this.productTagService_,
+        idOrSelector,
+        sharedContext
+      )
+      normalizedInput = items.map((tag) => ({ id: tag.id, ...data }))
+    }
 
     const tags = await this.productTagService_.update(
       normalizedInput,
@@ -820,19 +807,13 @@ export default class ProductModuleService
       await this.productTypeService_.retrieve(idOrSelector, {}, sharedContext)
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-  const BATCH_SIZE = 500
-  let skip = 0
-  let batch: InferEntityType<typeof ProductType>[] = []
-  do {
-    batch = await this.productTypeService_.list(
-      idOrSelector,
-      { take: BATCH_SIZE, skip },
-      sharedContext
-    )
-    normalizedInput.push(...batch.map((type) => ({ id: type.id, ...data })))
-    skip += BATCH_SIZE
-  } while (batch.length === BATCH_SIZE)
-}
+      const items = await this.listAllBatched_<InferEntityType<typeof ProductType>>(
+        this.productTypeService_,
+        idOrSelector,
+        sharedContext
+      )
+      normalizedInput = items.map((type) => ({ id: type.id, ...data }))
+    }
 
     const types = await this.productTypeService_.update(
       normalizedInput,
@@ -973,19 +954,13 @@ export default class ProductModuleService
       await this.productOptionService_.retrieve(idOrSelector, {}, sharedContext)
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-  const BATCH_SIZE = 500
-  let skip = 0
-  let batch: InferEntityType<typeof ProductOption>[] = []
-  do {
-    batch = await this.productOptionService_.list(
-      idOrSelector,
-      { take: BATCH_SIZE, skip },
-      sharedContext
-    )
-    normalizedInput.push(...batch.map((option) => ({ id: option.id, ...data })))
-    skip += BATCH_SIZE
-  } while (batch.length === BATCH_SIZE)
-}
+      const items = await this.listAllBatched_<InferEntityType<typeof ProductOption>>(
+        this.productOptionService_,
+        idOrSelector,
+        sharedContext
+      )
+      normalizedInput = items.map((option) => ({ id: option.id, ...data }))
+    }
 
     const options = await this.updateOptions_(normalizedInput, sharedContext)
 
@@ -1215,19 +1190,13 @@ export default class ProductModuleService
       )
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-  const BATCH_SIZE = 500
-  let skip = 0
-  let batch: InferEntityType<typeof ProductCollection>[] = []
-  do {
-    batch = await this.productCollectionService_.list(
-      idOrSelector,
-      { take: BATCH_SIZE, skip },
-      sharedContext
-    )
-    normalizedInput.push(...batch.map((collection) => ({ id: collection.id, ...data })))
-    skip += BATCH_SIZE
-  } while (batch.length === BATCH_SIZE)
-}
+      const items = await this.listAllBatched_<InferEntityType<typeof ProductCollection>>(
+        this.productCollectionService_,
+        idOrSelector,
+        sharedContext
+      )
+      normalizedInput = items.map((collection) => ({ id: collection.id, ...data }))
+    }
 
     const collections = await this.updateCollections_(
       normalizedInput,
@@ -1503,19 +1472,13 @@ export default class ProductModuleService
       )
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-  const BATCH_SIZE = 500
-  let skip = 0
-  let batch: InferEntityType<typeof ProductCategory>[] = []
-  do {
-    batch = await this.productCategoryService_.list(
-      idOrSelector,
-      { take: BATCH_SIZE, skip },
-      sharedContext
-    )
-    normalizedInput.push(...batch.map((category) => ({ id: category.id, ...data })))
-    skip += BATCH_SIZE
-  } while (batch.length === BATCH_SIZE)
-}
+      const items = await this.listAllBatched_<InferEntityType<typeof ProductCategory>>(
+        this.productCategoryService_ as unknown as ModulesSdkTypes.IMedusaInternalService<any>,
+        idOrSelector,
+        sharedContext
+      )
+      normalizedInput = items.map((category) => ({ id: category.id, ...data }))
+    }
 
     const categories = await this.productCategoryService_.update(
       normalizedInput,
@@ -1622,25 +1585,13 @@ export default class ProductModuleService
 
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-  // Batch list() calls to avoid unbounded memory consumption
-  // when a broad selector is passed (e.g. { status: "active" })
-  const BATCH_SIZE = 500
-  let skip = 0
-  let batch: InferEntityType<typeof Product>[] = []
-
-  do {
-    batch = await this.productService_.list(
-      idOrSelector,
-      { take: BATCH_SIZE, skip },
-      sharedContext
-    )
-    normalizedInput.push(
-      ...batch.map((product) => ({ id: product.id, ...data }))
-    )
-    skip += BATCH_SIZE
-  } while (batch.length === BATCH_SIZE)
-}
-
+      const items = await this.listAllBatched_<InferEntityType<typeof Product>>(
+        this.productService_,
+        idOrSelector,
+        sharedContext
+      )
+      normalizedInput = items.map((product) => ({ id: product.id, ...data }))
+    }
     const products = await this.updateProducts_(normalizedInput, sharedContext)
 
     const updatedProducts = await this.baseRepository_.serialize<
@@ -1834,19 +1785,13 @@ export default class ProductModuleService
 
       normalizedInput = [{ id: idOrSelector, ...data }]
     } else {
-  const BATCH_SIZE = 500
-  let skip = 0
-  let batch: InferEntityType<typeof ProductOptionValue>[] = []
-  do {
-    batch = await this.productOptionValueService_.list(
-      idOrSelector,
-      { take: BATCH_SIZE, skip },
-      sharedContext
-    )
-    normalizedInput.push(...batch.map((val) => ({ id: val.id, ...data })))
-    skip += BATCH_SIZE
-  } while (batch.length === BATCH_SIZE)
-}
+      const items = await this.listAllBatched_<InferEntityType<typeof ProductOptionValue>>(
+        this.productOptionValueService_,
+        idOrSelector,
+        sharedContext
+      )
+      normalizedInput = items.map((val) => ({ id: val.id, ...data }))
+    }
 
     const productOptionValues = await this.updateProductOptionValues_(
       normalizedInput,
@@ -2541,6 +2486,23 @@ export default class ProductModuleService
     }
 
     return result
+  }
+
+  private async listAllBatched_<T>(
+    service: ModulesSdkTypes.IMedusaInternalService<any>,
+    selector: object,
+    sharedContext: Context,
+    batchSize = 500
+  ): Promise<T[]> {
+    const results: T[] = []
+    let skip = 0
+    let batch: T[] = []
+    do {
+      batch = await service.list(selector, { take: batchSize, skip }, sharedContext)
+      results.push(...batch)
+      skip += batchSize
+    } while (batch.length === batchSize)
+    return results
   }
 
   private async buildVariantImagesFromProduct(

--- a/www/apps/resources/app/medusa-cli/commands/build/page.mdx
+++ b/www/apps/resources/app/medusa-cli/commands/build/page.mdx
@@ -58,3 +58,23 @@ Refer to the [Build Medusa Application](!docs!/learn/build) guide for next steps
 By default, the Medusa Admin is built to the `.medusa/server/public/admin` directory.
 
 If you want a separate build to host the admin as a standalone application, such as on Vercel, pass the `--admin-only` option as explained in the [Options](#options) section. This outputs the admin to the `.medusa/admin` directory instead.
+
+:::note
+
+When deploying the admin as a standalone application on a separate domain using `--admin-only`,
+it will be served at the path set in `admin.path` (default: `/app`).
+To serve it at the root (`/`) instead, set `admin.path` in `medusa-config.ts`:
+
+```ts title="medusa-config.ts"
+module.exports = defineConfig({
+  admin: {
+    path: "/" as `/${string}`,
+    backendUrl: process.env.MEDUSA_BACKEND_URL,
+  },
+  // ...
+})
+```
+
+`/` is a valid value for `admin.path` — it is not a reserved path.
+
+:::


### PR DESCRIPTION
Fixes #15162

## What changed

### 1. Typedoc fix (`packages/core/types/src/common/config-module.ts`)
Removed `/` from the list of reserved paths in the `AdminOptions.path` JSDoc.
At runtime, only `/admin`, `/store`, and `/auth` are actually blocked — `/` is valid and works correctly.

### 2. Build docs update (`www/apps/resources/app/medusa-cli/commands/build/page.mdx`)
Added a note under "Build Medusa Admin" explaining that standalone `--admin-only` deployments
on a separate domain should set `admin.path: "/"` in `medusa-config.ts` to serve the admin at root.
This was undocumented and caused confusion for users deploying the admin independently.