### PR TITLE
fix(dashboard): prevent region detail crash on missing currency / provider metadata

### DIFF
--- a/.changeset/fix-region-detail-undefined-name.md
+++ b/.changeset/fix-region-detail-undefined-name.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+Prevent admin region detail from crashing when currency metadata is missing from the static list, when payment provider IDs are non-standard, or when country rows lack name/iso fields.

--- a/.changeset/fix-region-detail-undefined-name.md
+++ b/.changeset/fix-region-detail-undefined-name.md
@@ -2,4 +2,4 @@
 "@medusajs/dashboard": patch
 ---
 
-Prevent admin region detail from crashing when currency metadata is missing from the static list, when payment provider IDs are non-standard, or when country rows lack name/iso fields.
+fix(dashboard): prevent region detail crash on missing currency / provider metadata

--- a/packages/admin/dashboard/src/lib/__tests__/format-provider.spec.ts
+++ b/packages/admin/dashboard/src/lib/__tests__/format-provider.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { formatProvider } from "../format-provider"
+
+describe("formatProvider", () => {
+  it("formats a typical Medusa provider id", () => {
+    expect(formatProvider("pp_stripe-blik_dkk")).toBe("Stripe Blik (DKK)")
+  })
+
+  it("returns the raw id when there is no second underscore segment (no throw)", () => {
+    expect(formatProvider("manual")).toBe("manual")
+    expect(formatProvider("stripe")).toBe("stripe")
+  })
+
+  it("returns empty string for nullish or empty input", () => {
+    expect(formatProvider("")).toBe("")
+    expect(formatProvider(null as unknown as string)).toBe("")
+    expect(formatProvider(undefined as unknown as string)).toBe("")
+  })
+
+  it("returns the raw id when the name segment is empty", () => {
+    expect(formatProvider("pp_")).toBe("pp_")
+    expect(formatProvider("pp__usd")).toBe("pp__usd")
+  })
+
+  it("handles id with type segment after provider name", () => {
+    expect(formatProvider("pp_system_default")).toBe("System (DEFAULT)")
+  })
+})

--- a/packages/admin/dashboard/src/lib/format-provider.ts
+++ b/packages/admin/dashboard/src/lib/format-provider.ts
@@ -8,11 +8,22 @@
  * @returns A formatted string
  */
 export const formatProvider = (id: string) => {
-  const [_, name, type] = id.split("_")
+  if (id == null || id === "") {
+    return ""
+  }
+
+  const parts = id.split("_")
+  const name = parts[1]
+  if (name == null || name === "") {
+    return id
+  }
+
+  const type = parts[2]
   return (
     name
       .split("-")
-      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .map((s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : ""))
+      .filter(Boolean)
       .join(" ") + (type ? ` (${type.toUpperCase()})` : "")
   )
 }

--- a/packages/admin/dashboard/src/routes/regions/common/hooks/__tests__/use-countries.spec.ts
+++ b/packages/admin/dashboard/src/routes/regions/common/hooks/__tests__/use-countries.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+
+import type { StaticCountry } from "../../../../../lib/data/countries"
+import { useCountries } from "../use-countries"
+
+describe("useCountries", () => {
+  it("filters by query without throwing when name or iso_2 is missing (API-shaped rows)", () => {
+    const countries = [
+      {
+        iso_2: "xx",
+        iso_3: "xxx",
+        num_code: "999",
+        display_name: "Testland",
+        // intentional: some API payloads can omit `name`
+        name: undefined,
+      },
+      {
+        iso_2: "yy",
+        iso_3: "yyy",
+        num_code: "998",
+        display_name: "Other",
+        name: "OTHER",
+      },
+    ] as unknown as StaticCountry[]
+
+    expect(() =>
+      useCountries({
+        countries,
+        q: "xx",
+        limit: 10,
+      })
+    ).not.toThrow()
+
+    const { countries: filtered, count } = useCountries({
+      countries,
+      q: "xx",
+      limit: 10,
+    })
+
+    expect(count).toBe(1)
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].iso_2).toBe("xx")
+  })
+
+  it("matches iso_2 case-insensitively when name is present", () => {
+    const countries = [
+      {
+        iso_2: "us",
+        iso_3: "usa",
+        num_code: "840",
+        name: "UNITED STATES",
+        display_name: "United States",
+      },
+    ] as unknown as StaticCountry[]
+
+    const { count } = useCountries({
+      countries,
+      q: "US",
+      limit: 10,
+    })
+
+    expect(count).toBe(1)
+  })
+})

