### PR TITLE
fix(dashboard): pick existing rules field in PricingDetailsSchema (closes #15207)

### DIFF
--- a/.changeset/fix-price-list-create-customer-group-ids.md
+++ b/.changeset/fix-price-list-create-customer-group-ids.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): price-list create page no longer crashes — `PricingDetailsSchema` now picks the existing `rules` field from `PricingCreateSchema` instead of the unrecognized `customer_group_ids` key

--- a/packages/admin/dashboard/src/routes/price-lists/price-list-create/components/price-list-create-form/schema.ts
+++ b/packages/admin/dashboard/src/routes/price-lists/price-list-create/components/price-list-create-form/schema.ts
@@ -35,7 +35,7 @@ export const PricingDetailsSchema = PricingCreateSchema.pick({
   description: true,
   starts_at: true,
   ends_at: true,
-  customer_group_ids: true,
+  rules: true,
 })
 
 export const PricingDetailsFields = Object.keys(


### PR DESCRIPTION
Closes #15207.

## What

`PricingDetailsSchema` in `packages/admin/dashboard/src/routes/price-lists/price-list-create/components/price-list-create-form/schema.ts` was picking `customer_group_ids: true` from `PricingCreateSchema`, but that key does not exist on `PricingCreateSchema`. Customer-group targeting on this form lives under `rules.customer_group_id` (see `price-list-details-form.tsx:37`). Zod throws \`Unrecognized key: customer_group_ids\` at parse time, crashing the entire price-list-create page.

## Why

Replicates the bot-confirmed bug from issue #15207. The existing form only ever reads/writes `rules.*` for customer-group targeting, so `PricingDetailsSchema` should expose `rules`, not the (non-existent) `customer_group_ids`.

## How

One-line change: `customer_group_ids: true` → `rules: true` on the \`pick\` call. Added a \`patch\` changeset for \`@medusajs/dashboard\`.

## Testing

- Loaded the affected file path against the schema in \`packages/admin/dashboard/src/routes/price-lists/price-list-create/components/price-list-create-form/price-list-details-form.tsx\` and confirmed the form binds via \`rules.customer_group_id\`, not \`customer_group_ids\`.
- Manual verification: with the fix, navigating to /price-lists/create no longer triggers the \`Unrecognized key\` Zod error from \`PricingDetailsSchema\`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk one-line schema adjustment plus a changeset; affects only dashboard form validation/shape for the price list create flow.
> 
> **Overview**
> Fixes a crash on the price list create page by updating `PricingDetailsSchema` to pick the existing `rules` field from `PricingCreateSchema` instead of the non-existent `customer_group_ids` key.
> 
> Adds a patch changeset for `@medusajs/dashboard` to ship the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f7df8e457d209b4e4f8d7da0ff87f05daf6f03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->