### PR TITLE
feat(core-flows): add setPromotionContext hook to pass additional context for promotion computation

### DIFF
--- a/.changeset/mighty-snails-nail.md
+++ b/.changeset/mighty-snails-nail.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/core-flows": patch
+---
+
+feat(core-flows): add setPromotionContext hook to pass additional context for promotion computation

--- a/integration-tests/modules/__tests__/cart/store/set-promotion-context-hook.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/set-promotion-context-hook.spec.ts
@@ -262,6 +262,100 @@ medusaIntegrationTestRunner({
         )
       })
 
+      it("should not apply the promotion when the hook supplies the attribute but with a non-matching value", async () => {
+        const promotion = await promotionModuleService.createPromotions({
+          code: "B2B_DISCOUNT_WRONG_VALUE",
+          type: PromotionType.STANDARD,
+          status: PromotionStatus.ACTIVE,
+          rules: [
+            {
+              attribute: "company_id",
+              operator: "eq",
+              values: ["comp_acme"],
+            },
+          ],
+          application_method: {
+            type: "fixed",
+            target_type: "items",
+            allocation: "across",
+            value: 500,
+            apply_to_quantity: 1,
+            currency_code: "usd",
+          },
+        })
+
+        const cart = await cartModuleService.createCarts({
+          currency_code: "usd",
+          items: [
+            {
+              unit_price: 2000,
+              quantity: 1,
+              title: "Test item",
+            } as any,
+          ],
+        })
+
+        // Hook supplies company_id but with a value that does not satisfy the rule.
+        setPromotionContextHook = () =>
+          new StepResponse({ company_id: "comp_other" })
+
+        const response = await api.post(
+          `/store/carts/${cart.id}/promotions`,
+          { promo_codes: [promotion.code] },
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.cart.items[0].adjustments).toEqual([])
+      })
+
+      it("should use the hook context value over the existing cart attribute when keys conflict", async () => {
+        const promotion = await promotionModuleService.createPromotions({
+          code: "EMAIL_DISCOUNT_OVERRIDE",
+          type: PromotionType.STANDARD,
+          status: PromotionStatus.ACTIVE,
+          rules: [
+            {
+              attribute: "email",
+              operator: "eq",
+              values: ["cart@example.com"],
+            },
+          ],
+          application_method: {
+            type: "fixed",
+            target_type: "items",
+            allocation: "across",
+            value: 300,
+            apply_to_quantity: 1,
+            currency_code: "usd",
+          },
+        })
+
+        const cart = await cartModuleService.createCarts({
+          currency_code: "usd",
+          email: "cart@example.com",
+          items: [
+            {
+              unit_price: 2000,
+              quantity: 1,
+              title: "Test item",
+            } as any,
+          ],
+        })
+
+        setPromotionContextHook = () =>
+          new StepResponse({ email: "hook@example.com" })
+
+        const response = await api.post(
+          `/store/carts/${cart.id}/promotions`,
+          { promo_codes: [promotion.code] },
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.cart.items[0].adjustments).toEqual([])
+      })
+
       it("should reject a non-object response from the hook", async () => {
         const cart = await cartModuleService.createCarts({
           currency_code: "usd",

--- a/integration-tests/modules/__tests__/cart/store/set-promotion-context-hook.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/set-promotion-context-hook.spec.ts
@@ -1,0 +1,311 @@
+import { updateCartPromotionsWorkflow } from "@medusajs/core-flows"
+import { StepResponse } from "@medusajs/framework/workflows-sdk"
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { ICartModuleService, IPromotionModuleService } from "@medusajs/types"
+import {
+  Modules,
+  PromotionActions,
+  PromotionStatus,
+  PromotionType,
+} from "@medusajs/utils"
+import {
+  adminHeaders,
+  createAdminUser,
+  generatePublishableKey,
+  generateStoreHeaders,
+} from "../../../../helpers/create-admin-user"
+
+jest.setTimeout(50000)
+
+const env = {}
+
+medusaIntegrationTestRunner({
+  env,
+  testSuite: ({ dbConnection, getContainer, api }) => {
+    describe("updateCartPromotionsWorkflow: setPromotionContext hook", () => {
+      let appContainer
+      let cartModuleService: ICartModuleService
+      let promotionModuleService: IPromotionModuleService
+      let storeHeaders
+
+      // Toggled per test so we can register the hook once globally and
+      // opt into different behaviour per case without re-registering.
+      let setPromotionContextHook:
+        | ((input: any) => StepResponse<Record<string, unknown> | undefined>)
+        | undefined
+
+      beforeAll(async () => {
+        appContainer = getContainer()
+        cartModuleService = appContainer.resolve(Modules.CART)
+        promotionModuleService = appContainer.resolve(Modules.PROMOTION)
+
+        updateCartPromotionsWorkflow.hooks.setPromotionContext(
+          (input) => {
+            if (setPromotionContextHook) {
+              return setPromotionContextHook(input)
+            }
+          },
+          () => {}
+        )
+      })
+
+      beforeEach(async () => {
+        await createAdminUser(dbConnection, adminHeaders, appContainer)
+        const publishableKey = await generatePublishableKey(appContainer)
+        storeHeaders = generateStoreHeaders({ publishableKey })
+      })
+
+      afterEach(() => {
+        setPromotionContextHook = undefined
+      })
+
+      it("should expose the cart, action and promo_codes to the hook", async () => {
+        const promotion = await promotionModuleService.createPromotions({
+          code: "HOOK_INPUT_SHAPE",
+          type: PromotionType.STANDARD,
+          status: PromotionStatus.ACTIVE,
+          application_method: {
+            type: "fixed",
+            target_type: "items",
+            allocation: "across",
+            value: 100,
+            apply_to_quantity: 1,
+            currency_code: "usd",
+          },
+        })
+
+        const cart = await cartModuleService.createCarts({
+          currency_code: "usd",
+          items: [
+            {
+              unit_price: 2000,
+              quantity: 1,
+              title: "Test item",
+            } as any,
+          ],
+        })
+
+        let receivedInput: any
+        setPromotionContextHook = (input) => {
+          receivedInput = input
+          return new StepResponse(undefined)
+        }
+
+        const response = await api.post(
+          `/store/carts/${cart.id}/promotions`,
+          { promo_codes: [promotion.code] },
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(receivedInput).toEqual(
+          expect.objectContaining({
+            cart: expect.objectContaining({ id: cart.id }),
+            action: PromotionActions.ADD,
+            promo_codes: [promotion.code],
+          })
+        )
+      })
+
+      it("should apply a promotion whose rule depends on a custom context attribute supplied by the hook", async () => {
+        const companyId = "comp_acme"
+        const promotion = await promotionModuleService.createPromotions({
+          code: "B2B_DISCOUNT",
+          type: PromotionType.STANDARD,
+          status: PromotionStatus.ACTIVE,
+          rules: [
+            {
+              attribute: "company_id",
+              operator: "eq",
+              values: [companyId],
+            },
+          ],
+          application_method: {
+            type: "fixed",
+            target_type: "items",
+            allocation: "across",
+            value: 500,
+            apply_to_quantity: 1,
+            currency_code: "usd",
+          },
+        })
+
+        const cart = await cartModuleService.createCarts({
+          currency_code: "usd",
+          items: [
+            {
+              unit_price: 2000,
+              quantity: 1,
+              title: "Test item",
+            } as any,
+          ],
+        })
+
+        setPromotionContextHook = () =>
+          new StepResponse({ company_id: companyId })
+
+        const response = await api.post(
+          `/store/carts/${cart.id}/promotions`,
+          { promo_codes: [promotion.code] },
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.cart.items[0].adjustments).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              code: promotion.code,
+              amount: 500,
+            }),
+          ])
+        )
+      })
+
+      it("should not apply the promotion when the hook does not supply the attribute its rule depends on", async () => {
+        const promotion = await promotionModuleService.createPromotions({
+          code: "B2B_DISCOUNT_UNMATCHED",
+          type: PromotionType.STANDARD,
+          status: PromotionStatus.ACTIVE,
+          rules: [
+            {
+              attribute: "company_id",
+              operator: "eq",
+              values: ["comp_acme"],
+            },
+          ],
+          application_method: {
+            type: "fixed",
+            target_type: "items",
+            allocation: "across",
+            value: 500,
+            apply_to_quantity: 1,
+            currency_code: "usd",
+          },
+        })
+
+        const cart = await cartModuleService.createCarts({
+          currency_code: "usd",
+          items: [
+            {
+              unit_price: 2000,
+              quantity: 1,
+              title: "Test item",
+            } as any,
+          ],
+        })
+
+        // No hook is registered for this case — the cart context lacks
+        // `company_id`, so the rule cannot be satisfied and the promotion
+        // is not applied.
+        const response = await api.post(
+          `/store/carts/${cart.id}/promotions`,
+          { promo_codes: [promotion.code] },
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.cart.items[0].adjustments).toEqual([])
+      })
+
+      it("should resolve nested attributes from the hook context (dot-path)", async () => {
+        const promotion = await promotionModuleService.createPromotions({
+          code: "B2B_TIER_DISCOUNT",
+          type: PromotionType.STANDARD,
+          status: PromotionStatus.ACTIVE,
+          rules: [
+            {
+              attribute: "company.tier",
+              operator: "eq",
+              values: ["gold"],
+            },
+          ],
+          application_method: {
+            type: "fixed",
+            target_type: "items",
+            allocation: "across",
+            value: 700,
+            apply_to_quantity: 1,
+            currency_code: "usd",
+          },
+        })
+
+        const cart = await cartModuleService.createCarts({
+          currency_code: "usd",
+          items: [
+            {
+              unit_price: 2000,
+              quantity: 1,
+              title: "Test item",
+            } as any,
+          ],
+        })
+
+        setPromotionContextHook = () =>
+          new StepResponse({
+            company: { id: "comp_acme", tier: "gold" },
+          })
+
+        const response = await api.post(
+          `/store/carts/${cart.id}/promotions`,
+          { promo_codes: [promotion.code] },
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.cart.items[0].adjustments).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              code: promotion.code,
+              amount: 700,
+            }),
+          ])
+        )
+      })
+
+      it("should reject a non-object response from the hook", async () => {
+        const cart = await cartModuleService.createCarts({
+          currency_code: "usd",
+          items: [
+            {
+              unit_price: 2000,
+              quantity: 1,
+              title: "Test item",
+            } as any,
+          ],
+        })
+
+        setPromotionContextHook = () =>
+          new StepResponse([1] as unknown as Record<string, unknown>)
+
+        const { errors } = await updateCartPromotionsWorkflow(appContainer).run(
+          {
+            throwOnError: false,
+            input: {
+              cart_id: cart.id,
+              promo_codes: [],
+              action: PromotionActions.ADD,
+            },
+          }
+        )
+
+        expect(errors).toHaveLength(1)
+        expect(errors[0]).toEqual(
+          expect.objectContaining({
+            action: "get-setPromotionContext-result",
+            handlerType: "invoke",
+            error: expect.objectContaining({
+              issues: [
+                {
+                  code: "invalid_type",
+                  expected: "record",
+                  message: "Invalid input: expected record, received array",
+                  path: [],
+                },
+              ],
+            }),
+          })
+        )
+      })
+    })
+  },
+})

