### PR TITLE
docs: add TSDocs for "validate cart has items before completing (#15231)"

### DIFF
--- a/packages/core/core-flows/src/cart/steps/validate-cart-items.ts
+++ b/packages/core/core-flows/src/cart/steps/validate-cart-items.ts
@@ -2,10 +2,23 @@ import type { CartWorkflowDTO } from "@medusajs/framework/types"
 import { MedusaError } from "@medusajs/framework/utils"
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 
+/**
+ * The input for the validate cart items step.
+ *
+ * @since 2.14.3
+ */
 export interface ValidateCartItemsStepInput {
+  /**
+   * The cart to validate.
+   */
   cart: CartWorkflowDTO
 }
 
+/**
+ * The ID of the validate cart items step.
+ *
+ * @since 2.14.3
+ */
 export const validateCartItemsStepId = "validate-cart-items"
 /**
  * This step validates that a cart has at least one line item before
@@ -16,6 +29,8 @@ export const validateCartItemsStepId = "validate-cart-items"
  * validateCartItemsStep({
  *   cart
  * })
+ *
+ * @since 2.14.3
  */
 export const validateCartItemsStep = createStep(
   validateCartItemsStepId,


### PR DESCRIPTION
## Automated TSDoc Additions

This PR adds TSDoc comments to TypeScript source files changed in commit [`7747d05`](https://github.com/medusajs/medusa/commit/7747d0510b24bcce5e68bf32236559d809dabdee).

**Triggered by:** fix(core-flows): validate cart has items before completing (#15231)

**Files updated:**
- `packages/core/core-flows/src/cart/steps/index.ts`
- `packages/core/core-flows/src/cart/steps/validate-cart-items.ts`
- `packages/core/core-flows/src/cart/workflows/complete-cart.ts`

> Review carefully before merging. Claude may have missed context or used incorrect descriptions.