### PR TITLE
chore(dashboard): fix type and lint errors (15/n)

### DIFF
--- a/.changeset/busy-dogs-call.md
+++ b/.changeset/busy-dogs-call.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/types": patch
+---
+
+fix(types): fixes to some HTTP types

--- a/packages/core/types/src/http/claim/admin/payloads.ts
+++ b/packages/core/types/src/http/claim/admin/payloads.ts
@@ -130,7 +130,15 @@ export interface AdminUpdateClaimItem
 export interface AdminAddClaimInboundItems extends AdminClaimAddItems {}
 export interface AdminUpdateClaimInboundItem extends AdminClaimUpdateItem {}
 
-export interface AdminAddClaimOutboundItems extends AdminClaimAddItems {}
+export interface AdminAddClaimOutboundItems {
+  items: {
+    variant_id: string
+    quantity: number
+    unit_price?: number
+    internal_note?: string
+    metadata?: Record<string, unknown> | null
+  }[]
+}
 export interface AdminUpdateClaimOutboundItem
   extends Omit<AdminClaimUpdateItem, "description"> {}
 

--- a/packages/core/types/src/http/claim/common.ts
+++ b/packages/core/types/src/http/claim/common.ts
@@ -2,6 +2,7 @@ import { OperatorMap } from "../../dal"
 import { ClaimReason, OrderClaimType } from "../../order"
 import { BigNumberRawValue } from "../../totals"
 import { FindParams } from "../common"
+import { AdminOrderLineItem } from "../order"
 import {
   BaseOrder,
   BaseOrderShippingMethod,
@@ -20,6 +21,7 @@ export interface BaseClaimItem {
   metadata?: Record<string, unknown> | null
   created_at?: Date | string
   updated_at?: Date | string
+  item?: AdminOrderLineItem
 }
 
 export interface BaseClaim {

--- a/packages/core/types/src/http/exchange/common.ts
+++ b/packages/core/types/src/http/exchange/common.ts
@@ -1,5 +1,6 @@
 import { OperatorMap } from "../../dal"
 import { FindParams } from "../common"
+import { AdminOrderLineItem } from "../order"
 import {
   BaseOrder,
   BaseOrderShippingMethod,
@@ -41,6 +42,7 @@ export interface BaseExchangeItem {
    * The date the exchange item was updated.
    */
   updated_at: string | null
+  item?: AdminOrderLineItem
 }
 
 export interface BaseExchange {

--- a/packages/core/types/src/http/file/common.ts
+++ b/packages/core/types/src/http/file/common.ts
@@ -16,15 +16,18 @@ export type BaseUploadFile =
       /**
        * The list of files to upload.
        */
-      files: ({
-        /**
-         * The name of the file.
-         */ 
-        name: string; 
-        /**
-         * The content of the file.
-         */
-        content: string
-      } | File)[]
+      files: (
+        | {
+            /**
+             * The name of the file.
+             */
+            name: string
+            /**
+             * The content of the file.
+             */
+            content: string
+          }
+        | File
+      )[]
     }
   | FileList

--- a/packages/core/types/src/http/fulfillment-provider/common.ts
+++ b/packages/core/types/src/http/fulfillment-provider/common.ts
@@ -18,4 +18,11 @@ export interface BaseFulfillmentProviderOption {
    * Whether the fulfillment provider option can be used for returns.
    */
   is_return: boolean
+  /**
+   * Additional properties of the fulfillment provider option.
+   * These are provider-specific and can include any additional data relevant to the option.
+   * 
+   * It may commonly include properties like `name` (the name of the option).
+   */
+  [k: string]: unknown
 }

--- a/packages/core/types/src/http/inventory/admin/entities.ts
+++ b/packages/core/types/src/http/inventory/admin/entities.ts
@@ -63,6 +63,14 @@ export interface AdminInventoryItem {
    * The item's associated inventory levels.
    */
   location_levels?: AdminInventoryLevel[]
+  /**
+   * The total quantity of the inventory item that is stocked across all locations.
+   */
+  stocked_quantity: number
+  /**
+   * The total quantity of the inventory item that is reserved across all locations.
+   */
+  reserved_quantity: number
 }
 
 export interface AdminInventoryLevel {

--- a/packages/core/types/src/http/order/admin/entities.ts
+++ b/packages/core/types/src/http/order/admin/entities.ts
@@ -159,6 +159,11 @@ export interface AdminOrderAddress extends BaseOrderAddress {
 
 export interface AdminOrderShippingMethod extends BaseOrderShippingMethod {}
 
+export interface AdminOrderLinePreview extends AdminOrderLineItem {
+  actions?: AdminOrderChangeAction[]
+  return_requested_total: number
+}
+
 export interface AdminOrderPreview
   extends Omit<AdminOrder, "items" | "shipping_methods"> {
   /**
@@ -172,7 +177,7 @@ export interface AdminOrderPreview
   /**
    * The order's items.
    */
-  items: (AdminOrderLineItem & { actions?: AdminOrderChangeAction[] })[]
+  items: AdminOrderLinePreview[]
   /**
    * The order's shipping methods.
    */

--- a/packages/core/types/src/http/order/common.ts
+++ b/packages/core/types/src/http/order/common.ts
@@ -1071,7 +1071,7 @@ export interface BaseOrderChange {
   declined_at: Date | null
 
   /**
-   * The canceled by of the order change
+   * The ID of the user that canceled the order change
    */
   canceled_by: string | null
 
@@ -1079,6 +1079,11 @@ export interface BaseOrderChange {
    * When the order change was canceled
    */
   canceled_at: Date | null
+
+  /**
+   * The ID of the user that created the order change
+   */
+  created_by: string | null
 
   /**
    * When the order change was created

--- a/packages/core/types/src/http/product/common.ts
+++ b/packages/core/types/src/http/product/common.ts
@@ -419,7 +419,7 @@ export interface BaseProductListParams
   /**
    * Filter by the product's tag(s).
    */
-  tags?: string | string[]
+  tag_id?: string | string[]
   /**
    * Filter by the product's type(s).
    */

--- a/packages/core/types/src/http/return/common.ts
+++ b/packages/core/types/src/http/return/common.ts
@@ -104,4 +104,5 @@ export interface BaseReturn {
    * The date when the return was canceled.
    */
   canceled_at: string
+  requested_at: string
 }

--- a/packages/core/types/src/http/tax-rate/admin/entities.ts
+++ b/packages/core/types/src/http/tax-rate/admin/entities.ts
@@ -15,6 +15,10 @@ export interface AdminTaxRateRule {
    * "protyp_123"
    */
   reference_id: string
+  /**
+   * The date the tax rate rule was created.
+   */
+  created_at: string
 }
 
 export interface AdminTaxRate {

--- a/packages/core/types/src/order/common.ts
+++ b/packages/core/types/src/order/common.ts
@@ -3050,7 +3050,10 @@ export interface OrderPreviewDTO
   /**
    * The items of the order, along with changes on the items.
    */
-  items: (OrderLineItemDTO & { actions?: OrderChangeActionDTO[] })[]
+  items: (OrderLineItemDTO & { 
+    actions?: OrderChangeActionDTO[]
+    return_requested_total: number
+  })[]
   /**
    * The shipping methods of the order, along with changes on the shipping methods.
    */


### PR DESCRIPTION
> This PR is part of a series of PRs to fix type and lint issues in the dashboard package. The last PR will enable the type checking as part of the build and add a changeset

Fixes in the `types` package to entities and responses, which are also used in the dashboard