--- a/packages/core/core-flows/src/cart/steps/get-actions-to-compute-from-promotions.ts
+++ b/packages/core/core-flows/src/cart/steps/get-actions-to-compute-from-promotions.ts
@@ -1,7 +1,7 @@
 import {
   ComputeActionContext,
   ComputeActionOptions,
-  IPromotionModuleService
+  IPromotionModuleService,
 } from "@medusajs/framework/types"
 import { Modules } from "@medusajs/framework/utils"
 import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
@@ -22,6 +22,16 @@ export interface GetActionsToComputeFromPromotionsStepInput {
    * The options to configure how the actions are computed.
    */
   options?: ComputeActionOptions
+  /**
+   * The result of the `setPromotionContext` hook, forwarded by the calling
+   * workflow. Its keys are merged on top of `computeActionContext` before
+   * promotion rules are evaluated, so consumers can extend the rule evaluation
+   * context with arbitrary attributes (e.g. `company.id`, "custom_tier").
+   *
+   * Values from `setPromotionContextResult` take precedence over values on
+   * `computeActionContext` when keys conflict.
+   */
+  setPromotionContextResult?: Record<string, unknown>
 }
 
 export const getActionsToComputeFromPromotionsStepId =
@@ -47,16 +57,25 @@ export const getActionsToComputeFromPromotionsStepId =
 export const getActionsToComputeFromPromotionsStep = createStep(
   getActionsToComputeFromPromotionsStepId,
   async (data: GetActionsToComputeFromPromotionsStepInput, { container }) => {
-    const { computeActionContext, promotionCodesToApply = [], options } = data
+    const {
+      computeActionContext,
+      promotionCodesToApply = [],
+      options,
+      setPromotionContextResult,
+    } = data
 
-    
     const promotionService = container.resolve<IPromotionModuleService>(
       Modules.PROMOTION
     )
-    
+
+    const mergedContext: ComputeActionContext = {
+      ...computeActionContext,
+      ...(setPromotionContextResult ?? {}),
+    }
+
     const actionsToCompute = await promotionService.computeActions(
       promotionCodesToApply,
-      computeActionContext,
+      mergedContext,
       options
     )
 

--- a/packages/core/core-flows/src/cart/steps/get-actions-to-compute-from-promotions.ts
+++ b/packages/core/core-flows/src/cart/steps/get-actions-to-compute-from-promotions.ts
@@ -23,15 +23,15 @@ export interface GetActionsToComputeFromPromotionsStepInput {
    */
   options?: ComputeActionOptions
   /**
-   * The result of the `setPromotionContext` hook, forwarded by the calling
+   * The result of the `additional_promotion_context` hook, forwarded by the calling
    * workflow. Its keys are merged on top of `computeActionContext` before
    * promotion rules are evaluated, so consumers can extend the rule evaluation
    * context with arbitrary attributes (e.g. `company.id`, "custom_tier").
    *
-   * Values from `setPromotionContextResult` take precedence over values on
+   * Values from `additional_promotion_context` take precedence over values on
    * `computeActionContext` when keys conflict.
    */
-  setPromotionContextResult?: Record<string, unknown>
+  additional_promotion_context?: Record<string, unknown>
 }
 
 export const getActionsToComputeFromPromotionsStepId =
@@ -61,7 +61,7 @@ export const getActionsToComputeFromPromotionsStep = createStep(
       computeActionContext,
       promotionCodesToApply = [],
       options,
-      setPromotionContextResult,
+      additional_promotion_context: setPromotionContextResult,
     } = data
 
     const promotionService = container.resolve<IPromotionModuleService>(

--- a/packages/core/core-flows/src/cart/utils/schemas.ts
+++ b/packages/core/core-flows/src/cart/utils/schemas.ts
@@ -1,3 +1,4 @@
 import { z } from "@medusajs/framework/zod"
 export const pricingContextResult = z.record(z.string(), z.any()).optional()
 export const shippingOptionsContextResult = z.record(z.string(), z.any()).optional()
+export const promotionContextResult = z.record(z.string(), z.any()).optional()

--- a/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
@@ -1,4 +1,3 @@
-import { AdditionalData } from "@medusajs/framework/types"
 import { PromotionActions } from "@medusajs/framework/utils"
 import {
   createHook,
@@ -88,7 +87,7 @@ export const updateCartPromotionsWorkflow = createWorkflow(
     name: updateCartPromotionsWorkflowId,
     idempotent: false,
   },
-  (input: WorkflowData<UpdateCartPromotionsWorkflowInput & AdditionalData>) => {
+  (input: WorkflowData<UpdateCartPromotionsWorkflowInput>) => {
     const fetchCart = when("should-fetch-cart", { input }, ({ input }) => {
       return !input.cart
     }).then(() => {
@@ -133,7 +132,6 @@ export const updateCartPromotionsWorkflow = createWorkflow(
         cart,
         action,
         promo_codes,
-        additional_data: input.additional_data,
       },
       {
         resultValidator: promotionContextResult,

--- a/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
@@ -148,7 +148,7 @@ export const updateCartPromotionsWorkflow = createWorkflow(
     const actions = getActionsToComputeFromPromotionsStep({
       computeActionContext: cart,
       promotionCodesToApply,
-      setPromotionContextResult,
+      additional_promotion_context: setPromotionContextResult,
     })
 
     const {

--- a/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
@@ -1,3 +1,4 @@
+import { AdditionalData } from "@medusajs/framework/types"
 import { PromotionActions } from "@medusajs/framework/utils"
 import {
   createHook,
@@ -22,6 +23,7 @@ import {
 } from "../steps"
 import { updateCartPromotionsStep } from "../steps/update-cart-promotions"
 import { cartFieldsForRefreshSteps } from "../utils/fields"
+import { promotionContextResult } from "../utils/schemas"
 import { refreshPaymentCollectionForCartWorkflow } from "./refresh-payment-collection"
 
 /**
@@ -48,11 +50,11 @@ export type UpdateCartPromotionsWorkflowInput = {
     | PromotionActions.ADD
     | PromotionActions.REMOVE
     | PromotionActions.REPLACE
-    /**
-     * Wether to force the refresh of the cart payment collection. If the caller doesn't refresh it explicitly,
-     * you should probably set this property to true.
-     */
-    force_refresh_payment_collection?: boolean
+  /**
+   * Wether to force the refresh of the cart payment collection. If the caller doesn't refresh it explicitly,
+   * you should probably set this property to true.
+   */
+  force_refresh_payment_collection?: boolean
 }
 
 export const updateCartPromotionsWorkflowId = "update-cart-promotions"
@@ -79,13 +81,14 @@ export const updateCartPromotionsWorkflowId = "update-cart-promotions"
  * Update a cart's applied promotions to add, replace, or remove them.
  *
  * @property hooks.validate - This hook is executed before all operations. You can consume this hook to perform any custom validation. If validation fails, you can throw an error to stop the workflow execution.
+ * @property hooks.setPromotionContext - This hook is executed after the cart is fetched and before promotion rules are evaluated. You can consume this hook to return any custom context useful for promotion rule evaluation. The returned object is merged on top of the cart context (consumer values win on key conflict).
  */
 export const updateCartPromotionsWorkflow = createWorkflow(
   {
     name: updateCartPromotionsWorkflowId,
     idempotent: false,
   },
-  (input: WorkflowData<UpdateCartPromotionsWorkflowInput>) => {
+  (input: WorkflowData<UpdateCartPromotionsWorkflowInput & AdditionalData>) => {
     const fetchCart = when("should-fetch-cart", { input }, ({ input }) => {
       return !input.cart
     }).then(() => {
@@ -124,6 +127,20 @@ export const updateCartPromotionsWorkflow = createWorkflow(
       return data.input.action || PromotionActions.ADD
     })
 
+    const setPromotionContext = createHook(
+      "setPromotionContext",
+      {
+        cart,
+        action,
+        promo_codes,
+        additional_data: input.additional_data,
+      },
+      {
+        resultValidator: promotionContextResult,
+      }
+    )
+    const setPromotionContextResult = setPromotionContext.getResult()
+
     const promotionCodesToApply = getPromotionCodesToApply({
       cart: cart,
       promo_codes,
@@ -133,6 +150,7 @@ export const updateCartPromotionsWorkflow = createWorkflow(
     const actions = getActionsToComputeFromPromotionsStep({
       computeActionContext: cart,
       promotionCodesToApply,
+      setPromotionContextResult,
     })
 
     const {
@@ -173,7 +191,7 @@ export const updateCartPromotionsWorkflow = createWorkflow(
     })
 
     return new WorkflowResponse(void 0, {
-      hooks: [validate],
+      hooks: [validate, setPromotionContext] as const,
     })
   }
 )

--- a/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
@@ -80,7 +80,7 @@ export const updateCartPromotionsWorkflowId = "update-cart-promotions"
  * Update a cart's applied promotions to add, replace, or remove them.
  *
  * @property hooks.validate - This hook is executed before all operations. You can consume this hook to perform any custom validation. If validation fails, you can throw an error to stop the workflow execution.
- * @property hooks.setPromotionContext - This hook is executed after the cart is fetched and before promotion rules are evaluated. You can consume this hook to return any custom context useful for promotion rule evaluation. The returned object is merged on top of the cart context (consumer values win on key conflict).
+ * @property hooks.setPromotionContext - This hook is executed after the cart is fetched and before promotion rules are evaluated. You can consume this hook to add custom rules that determine whether a promotion is applied. The returned object is merged on top of the cart context, allowing you to override existing context.
  */
 export const updateCartPromotionsWorkflow = createWorkflow(
   {

--- a/packages/core/core-flows/src/draft-order/workflows/compute-draft-order-adjustments.ts
+++ b/packages/core/core-flows/src/draft-order/workflows/compute-draft-order-adjustments.ts
@@ -8,7 +8,6 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import type {
-  AdditionalData,
   OrderChangeDTO,
   OrderDTO,
   PromotionDTO,
@@ -68,11 +67,7 @@ export interface ComputeDraftOrderAdjustmentsWorkflowInput {
  */
 export const computeDraftOrderAdjustmentsWorkflow = createWorkflow(
   computeDraftOrderAdjustmentsWorkflowId,
-  function (
-    input: WorkflowData<
-      ComputeDraftOrderAdjustmentsWorkflowInput & AdditionalData
-    >
-  ) {
+  function (input: WorkflowData<ComputeDraftOrderAdjustmentsWorkflowInput>) {
     acquireLockStep({
       key: input.order_id,
       timeout: 2,
@@ -108,7 +103,6 @@ export const computeDraftOrderAdjustmentsWorkflow = createWorkflow(
       {
         order,
         orderChange,
-        additional_data: input.additional_data,
       },
       {
         resultValidator: promotionContextResult,

--- a/packages/core/core-flows/src/draft-order/workflows/compute-draft-order-adjustments.ts
+++ b/packages/core/core-flows/src/draft-order/workflows/compute-draft-order-adjustments.ts
@@ -1,5 +1,6 @@
 import { ChangeActionType, OrderChangeStatus } from "@medusajs/framework/utils"
 import {
+  createHook,
   createWorkflow,
   transform,
   when,
@@ -7,6 +8,7 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import type {
+  AdditionalData,
   OrderChangeDTO,
   OrderDTO,
   PromotionDTO,
@@ -15,6 +17,7 @@ import {
   getActionsToComputeFromPromotionsStep,
   prepareAdjustmentsFromPromotionActionsStep,
 } from "../../cart"
+import { promotionContextResult } from "../../cart/utils/schemas"
 import { createOrderChangeActionsWorkflow } from "../../order/workflows/create-order-change-actions"
 import { previewOrderChangeStep } from "../../order/steps/preview-order-change"
 import { validateDraftOrderChangeStep } from "../steps/validate-draft-order-change"
@@ -60,10 +63,16 @@ export interface ComputeDraftOrderAdjustmentsWorkflowInput {
  * @summary
  *
  * Refresh the promotions in a draft order.
+ *
+ * @property hooks.setPromotionContext - This hook is executed before promotion rules are evaluated for the draft order. You can consume this hook to return any custom context that should be merged on top of the order context when evaluating promotion rules (e.g. `company.id`, `custom_tier`).
  */
 export const computeDraftOrderAdjustmentsWorkflow = createWorkflow(
   computeDraftOrderAdjustmentsWorkflowId,
-  function (input: WorkflowData<ComputeDraftOrderAdjustmentsWorkflowInput>) {
+  function (
+    input: WorkflowData<
+      ComputeDraftOrderAdjustmentsWorkflowInput & AdditionalData
+    >
+  ) {
     acquireLockStep({
       key: input.order_id,
       timeout: 2,
@@ -93,6 +102,19 @@ export const computeDraftOrderAdjustmentsWorkflow = createWorkflow(
     }).config({ name: "order-change-query" })
 
     validateDraftOrderChangeStep({ order, orderChange })
+
+    const setPromotionContext = createHook(
+      "setPromotionContext",
+      {
+        order,
+        orderChange,
+        additional_data: input.additional_data,
+      },
+      {
+        resultValidator: promotionContextResult,
+      }
+    )
+    const setPromotionContextResult = setPromotionContext.getResult()
 
     const toDeleteActions = transform(orderChange, (orderChange) => {
       return orderChange.actions
@@ -156,6 +178,7 @@ export const computeDraftOrderAdjustmentsWorkflow = createWorkflow(
       const actions = getActionsToComputeFromPromotionsStep({
         computeActionContext: actionsToComputeItemsInput,
         promotionCodesToApply: orderPromotions,
+        setPromotionContextResult,
       })
 
       const { lineItemAdjustmentsToCreate } =
@@ -202,6 +225,8 @@ export const computeDraftOrderAdjustmentsWorkflow = createWorkflow(
       key: input.order_id,
     })
 
-    return new WorkflowResponse(void 0)
+    return new WorkflowResponse(void 0, {
+      hooks: [setPromotionContext] as const,
+    })
   }
 )

--- a/packages/core/core-flows/src/draft-order/workflows/compute-draft-order-adjustments.ts
+++ b/packages/core/core-flows/src/draft-order/workflows/compute-draft-order-adjustments.ts
@@ -172,7 +172,7 @@ export const computeDraftOrderAdjustmentsWorkflow = createWorkflow(
       const actions = getActionsToComputeFromPromotionsStep({
         computeActionContext: actionsToComputeItemsInput,
         promotionCodesToApply: orderPromotions,
-        setPromotionContextResult,
+        additional_promotion_context: setPromotionContextResult,
       })
 
       const { lineItemAdjustmentsToCreate } =

--- a/packages/core/core-flows/src/draft-order/workflows/refresh-draft-order-adjustments.ts
+++ b/packages/core/core-flows/src/draft-order/workflows/refresh-draft-order-adjustments.ts
@@ -115,7 +115,7 @@ export const refreshDraftOrderAdjustmentsWorkflow = createWorkflow(
     const actions = getActionsToComputeFromPromotionsStep({
       computeActionContext: input.order as any,
       promotionCodesToApply,
-      setPromotionContextResult,
+      additional_promotion_context: setPromotionContextResult,
     })
 
     const {

--- a/packages/core/core-flows/src/draft-order/workflows/refresh-draft-order-adjustments.ts
+++ b/packages/core/core-flows/src/draft-order/workflows/refresh-draft-order-adjustments.ts
@@ -6,7 +6,7 @@ import {
   WorkflowData,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
-import type { AdditionalData, OrderDTO } from "@medusajs/framework/types"
+import type { OrderDTO } from "@medusajs/framework/types"
 import {
   getActionsToComputeFromPromotionsStep,
   getPromotionCodesToApply,
@@ -86,11 +86,7 @@ export interface RefreshDraftOrderAdjustmentsWorkflowInput {
  */
 export const refreshDraftOrderAdjustmentsWorkflow = createWorkflow(
   refreshDraftOrderAdjustmentsWorkflowId,
-  function (
-    input: WorkflowData<
-      RefreshDraftOrderAdjustmentsWorkflowInput & AdditionalData
-    >
-  ) {
+  function (input: WorkflowData<RefreshDraftOrderAdjustmentsWorkflowInput>) {
     acquireLockStep({
       key: input.order.id,
       timeout: 2,
@@ -103,7 +99,6 @@ export const refreshDraftOrderAdjustmentsWorkflow = createWorkflow(
         order: input.order,
         promo_codes: input.promo_codes,
         action: input.action,
-        additional_data: input.additional_data,
       },
       {
         resultValidator: promotionContextResult,

--- a/packages/core/core-flows/src/draft-order/workflows/refresh-draft-order-adjustments.ts
+++ b/packages/core/core-flows/src/draft-order/workflows/refresh-draft-order-adjustments.ts
@@ -1,16 +1,18 @@
 import { PromotionActions } from "@medusajs/framework/utils"
 import {
+  createHook,
   createWorkflow,
   parallelize,
   WorkflowData,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
-import type { OrderDTO } from "@medusajs/framework/types"
+import type { AdditionalData, OrderDTO } from "@medusajs/framework/types"
 import {
   getActionsToComputeFromPromotionsStep,
   getPromotionCodesToApply,
   prepareAdjustmentsFromPromotionActionsStep,
 } from "../../cart"
+import { promotionContextResult } from "../../cart/utils/schemas"
 import { createDraftOrderLineItemAdjustmentsStep } from "../steps/create-draft-order-line-item-adjustments"
 import { createDraftOrderShippingMethodAdjustmentsStep } from "../steps/create-draft-order-shipping-method-adjustments"
 import { removeDraftOrderLineItemAdjustmentsStep } from "../steps/remove-draft-order-line-item-adjustments"
@@ -79,15 +81,35 @@ export interface RefreshDraftOrderAdjustmentsWorkflowInput {
  * @summary
  *
  * Refresh the promotions in a draft order.
+ *
+ * @property hooks.setPromotionContext - This hook is executed before promotion rules are evaluated for the draft order. You can consume this hook to return any custom context that should be merged on top of the order context when evaluating promotion rules (e.g. `company.id`, `custom_tier`).
  */
 export const refreshDraftOrderAdjustmentsWorkflow = createWorkflow(
   refreshDraftOrderAdjustmentsWorkflowId,
-  function (input: WorkflowData<RefreshDraftOrderAdjustmentsWorkflowInput>) {
+  function (
+    input: WorkflowData<
+      RefreshDraftOrderAdjustmentsWorkflowInput & AdditionalData
+    >
+  ) {
     acquireLockStep({
       key: input.order.id,
       timeout: 2,
       ttl: 10,
     })
+
+    const setPromotionContext = createHook(
+      "setPromotionContext",
+      {
+        order: input.order,
+        promo_codes: input.promo_codes,
+        action: input.action,
+        additional_data: input.additional_data,
+      },
+      {
+        resultValidator: promotionContextResult,
+      }
+    )
+    const setPromotionContextResult = setPromotionContext.getResult()
 
     const promotionCodesToApply = getPromotionCodesToApply({
       cart: input.order,
@@ -98,6 +120,7 @@ export const refreshDraftOrderAdjustmentsWorkflow = createWorkflow(
     const actions = getActionsToComputeFromPromotionsStep({
       computeActionContext: input.order as any,
       promotionCodesToApply,
+      setPromotionContextResult,
     })
 
     const {
@@ -134,6 +157,8 @@ export const refreshDraftOrderAdjustmentsWorkflow = createWorkflow(
       key: input.order.id,
     })
 
-    return new WorkflowResponse(void 0)
+    return new WorkflowResponse(void 0, {
+      hooks: [setPromotionContext] as const,
+    })
   }
 )

--- a/packages/core/core-flows/src/order/workflows/compute-adjustments-for-preview.ts
+++ b/packages/core/core-flows/src/order/workflows/compute-adjustments-for-preview.ts
@@ -1,19 +1,23 @@
 import {
+  AdditionalData,
   OrderChangeDTO,
   OrderDTO,
   PromotionDTO,
 } from "@medusajs/framework/types"
 import { ChangeActionType } from "@medusajs/framework/utils"
 import {
+  createHook,
   createWorkflow,
   transform,
   when,
   WorkflowData,
+  WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import {
   getActionsToComputeFromPromotionsStep,
   prepareAdjustmentsFromPromotionActionsStep,
 } from "../../cart"
+import { promotionContextResult } from "../../cart/utils/schemas"
 import { previewOrderChangeStep } from "../steps/preview-order-change"
 import { createOrderChangeActionsWorkflow } from "./create-order-change-actions"
 import {
@@ -76,11 +80,31 @@ export const computeAdjustmentsForPreviewWorkflowId =
  * @summary
  *
  * Compute adjustments for an order edit, exchange, claim, or return.
+ *
+ * @property hooks.setPromotionContext - This hook is executed before promotion rules are evaluated for the previewed order. You can consume this hook to return any custom context that should be merged on top of the order context when evaluating promotion rules (e.g. `company.id`, `custom_tier`).
  */
 export const computeAdjustmentsForPreviewWorkflow = createWorkflow(
   computeAdjustmentsForPreviewWorkflowId,
-  function (input: WorkflowData<ComputeAdjustmentsForPreviewWorkflowInput>) {
+  function (
+    input: WorkflowData<
+      ComputeAdjustmentsForPreviewWorkflowInput & AdditionalData
+    >
+  ) {
     const previewedOrder = previewOrderChangeStep(input.order.id)
+
+    const setPromotionContext = createHook(
+      "setPromotionContext",
+      {
+        order: input.order,
+        orderChange: input.orderChange,
+        previewedOrder,
+        additional_data: input.additional_data,
+      },
+      {
+        resultValidator: promotionContextResult,
+      }
+    )
+    const setPromotionContextResult = setPromotionContext.getResult()
 
     when(
       { order: input.order, orderChange: input.orderChange },
@@ -107,6 +131,7 @@ export const computeAdjustmentsForPreviewWorkflow = createWorkflow(
         options: {
           skip_usage_limit_checks: true,
         },
+        setPromotionContextResult,
       })
 
       const { lineItemAdjustmentsToCreate, shippingMethodAdjustmentsToCreate } =
@@ -202,6 +227,10 @@ export const computeAdjustmentsForPreviewWorkflow = createWorkflow(
       )
 
       deleteOrderChangeActionsStep({ ids: allActionIds })
+    })
+
+    return new WorkflowResponse(void 0, {
+      hooks: [setPromotionContext] as const,
     })
   }
 )

--- a/packages/core/core-flows/src/order/workflows/compute-adjustments-for-preview.ts
+++ b/packages/core/core-flows/src/order/workflows/compute-adjustments-for-preview.ts
@@ -125,7 +125,7 @@ export const computeAdjustmentsForPreviewWorkflow = createWorkflow(
         options: {
           skip_usage_limit_checks: true,
         },
-        setPromotionContextResult,
+        additional_promotion_context: setPromotionContextResult,
       })
 
       const { lineItemAdjustmentsToCreate, shippingMethodAdjustmentsToCreate } =

--- a/packages/core/core-flows/src/order/workflows/compute-adjustments-for-preview.ts
+++ b/packages/core/core-flows/src/order/workflows/compute-adjustments-for-preview.ts
@@ -1,5 +1,4 @@
 import {
-  AdditionalData,
   OrderChangeDTO,
   OrderDTO,
   PromotionDTO,
@@ -85,11 +84,7 @@ export const computeAdjustmentsForPreviewWorkflowId =
  */
 export const computeAdjustmentsForPreviewWorkflow = createWorkflow(
   computeAdjustmentsForPreviewWorkflowId,
-  function (
-    input: WorkflowData<
-      ComputeAdjustmentsForPreviewWorkflowInput & AdditionalData
-    >
-  ) {
+  function (input: WorkflowData<ComputeAdjustmentsForPreviewWorkflowInput>) {
     const previewedOrder = previewOrderChangeStep(input.order.id)
 
     const setPromotionContext = createHook(
@@ -98,7 +93,6 @@ export const computeAdjustmentsForPreviewWorkflow = createWorkflow(
         order: input.order,
         orderChange: input.orderChange,
         previewedOrder,
-        additional_data: input.additional_data,
       },
       {
         resultValidator: promotionContextResult,


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Introduce a new `setPromotionContext` hook that can be used to inject additional context for promotion rule evaluation.

**Why** — Why are these changes relevant or necessary?  

You are not able to pass additional context, like custom module fields and other customizations and end up having to use `cart.metadata` as a workaround, which forces you to keep the cart in sync with whatever logic you've defined to set/unset these additional context fields.

**How** — How have these changes been implemented?

Introduce a new `setPromotionContext` hook, that passes down `setPromotionContextResult` and merges it with the base context to be consumed by the Promotions engine.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

To test, you can consume the hook and define a promotion with custom rules like below:

```ts
// in src/workflows/hooks/test-promotion.ts
import { StepResponse } from "@medusajs/framework/workflows-sdk";
import { updateCartPromotionsWorkflow } from "@medusajs/medusa/core-flows";

updateCartPromotionsWorkflow.hooks.setPromotionContext(
  ({ cart }, { container }) => {
    if (cart.items.length >= 2) {
      return new StepResponse({
        foo: true,
      });
    }
  }
);

// in src/scripts/test-promotion.ts
import { ExecArgs } from "@medusajs/framework/types"; 

export default async function test({ container }: ExecArgs) {
  await createPromotionsWorkflow(container).run({
    input: {
      promotionsData: [
        {
          code: "test-context",
          type: "standard",
          status: "active",
          application_method: {
            type: "percentage",
            target_type: "order",
            value: 10,
            currency_code: "eur",
          },
          is_automatic: true,
          rules: [
            {
              attribute: "foo",
              operator: "eq",
              values: "true",
            },
          ],
        },
      ],
    },
  });
}

```

Then in the storefront, notice how after adding two different line items, the promotion is automatically applied. Decreasing the line items to 1 removes the promotion as the promotion context now doesn't set the custom property.
