### PR TITLE
fix(medusa): include prices in price list queries

### DIFF
--- a/.changeset/fix-price-list-price-variant-id.md
+++ b/.changeset/fix-price-list-price-variant-id.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): include price fields in admin price list queries

--- a/integration-tests/http/__tests__/price-list/admin/price-list.spec.ts
+++ b/integration-tests/http/__tests__/price-list/admin/price-list.spec.ts
@@ -202,6 +202,29 @@ medusaIntegrationTestRunner({
           expect(response.data.price_list).not.toHaveProperty("prices")
         })
 
+        it("returns a price list by :id with price variant ids", async () => {
+          const response = await api.get(
+            `/admin/price-lists/${pricelist1.id}?fields=prices.*`,
+            adminHeaders
+          )
+
+          expect(response.status).toEqual(200)
+          expect(response.data.price_list.prices).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                amount: 100,
+                currency_code: "usd",
+                variant_id: product1.variants[0].id,
+              }),
+              expect.objectContaining({
+                amount: 80,
+                currency_code: "usd",
+                variant_id: product1.variants[0].id,
+              }),
+            ])
+          )
+        })
+
         it("returns a list of price lists", async () => {
           const response = await api.get("/admin/price-lists", adminHeaders)
 
@@ -214,6 +237,35 @@ medusaIntegrationTestRunner({
               }),
               expect.objectContaining({
                 id: pricelist2.id,
+              }),
+            ])
+          )
+        })
+
+        it("returns a list of price lists with price variant ids", async () => {
+          const response = await api.get(
+            "/admin/price-lists?fields=prices.*",
+            adminHeaders
+          )
+
+          expect(response.status).toEqual(200)
+
+          const priceList = response.data.price_lists.find(
+            (priceList) => priceList.id === pricelist1.id
+          )
+
+          expect(priceList).toBeDefined()
+          expect(priceList?.prices).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                amount: 100,
+                currency_code: "usd",
+                variant_id: product1.variants[0].id,
+              }),
+              expect.objectContaining({
+                amount: 80,
+                currency_code: "usd",
+                variant_id: product1.variants[0].id,
               }),
             ])
           )

--- a/packages/medusa/src/api/admin/price-lists/__tests__/query-config.spec.ts
+++ b/packages/medusa/src/api/admin/price-lists/__tests__/query-config.spec.ts
@@ -1,0 +1,14 @@
+import { adminPriceListRemoteQueryFields } from "../query-config"
+
+describe("adminPriceListRemoteQueryFields", () => {
+  it("includes price fields needed to map variant_id", () => {
+    expect(adminPriceListRemoteQueryFields).toEqual(
+      expect.arrayContaining([
+        "prices.id",
+        "prices.price_set.variant.id",
+        "prices.price_rules.value",
+        "prices.price_rules.attribute",
+      ])
+    )
+  })
+})

--- a/packages/medusa/src/api/admin/price-lists/query-config.ts
+++ b/packages/medusa/src/api/admin/price-lists/query-config.ts
@@ -32,6 +32,7 @@ export const adminPriceListRemoteQueryFields = [
   "metadata",
   "price_list_rules.value",
   "price_list_rules.attribute",
+  ...adminPriceListPriceQueryFields.map((field) => `prices.${field}`),
 ]
 
 export const retrivePriceListPriceQueryConfig = {


### PR DESCRIPTION
## Summary

**What** — Includes price fields in the admin price list query defaults, including the nested variant id needed to map `variant_id` on prices.

**Why** — Price list responses can omit `variant_id` because the list/retrieve query config did not fetch the `prices.price_set.variant.id` data consumed by the existing price transformation.

**How** — Reuses the existing price field list with a `prices.` prefix in the price list query config and adds a regression test for the required fields.

**Testing** — Ran `../../node_modules/.bin/jest --bail --forceExit --testPathIgnorePatterns='/integration-tests/' --runTestsByPath src/api/admin/price-lists/__tests__/query-config.spec.ts`, `yarn prettier --check ...`, and `git diff --check`.

---

## Examples

Admin price list queries now request `prices.price_set.variant.id`, so the existing transformation has the data required to expose `variant_id` on prices.

---

## Checklist

- [x] I have added a **changeset** for this PR
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Closes #14995.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: expands default admin price list query fields to include nested price/variant data and adds a regression test; main impact is slightly larger query payloads.
> 
> **Overview**
> Admin price list list/retrieve default remote query fields now **include all price fields** (prefixed under `prices.*`), including `prices.price_set.variant.id`, so price responses can reliably map/expose `variant_id`.
> 
> Adds a focused Jest test to prevent regressions in the required `prices.*` field selection, and includes a patch changeset for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef8455f0abd46e6b68e284a44b60c2f2467ab21a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->