### PR TITLE
feat(currencies): add GMD (Gambian Dalasi) to default currency lists

### DIFF
--- a/.changeset/say5-add-gmd-currency-15265.md
+++ b/.changeset/say5-add-gmd-currency-15265.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/utils": patch
+"@medusajs/dashboard": patch
+---
+
+Add GMD (Gambian Dalasi) to the bundled currency lists in `@medusajs/utils` and the admin dashboard so admin pages don't crash with `Cannot read properties of undefined (reading 'code')` when GMD is one of the store's supported currencies.

--- a/packages/admin/dashboard/src/lib/data/currencies.ts
+++ b/packages/admin/dashboard/src/lib/data/currencies.ts
@@ -241,6 +241,12 @@ export const currencies: Record<string, CurrencyInfo> = {
     symbol_native: "GEL",
     decimal_digits: 2,
   },
+  GMD: {
+    code: "GMD",
+    name: "Gambian Dalasi",
+    symbol_native: "D",
+    decimal_digits: 2,
+  },
   GHS: {
     code: "GHS",
     name: "Ghanaian Cedi",

--- a/packages/core/utils/src/defaults/currencies.ts
+++ b/packages/core/utils/src/defaults/currencies.ts
@@ -360,6 +360,15 @@ export const defaultCurrencies: Record<string, Currency> = {
     code: "GEL",
     name_plural: "Georgian laris",
   },
+  GMD: {
+    symbol: "D",
+    name: "Gambian Dalasi",
+    symbol_native: "D",
+    decimal_digits: 2,
+    rounding: 0,
+    code: "GMD",
+    name_plural: "Gambian Dalasis",
+  },
   GHS: {
     symbol: "GH₵",
     name: "Ghanaian Cedi",


### PR DESCRIPTION
Fixes #15265.

Adds GMD entries to the two hardcoded currency maps consumed by the admin (`@medusajs/utils` and the dashboard). Stores listing GMD as a supported currency previously crashed admin pages (regions create, pricing) with `Cannot read properties of undefined (reading 'code')` because the iterators looked each `store.supported_currencies` entry up in those maps and got `undefined` back. Same shape and alphabetical placement as the surrounding entries (`GEL` → `GMD` → `GHS`).

Filing this scoped to GMD per the issue; happy to send a follow-up sweep for the ~50 other ISO 4217 codes still missing (SLE, MRU, ZMW, VES, ZWG, STN, HTG, ...) if that's preferred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: data-only additions to static currency maps in `@medusajs/utils` and the dashboard, with no behavioral changes beyond preventing missing-currency lookups.
> 
> **Overview**
> Adds `GMD` (Gambian Dalasi) to the bundled currency maps used by `@medusajs/utils` and the admin dashboard.
> 
> This prevents admin pages from crashing when a store includes `GMD` in `supported_currencies` by ensuring lookups return a defined currency entry, and ships the change as patch releases via a new changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ff01db8cda4b937844e435e11763051231f18e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->