### PR TITLE
fix(dashboard): fix type import targeting framework instead of types

### DIFF
--- a/.changeset/hungry-geckos-behave.md
+++ b/.changeset/hungry-geckos-behave.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): fix type import targeting framework instead of types

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-payment-section/order-payment-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-payment-section/order-payment-section.tsx
@@ -1,4 +1,4 @@
-import { OrderCreditLineDTO } from "@medusajs/framework/types"
+import { OrderCreditLineDTO } from "@medusajs/types"
 import { ArrowDownRightMini, DocumentText, XCircle } from "@medusajs/icons"
 import { AdminOrder, AdminPayment, HttpTypes } from "@medusajs/types"
 import {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

After adding the typecheck, dependencies that haven't been built will fail (`@medusajs/framework/types`) won't be built by turbo since it's not a dependency of dashboard. Updated the import to the correct dependency `@medusajs/types`

**Why** — Why are these changes relevant or necessary?  

*Please provide answer here*

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
