### PR TITLE
fix(pricing): calculatePrices() with empty context selects prices from pricelists that explicitly have rules

### DIFF
--- a/.changeset/long-bobcats-know.md
+++ b/.changeset/long-bobcats-know.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/pricing": patch
+---
+
+fix(pricing): exclude rule-protected price lists from empty-context price calculation

--- a/packages/modules/pricing/integration-tests/__tests__/services/pricing-module/calculate-price.spec.ts
+++ b/packages/modules/pricing/integration-tests/__tests__/services/pricing-module/calculate-price.spec.ts
@@ -1357,6 +1357,54 @@ moduleIntegrationTestRunner<IPricingModuleService>({
               },
             ])
           })
+          
+          it("should not return price list prices when price list have rules but no context is loaded", async() => {
+            await createPriceLists(service)
+
+            const priceSetsResult = await service.calculatePrices(
+              { id: ["price-set-EUR", "price-set-PLN"] },
+              {
+                context: {
+                  currency_code: "pln",
+                },
+              }
+            )
+
+            expect(priceSetsResult).toEqual([
+              {
+                id: "price-set-PLN",
+                is_calculated_price_price_list: false,
+                is_calculated_price_tax_inclusive: false,
+                calculated_amount: 1000,
+                raw_calculated_amount: {
+                  value: "1000",
+                  precision: 20,
+                },
+                is_original_price_price_list: false,
+                is_original_price_tax_inclusive: false,
+                original_amount: 1000,
+                raw_original_amount: {
+                  value: "1000",
+                  precision: 20,
+                },
+                currency_code: "pln",
+                calculated_price: {
+                  id: "price-PLN",
+                  price_list_id: null,
+                  price_list_type: null,
+                  min_quantity: 1,
+                  max_quantity: 10,
+                },
+                original_price: {
+                  id: "price-PLN",
+                  price_list_id: null,
+                  price_list_type: null,
+                  min_quantity: 1,
+                  max_quantity: 10,
+                },
+              }
+            ])
+          })
 
           it("should return price list prices when price list dont have any rules", async () => {
             await createPriceLists(service, {}, {})

--- a/packages/modules/pricing/src/repositories/pricing.ts
+++ b/packages/modules/pricing/src/repositories/pricing.ts
@@ -281,10 +281,10 @@ export class PricingRepository
       })
     } else {
       query.where(function (this: Knex.QueryBuilder) {
-        this.where("price.rules_count", 0).orWhere(function (
-          this: Knex.QueryBuilder
-        ) {
-          this.whereNotNull("price.price_list_id").where("pl.rules_count", 0)
+        this.where(function (this: Knex.QueryBuilder) {
+          this.whereNull("price.price_list_id").where("price.rules_count", 0)
+        }).orWhere(function (this: Knex.QueryBuilder) {
+          this.whereNotNull("price.price_list_id").where("price.rules_count", 0).where("pl.rules_count", 0)
         })
       })
     }


### PR DESCRIPTION
Closes #14873


## Summary

**What** — What changes are introduced in this PR?

The query in /packages/modules/pricing/src/repositories/pricing.ts:
```
if (hasComplexContext) {
    ..

} else {
    query.where(function (this: Knex.QueryBuilder) {
    this.where("price.rules_count", 0).orWhere(function (
        this: Knex.QueryBuilder
    ) {
        this.whereNotNull("price.price_list_id").where("pl.rules_count", 0)
    })
    })
}
```
is updated to 
```
    query.where(function (this: Knex.QueryBuilder) {
        this.where(function (this: Knex.QueryBuilder) {
          this.whereNull("price.price_list_id").where("price.rules_count", 0)
        }).orWhere(function (this: Knex.QueryBuilder) {
          this.whereNotNull("price.price_list_id").where("price.rules_count", 0).where("pl.rules_count", 0)
        })
      })
```
And, a test case is written to confirm results of the updated query. 


**Why** — Why are these changes relevant or necessary?  

The calculatePrices() in /packages/modules/pricing/src/repositories/pricing.ts takes a shortcut when the provided context has no rules to evaluate:
```
if (hasComplexContext) {
    ..

} else {
    query.where(function (this: Knex.QueryBuilder) {
    this.where("price.rules_count", 0).orWhere(function (
        this: Knex.QueryBuilder
    ) {
        this.whereNotNull("price.price_list_id").where("pl.rules_count", 0)
    })
    })
}
```
where the rules for the price itself is checked but the rules for the price list are not checked. This can lead to unintended behavior as described in the original issue.

**How** — How have these changes been implemented?

The previous query:
```
    query.where(function (this: Knex.QueryBuilder) {
    this.where("price.rules_count", 0).orWhere(function (
        this: Knex.QueryBuilder
    ) {
        this.whereNotNull("price.price_list_id").where("pl.rules_count", 0)
    })
    })
```
has been updated to:
```
    query.where(function (this: Knex.QueryBuilder) {
        this.where(function (this: Knex.QueryBuilder) {
          this.whereNull("price.price_list_id").where("price.rules_count", 0)
        }).orWhere(function (this: Knex.QueryBuilder) {
          this.whereNotNull("price.price_list_id").where("price.rules_count", 0).where("pl.rules_count", 0)
        })
      })
```
to handle prices without rules that may be a part of the price list that itself contains rules. The first part of the query is used to check for a price that does not have a price_list_id and does not have any rules. The second part of the query is used to check for a price that has a price_list_id but there are no rules for the price list and no rules on the price itself.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

A test case for the change in query has been added to packages/modules/pricing/integration-tests/__tests__/services/pricing-module/calculate-price.spec.ts. The test case was developed as follows to verify that the price returned is not from a restricted price list:
```
  it("should not return price list prices when price list have rules but no context is loaded", async() => {
            await createPriceLists(service)

            const priceSetsResult = await service.calculatePrices(
              { id: ["price-set-EUR", "price-set-PLN"] },
              {
                context: {
                  currency_code: "pln",
                },
              }
            )

            expect(priceSetsResult).toEqual([
              {
                id: "price-set-PLN",
                is_calculated_price_price_list: false,
                is_calculated_price_tax_inclusive: false,
                calculated_amount: 1000,
                raw_calculated_amount: {
                  value: "1000",
                  precision: 20,
                },
                is_original_price_price_list: false,
                is_original_price_tax_inclusive: false,
                original_amount: 1000,
                raw_original_amount: {
                  value: "1000",
                  precision: 20,
                },
                currency_code: "pln",
                calculated_price: {
                  id: "price-PLN",
                  price_list_id: null,
                  price_list_type: null,
                  min_quantity: 1,
                  max_quantity: 10,
                },
                original_price: {
                  id: "price-PLN",
                  price_list_id: null,
                  price_list_type: null,
                  min_quantity: 1,
                  max_quantity: 10,
                },
              }
            ])
          })
```
Lines (1361 - 1407)

Verified locally:
- Without the fix, the new test fails (returns 232 from the rule-protected price list)
- With the fix, the new test passes
- All 42 pre-existing tests in the file continue to pass

Results: 43/43 passing with the fix.