### PR TITLE
 chore(workflow-engine-redis): fix flaky tests by isolating job and queues between specs

### DIFF
--- a/.changeset/brown-tigers-relate.md
+++ b/.changeset/brown-tigers-relate.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/workflow-engine-redis": patch
+---
+
+chore(workflow-engine-redis): fix flaky tests by isolating job and queues between specs

--- a/packages/modules/workflow-engine-redis/integration-tests/__tests__/index.spec.ts
+++ b/packages/modules/workflow-engine-redis/integration-tests/__tests__/index.spec.ts
@@ -88,12 +88,20 @@ function times(num) {
 
 // REF:https://stackoverflow.com/questions/78028715/jest-async-test-with-event-emitter-isnt-ending
 
+const testRunId = ulid()
+
 moduleIntegrationTestRunner<IWorkflowEngineService>({
   moduleName: Modules.WORKFLOW_ENGINE,
   resolve: __dirname + "/../..",
   moduleOptions: {
     redis: {
       url: "localhost:6379",
+      queueName: `medusa-workflows-${
+        process.env.JEST_WORKER_ID ?? "1"
+      }-${testRunId}`,
+      jobQueueName: `medusa-workflows-jobs-${
+        process.env.JEST_WORKER_ID ?? "1"
+      }-${testRunId}`,
     },
   },
   testSuite: ({ service: workflowOrcModule, medusaApp }) => {

--- a/packages/modules/workflow-engine-redis/integration-tests/__tests__/race.spec.ts
+++ b/packages/modules/workflow-engine-redis/integration-tests/__tests__/race.spec.ts
@@ -16,12 +16,20 @@ import { TestDatabase } from "../utils/database"
 
 jest.setTimeout(20000)
 
+const testRunId = ulid()
+
 moduleIntegrationTestRunner<IWorkflowEngineService>({
   moduleName: Modules.WORKFLOW_ENGINE,
   resolve: __dirname + "/../..",
   moduleOptions: {
     redis: {
       url: "localhost:6379",
+      queueName: `medusa-workflows-${
+        process.env.JEST_WORKER_ID ?? "1"
+      }-${testRunId}`,
+      jobQueueName: `medusa-workflows-jobs-${
+        process.env.JEST_WORKER_ID ?? "1"
+      }-${testRunId}`,
     },
   },
   testSuite: ({ service: workflowOrcModule, medusaApp }) => {

--- a/packages/modules/workflow-engine-redis/integration-tests/__tests__/retry-interval.spec.ts
+++ b/packages/modules/workflow-engine-redis/integration-tests/__tests__/retry-interval.spec.ts
@@ -9,6 +9,7 @@
 import { IWorkflowEngineService } from "@medusajs/framework/types"
 import { Modules } from "@medusajs/framework/utils"
 import { moduleIntegrationTestRunner } from "@medusajs/test-utils"
+import { ulid } from "ulid"
 import {
   retryIntervalStep1InvokeMock,
   retryIntervalStep2InvokeMock,
@@ -24,12 +25,20 @@ import { TestDatabase } from "../utils"
 
 jest.setTimeout(60000) // Increase timeout for async retries
 
+const testRunId = ulid()
+
 moduleIntegrationTestRunner<IWorkflowEngineService>({
   moduleName: Modules.WORKFLOW_ENGINE,
   resolve: __dirname + "/../..",
   moduleOptions: {
     redis: {
       url: "localhost:6379",
+      queueName: `medusa-workflows-${
+        process.env.JEST_WORKER_ID ?? "1"
+      }-${testRunId}`,
+      jobQueueName: `medusa-workflows-jobs-${
+        process.env.JEST_WORKER_ID ?? "1"
+      }-${testRunId}`,
     },
   },
   testSuite: ({ service: workflowOrcModule }) => {


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Set unique BullMQ queueName and jobQueueName per Jest invocation in the three workflow-engine-redis integration test files (index.spec.ts, race.spec.ts, retry-interval.spec.ts)

**Why** — Why are these changes relevant or necessary?  

Fixes long-standing flakiness in race.spec.ts > should manage saving multiple async steps in concurrency. The default queue name medusa-workflows was shared across the sequential Jest invocations chained by test:integration. Combined with --forceExit and the fact that init-modules skips onApplicationPrepareShutdown when a shared PG connection is provided, BullMQ jobs scheduled by an earlier file (e.g. workflow_1_auto_retries) would survive into the next file. The new Worker would pick them up, snowball retries on a concurrency-1 queue, and the test's own jobs would wait past the 20s timeout.

**How** — How have these changes been implemented?

Each spec defines unique names for the queues, removing the problem where jobs from the previous spec would interfere with the current one.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
