### PR TITLE
fix(admin): add copy action to original translation values

### DIFF
--- a/packages/admin/dashboard/src/routes/translations/translations-edit/components/translations-edit-form/translations-edit-form.tsx
+++ b/packages/admin/dashboard/src/routes/translations/translations-edit/components/translations-edit-form/translations-edit-form.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { AdminStoreLocale, HttpTypes } from "@medusajs/types"
-import { Button, Prompt, Select, toast, Text } from "@medusajs/ui"
+import { Button, Prompt, Select, toast, Text, Copy } from "@medusajs/ui"
 import { ColumnDef } from "@tanstack/react-table"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
@@ -278,11 +278,18 @@ function useTranslationsGridColumns({
             return null
           }
 
+          const content = entity[row.field_name]
+
           return (
             <DataGrid.ReadonlyCell color="normal" context={context} isMultiLine>
-              <Text className="text-ui-fg-subtle" weight="plus" size="small">
-                {entity[row.field_name]}
-              </Text>
+              <div className="flex w-full items-start justify-between gap-x-2">
+                <Text className="text-ui-fg-subtle" weight="plus" size="small">
+                  {content}
+                </Text>
+                {content && (
+                  <Copy content={content} className="text-ui-fg-muted" />
+                )}
+              </div>
             </DataGrid.ReadonlyCell>
           )
         },


### PR DESCRIPTION
Fixes #14942

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a conditional `Copy` control next to displayed original translation content. No API, persistence, or business-logic behavior is modified.
> 
> **Overview**
> Adds a copy-to-clipboard affordance to the **Original** column in the translations edit grid.
> 
> The original value cell now renders the text alongside a conditional `Copy` button (only when content is non-empty), enabling quick copying of source translation strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c551cef7e44de4156b9dc0fdb84a853e055544e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->