### PR TITLE
fix(dashboard): compute selected value for eq operator in promo rule value form

### DIFF
--- a/.changeset/red-apples-remain.md
+++ b/.changeset/red-apples-remain.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): compute selected value for eq operator in promo rule value form

--- a/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
@@ -62,10 +62,9 @@ export const RuleValueFormField = ({
 
   const { store, isLoading: isStoreLoading } = useStore()
 
-  const selectedValue =
-    typeof fieldRule.values === "string" && fieldRule.values
-      ? fieldRule.values
-      : undefined
+  const selectedValue = !Array.isArray(fieldRule.values)
+    ? fieldRule.values
+    : undefined
 
   const comboboxData = useComboboxData({
     queryFn: async (params) => {

--- a/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rule-value-form-field/rule-value-form-field.tsx
@@ -62,6 +62,11 @@ export const RuleValueFormField = ({
 
   const { store, isLoading: isStoreLoading } = useStore()
 
+  const selectedValue =
+    typeof fieldRule.values === "string" && fieldRule.values
+      ? fieldRule.values
+      : undefined
+
   const comboboxData = useComboboxData({
     queryFn: async (params) => {
       return await sdk.admin.promotion.listRuleValues(
@@ -80,6 +85,7 @@ export const RuleValueFormField = ({
       !isStoreLoading,
     getOptions: (data) => data.values,
     queryKey: ["rule-value-options", ruleType, attribute?.id],
+    selectedValue,
   })
 
   const watchOperator = useWatch({


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Make sure the selected value for `eq` operator in the promotion rule value form is rendered.

<img width="1126" height="1630" alt="CleanShot 2026-04-24 at 13 22 46@2x" src="https://github.com/user-attachments/assets/2fb0d1bd-31f9-47a4-b002-e4d9996a1e95" />

**Why** — Why are these changes relevant or necessary?  

Without this, even though a value is set its label is not resolved.

**How** — How have these changes been implemented?

Make sure we pass the `selectedValue` property to `useComboboxData` when the input represents a single selection flow, like with `eq` operator, so it is able to resolve the display label.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Verified the input renders the selected value correctly after the fix.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
