### PR TITLE
fix(dashboard): use two-arg z.record for Zod v4 in currencies and translations forms

### DIFF
--- a/.changeset/fix-dashboard-zod-v4-record.md
+++ b/.changeset/fix-dashboard-zod-v4-record.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): use two-arg z.record in add-currencies and translations forms for Zod v4 compatibility

--- a/packages/admin/dashboard/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.tsx
+++ b/packages/admin/dashboard/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.tsx
@@ -33,7 +33,7 @@ type AddCurrenciesFormProps = {
 
 const AddCurrenciesSchema = zod.object({
   currencies: zod.array(zod.string()).min(1),
-  pricePreferences: zod.record(zod.boolean()),
+  pricePreferences: zod.record(zod.string(), zod.boolean()),
 })
 
 const PAGE_SIZE = 50

--- a/packages/admin/dashboard/src/routes/translations/translations-edit/components/translations-edit-form/translations-edit-form.tsx
+++ b/packages/admin/dashboard/src/routes/translations/translations-edit/components/translations-edit-form/translations-edit-form.tsx
@@ -20,12 +20,12 @@ import { useBatchTranslations } from "../../../../../hooks/api/translations"
 
 const EntityTranslationsSchema = z.object({
   id: z.string().nullish(),
-  fields: z.record(z.string().optional()),
+  fields: z.record(z.string(), z.string().optional()),
 })
 export type EntityTranslationsSchema = z.infer<typeof EntityTranslationsSchema>
 
 export const TranslationsFormSchema = z.object({
-  entities: z.record(EntityTranslationsSchema),
+  entities: z.record(z.string(), EntityTranslationsSchema),
 })
 export type TranslationsFormSchema = z.infer<typeof TranslationsFormSchema>
 


### PR DESCRIPTION
## Summary

**What** — Fixes Zod v4 validation failures in the admin dashboard's "Add currencies" and "Edit translations" forms caused by single-arg `z.record(valueSchema)` usage.

**Why** — The repo upgraded to `zod@4.2.0`. In Zod v4, `z.record(...)` requires both a key schema and a value schema: `z.record(keySchema, valueSchema)`. When a single argument is passed, it's interpreted as the *key* schema, so forms that tried to express `Record<string, boolean>` (currency tax-inclusivity) or `Record<string, EntityTranslationsSchema>` (per-entity translations) would reject their real string keys at submit time with errors like:

```
ZodError: invalid_key at path ["pricePreferences", "eur"]
  expected: "boolean", received: "string"
```

This made the "Add currencies" modal in Store Settings impossible to save, and would have the same effect on the translations editor.

**How** — Pass `z.string()` explicitly as the key schema in each affected schema:

- [`store-add-currencies/.../add-currencies-form.tsx`](https://github.com/medusajs/medusa/blob/develop/packages/admin/dashboard/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.tsx) — `pricePreferences`
- [`translations-edit/.../translations-edit-form.tsx`](https://github.com/medusajs/medusa/blob/develop/packages/admin/dashboard/src/routes/translations/translations-edit/components/translations-edit-form/translations-edit-form.tsx) — `fields` and `entities`

I swept the rest of `packages/admin/dashboard/src` for `.record(` calls — these were the only single-arg offenders. Every other `.record(...)` was already using the two-arg form.

**Testing** —
1. Start the admin dashboard against a Medusa backend.
2. Go to **Settings → Store → Currencies → Add Currencies**, select at least one new currency, toggle its tax-inclusive switch, and save. Previously this produced a `ZodError`; it now saves successfully.
3. Open any entity's translation edit modal, change a field, and save — the form no longer rejects valid string keys.

---

## Examples

Before (fails under Zod v4):

```ts
const AddCurrenciesSchema = zod.object({
  currencies: zod.array(zod.string()).min(1),
  pricePreferences: zod.record(zod.boolean()),
})
```

After:

```ts
const AddCurrenciesSchema = zod.object({
  currencies: zod.array(zod.string()).min(1),
  pricePreferences: zod.record(zod.string(), zod.boolean()),
})
```

---

## Checklist

- [x] I have added a **changeset** for this PR (`@medusajs/dashboard` patch)
- [ ] The changes are covered by relevant **tests** — no new tests; these are schema-only call-signature fixes that the existing TS compiler + form flows verify
- [x] I have verified the code works as intended locally (reproduced the Zod error in the Store Currencies flow, confirmed it's resolved after the fix)
- [ ] I have linked the related issue(s) if applicable — none filed

---

## Additional Context

Companion to the recent `docs-util: maintain support for Zod v3 and v4` work on `develop` (#15138) — this extends the same v3→v4 call-shape update to the dashboard forms that were missed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: schema-only changes that adjust `z.record` call signatures for Zod v4; main risk is unintended validation tightening/loosening in the affected forms.
> 
> **Overview**
> Fixes Zod v4 form validation in the dashboard by updating single-arg `z.record(valueSchema)` usages to the two-arg `z.record(z.string(), valueSchema)` form.
> 
> This unblocks submitting the Store **Add Currencies** form (`pricePreferences`) and the **Translations** edit form (`fields` and `entities`) when record keys are dynamic strings, and includes a patch changeset for `@medusajs/dashboard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f369b5c6fdead69ee578bb7e08879cc4a96a2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->