### PR TITLE
Allow users to change their mind during the checkout process and upda…

### DIFF
--- a/packages/core/js-sdk/src/store/index.ts
+++ b/packages/core/js-sdk/src/store/index.ts
@@ -1083,22 +1083,20 @@ export class Store {
       query?: SelectParams,
       headers?: ClientHeaders
     ) => {
-      let paymentCollectionId = (cart as any).payment_collection?.id
-      if (!paymentCollectionId) {
-        const collectionBody = {
-          cart_id: cart.id,
-        }
-        paymentCollectionId = (
-          await this.client.fetch<HttpTypes.StorePaymentCollectionResponse>(
-            `/store/payment-collections`,
-            {
-              method: "POST",
-              headers,
-              body: collectionBody,
-            }
-          )
-        ).payment_collection.id
+      const collectionBody = {
+        cart_id: cart.id,
       }
+      const paymentCollectionId = (
+        await this.client.fetch<HttpTypes.StorePaymentCollectionResponse>(
+          `/store/payment-collections`,
+          {
+            method: "POST",
+            headers,
+            body: collectionBody,
+          }
+        )
+      ).payment_collection.id
+
 
       return this.client.fetch<HttpTypes.StorePaymentCollectionResponse>(
         `/store/payment-collections/${paymentCollectionId}/payment-sessions`,

--- a/packages/medusa/src/api/store/payment-collections/route.ts
+++ b/packages/medusa/src/api/store/payment-collections/route.ts
@@ -1,4 +1,8 @@
-import { createPaymentCollectionForCartWorkflowId } from "@medusajs/core-flows"
+import { createPaymentCollectionForCartWorkflow, refreshPaymentCollectionForCartWorkflow } from "@medusajs/core-flows"
+import {
+  ContainerRegistrationKeys,
+  remoteQueryObjectFromString,
+} from "@medusajs/framework/utils"
 import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
@@ -10,40 +14,42 @@ import {
 } from "@medusajs/framework/utils"
 import { Modules } from "@medusajs/utils"
 
-export const POST = async (
-  req: AuthenticatedMedusaRequest<
-    HttpTypes.StoreCreatePaymentCollection,
-    HttpTypes.SelectParams
-  >,
-  res: MedusaResponse<HttpTypes.StorePaymentCollectionResponse>
-) => {
+const getPaymentCollectionForCart = async (req: AuthenticatedMedusaRequest<HttpTypes.StoreCreatePaymentCollection>) => {
   const remoteQuery = req.scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
   const { cart_id } = req.body
 
-  // We can potentially refactor the workflow to behave more like an upsert and return an existing collection if there is one.
   const [cartCollectionRelation] = await remoteQuery(
     remoteQueryObjectFromString({
       entryPoint: "cart_payment_collection",
       variables: { filters: { cart_id } },
-      fields: req.queryConfig.fields.map((f) => `payment_collection.${f}`),
+      fields: req.remoteQueryConfig.fields.map(
+        (f) => `payment_collection.${f}`
+      ) as any,
     })
   )
-  let paymentCollection = cartCollectionRelation?.payment_collection
+  return cartCollectionRelation?.payment_collection
+}
 
+export const POST = async (
+  req: AuthenticatedMedusaRequest<HttpTypes.StoreCreatePaymentCollection>,
+  res: MedusaResponse<HttpTypes.StorePaymentCollectionResponse>
+) => {
+  const { cart_id } = req.body
+
+  // We can potentially refactor the workflow to behave more like an upsert and return an existing collection if there is one.
+
+  let paymentCollection = await getPaymentCollectionForCart(req)
   if (!paymentCollection) {
     const we = req.scope.resolve(Modules.WORKFLOW_ENGINE)
     await we.run(createPaymentCollectionForCartWorkflowId, {
       input: req.body,
     })
-
-    const [cartCollectionRelation] = await remoteQuery(
-      remoteQueryObjectFromString({
-        entryPoint: "cart_payment_collection",
-        variables: { filters: { cart_id } },
-        fields: req.queryConfig.fields.map((f) => `payment_collection.${f}`),
-      })
-    )
-    paymentCollection = cartCollectionRelation?.payment_collection
+    paymentCollection = await getPaymentCollectionForCart(req)
+  } else {
+    await refreshPaymentCollectionForCartWorkflow(req.scope).run({
+      input: { cart_id },
+    })
+    paymentCollection = await getPaymentCollectionForCart(req)
   }
 
   res.status(200).json({ payment_collection: paymentCollection })


### PR DESCRIPTION
…te the payment collection accordingly

- refresh the payment collection on every POST request in the API (makes use of the pre-existing workflow that only creates a new collection if the existing one is out of sync with the cart)
- change the frontend library to request a check of the payment collection everytime before initializing a payment session

## Summary

**What** — What changes are introduced in this PR?

*Please provide answer here*

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes store payment-collection creation/refresh behavior during checkout, which can affect payment-session initialization and totals if the refresh/create workflow or remote query selection is incorrect.
> 
> **Overview**
> Ensures checkout uses an up-to-date payment collection when starting payment by **always POSTing to `/store/payment-collections`** from the JS SDK before calling the payment-sessions endpoint (instead of reusing a `cart.payment_collection.id` when present).
> 
> Updates the Store API `POST /store/payment-collections` route to behave more like an upsert: it now fetches any existing cart↔payment-collection relation, **refreshes the payment collection** via `refreshPaymentCollectionForCartWorkflow` when one exists, and then returns the latest payment collection from remote query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb46d9082d5dfa2aa860a6f127ab660a75a781de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->