### PR TITLE
docs: add TSDocs for "add setPromotionContext hook to pass additional context for "

### DIFF
--- a/packages/core/core-flows/src/cart/utils/schemas.ts
+++ b/packages/core/core-flows/src/cart/utils/schemas.ts
@@ -1,4 +1,18 @@
 import { z } from "@medusajs/framework/zod"
+
+/**
+ * Schema for validating pricing context result data.
+ */
 export const pricingContextResult = z.record(z.string(), z.any()).optional()
+
+/**
+ * Schema for validating shipping options context result data.
+ */
 export const shippingOptionsContextResult = z.record(z.string(), z.any()).optional()
+
+/**
+ * Schema for validating promotion context result data.
+ *
+ * @since 2.14.3
+ */
 export const promotionContextResult = z.record(z.string(), z.any()).optional()


### PR DESCRIPTION
## Automated TSDoc Additions

This PR adds TSDoc comments to TypeScript source files changed in commit [`8539bc7`](https://github.com/medusajs/medusa/commit/8539bc71a554ba0dd6bc48511aa980d93d3f2664).

**Triggered by:** feat(core-flows): add setPromotionContext hook to pass additional context for promotion computation (#15301)

**Files updated:**
- `packages/core/core-flows/src/cart/steps/get-actions-to-compute-from-promotions.ts`
- `packages/core/core-flows/src/cart/utils/schemas.ts`
- `packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts`
- `packages/core/core-flows/src/draft-order/workflows/compute-draft-order-adjustments.ts`
- `packages/core/core-flows/src/draft-order/workflows/refresh-draft-order-adjustments.ts`
- `packages/core/core-flows/src/order/workflows/compute-adjustments-for-preview.ts`

> Review carefully before merging. Claude may have missed context or used incorrect descriptions.