--- a/packages/admin/dashboard/src/routes/regions/common/hooks/use-countries.tsx
+++ b/packages/admin/dashboard/src/routes/regions/common/hooks/use-countries.tsx
@@ -52,8 +52,8 @@ export const useCountries = ({
     const query = q.toLowerCase()
     const results = countries.filter(
       (c) =>
-        c.name.toLowerCase().includes(query) ||
-        c.iso_2.toLowerCase().includes(query)
+        (c.name?.toLowerCase() ?? "").includes(query) ||
+        (c.iso_2?.toLowerCase() ?? "").includes(query)
     )
     return {
       countries: results,

--- a/packages/admin/dashboard/src/routes/regions/region-detail/components/region-general-section/region-general-section.tsx
+++ b/packages/admin/dashboard/src/routes/regions/region-detail/components/region-general-section/region-general-section.tsx
@@ -26,6 +26,11 @@ export const RegionGeneralSection = ({
       preference.attribute === "region_id" && preference.value === region.id
   )
 
+  const currencyCodeUpper = region.currency_code?.toUpperCase() ?? ""
+  const currencyDisplayName = currencyCodeUpper
+    ? (currencies[currencyCodeUpper]?.name ?? region.currency_code)
+    : null
+
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
@@ -37,10 +42,10 @@ export const RegionGeneralSection = ({
         value={
           <div className="flex items-center gap-x-2">
             <Badge size="2xsmall" className="uppercase">
-              {region.currency_code}
+              {region.currency_code ?? "-"}
             </Badge>
             <Text size="small" leading="compact">
-              {currencies[region.currency_code.toUpperCase()]?.name}
+              {currencyDisplayName ?? "-"}
             </Text>
           </div>
         }
@@ -66,7 +71,9 @@ export const RegionGeneralSection = ({
           <div className="inline-flex">
             {region.payment_providers?.length ? (
               <ListSummary
-                list={region.payment_providers.map((p) => formatProvider(p.id))}
+                list={region.payment_providers.map((p) =>
+                  formatProvider(p.id ?? "")
+                )}
               />
             ) : (
               "-"

--- a/packages/admin/dashboard/src/routes/regions/region-edit/components/edit-region-form/edit-region-form.tsx
+++ b/packages/admin/dashboard/src/routes/regions/region-edit/components/edit-region-form/edit-region-form.tsx
@@ -47,7 +47,7 @@ export const EditRegionForm = ({
   const form = useForm<zod.infer<typeof EditRegionSchema>>({
     defaultValues: {
       name: region.name,
-      currency_code: region.currency_code.toUpperCase(),
+      currency_code: region.currency_code?.toUpperCase() ?? "",
       payment_providers: region.payment_providers?.map((pp) => pp.id) || [],
       automatic_taxes: region.automatic_taxes,
       is_tax_inclusive: pricePreferenceForRegion?.is_tax_inclusive || false,


### PR DESCRIPTION
Fixes #15229

## Summary

**What** — Hardens the admin region detail UI so it does not throw when currency metadata is missing from the static map, payment provider IDs are non-standard, or country rows omit `name` / `iso_2`.

**Why** — Users hitting the default region settings screen could see `TypeError: Cannot read properties of undefined (reading 'name')` in `RegionGeneralSection`, blocking the page and Edit.

**How** — Safe currency label resolution and fallbacks in `region-general-section`, defensive `formatProvider` parsing, null-safe country search in `useCountries`, and safe `currency_code` defaults in the region edit form.

**Testing** — `yarn workspace @medusajs/dashboard test` (includes new `format-provider` and `use-countries` specs). Changeset added for `@medusajs/dashboard`.

## Checklist

- [x] Changeset included (`.changeset/fix-region-detail-undefined-name.md`)
- [x] Tests added / passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are defensive null/format handling in the dashboard UI plus added unit tests, with no auth, persistence, or API contract changes.
> 
> **Overview**
> Prevents region detail/edit UI crashes when region data is missing or non-standard by adding safe fallbacks for `currency_code`, currency display name lookups, and payment provider IDs.
> 
> Hardens `formatProvider` and `useCountries` against nullish/partial inputs, and adds Vitest coverage for these edge cases. Includes a patch changeset for `@medusajs/dashboard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46a9d7ed9234ac774b60bab43c82dc7bcc3d763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->