### PR TITLE
fix(order): fix regression on order.items.metadata showing null when line item metadata is set

### DIFF
--- a/.changeset/mighty-candies-sleep.md
+++ b/.changeset/mighty-candies-sleep.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/order": patch
+---
+
+fix(order): fix regression on order.items.metadata showing null when line item metadata is set

--- a/packages/modules/order/src/services/__tests__/util/transform-order.spec.ts
+++ b/packages/modules/order/src/services/__tests__/util/transform-order.spec.ts
@@ -1,0 +1,104 @@
+import { formatOrder } from "../../../utils/transform-order"
+
+// Minimal raw shape that comes back from the ORM before formatOrder transforms it:
+// order.items[] are OrderItem records, each with an `item` property (OrderLineItem).
+function makeRawOrder({
+  orderItemMetadata,
+  lineItemMetadata,
+}: {
+  orderItemMetadata: Record<string, unknown> | null
+  lineItemMetadata: Record<string, unknown> | null
+}) {
+  return {
+    id: "order_1",
+    items: [
+      {
+        // OrderItem (order_item table)
+        id: "orditem_1",
+        version: 1,
+        order_id: "order_1",
+        item_id: "ordli_1",
+        quantity: 1,
+        unit_price: 10,
+        compare_at_unit_price: null,
+        fulfilled_quantity: 0,
+        delivered_quantity: 0,
+        shipped_quantity: 0,
+        return_requested_quantity: 0,
+        return_received_quantity: 0,
+        return_dismissed_quantity: 0,
+        written_off_quantity: 0,
+        metadata: orderItemMetadata,
+        // OrderLineItem (order_line_item table)
+        item: {
+          id: "ordli_1",
+          title: "Test Product",
+          unit_price: 10,
+          compare_at_unit_price: null,
+          quantity: 1,
+          metadata: lineItemMetadata,
+          tax_lines: [],
+          adjustments: [],
+        },
+      },
+    ],
+    shipping_methods: [],
+    summary: null,
+  }
+}
+
+// Pass a plain object so toMikroORMEntity returns it as-is with name "Order",
+// making isRelatedEntity = false (the normal order retrieval path).
+const orderEntity = { name: "Order" }
+
+describe("formatOrder: item metadata resolution", function () {
+  it("should fall back to order_line_item metadata when order_item metadata is null", function () {
+    const lineItemMetadata = { source: "line_item", key: "value" }
+
+    const rawOrder = makeRawOrder({
+      orderItemMetadata: null, // default DB value — not explicitly set
+      lineItemMetadata,
+    })
+
+    const result = formatOrder(rawOrder, { entity: orderEntity }) as any
+
+    expect(result.items[0].metadata).toEqual(lineItemMetadata)
+  })
+
+  it("should use order_item metadata when it has been explicitly set", function () {
+    const orderItemMetadata = { source: "order_item", updated: true }
+    const lineItemMetadata = { source: "line_item", key: "value" }
+
+    const rawOrder = makeRawOrder({ orderItemMetadata, lineItemMetadata })
+
+    const result = formatOrder(rawOrder, { entity: orderEntity }) as any
+
+    expect(result.items[0].metadata).toEqual(orderItemMetadata)
+  })
+
+  it("should use null when both order_item and order_line_item metadata are null", function () {
+    const rawOrder = makeRawOrder({
+      orderItemMetadata: null,
+      lineItemMetadata: null,
+    })
+
+    const result = formatOrder(rawOrder, { entity: orderEntity }) as any
+
+    expect(result.items[0].metadata).toBeNull()
+  })
+
+  it("should place the OrderItem record in items[].detail", function () {
+    const rawOrder = makeRawOrder({
+      orderItemMetadata: null,
+      lineItemMetadata: null,
+    })
+
+    const result = formatOrder(rawOrder, { entity: orderEntity }) as any
+    const item = result.items[0]
+
+    expect(item.detail).toBeDefined()
+    expect(item.detail.fulfilled_quantity).toBeDefined()
+    expect(item.id).toBe("ordli_1") // top-level id is from OrderLineItem
+    expect(item.detail.id).toBe("orditem_1") // detail id is from OrderItem
+  })
+})

--- a/packages/modules/order/src/utils/transform-order.ts
+++ b/packages/modules/order/src/utils/transform-order.ts
@@ -55,9 +55,7 @@ export function formatOrder<T = any>(
         raw_compare_at_unit_price:
           detail.raw_compare_at_unit_price ??
           orderItem.item.raw_compare_at_unit_price,
-        metadata: isDefined(detail.metadata)
-          ? detail.metadata
-          : orderItem.item.metadata,
+        metadata: detail.metadata ?? orderItem.item.metadata,
         detail,
       }
     })


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fix the regression introduced in #14570. Among the things introduced by the PR, was the ability to update the metadata for order items when performing order edits. Order line item is a snapshot containing several pieces of product information and this is what gets its metadata generally set on creation; order item on the other hand, is the versioned item that follows changes to several quantity/price fields and on creation won't have metadata set and rather, it should obtain it from order line item.

The regression was checking `isDefined` on the order item metadata to decide if keeping it or coalescing to the order line item. Since `null` returns true for this check, the `formatOrder` then returns `null` instead of whatever the user set for the order line item metadata. Unless they create an order edit where they specifically update the order item metadata, they will keep receiving this result.

**Why** — Why are these changes relevant or necessary?  

By removing the `isDefined` check and adding the coalesce operator, we know return the order line item's metadata if the order item metadata is null, having the same behavior as before.

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
