### PR TITLE
chore(dashboard): fix type and lint errors (5/n)

### DIFF
--- a/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/adjust-inventory/adjust-inventory-drawer.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/adjust-inventory/adjust-inventory-drawer.tsx
@@ -1,4 +1,3 @@
-import { InventoryTypes } from "@medusajs/types"
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
@@ -19,8 +18,7 @@ export const AdjustInventoryDrawer = () => {
   } = useInventoryItem(id!)
 
   const inventoryLevel = inventoryItem?.location_levels!.find(
-    (level: InventoryTypes.InventoryLevelDTO) =>
-      level.location_id === location_id
+    (level) => level.location_id === location_id
   )
 
   const { stock_location, isLoading: isLoadingLocation } = useStockLocation(

--- a/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/adjust-inventory/components/adjust-inventory-form.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/adjust-inventory/components/adjust-inventory-form.tsx
@@ -1,5 +1,9 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { HttpTypes, InventoryLevelDTO, StockLocationDTO } from "@medusajs/types"
+import {
+  AdminInventoryLevel,
+  AdminStockLocation,
+  HttpTypes,
+} from "@medusajs/types"
 import { Button, Input, Text, toast } from "@medusajs/ui"
 import { useForm, useWatch } from "react-hook-form"
 import { useTranslation } from "react-i18next"
@@ -13,8 +17,8 @@ import { castNumber } from "../../../../../../lib/cast-number"
 
 type AdjustInventoryFormProps = {
   item: HttpTypes.AdminInventoryItem
-  level: InventoryLevelDTO
-  location: StockLocationDTO
+  level: AdminInventoryLevel
+  location: AdminStockLocation
 }
 
 const AttributeGridRow = ({

--- a/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/edit-inventory-item-attributes/components/edit-item-attributes-form.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/edit-inventory-item-attributes/components/edit-item-attributes-form.tsx
@@ -4,7 +4,7 @@ import { Button, Input, toast } from "@medusajs/ui"
 import { RouteDrawer, useRouteModal } from "../../../../../../components/modals"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { InventoryTypes } from "@medusajs/types"
+import { AdminInventoryItem } from "@medusajs/types"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { z } from "zod"
@@ -15,7 +15,7 @@ import { KeyboundForm } from "../../../../../../components/utilities/keybound-fo
 import { useUpdateInventoryItem } from "../../../../../../hooks/api/inventory"
 
 type EditInventoryItemAttributeFormProps = {
-  item: InventoryTypes.InventoryItemDTO
+  item: AdminInventoryItem
 }
 
 const EditInventoryItemAttributesSchema = z.object({
@@ -29,7 +29,7 @@ const EditInventoryItemAttributesSchema = z.object({
   origin_country: z.string().optional(),
 })
 
-const getDefaultValues = (item: InventoryTypes.InventoryItemDTO) => {
+const getDefaultValues = (item: AdminInventoryItem) => {
   return {
     height: item.height ?? undefined,
     width: item.width ?? undefined,

--- a/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/edit-inventory-item/components/edit-item-form.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/edit-inventory-item/components/edit-item-form.tsx
@@ -4,7 +4,7 @@ import { Button, Input, toast } from "@medusajs/ui"
 import { RouteDrawer, useRouteModal } from "../../../../../../components/modals"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { InventoryTypes } from "@medusajs/types"
+import { AdminInventoryItem } from "@medusajs/types"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { z } from "zod"
@@ -13,7 +13,7 @@ import { KeyboundForm } from "../../../../../../components/utilities/keybound-fo
 import { useUpdateInventoryItem } from "../../../../../../hooks/api/inventory"
 
 type EditInventoryItemFormProps = {
-  item: InventoryTypes.InventoryItemDTO
+  item: AdminInventoryItem
 }
 
 const EditInventoryItemSchema = z.object({
@@ -21,7 +21,7 @@ const EditInventoryItemSchema = z.object({
   sku: z.string().min(1),
 })
 
-const getDefaultValues = (item: InventoryTypes.InventoryItemDTO) => {
+const getDefaultValues = (item: AdminInventoryItem) => {
   return {
     title: item.title ?? undefined,
     sku: item.sku ?? undefined,

--- a/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/inventory-item-variants/variants-section.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/inventory-item-variants/variants-section.tsx
@@ -45,7 +45,7 @@ export const InventoryItemVariantsSection = ({
                     {variant.options.map((o) => o.value).join(" ⋅ ")}
                   </span>
                 </div>
-                <div className="size-7 flex items-center justify-center">
+                <div className="flex size-7 items-center justify-center">
                   <TriangleRightMini className="text-ui-fg-muted rtl:rotate-180" />
                 </div>
               </div>
@@ -60,7 +60,7 @@ export const InventoryItemVariantsSection = ({
             <Link
               to={link}
               key={variant.id}
-              className="outline-none focus-within:shadow-borders-interactive-with-focus rounded-md [&:hover>div]:bg-ui-bg-component-hover"
+              className="focus-within:shadow-borders-interactive-with-focus [&:hover>div]:bg-ui-bg-component-hover rounded-md outline-none"
             >
               {Inner}
             </Link>

--- a/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/location-levels-table/use-location-list-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/location-levels-table/use-location-list-table-columns.tsx
@@ -1,4 +1,4 @@
-import { InventoryTypes, StockLocationDTO } from "@medusajs/types"
+import { AdminInventoryLevel } from "@medusajs/types"
 import { PencilSquare, Trash } from "@medusajs/icons"
 
 import { useMemo } from "react"
@@ -13,17 +13,7 @@ import { sdk } from "../../../../../lib/client"
 import { queryClient } from "../../../../../lib/query-client"
 import { useNavigate } from "react-router-dom"
 
-/**
- * Adds missing properties to the InventoryLevelDTO type.
- */
-interface ExtendedLocationLevel extends InventoryTypes.InventoryLevelDTO {
-  stock_locations: StockLocationDTO[]
-  reserved_quantity: number
-  stocked_quantity: number
-  available_quantity: number
-}
-
-const columnHelper = createDataTableColumnHelper<ExtendedLocationLevel>()
+const columnHelper = createDataTableColumnHelper<AdminInventoryLevel>()
 
 export const useLocationListTableColumns = () => {
   const { t } = useTranslation()
@@ -31,7 +21,7 @@ export const useLocationListTableColumns = () => {
 
   const prompt = usePrompt()
 
-  const handleDelete = async (level: ExtendedLocationLevel) => {
+  const handleDelete = async (level: AdminInventoryLevel) => {
     const res = await prompt({
       title: t("general.areYouSure"),
       description: t("inventory.deleteWarning"),
@@ -66,13 +56,13 @@ export const useLocationListTableColumns = () => {
         queryKey: inventoryItemLevelsQueryKeys.detail(level.inventory_item_id),
       })
     } catch (e) {
-      toast.error(e.message)
+      toast.error(e instanceof Error ? e.message : t("errorBoundary.defaultTitle"))
     }
   }
 
   return useMemo(
     () => [
-      columnHelper.accessor("stock_locations.0.name", {
+      columnHelper.accessor("stock_locations.0.name" as any, {
         header: t("fields.location"),
         cell: ({ getValue }) => {
           const locationName = getValue()
@@ -147,7 +137,7 @@ export const useLocationListTableColumns = () => {
                 icon: <PencilSquare />,
                 label: t("actions.edit"),
 
-                onClick: (row) => {
+                onClick: () => {
                   navigate(`locations/${level.location_id}`)
                 },
               },

--- a/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/reservations-table/use-reservation-list-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-detail/components/reservations-table/use-reservation-list-table-columns.tsx
@@ -4,7 +4,10 @@ import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { CreatedAtCell } from "../../../../../components/table/table-cells/common/created-at-cell"
 import { PlaceholderCell } from "../../../../../components/table/table-cells/common/placeholder-cell"
-import { TextCell, TextHeader } from "../../../../../components/table/table-cells/common/text-cell"
+import {
+  TextCell,
+  TextHeader,
+} from "../../../../../components/table/table-cells/common/text-cell"
 import { ReservationActions } from "./reservation-actions"
 
 /**
@@ -26,9 +29,7 @@ export const useReservationTableColumn = ({ sku }: { sku: string }) => {
         id: "sku",
         header: () => <TextHeader text={t("fields.sku")} />,
         cell: () => {
-          return (
-            <TextCell text={sku} />
-          )
+          return <TextCell text={sku} />
         },
       }),
       columnHelper.accessor("line_item.order_id", {
@@ -40,9 +41,7 @@ export const useReservationTableColumn = ({ sku }: { sku: string }) => {
             return <PlaceholderCell />
           }
 
-          return (
-            <TextCell text={orderId} />
-          )
+          return <TextCell text={orderId} />
         },
       }),
       columnHelper.accessor("description", {
@@ -54,9 +53,7 @@ export const useReservationTableColumn = ({ sku }: { sku: string }) => {
             return <PlaceholderCell />
           }
 
-          return (
-            <TextCell text={description} />
-          )
+          return <TextCell text={description} />
         },
       }),
       columnHelper.accessor("location.name", {
@@ -68,9 +65,7 @@ export const useReservationTableColumn = ({ sku }: { sku: string }) => {
             return <PlaceholderCell />
           }
 
-          return (
-            <TextCell text={location} />
-          )
+          return <TextCell text={location} />
         },
       }),
       columnHelper.accessor("created_at", {

--- a/packages/admin/dashboard/src/routes/inventory/inventory-list/components/inventory-actions.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-list/components/inventory-actions.tsx
@@ -1,12 +1,12 @@
 import { PencilSquare, Trash } from "@medusajs/icons"
 
 import { ActionMenu } from "../../../../components/common/action-menu"
-import { InventoryItemDTO } from "@medusajs/types"
+import { AdminInventoryItem } from "@medusajs/types"
 import { useDeleteInventoryItem } from "../../../../hooks/api/inventory"
 import { usePrompt } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 
-export const InventoryActions = ({ item }: { item: InventoryItemDTO }) => {
+export const InventoryActions = ({ item }: { item: AdminInventoryItem }) => {
   const { t } = useTranslation()
   const prompt = usePrompt()
   const { mutateAsync } = useDeleteInventoryItem(item.id)

--- a/packages/admin/dashboard/src/routes/inventory/inventory-list/components/inventory-list-table.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-list/components/inventory-list-table.tsx
@@ -1,4 +1,3 @@
-import { InventoryTypes } from "@medusajs/types"
 import { Button, Container, Heading, Text } from "@medusajs/ui"
 
 import { RowSelectionState } from "@tanstack/react-table"
@@ -39,7 +38,7 @@ export const InventoryListTable = () => {
   const columns = useInventoryTableColumns()
 
   const { table } = useDataTable({
-    data: (inventory_items ?? []) as InventoryTypes.InventoryItemDTO[],
+    data: inventory_items,
     columns,
     count,
     enablePagination: true,

--- a/packages/admin/dashboard/src/routes/inventory/inventory-list/components/use-inventory-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-list/components/use-inventory-table-columns.tsx
@@ -1,4 +1,4 @@
-import { InventoryTypes, ProductVariantDTO } from "@medusajs/types"
+import { AdminInventoryItem } from "@medusajs/types"
 
 import { Checkbox } from "@medusajs/ui"
 import { createColumnHelper } from "@tanstack/react-table"
@@ -7,16 +7,7 @@ import { useTranslation } from "react-i18next"
 import { PlaceholderCell } from "../../../../components/table/table-cells/common/placeholder-cell"
 import { InventoryActions } from "./inventory-actions"
 
-/**
- * Adds missing properties to the InventoryItemDTO type.
- */
-interface ExtendedInventoryItem extends InventoryTypes.InventoryItemDTO {
-  variants?: ProductVariantDTO[] | null
-  stocked_quantity?: number
-  reserved_quantity?: number
-}
-
-const columnHelper = createColumnHelper<ExtendedInventoryItem>()
+const columnHelper = createColumnHelper<AdminInventoryItem>()
 
 export const useInventoryTableColumns = () => {
   const { t } = useTranslation()

--- a/packages/admin/dashboard/src/routes/inventory/inventory-list/components/use-inventory-table-query.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-list/components/use-inventory-table-query.tsx
@@ -41,7 +41,7 @@ export const useInventoryTableQuery = ({
     ...params
   } = raw
 
-  const searchParams: HttpTypes.AdminInventoryItemParams = {
+  const searchParams: HttpTypes.AdminInventoryItemsParams = {
     limit: pageSize,
     offset: offset ? parseInt(offset) : undefined,
     weight: weight ? JSON.parse(weight) : undefined,

--- a/packages/admin/dashboard/src/routes/inventory/inventory-metadata/inventory-metadata.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-metadata/inventory-metadata.tsx
@@ -7,8 +7,12 @@ import { RouteDrawer } from "../../../components/modals"
 export const InventoryItemMetadata = () => {
   const { id } = useParams()
 
-  const { inventory_item, isPending, isError, error } = useInventoryItem(id)
-  const { mutateAsync, isPending: isMutating } = useUpdateInventoryItem(id)
+  const { inventory_item, isPending, isError, error } = useInventoryItem(
+    id ?? ""
+  )
+  const { mutateAsync, isPending: isMutating } = useUpdateInventoryItem(
+    id ?? ""
+  )
 
   if (isError) {
     throw error

--- a/packages/admin/dashboard/src/routes/inventory/inventory-stock/components/inventory-stock-form/inventory-stock-form.tsx
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-stock/components/inventory-stock-form/inventory-stock-form.tsx
@@ -60,7 +60,7 @@ export const InventoryStockForm = ({
               ?.locations?.[location_id]?.checked
 
           if (wasChecked && !level.checked) {
-            payload.delete.push(level.id)
+            payload.delete?.push(level.id)
           } else {
             const newQuantity =
               level.quantity !== "" ? castNumber(level.quantity) : 0
@@ -69,7 +69,7 @@ export const InventoryStockForm = ({
                 ?.locations?.[location_id]?.quantity
 
             if (newQuantity !== originalQuantity) {
-              payload.update.push({
+              payload.update?.push({
                 id: level.id,
                 inventory_item_id,
                 location_id,
@@ -80,7 +80,7 @@ export const InventoryStockForm = ({
         }
 
         if (!level.id && level.quantity !== "") {
-          payload.create.push({
+          payload.create?.push({
             inventory_item_id,
             location_id,
             stocked_quantity: castNumber(level.quantity),

--- a/packages/admin/dashboard/src/routes/locations/common/hooks/use-shipping-option-price-columns.tsx
+++ b/packages/admin/dashboard/src/routes/locations/common/hooks/use-shipping-option-price-columns.tsx
@@ -61,7 +61,7 @@ export const useShippingOptionPriceColumns = ({
 
 type CreateDataGridPriceColumnsProps<
   TData,
-  TFieldValues extends FieldValues,
+  TFieldValues extends FieldValues
 > = {
   currencies?: string[]
   regions?: HttpTypes.AdminRegion[]
@@ -75,7 +75,7 @@ type CreateDataGridPriceColumnsProps<
 
 export const createDataGridPriceColumns = <
   TData,
-  TFieldValues extends FieldValues,
+  TFieldValues extends FieldValues
 >({
   currencies,
   regions,

--- a/packages/admin/dashboard/src/routes/locations/location-detail/components/location-general-section/location-general-section.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-detail/components/location-general-section/location-general-section.tsx
@@ -66,7 +66,11 @@ export const LocationGeneralSection = ({
           <div>
             <Heading>{location.name}</Heading>
             <Text className="text-ui-fg-subtle txt-small">
-              {getFormattedAddress({ address: location.address }).join(", ")}
+              {getFormattedAddress({
+                address: location.address as
+                  | HttpTypes.AdminOrderAddress
+                  | undefined,
+              }).join(", ")}
             </Text>
           </div>
           <Actions location={location} />

--- a/packages/admin/dashboard/src/routes/locations/location-list/components/location-list-item/location-list-item.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-list/components/location-list-item/location-list-item.tsx
@@ -130,7 +130,11 @@ function LocationListItem(props: LocationProps) {
           <div className="grow-1 flex flex-1 flex-col">
             <Text weight="plus">{location.name}</Text>
             <Text className="text-ui-fg-subtle txt-small">
-              {getFormattedAddress({ address: location.address }).join(", ")}
+              {getFormattedAddress({
+                address: location.address as
+                  | HttpTypes.AdminOrderAddress
+                  | undefined,
+              }).join(", ")}
             </Text>
           </div>
 

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-manage-areas/location-service-zone-manage-areas.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-manage-areas/location-service-zone-manage-areas.tsx
@@ -9,7 +9,8 @@ export const LocationServiceZoneManageAreas = () => {
 
   const { stock_location, isPending, isFetching, isError, error } =
     useStockLocation(location_id!, {
-      fields: "*fulfillment_sets.service_zones.geo_zones,fulfillment_sets.service_zones.name",
+      fields:
+        "*fulfillment_sets.service_zones.geo_zones,fulfillment_sets.service_zones.name",
     })
 
   const zone = stock_location?.fulfillment_sets

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-option-details-form.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-option-details-form.tsx
@@ -10,7 +10,10 @@ import { Combobox } from "../../../../../components/inputs/combobox"
 import { useComboboxData } from "../../../../../hooks/use-combobox-data"
 import { sdk } from "../../../../../lib/client"
 import { formatProvider } from "../../../../../lib/format-provider"
-import { FulfillmentSetType, ShippingOptionPriceType, } from "../../../common/constants"
+import {
+  FulfillmentSetType,
+  ShippingOptionPriceType,
+} from "../../../common/constants"
 import { CreateShippingOptionSchema } from "./schema"
 import { useDocumentDirection } from "../../../../../hooks/use-document-direction"
 
@@ -269,7 +272,7 @@ export const CreateShippingOptionDetailsForm = ({
                           ?.filter((fo) => !!fo.is_return === isReturn)
                           .map((option) => (
                             <Select.Item value={option.id} key={option.id}>
-                              {option.name || option.id}
+                              {(option.name as string) || option.id}
                             </Select.Item>
                           ))}
                       </Select.Content>

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
@@ -1,5 +1,9 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { HttpTypes } from "@medusajs/types"
+import {
+  AdminCreateShippingOptionPriceWithCurrency,
+  AdminCreateShippingOptionPriceWithRegion,
+  HttpTypes,
+} from "@medusajs/types"
 import { Button, ProgressStatus, ProgressTabs, toast } from "@medusajs/ui"
 import { useForm, useWatch } from "react-hook-form"
 import { useTranslation } from "react-i18next"
@@ -111,12 +115,12 @@ export function CreateShippingOptionsForm({
     const conditionalRegionPrices = Object.entries(
       data.conditional_region_prices
     ).flatMap(([region_id, value]) => {
-      const prices: HttpTypes.AdminCreateShippingOptionPriceWithRegion[] =
+      const prices =
         value?.map((rule) => ({
           region_id: region_id,
           amount: castNumber(rule.amount),
           rules: buildShippingOptionPriceRules(rule),
-        })) || []
+        })) || [] as AdminCreateShippingOptionPriceWithRegion[]
 
       return prices?.filter(Boolean)
     })
@@ -124,12 +128,12 @@ export function CreateShippingOptionsForm({
     const conditionalCurrencyPrices = Object.entries(
       data.conditional_currency_prices
     ).flatMap(([currency_code, value]) => {
-      const prices: HttpTypes.AdminCreateShippingOptionPriceWithCurrency[] =
+      const prices =
         value?.map((rule) => ({
           currency_code,
           amount: castNumber(rule.amount),
           rules: buildShippingOptionPriceRules(rule),
-        })) || []
+        })) || [] as AdminCreateShippingOptionPriceWithCurrency[]
 
       return prices?.filter(Boolean)
     })
@@ -156,13 +160,11 @@ export function CreateShippingOptionsForm({
         data: fulfillmentOptionData as unknown as Record<string, unknown>,
         rules: [
           {
-            // eslint-disable-next-line
             value: isReturn ? "true" : "false",
             attribute: "is_return",
             operator: "eq",
           },
           {
-            // eslint-disable-next-line
             value: data.enabled_in_store ? "true" : "false",
             attribute: "enabled_in_store",
             operator: "eq",
@@ -198,7 +200,7 @@ export function CreateShippingOptionsForm({
       })
 
       if (!result.success) {
-        const [firstError, ...rest] = result.error.errors
+        const [firstError, ...rest] = result.error.issues
 
         for (const error of rest) {
           const _path = error.path.join(".") as keyof CreateShippingOptionSchema

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-edit/components/edit-region-form/edit-shipping-option-form.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-edit/components/edit-region-form/edit-shipping-option-form.tsx
@@ -87,7 +87,9 @@ export const EditShippingOptionForm = ({
   const handleSubmit = form.handleSubmit(async (values) => {
     const rules = shippingOption.rules.map((r) => ({
       ...pick(r, ["id", "attribute", "operator", "value"]),
-    })) as HttpTypes.AdminUpdateShippingOptionRule[]
+    })) as (Omit<HttpTypes.AdminUpdateShippingOptionRule, "id"> & {
+      id?: string
+    })[]
 
     const storeRule = rules.find((r) => r.attribute === "enabled_in_store")
 
@@ -255,7 +257,7 @@ export const EditShippingOptionForm = ({
                   control={form.control}
                   name="provider_id"
                   disabled={true}
-                  render={({ field }) => {
+                  render={() => {
                     return (
                       <Form.Item>
                         <Form.Label>

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-edit/location-service-zone-shipping-option-edit.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-edit/location-service-zone-shipping-option-edit.tsx
@@ -40,7 +40,9 @@ export const LocationServiceZoneShippingOptionEdit = () => {
       <RouteDrawer.Header>
         <Heading>
           {t(
-            `stockLocations.${isPickup ? "pickupOptions" : "shippingOptions"}.edit.header`
+            `stockLocations.${
+              isPickup ? "pickupOptions" : "shippingOptions"
+            }.edit.header`
           )}
         </Heading>
       </RouteDrawer.Header>

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
@@ -165,7 +165,7 @@ export function EditShippingOptionsPricingForm({
         amount: castNumber(rule.amount),
         rules: buildShippingOptionPriceRules(rule),
       }))
-    )
+    ) as PriceRecord[]
 
     /**
      * TODO: If we try to update an existing region price the API throws an error.
@@ -195,7 +195,7 @@ export function EditShippingOptionsPricingForm({
         amount: castNumber(rule.amount),
         rules: buildShippingOptionPriceRules(rule),
       }))
-    )
+    ) as PriceRecord[]
 
     const allPrices = [
       ...currencyPrices,
@@ -359,6 +359,10 @@ const getDefaultValues = (prices: HttpTypes.AdminShippingOptionPrice[]) => {
         (r) => r.attribute === REGION_ID_ATTRIBUTE
       )?.value
 
+      if (!regionId) {
+        return
+      }
+
       region_prices[regionId] = price.amount
       return
     }
@@ -367,6 +371,10 @@ const getDefaultValues = (prices: HttpTypes.AdminShippingOptionPrice[]) => {
       const regionId = price.price_rules.find(
         (r) => r.attribute === REGION_ID_ATTRIBUTE
       )?.value
+
+      if (!regionId) {
+        return
+      }
 
       if (!conditional_region_prices[regionId]) {
         conditional_region_prices[regionId] = []


### PR DESCRIPTION
> This PR is part of a series of PRs to fix type and lint issues in the dashboard package. The last PR will enable the type checking as part of the build and add a changeset

Type fixes in the inventory domain routes. Most of these routes used DTO types instead of HTTP types, which resulted in incorrect type casts 