### PR TITLE
docs: add TSDocs for "align product and variant volumetric attributes data types ("

### DIFF
--- a/packages/modules/product/src/models/product-variant.ts
+++ b/packages/modules/product/src/models/product-variant.ts
@@ -2,30 +2,90 @@ import { model } from "@medusajs/framework/utils"
 import { Product, ProductImage, ProductOptionValue } from "@models"
 import ProductVariantProductImage from "./product-variant-product-image"
 
+/**
+ * The product variant model represents a variant of a product. Each product can have multiple variants.
+ */
 const ProductVariant = model
   .define("ProductVariant", {
+    /**
+     * The variant's ID.
+     */
     id: model.id({ prefix: "variant" }).primaryKey(),
+    /**
+     * The variant's title.
+     */
     title: model.text().searchable().translatable(),
+    /**
+     * The variant's SKU (Stock Keeping Unit).
+     */
     sku: model.text().searchable().nullable(),
+    /**
+     * The variant's barcode.
+     */
     barcode: model.text().searchable().nullable(),
+    /**
+     * The variant's EAN (European Article Number).
+     */
     ean: model.text().searchable().nullable(),
+    /**
+     * The variant's UPC (Universal Product Code).
+     */
     upc: model.text().searchable().nullable(),
+    /**
+     * Whether the variant allows backorders when it's out of stock.
+     */
     allow_backorder: model.boolean().default(false),
+    /**
+     * Whether inventory should be managed for this variant.
+     */
     manage_inventory: model.boolean().default(true),
+    /**
+     * The variant's HS (Harmonized System) code for customs and tariff purposes.
+     */
     hs_code: model.text().nullable(),
+    /**
+     * The variant's country of origin.
+     */
     origin_country: model.text().nullable(),
+    /**
+     * The variant's MID code.
+     */
     mid_code: model.text().nullable(),
+    /**
+     * The variant's material description.
+     */
     material: model.text().translatable().nullable(),
+    /**
+     * The variant's weight.
+     */
     weight: model.float().nullable(),
+    /**
+     * The variant's length.
+     */
     length: model.float().nullable(),
+    /**
+     * The variant's height.
+     */
     height: model.float().nullable(),
+    /**
+     * The variant's width.
+     */
     width: model.float().nullable(),
+    /**
+     * The variant's metadata.
+     */
     metadata: model.json().nullable(),
+    /**
+     * The variant's ranking order within its product.
+     */
     variant_rank: model.number().default(0).nullable(),
     /**
      * @since 2.11.2
      */
     thumbnail: model.text().nullable(),
+    /**
+     * The product this variant belongs to.
+     */
     product: model
       .belongsTo(() => Product, {
         mappedBy: "variants",
@@ -39,6 +99,9 @@ const ProductVariant = model
       mappedBy: "variants",
       pivotEntity: () => ProductVariantProductImage,
     }),
+    /**
+     * The option values associated with this variant.
+     */
     options: model.manyToMany(() => ProductOptionValue, {
       pivotTable: "product_variant_option",
       mappedBy: "variants",

--- a/packages/modules/product/src/models/product.ts
+++ b/packages/modules/product/src/models/product.ts
@@ -13,6 +13,9 @@ import ProductVariant from "./product-variant"
  */
 const Product = model
   .define("Product", {
+    /**
+     * The product's ID.
+     */
     id: model.id({ prefix: "prod" }).primaryKey(),
     /**
      * The product's display title.


### PR DESCRIPTION
## Automated TSDoc Additions

This PR adds TSDoc comments to TypeScript source files changed in commit [`34f326d`](https://github.com/medusajs/medusa/commit/34f326d729aa9e1bafd6ef644ccb47621bf2a14e).

**Triggered by:** fix(product, dashboard): align product and variant volumetric attributes data types (#14762)

**Files updated:**
- `packages/modules/product/src/models/product-variant.ts`
- `packages/modules/product/src/models/product.ts`

> Review carefully before merging. Claude may have missed context or used incorrect descriptions.