### PR TITLE
Fix/index pagination count

### DIFF
--- a/.changeset/fix-index-pagination-count.md
+++ b/.changeset/fix-index-pagination-count.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/index": patch
+---
+
+fix(index): update query builder to perform exact record counts instead of estimations

--- a/packages/modules/index/src/utils/query-builder.ts
+++ b/packages/modules/index/src/utils/query-builder.ts
@@ -988,7 +988,7 @@ export class QueryBuilder {
       innerQueryBuilder.orderBy(`${rootAlias}.id`, "ASC")
     }
 
-    // Count query to estimate the number of results in parallel
+    // Count query to get the exact number of results in parallel
     let countQuery: Knex.Raw | undefined
     if (hasCount) {
       const estimateQuery = innerQueryBuilder.clone()
@@ -997,8 +997,7 @@ export class QueryBuilder {
       estimateQuery.clearCounters()
 
       countQuery = this.knex.raw(
-        `SELECT count_estimate(?) AS estimate_count`,
-        estimateQuery.toQuery()
+        `SELECT COUNT(*) AS estimate_count FROM (${estimateQuery.toQuery()}) AS count_subquery`
       )
     }
 


### PR DESCRIPTION
**What** - Update query builder to use `COUNT(*)` instead of estimations

**Why** - Fixes a bug where `index_engine` returns wildly inaccurate total counts for small tables with filters, breaking pagination in the Admin UI.

**How** - Modified `countQuery` in `@medusajs/index query` builder to use an exact count subquery instead of the `EXPLAIN`-based `count_estimate()` PostgreSQL function.

**Testing** - Tested locally; Admin UI pagination now displays correctly with `index_engine: true`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching from `count_estimate()` to an exact `COUNT(*)` subquery fixes incorrect pagination totals but can increase query cost on large/complex filtered datasets.
> 
> **Overview**
> Fixes pagination total counts produced by the index query builder by replacing the `count_estimate()`-based count with an exact `COUNT(*)` over the unpaginated inner query.
> 
> Adds a patch changeset for `@medusajs/index` reflecting the updated count behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337bc48e9c5d3a638dfe623ce4279007f2575042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->