### PR TITLE
Fix/return fulfillment delivery address

### DIFF
--- a/.changeset/fix-return-fulfillment-delivery-address.md
+++ b/.changeset/fix-return-fulfillment-delivery-address.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+Fix `delivery_address` being null on return fulfillment when using `createAndCompleteReturnOrderWorkflow`. The order query was missing `shipping_address.*` in its fields, so `order.shipping_address` was undefined when passed as `delivery_address` to the fulfillment creation step.

--- a/.changeset/fix-return-fulfillment-delivery-address.md
+++ b/.changeset/fix-return-fulfillment-delivery-address.md
@@ -2,4 +2,4 @@
 "@medusajs/core-flows": patch
 ---
 
-Fix `delivery_address` being null on return fulfillment when using `createAndCompleteReturnOrderWorkflow`. The order query was missing `shipping_address.*` in its fields, so `order.shipping_address` was undefined when passed as `delivery_address` to the fulfillment creation step.
+fix(core-flows): "delivery_address" being null on return fulfillment when using "createAndCompleteReturnOrderWorkflow". The order query was missing "shipping_address.*" in its fields, so "order.shipping_address" was undefined when passed as "delivery_address" to the fulfillment creation step.

--- a/integration-tests/modules/__tests__/order/workflows/create-complete-return.spec.ts
+++ b/integration-tests/modules/__tests__/order/workflows/create-complete-return.spec.ts
@@ -525,12 +525,12 @@ medusaIntegrationTestRunner({
         const remoteQueryObject = remoteQueryObjectFromString({
           entryPoint: "return",
           variables: { id: returnResult.id },
-          fields: ["id", "fulfillment.id", "fulfillment.delivery_address.*"],
+          fields: ["id", "fulfillments.id", "fulfillments.delivery_address.*"],
         })
 
         const [returnWithFulfillment] = await remoteQuery(remoteQueryObject)
 
-        expect(returnWithFulfillment.fulfillment.delivery_address).toEqual(
+        expect(returnWithFulfillment.fulfillments[0].delivery_address).toEqual(
           expect.objectContaining({
             first_name: "Test",
             last_name: "Test",

--- a/integration-tests/modules/__tests__/order/workflows/create-complete-return.spec.ts
+++ b/integration-tests/modules/__tests__/order/workflows/create-complete-return.spec.ts
@@ -491,6 +491,56 @@ medusaIntegrationTestRunner({
         )
       })
 
+      it("should populate delivery_address from order shipping_address", async () => {
+        const order = await createOrderFixture({ container, product })
+        const reasons = await orderService.listReturnReasons({})
+        const testReason = reasons.find(
+          (r) => r.value.toLowerCase() === "test child reason"
+        )!
+
+        const createReturnOrderData: OrderWorkflow.CreateOrderReturnWorkflowInput =
+          {
+            order_id: order.id,
+            return_shipping: {
+              option_id: shippingOption.id,
+            },
+            items: [
+              {
+                id: order.items![0].id,
+                quantity: 1,
+                reason_id: testReason.id,
+              },
+            ],
+          }
+
+        await createAndCompleteReturnOrderWorkflow(container).run({
+          input: createReturnOrderData,
+          throwOnError: true,
+        })
+
+        const remoteQuery = container.resolve(
+          ContainerRegistrationKeys.REMOTE_QUERY
+        )
+        const remoteQueryObject = remoteQueryObjectFromString({
+          entryPoint: "fulfillment",
+          fields: ["id", "delivery_address.*"],
+        })
+
+        const [fulfillment] = await remoteQuery(remoteQueryObject)
+
+        expect(fulfillment.delivery_address).toEqual(
+          expect.objectContaining({
+            first_name: "Test",
+            last_name: "Test",
+            address_1: "Test",
+            city: "Test",
+            country_code: "US",
+            postal_code: "12345",
+            phone: "12345",
+          })
+        )
+      })
+
       it("should fail when location is not linked", async () => {
         const order = await createOrderFixture({ container, product })
         const createReturnOrderData: OrderWorkflow.CreateOrderReturnWorkflowInput =

--- a/integration-tests/modules/__tests__/order/workflows/create-complete-return.spec.ts
+++ b/integration-tests/modules/__tests__/order/workflows/create-complete-return.spec.ts
@@ -513,22 +513,24 @@ medusaIntegrationTestRunner({
             ],
           }
 
-        await createAndCompleteReturnOrderWorkflow(container).run({
-          input: createReturnOrderData,
-          throwOnError: true,
-        })
+        const { result: returnResult } =
+          await createAndCompleteReturnOrderWorkflow(container).run({
+            input: createReturnOrderData,
+            throwOnError: true,
+          })
 
         const remoteQuery = container.resolve(
           ContainerRegistrationKeys.REMOTE_QUERY
         )
         const remoteQueryObject = remoteQueryObjectFromString({
-          entryPoint: "fulfillment",
-          fields: ["id", "delivery_address.*"],
+          entryPoint: "return",
+          variables: { id: returnResult.id },
+          fields: ["id", "fulfillment.id", "fulfillment.delivery_address.*"],
         })
 
-        const [fulfillment] = await remoteQuery(remoteQueryObject)
+        const [returnWithFulfillment] = await remoteQuery(remoteQueryObject)
 
-        expect(fulfillment.delivery_address).toEqual(
+        expect(returnWithFulfillment.fulfillment.delivery_address).toEqual(
           expect.objectContaining({
             first_name: "Test",
             last_name: "Test",

--- a/packages/core/core-flows/src/order/workflows/return/create-complete-return.ts
+++ b/packages/core/core-flows/src/order/workflows/return/create-complete-return.ts
@@ -364,6 +364,7 @@ export const createAndCompleteReturnOrderWorkflow = createWorkflow(
         "total",
         "item_total",
         "items.*",
+        "shipping_address.*",
       ],
       variables: { id: input.order_id },
       list: false,


### PR DESCRIPTION
   Fixes #14830 — the createAndCompleteReturnOrderWorkflow was not
   fetching shipping_address.* when querying the order, causing
   delivery_address on the return fulfillment to always be null.

## Summary

**What** — What changes are introduced in this PR?

  Added "shipping_address.*" to the fields array in the useRemoteQueryStep order query inside createAndCompleteReturnOrderWorkflow.                                                            
   Also adds an integration test that asserts delivery_address on the created fulfillment is populated with the order's shipping address data.   

**Why** — Why are these changes relevant or necessary?  

Fixes #14830 — when createAndCompleteReturnOrderWorkflow runs, it queries the order but shipping_address was not included in the fields list. Because useRemoteQueryStep only returns fields that are explicitly requested, order.shipping_address was undefined at runtime. The prepareFulfillmentData function then fell back to {} as any, so a fulfillment address record was created with every field set to null. This broke any custom FulfillmentProvider that relies on delivery_address (e.g. to generate a return label with a 3rd-party carrier API).    

**How** — How have these changes been implemented?

Single-line change in packages/core/core-flows/src/order/workflows/return/create-complete-return.ts:                                                                                         
   
    fields: [                                                                                                                                                                                  
      "id",                                                                                                                                                                                    
      "status",
      "region_id",                                                                                                                                                                             
      "currency_code",                                      
      "total",
      "item_total",                                                                                                                                                                            
      "items.*",
  +   "shipping_address.*",                                                                                                                                                                    
    ], 

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration test added to integration-tests/modules/__tests__/order/workflows/create-complete-return.spec.ts:

  - Creates an order fixture with a known shipping address
  - Runs createAndCompleteReturnOrderWorkflow
  - Queries the resulting fulfillment via remoteQuery with delivery_address.*
  - Asserts all address fields (first_name, last_name, address_1, city, country_code, postal_code, phone) match the order's shipping address

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line query field addition plus an integration test; behavior change is limited to ensuring return fulfillments get a non-null `delivery_address`.
> 
> **Overview**
> Fixes `createAndCompleteReturnOrderWorkflow` returning fulfillments with `delivery_address` set to null by including `shipping_address.*` in the order `useRemoteQueryStep` fields.
> 
> Adds an integration test asserting the created return fulfillment’s `delivery_address` matches the originating order’s `shipping_address`, and includes a patch changeset for `@medusajs/core-flows`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b733f97c75c8b29b718bd43d6ac92c3321cd99ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->