### PR TITLE
 Fixes #15341 Replaced the substring match with a path-segment comparison

### DIFF
--- a/.changeset/fix-compiler-build-excludes-test-filenames.md
+++ b/.changeset/fix-compiler-build-excludes-test-filenames.md
@@ -1,0 +1,19 @@
+---
+"@medusajs/framework": patch
+---
+
+fix(framework): build no longer silently drops source files whose name contains "test"
+
+`medusa build` filtered compiled files using a naive `String.includes()` check
+against the ignore list (`integration-tests`, `test`, `unit-tests`, `src/admin`).
+Any file whose *path* contained the substring `test` — including user-authored
+scripts like `reset-test-vendor-password.ts` or `seed-test-accounts.ts` — was
+silently excluded from the build output with no warning.
+
+The filter now compares path *segments* so that only files located inside a
+directory named exactly `test/`, `unit-tests/`, or `integration-tests/` are
+excluded. Files whose filename happens to contain the word "test" but live
+outside those directories are compiled normally.
+
+No user action is required; previously dropped scripts will appear in
+`.medusa/server/` after the next build.

--- a/packages/core/framework/src/build-tools/__tests__/compiler.spec.ts
+++ b/packages/core/framework/src/build-tools/__tests__/compiler.spec.ts
@@ -1,0 +1,102 @@
+import path from "path"
+import { shouldIgnoreFile } from "../compiler"
+
+const SEP = path.sep
+
+// Normalise a POSIX-style path to the platform separator so tests are
+// portable between Unix and Windows.
+const p = (...parts: string[]) => parts.join(SEP)
+
+describe("shouldIgnoreFile", () => {
+  const ignoreList = ["integration-tests", "test", "unit-tests", "src/admin"]
+
+  // ── files that MUST be excluded ─────────────────────────────────────────
+  describe("excludes files inside ignored directories", () => {
+    it("excludes a file directly inside test/", () => {
+      expect(shouldIgnoreFile(p("test", "foo.ts"), ignoreList)).toBe(true)
+    })
+
+    it("excludes a file nested inside test/", () => {
+      expect(shouldIgnoreFile(p("test", "helpers", "bar.ts"), ignoreList)).toBe(
+        true
+      )
+    })
+
+    it("excludes a file inside unit-tests/", () => {
+      expect(
+        shouldIgnoreFile(p("unit-tests", "services", "order.spec.ts"), ignoreList)
+      ).toBe(true)
+    })
+
+    it("excludes a file inside integration-tests/", () => {
+      expect(
+        shouldIgnoreFile(
+          p("integration-tests", "__tests__", "cart.spec.ts"),
+          ignoreList
+        )
+      ).toBe(true)
+    })
+
+    it("excludes a file inside src/admin/", () => {
+      expect(
+        shouldIgnoreFile(p("src", "admin", "routes", "page.tsx"), ignoreList)
+      ).toBe(true)
+    })
+  })
+
+  // ── files that MUST be included (regression cases from the bug report) ──
+  describe("includes files whose name contains 'test' but are not inside an ignored directory", () => {
+    it("includes src/scripts/reset-test-vendor-password.ts", () => {
+      expect(
+        shouldIgnoreFile(
+          p("src", "scripts", "reset-test-vendor-password.ts"),
+          ignoreList
+        )
+      ).toBe(false)
+    })
+
+    it("includes src/scripts/seed-test-accounts.ts", () => {
+      expect(
+        shouldIgnoreFile(p("src", "scripts", "seed-test-accounts.ts"), ignoreList)
+      ).toBe(false)
+    })
+
+    it("includes src/scripts/my-test-helper.ts", () => {
+      expect(
+        shouldIgnoreFile(p("src", "scripts", "my-test-helper.ts"), ignoreList)
+      ).toBe(false)
+    })
+
+    it("includes a top-level file with 'test' in the name", () => {
+      expect(shouldIgnoreFile("contest-results.ts", ignoreList)).toBe(false)
+    })
+
+    it("includes src/subscribers/test-order-subscriber.ts", () => {
+      expect(
+        shouldIgnoreFile(
+          p("src", "subscribers", "test-order-subscriber.ts"),
+          ignoreList
+        )
+      ).toBe(false)
+    })
+  })
+
+  // ── edge cases ───────────────────────────────────────────────────────────
+  describe("edge cases", () => {
+    it("returns false for a normal source file", () => {
+      expect(
+        shouldIgnoreFile(p("src", "workflows", "create-order.ts"), ignoreList)
+      ).toBe(false)
+    })
+
+    it("returns false when chunksToIgnore is empty", () => {
+      expect(shouldIgnoreFile(p("test", "foo.ts"), [])).toBe(false)
+    })
+
+    it("does not confuse a directory named 'testutils' with 'test'", () => {
+      expect(
+        shouldIgnoreFile(p("src", "testutils", "helpers.ts"), ignoreList)
+      ).toBe(false)
+    })
+  })
+})

