### PR TITLE
fix(dashboard): allow empty currency selection

### DIFF
--- a/.changeset/fix-add-currencies-empty-selection.md
+++ b/.changeset/fix-add-currencies-empty-selection.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): allow saving store currency preferences without new currency selections

--- a/packages/admin/dashboard/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.schema.spec.ts
+++ b/packages/admin/dashboard/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.schema.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { AddCurrenciesSchema } from "./add-currencies-form.schema"
+
+describe("AddCurrenciesSchema", () => {
+  it("allows saving without selecting new currencies", () => {
+    expect(() =>
+      AddCurrenciesSchema.parse({
+        currencies: [],
+        pricePreferences: {
+          eur: true,
+        },
+      })
+    ).not.toThrow()
+  })
+
+  it("accepts selected currencies", () => {
+    expect(
+      AddCurrenciesSchema.parse({
+        currencies: ["usd"],
+        pricePreferences: {
+          usd: false,
+        },
+      })
+    ).toEqual({
+      currencies: ["usd"],
+      pricePreferences: {
+        usd: false,
+      },
+    })
+  })
+})

--- a/packages/admin/dashboard/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.schema.ts
+++ b/packages/admin/dashboard/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.schema.ts
@@ -1,0 +1,6 @@
+import * as zod from "zod"
+
+export const AddCurrenciesSchema = zod.object({
+  currencies: zod.array(zod.string()),
+  pricePreferences: zod.record(zod.string(), zod.boolean()),
+})

--- a/packages/admin/dashboard/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.tsx
+++ b/packages/admin/dashboard/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.tsx
@@ -25,16 +25,12 @@ import { useDataTable } from "../../../../../hooks/use-data-table"
 import { queryClient } from "../../../../../lib/query-client"
 import { useCurrenciesTableColumns } from "../../../common/hooks/use-currencies-table-columns"
 import { useCurrenciesTableQuery } from "../../../common/hooks/use-currencies-table-query"
+import { AddCurrenciesSchema } from "./add-currencies-form.schema"
 
 type AddCurrenciesFormProps = {
   store: HttpTypes.AdminStore
   pricePreferences: HttpTypes.AdminPricePreference[]
 }
-
-const AddCurrenciesSchema = zod.object({
-  currencies: zod.array(zod.string()).min(1),
-  pricePreferences: zod.record(zod.string(), zod.boolean()),
-})
 
 const PAGE_SIZE = 50
 const PREFIX = "ac"


### PR DESCRIPTION
## Summary

**What** — Allows the store add-currencies form to submit when no new currency rows are selected.

**Why** — The form can be used to save existing currency preferences, and an empty `currencies` array is valid when there are no new currencies to add. The previous `.min(1)` validation caused the reported “Array must contain at least 1 element(s)” error.

**How** — Moves the add-currencies schema into an exported module, removes the incorrect minimum length constraint, and adds regression tests for empty and non-empty selections.

**Testing** — Ran `yarn workspace @medusajs/admin-shared build`, `yarn workspace @medusajs/admin-vite-plugin build`, `yarn workspace @medusajs/dashboard test src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.schema.spec.ts`, `yarn prettier --check ...`, and `git diff --check`.

---

## Examples

Submitting with `currencies: []` now passes validation, while selected currencies continue to validate as before.

---

## Checklist

- [x] I have added a **changeset** for this PR
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Closes #14963.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: relaxes client-side Zod validation for a single form and adds focused unit tests; no auth/data-model changes.
> 
> **Overview**
> Fixes the store add-currencies flow so the form can be submitted with an empty `currencies` array (e.g., when only updating tax-inclusive price preferences).
> 
> This extracts `AddCurrenciesSchema` into a dedicated module, removes the previous `.min(1)` requirement, adds Vitest coverage for empty vs non-empty selections, and includes a patch changeset for `@medusajs/dashboard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c4adc01d338decb0be488aa49a03b13051cd46c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->