### PR TITLE
docs: add TSDocs for "add metadata support for price lists (#15238)"

### DIFF
--- a/packages/core/types/src/http/price-list/admin/entities.ts
+++ b/packages/core/types/src/http/price-list/admin/entities.ts
@@ -1,6 +1,9 @@
 import { PriceListStatus, PriceListType } from "../../../pricing"
 import { AdminPrice } from "../../price-preference"
 
+/**
+ * A price list price returned in admin API responses.
+ */
 export interface AdminPriceListPrice extends AdminPrice {
   /**
    * The ID of the variant that this price is for.
@@ -12,6 +15,9 @@ export interface AdminPriceListPrice extends AdminPrice {
   rules: Record<string, unknown>
 }
 
+/**
+ * A price list returned in admin API responses.
+ */
 export interface AdminPriceList {
   /**
    * The price list's ID.
@@ -63,6 +69,7 @@ export interface AdminPriceList {
   deleted_at: string | null
   /**
    * Holds custom data in key-value pairs.
+   * @since 2.14.2
    */
   metadata: Record<string, unknown> | null
 }

--- a/packages/core/types/src/http/price-list/admin/payloads.ts
+++ b/packages/core/types/src/http/price-list/admin/payloads.ts
@@ -1,5 +1,8 @@
 import { PriceListStatus, PriceListType } from "../../../pricing"
 
+/**
+ * The details of a price to create and add to a price list.
+ */
 export interface AdminCreatePriceListPrice {
   /**
    * The price's currency code.
@@ -30,6 +33,9 @@ export interface AdminCreatePriceListPrice {
   rules?: Record<string, string>
 }
 
+/**
+ * The details of a price list to create.
+ */
 export interface AdminCreatePriceList {
   /**
    * The price list's title.
@@ -65,10 +71,14 @@ export interface AdminCreatePriceList {
   prices?: AdminCreatePriceListPrice[]
   /**
    * Holds custom data in key-value pairs.
+   * @since 2.14.2
    */
   metadata?: Record<string, unknown> | null
 }
 
+/**
+ * The details of a price list price to update.
+ */
 export interface AdminUpdatePriceListPrice {
   /**
    * The ID of the price to update.
@@ -103,6 +113,9 @@ export interface AdminUpdatePriceListPrice {
   rules?: Record<string, string>
 }
 
+/**
+ * The details of a price list to update.
+ */
 export interface AdminUpdatePriceList {
   /**
    * The price list's title.
@@ -134,10 +147,14 @@ export interface AdminUpdatePriceList {
   rules?: Record<string, string[]>
   /**
    * Holds custom data in key-value pairs.
+   * @since 2.14.2
    */
   metadata?: Record<string, unknown> | null
 }
 
+/**
+ * The price operations to perform in a batch operation.
+ */
 export interface AdminBatchPriceListPrice {
   /**
    * The prices to create and add to the price list.
@@ -153,6 +170,9 @@ export interface AdminBatchPriceListPrice {
   delete?: string[]
 }
 
+/**
+ * The details to link or unlink products from a price list.
+ */
 export interface AdminLinkPriceListProducts {
   /**
    * The IDs of products to remove from the price list.

--- a/packages/core/types/src/pricing/common/price-list.ts
+++ b/packages/core/types/src/pricing/common/price-list.ts
@@ -81,6 +81,7 @@ export interface PriceListDTO {
   price_list_rules?: PriceListRuleDTO[]
   /**
    * Holds custom data in key-value pairs.
+   * @since 2.14.2
    */
   metadata?: Record<string, unknown> | null
 }
@@ -101,6 +102,11 @@ export interface CreatePriceListPriceDTO extends CreateMoneyAmountDTO {
   rules?: CreatePriceListPriceRules
 }
 
+/**
+ * @interface
+ *
+ * The prices associated with a price list to update.
+ */
 export interface UpdatePriceListPriceDTO extends UpdateMoneyAmountDTO {
   /**
    * The ID of the associated price set.
@@ -170,6 +176,7 @@ export interface CreatePriceListDTO {
   prices?: CreatePriceListPriceDTO[]
   /**
    * Holds custom data in key-value pairs.
+   * @since 2.14.2
    */
   metadata?: Record<string, unknown> | null
 }
@@ -210,6 +217,7 @@ export interface UpdatePriceListDTO {
   rules?: CreatePriceListRules
   /**
    * Holds custom data in key-value pairs.
+   * @since 2.14.2
    */
   metadata?: Record<string, unknown> | null
 }


### PR DESCRIPTION
## Automated TSDoc Additions

This PR adds TSDoc comments to TypeScript source files changed in commit [`d29b9a1`](https://github.com/medusajs/medusa/commit/d29b9a1d80580d4b5dce926387c465260936e5ec).

**Triggered by:** feat(pricing,medusa,dashboard,types): add metadata support for price lists (#15238)

**Files updated:**
- `packages/core/types/src/http/price-list/admin/entities.ts`
- `packages/core/types/src/http/price-list/admin/payloads.ts`
- `packages/core/types/src/pricing/common/price-list.ts`
- `packages/core/types/src/pricing/workflows.ts`
- `packages/medusa/src/api/admin/price-lists/query-config.ts`
- `packages/medusa/src/api/admin/price-lists/validators.ts`
- `packages/modules/pricing/src/models/price-list.ts`

> Review carefully before merging. Claude may have missed context or used incorrect descriptions.