### PR TITLE
fix(dashboard): prevent region detail crash on missing currency / provider metadata

### DIFF
--- a/.changeset/fix-region-detail-undefined-name.md
+++ b/.changeset/fix-region-detail-undefined-name.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(@medusajs/dashboard): prevent region detail crash on missing currency / provider metadata

--- a/packages/admin/dashboard/src/lib/__tests__/format-provider.test.ts
+++ b/packages/admin/dashboard/src/lib/__tests__/format-provider.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { formatProvider } from "../format-provider"
+
+describe("formatProvider", () => {
+  it("formats a standard provider ID", () => {
+    expect(formatProvider("pp_stripe_usd")).toBe("Stripe (USD)")
+  })
+
+  it("formats a provider ID with hyphenated name", () => {
+    expect(formatProvider("pp_stripe-blik_dkk")).toBe("Stripe Blik (DKK)")
+  })
+
+  it("formats a provider ID with no suffix", () => {
+    expect(formatProvider("pp_stripe")).toBe("Stripe")
+  })
+
+  it("does not crash on 'manual' (no underscores)", () => {
+    expect(formatProvider("manual")).toBe("Manual")
+  })
+
+  it("does not crash on 'system' (no underscores)", () => {
+    expect(formatProvider("system")).toBe("System")
+  })
+})

--- a/packages/admin/dashboard/src/lib/format-provider.ts
+++ b/packages/admin/dashboard/src/lib/format-provider.ts
@@ -8,7 +8,13 @@
  * @returns A formatted string
  */
 export const formatProvider = (id: string) => {
-  const [_, name, type] = id.split("_")
+  const parts = id.split("_")
+
+  if (parts.length < 2) {
+    return id.charAt(0).toUpperCase() + id.slice(1)
+  }
+
+  const [_, name, type] = parts
   return (
     name
       .split("-")

--- a/packages/admin/dashboard/src/routes/regions/common/hooks/use-countries.tsx
+++ b/packages/admin/dashboard/src/routes/regions/common/hooks/use-countries.tsx
@@ -52,8 +52,8 @@ export const useCountries = ({
     const query = q.toLowerCase()
     const results = countries.filter(
       (c) =>
-        c.name.toLowerCase().includes(query) ||
-        c.iso_2.toLowerCase().includes(query)
+        c.name?.toLowerCase().includes(query) ||
+        c.iso_2?.toLowerCase().includes(query)
     )
     return {
       countries: results,

--- a/packages/admin/dashboard/src/routes/regions/region-detail/components/region-general-section/region-general-section.tsx
+++ b/packages/admin/dashboard/src/routes/regions/region-detail/components/region-general-section/region-general-section.tsx
@@ -40,7 +40,7 @@ export const RegionGeneralSection = ({
               {region.currency_code}
             </Badge>
             <Text size="small" leading="compact">
-              {currencies[region.currency_code.toUpperCase()]?.name}
+              {currencies[region.currency_code?.toUpperCase()]?.name}
             </Text>
           </div>
         }

--- a/packages/admin/dashboard/src/routes/regions/region-edit/components/edit-region-form/edit-region-form.tsx
+++ b/packages/admin/dashboard/src/routes/regions/region-edit/components/edit-region-form/edit-region-form.tsx
@@ -47,7 +47,7 @@ export const EditRegionForm = ({
   const form = useForm<zod.infer<typeof EditRegionSchema>>({
     defaultValues: {
       name: region.name,
-      currency_code: region.currency_code.toUpperCase(),
+      currency_code: region.currency_code?.toUpperCase() ?? "",
       payment_providers: region.payment_providers?.map((pp) => pp.id) || [],
       automatic_taxes: region.automatic_taxes,
       is_tax_inclusive: pricePreferenceForRegion?.is_tax_inclusive || false,

--- a/packages/admin/dashboard/vitest.config.mts
+++ b/packages/admin/dashboard/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/__tests__/**/*.test.ts", "src/**/__tests__/**/*.test.tsx"],
+  },
+})


### PR DESCRIPTION
## What

Hardens the admin region detail UI so it does not crash when region data contains null/undefined fields.

## Why

Users navigating to the default region settings screen get a `TypeError: Cannot read properties of undefined (reading 'name')` in `RegionGeneralSection`, which blocks the page and the Edit drawer.

## How

- `region-general-section.tsx`: add `?.` optional chaining on `currency_code` before calling `toUpperCase()`
- `format-provider.ts`: guard against provider IDs without underscores (e.g. `manual`, `system`) that caused `name.split` to throw
- `edit-region-form.tsx`: same `currency_code?.toUpperCase() ?? ''` guard for the edit form default values
- `use-countries.tsx`: add `?.` optional chaining on `c.name` and `c.iso_2` in the search filter to prevent crash on null country rows

## Testing

**To reproduce the bug (before this fix):**

1. Run `npx create-medusa-app@latest` to scaffold a fresh project
2. Start the dev server and open `http://localhost:9000/app/settings/regions`
3. Click the default region — the page crashes with `TypeError: Cannot read properties of undefined (reading 'name')`

**To verify the fix:**

1. Navigate to the default region detail page — it should render without errors
2. Click **Edit** on the region — the edit drawer should open correctly
3. In the browser console, confirm no uncaught `TypeError`

**`formatProvider` edge case (manual/system providers):**

If the region has a payment provider whose ID contains no underscores (e.g. `manual` or `system`), the provider list previously crashed. After this fix it renders the capitalized name (`Manual`, `System`).

Unit tests are in `src/lib/__tests__/format-provider.test.ts` and can be run with:
```bash
yarn workspace @medusajs/dashboard test
```

Closes #15229

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds defensive null/format guards in region UI and provider formatting, plus unit tests/config, with no API or data model changes.
> 
> **Overview**
> Prevents crashes in the Regions screens when backend/static data contains missing fields by adding optional chaining around `currency_code` (detail + edit form) and around country `name`/`iso_2` in search filtering.
> 
> Hardens `formatProvider` to handle provider IDs without underscores (e.g. `manual`, `system`) and adds Vitest coverage for these formatting edge cases, including a new `vitest.config.mts` for the dashboard workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087c8a4ecd04531c08bff614a0ec6e1eba2c9681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->