--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -6,6 +6,25 @@ import path from "path"
 import type tsStatic from "typescript"
 
 /**
+ * Returns true when a relative file path should be excluded from compilation.
+ * Matches against path segments so that a chunk like "test" only skips files
+ * inside a directory named exactly "test/", not files whose name contains the
+ * substring "test" (e.g. "reset-test-vendor-password.ts").
+ */
+export function shouldIgnoreFile(
+  relativeFileName: string,
+  chunksToIgnore: string[]
+): boolean {
+  const relativeSegments = relativeFileName.split(path.sep)
+  return chunksToIgnore.some((chunk) => {
+    const chunkSegments = chunk.split("/")
+    return relativeSegments.some((_, i) =>
+      chunkSegments.every((seg, j) => relativeSegments[i + j] === seg)
+    )
+  })
+}
+
+/**
  * The compiler exposes the opinionated APIs for compiling Medusa
  * applications and plugins. You can perform the following
  * actions.
@@ -191,9 +210,7 @@ export class Compiler {
     const ts = await this.#loadTSCompiler()
     const filesToCompile = tsConfig.fileNames.filter((fileName) => {
       const relativeFileName = path.relative(this.#projectRoot, fileName)
-      return !chunksToIgnore.some((chunk) =>
-        relativeFileName.includes(`${chunk}`)
-      )
+      return !shouldIgnoreFile(relativeFileName, chunksToIgnore)
     })
 
     /**


### PR DESCRIPTION
Fixes #15341 Replaced the substring match with a path-segment comparison.

## Summary

**What** — What changes are introduced in this PR?

Compiler.#emitBuildOutput in @medusajs/framework previously filtered source files using a naive String.includes() check against the #backendIgnoreFiles list (integration-tests, test, unit-tests, src/admin). This PR replaces that check with a path-segment comparison and extracts it into an exported shouldIgnoreFile helper. A unit test suite is added alongside the fix.  

**Why** — Why are these changes relevant or necessary?  

The substring match is too broad: any file whose relative path contains the characters test anywhere — including in a filename like reset-test-vendor-password.ts or seed-test-accounts.ts  was silently excluded from the build output with no warning or log entry. The intent of the ignore list is to skip entire directories (test/, unit-tests/, integration-tests/) and the src/admin subtree, not to exclude arbitrary files whose names happen to contain those strings. Real user scripts were reaching deployed builds only after being renamed to remove the word "test".

**How** — How have these changes been implemented?

The filter now splits both the relative file path and each ignore chunk into path segments (using path.sep for the file path and / for the chunk). A chunk matches only when its segments appear as a consecutive run within the file's segments so "test" matches test/foo.ts but not src/scripts/reset-test-vendor-password.ts. The predicate is extracted into shouldIgnoreFile(relativeFileName, chunksToIgnore) and exported so it can be tested directly without mocking the TypeScript compiler. A changeset for @medusajs/framework (patch) is included.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?
                                                                                                                                                                                                          
  Unit tests are added at packages/core/framework/src/build-tools/__tests__/compiler.spec.ts and cover three scenarios:
                                                                                                                                                                                                          
  - Excluded — files under test/, unit-tests/, integration-tests/, and src/admin/ are correctly filtered out.                                                                                             
  - Included (regression) — the exact filenames from the bug report (reset-test-vendor-password.ts, seed-test-accounts.ts, my-test-helper.ts) are no longer excluded.                                     
  - Edge cases — empty ignore list, a directory named testutils (must not match the test chunk), and ordinary source files.                                                                               
                                                                                                                                                                                                          
  Run with:                                                                                                                                                                                               
  yarn workspace @medusajs/framework test --testPathPattern="build-tools"                                                                                                                                 

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable
