### PR TITLE
feat(core-flows): add workflows for programmatic auth identity registration

### DIFF
--- a/.changeset/feat-auth-identities.md
+++ b/.changeset/feat-auth-identities.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+feat(core-flows): add workflows for programmatic auth identity registration

--- a/packages/core/core-flows/src/auth/steps/__tests__/create-auth-identities.spec.ts
+++ b/packages/core/core-flows/src/auth/steps/__tests__/create-auth-identities.spec.ts
@@ -1,0 +1,53 @@
+import { createAuthIdentitiesStep } from "../create-auth-identities"
+import { Modules } from "@medusajs/framework/utils"
+
+describe("createAuthIdentitiesStep", () => {
+  it("should call createAuthIdentities and return the result", async () => {
+    const authModuleService = {
+      createAuthIdentities: jest.fn().mockResolvedValue([{ id: "auth_1" }]),
+    }
+
+    const container = {
+      resolve: jest.fn().mockReturnValue(authModuleService),
+    }
+
+    const data = [
+      {
+        provider_identities: [
+          {
+            provider: "emailpass",
+            entity_id: "test@test.com",
+          },
+        ],
+      },
+    ]
+
+    const result = await createAuthIdentitiesStep.run(data, {
+      container: container as any,
+    } as any)
+
+    expect(container.resolve).toHaveBeenCalledWith(Modules.AUTH)
+    expect(authModuleService.createAuthIdentities).toHaveBeenCalledWith(data)
+    expect(result.output).toEqual([{ id: "auth_1" }])
+    expect(result.compensationData).toEqual(["auth_1"])
+  })
+
+  it("should call deleteAuthIdentities on rollback", async () => {
+    const authModuleService = {
+      deleteAuthIdentities: jest.fn().mockResolvedValue(undefined),
+    }
+
+    const container = {
+      resolve: jest.fn().mockReturnValue(authModuleService),
+    }
+
+    const ids = ["auth_1"]
+
+    await createAuthIdentitiesStep.rollback(ids, {
+      container: container as any,
+    } as any)
+
+    expect(container.resolve).toHaveBeenCalledWith(Modules.AUTH)
+    expect(authModuleService.deleteAuthIdentities).toHaveBeenCalledWith(ids)
+  })
+})

--- a/packages/core/core-flows/src/auth/steps/__tests__/register-auth-identity.spec.ts
+++ b/packages/core/core-flows/src/auth/steps/__tests__/register-auth-identity.spec.ts
@@ -1,0 +1,76 @@
+import { registerAuthIdentityStep } from "../register-auth-identity"
+import { Modules, MedusaError } from "@medusajs/framework/utils"
+
+describe("registerAuthIdentityStep", () => {
+  it("should register auth identity", async () => {
+    const authModuleService = {
+      register: jest.fn().mockResolvedValue({
+        success: true,
+        authIdentity: { id: "auth_1" },
+      }),
+    }
+
+    const container = {
+      resolve: jest.fn().mockReturnValue(authModuleService),
+    }
+
+    const data = {
+      provider: "emailpass",
+      providerData: { email: "test@test.com", password: "password" },
+    }
+
+    const result = await registerAuthIdentityStep.run(data, {
+      container: container as any,
+    } as any)
+
+    expect(container.resolve).toHaveBeenCalledWith(Modules.AUTH)
+    expect(authModuleService.register).toHaveBeenCalledWith(data.provider, data.providerData)
+    expect(result.output).toEqual({ id: "auth_1" })
+    expect(result.compensationData).toEqual("auth_1")
+  })
+
+  it("should throw MedusaError on failure", async () => {
+    const authModuleService = {
+      register: jest.fn().mockResolvedValue({
+        success: false,
+        error: "Registration failed",
+      }),
+    }
+
+    const container = {
+      resolve: jest.fn().mockReturnValue(authModuleService),
+    }
+
+    const data = {
+      provider: "emailpass",
+      providerData: { email: "test@test.com", password: "password" },
+    }
+
+    const run = registerAuthIdentityStep.run(data, {
+      container: container as any,
+    } as any)
+
+    await expect(run).rejects.toThrow(
+      new MedusaError(MedusaError.Types.INVALID_DATA, "Registration failed")
+    )
+  })
+
+  it("should call deleteAuthIdentities on rollback", async () => {
+    const authModuleService = {
+      deleteAuthIdentities: jest.fn().mockResolvedValue(undefined),
+    }
+
+    const container = {
+      resolve: jest.fn().mockReturnValue(authModuleService),
+    }
+
+    const id = "auth_1"
+
+    await registerAuthIdentityStep.rollback(id, {
+      container: container as any,
+    } as any)
+
+    expect(container.resolve).toHaveBeenCalledWith(Modules.AUTH)
+    expect(authModuleService.deleteAuthIdentities).toHaveBeenCalledWith([id])
+  })
+})

--- a/packages/core/core-flows/src/auth/steps/create-auth-identities.ts
+++ b/packages/core/core-flows/src/auth/steps/create-auth-identities.ts
@@ -1,0 +1,34 @@
+import type { AuthTypes, IAuthModuleService } from "@medusajs/framework/types"
+import { Modules } from "@medusajs/framework/utils"
+import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
+
+export const createAuthIdentitiesStepId = "create-auth-identities"
+
+/**
+ * This step creates one or more auth identities.
+ */
+export const createAuthIdentitiesStep = createStep(
+  createAuthIdentitiesStepId,
+  async (
+    data: AuthTypes.CreateAuthIdentityDTO[],
+    { container }
+  ) => {
+    const service = container.resolve<IAuthModuleService>(Modules.AUTH)
+
+    const created = await service.createAuthIdentities(data)
+
+    return new StepResponse(
+      created,
+      created.map((c) => c.id)
+    )
+  },
+  async (ids, { container }) => {
+    if (!ids?.length) {
+      return
+    }
+
+    const service = container.resolve<IAuthModuleService>(Modules.AUTH)
+
+    await service.deleteAuthIdentities(ids)
+  }
+)

--- a/packages/core/core-flows/src/auth/steps/index.ts
+++ b/packages/core/core-flows/src/auth/steps/index.ts
@@ -1,1 +1,3 @@
+export * from "./create-auth-identities"
+export * from "./register-auth-identity"
 export * from "./set-auth-app-metadata"

--- a/packages/core/core-flows/src/auth/steps/register-auth-identity.ts
+++ b/packages/core/core-flows/src/auth/steps/register-auth-identity.ts
@@ -1,0 +1,45 @@
+import type { AuthTypes, IAuthModuleService } from "@medusajs/framework/types"
+import { Modules, MedusaError } from "@medusajs/framework/utils"
+import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
+
+export const registerAuthIdentityStepId = "register-auth-identity"
+
+/**
+ * This step registers a new auth identity using a specified provider.
+ * It uses the `register` method of the underlying provider, passing it the `providerData`.
+ */
+export const registerAuthIdentityStep = createStep(
+  registerAuthIdentityStepId,
+  async (
+    data: { provider: string; providerData: AuthTypes.AuthenticationInput },
+    { container }
+  ) => {
+    const service = container.resolve<IAuthModuleService>(Modules.AUTH)
+
+    const response = await service.register(data.provider, data.providerData)
+
+    if (!response.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        response.error || "Failed to register auth identity"
+      )
+    }
+
+    if (!response.authIdentity) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "Provider returned success but no auth identity was created"
+      )
+    }
+
+    return new StepResponse(response.authIdentity, response.authIdentity.id)
+  },
+  async (id, { container }) => {
+    if (!id) {
+      return
+    }
+
+    const service = container.resolve<IAuthModuleService>(Modules.AUTH)
+    await service.deleteAuthIdentities([id])
+  }
+)

--- a/packages/core/core-flows/src/auth/workflows/__tests__/create-auth-identities.spec.ts
+++ b/packages/core/core-flows/src/auth/workflows/__tests__/create-auth-identities.spec.ts
@@ -1,0 +1,32 @@
+import { createAuthIdentitiesWorkflow } from "../create-auth-identities"
+import { Modules } from "@medusajs/framework/utils"
+
+describe("createAuthIdentitiesWorkflow", () => {
+  it("should successfully create auth identities", async () => {
+    const authModuleService = {
+      createAuthIdentities: jest.fn().mockResolvedValue([{ id: "auth_1" }]),
+    }
+
+    const container = {
+      resolve: jest.fn().mockReturnValue(authModuleService),
+    }
+
+    const input = [
+      {
+        provider_identities: [
+          {
+            provider: "emailpass",
+            entity_id: "test@test.com",
+          },
+        ],
+      },
+    ]
+
+    const { result } = await createAuthIdentitiesWorkflow(container as any).run({
+      input,
+    })
+
+    expect(authModuleService.createAuthIdentities).toHaveBeenCalledWith(input)
+    expect(result).toEqual([{ id: "auth_1" }])
+  })
+})

--- a/packages/core/core-flows/src/auth/workflows/__tests__/register-auth-identity.spec.ts
+++ b/packages/core/core-flows/src/auth/workflows/__tests__/register-auth-identity.spec.ts
@@ -1,0 +1,29 @@
+import { registerAuthIdentityWorkflow } from "../register-auth-identity"
+import { Modules } from "@medusajs/framework/utils"
+
+describe("registerAuthIdentityWorkflow", () => {
+  it("should successfully register auth identity", async () => {
+    const authModuleService = {
+      register: jest.fn().mockResolvedValue({
+        success: true,
+        authIdentity: { id: "auth_1" },
+      }),
+    }
+
+    const container = {
+      resolve: jest.fn().mockReturnValue(authModuleService),
+    }
+
+    const input = {
+      provider: "emailpass",
+      providerData: { email: "test@test.com", password: "password" },
+    }
+
+    const { result } = await registerAuthIdentityWorkflow(container as any).run({
+      input,
+    })
+
+    expect(authModuleService.register).toHaveBeenCalledWith(input.provider, input.providerData)
+    expect(result).toEqual({ id: "auth_1" })
+  })
+})

--- a/packages/core/core-flows/src/auth/workflows/create-auth-identities.ts
+++ b/packages/core/core-flows/src/auth/workflows/create-auth-identities.ts
@@ -1,0 +1,20 @@
+import { AuthTypes } from "@medusajs/framework/types"
+import {
+  WorkflowData,
+  WorkflowResponse,
+  createWorkflow,
+} from "@medusajs/framework/workflows-sdk"
+import { createAuthIdentitiesStep } from "../steps"
+
+export const createAuthIdentitiesWorkflowId = "create-auth-identities"
+/**
+ * This workflow creates one or more auth identities.
+ */
+export const createAuthIdentitiesWorkflow = createWorkflow(
+  createAuthIdentitiesWorkflowId,
+  (
+    input: WorkflowData<AuthTypes.CreateAuthIdentityDTO[]>
+  ): WorkflowResponse<AuthTypes.AuthIdentityDTO[]> => {
+    return new WorkflowResponse(createAuthIdentitiesStep(input))
+  }
+)

--- a/packages/core/core-flows/src/auth/workflows/index.ts
+++ b/packages/core/core-flows/src/auth/workflows/index.ts
@@ -1,2 +1,4 @@
+export * from "./create-auth-identities"
 export * from "./generate-reset-password-token"
+export * from "./register-auth-identity"
 export * from "./set-auth-app-metadata"

--- a/packages/core/core-flows/src/auth/workflows/register-auth-identity.ts
+++ b/packages/core/core-flows/src/auth/workflows/register-auth-identity.ts
@@ -1,0 +1,21 @@
+import { AuthTypes } from "@medusajs/framework/types"
+import {
+  WorkflowData,
+  WorkflowResponse,
+  createWorkflow,
+} from "@medusajs/framework/workflows-sdk"
+import { registerAuthIdentityStep } from "../steps"
+
+export const registerAuthIdentityWorkflowId = "register-auth-identity"
+/**
+ * This workflow registers a new auth identity using a specified provider.
+ * It ensures that provider-specific logic (e.g. password hashing for emailpass) is executed.
+ */
+export const registerAuthIdentityWorkflow = createWorkflow(
+  registerAuthIdentityWorkflowId,
+  (
+    input: WorkflowData<{ provider: string; providerData: AuthTypes.AuthenticationInput }>
+  ): WorkflowResponse<AuthTypes.AuthIdentityDTO> => {
+    return new WorkflowResponse(registerAuthIdentityStep(input))
+  }
+)


### PR DESCRIPTION
Closes #15151

## Summary

**What** — What changes are introduced in this PR?

Introduced two new workflows (and their respective steps) in `@medusajs/core-flows` to allow programmatic creation and registration of Auth Identities natively from the backend:
1. `registerAuthIdentityWorkflow`: Executes the provider's `register` logic (crucial for things like password hashing with the `emailpass` provider).
2. `createAuthIdentitiesWorkflow`: Executes a standard bulk creation of auth identities via the auth module service.

**Why** — Why are these changes relevant or necessary?  

When developers are building custom migration scripts (e.g., migrating customers from WooCommerce or Magento), they need to programmatically create `emailpass` auth identities with appropriately hashed passwords, and then link them to the new customer profiles. 

Previously, `authService.createAuthIdentities` bypassed the provider's registration logic (leaving passwords unhashed and records incomplete), and there was no workflow to trigger the `register` logic. The only workaround was to have the backend hit the `/auth/customer/emailpass/register` HTTP endpoint during the migration script, which caused a clunky and inefficient Developer Experience.

**How** — How have these changes been implemented?

I added `register-auth-identity.ts` and `create-auth-identities.ts` to `packages/core/core-flows/src/auth/steps` and `packages/core/core-flows/src/auth/workflows`. 

The `registerAuthIdentityStep` resolves the `IAuthModuleService` and calls `service.register(provider, providerData)`, ensuring all provider-specific logic (like the password hashing for `emailpass`) runs successfully before returning the `AuthIdentity`. It also includes proper compensation logic to delete the identity if a larger workflow fails. 

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

I added unit tests for both steps and workflows in `packages/core/core-flows/src/auth/__tests__`. 
You can test this by importing `registerAuthIdentityWorkflow` into a backend script or subscriber, passing `{ provider: "emailpass", providerData: { email: "test@test.com", password: "password" } }`, and verifying that the resulting `AuthIdentity` is created successfully with the hashed password metadata intact.

---

## Examples

```ts
// Example usage in a migration script or API route:
import { registerAuthIdentityWorkflow } from "@medusajs/core-flows"

const { result: authIdentity } = await registerAuthIdentityWorkflow(container).run({
  input: {
    provider: "emailpass",
    providerData: {
      email: "customer@example.com",
      password: "securepassword123"
    }
  }
})

// Now you can safely link this properly registered AuthIdentity to a new Customer
