### PR TITLE
fix(framework): avoid excluding files with test in filename

### DIFF
--- a/.changeset/yellow-dots-slide.md
+++ b/.changeset/yellow-dots-slide.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/framework": patch
+---
+
+Fix compiler path filtering for files containing test in filename

--- a/.changeset/yellow-dots-slide.md
+++ b/.changeset/yellow-dots-slide.md
@@ -2,4 +2,4 @@
 "@medusajs/framework": patch
 ---
 
-Fix compiler path filtering for files containing test in filename
+fix(framework): avoid excluding files with test in filename

--- a/packages/core/framework/src/build-tools/__tests__/compiler.spec.ts
+++ b/packages/core/framework/src/build-tools/__tests__/compiler.spec.ts
@@ -1,0 +1,39 @@
+import path from "path"
+
+describe("compiler ignored paths filtering", () => {
+  const chunksToIgnore = [
+    "integration-tests",
+    "test",
+    "unit-tests",
+    "src/admin",
+  ]
+
+  const shouldIgnore = (fileName: string) => {
+    const relativeFileName = path.normalize(fileName)
+    const normalizedFile = relativeFileName.split(path.sep).join("/")
+
+    return chunksToIgnore.some((chunk) => {
+      const normalizedChunk = chunk.split(/[\\/]/).join("/")
+
+      if (!normalizedChunk.includes("/")) {
+        return normalizedFile.split("/").includes(normalizedChunk)
+      }
+
+      return normalizedFile.startsWith(normalizedChunk + "/")
+    })
+  }
+
+  it("includes files with test in filename outside ignored directories", () => {
+    expect(shouldIgnore("src/scripts/reset-test-vendor-password.ts")).toBe(
+      false
+    )
+  })
+
+  it("excludes files inside src/test directory", () => {
+    expect(shouldIgnore("src/test/foo.ts")).toBe(true)
+  })
+
+  it("excludes files inside src/admin directory", () => {
+    expect(shouldIgnore("src/admin/test-admin.ts")).toBe(true)
+  })
+})

--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -191,9 +191,10 @@ export class Compiler {
     const ts = await this.#loadTSCompiler()
     const filesToCompile = tsConfig.fileNames.filter((fileName) => {
       const relativeFileName = path.relative(this.#projectRoot, fileName)
-      return !chunksToIgnore.some((chunk) =>
-        relativeFileName.includes(`${chunk}`)
-      )
+
+      const segments = relativeFileName.split(path.sep)
+
+      return !chunksToIgnore.some((chunk) => segments.includes(chunk))
     })
 
     /**

--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -192,9 +192,19 @@ export class Compiler {
     const filesToCompile = tsConfig.fileNames.filter((fileName) => {
       const relativeFileName = path.relative(this.#projectRoot, fileName)
 
-      const segments = relativeFileName.split(path.sep)
+      const normalizedFile = relativeFileName.split(path.sep).join("/")
 
-      return !chunksToIgnore.some((chunk) => segments.includes(chunk))
+      return !chunksToIgnore.some((chunk) => {
+        const normalizedChunk = chunk.split(/[\\/]/).join("/")
+
+        if (!normalizedChunk.includes("/")) {
+          // single-segment: match against path segments only
+          return normalizedFile.split("/").includes(normalizedChunk)
+        }
+
+        // multi-segment: match as a path prefix
+        return normalizedFile.startsWith(normalizedChunk + "/")
+      })
     })
 
     /**


### PR DESCRIPTION
Fixes #15341

Replaced the substring match with path-segment based filtering to avoid incorrectly excluding files whose filenames contain `test`, while preserving exclusions for ignored directories such as `src/test` and `src/admin`.

## Summary

**What** — What changes are introduced in this PR?

This PR fixes an issue in the framework build compiler where files were incorrectly excluded from the build output if their path contained the substring `test`, even when `test` appeared only in the filename.

Previously, the compiler filtered files using:

```ts
relativeFileName.includes(chunk)
```

which caused valid files such as:

* `reset-test-vendor-password.ts`
* `seed-test-accounts.ts`

to be silently skipped during `medusa build`.

The filtering logic now matches against path segments instead of arbitrary substrings.

---

**Why** — Why are these changes relevant or necessary?

The current behavior unintentionally excludes user-authored scripts and fixtures whose filenames contain `test`, even when they are not located inside ignored directories like:

* `src/test`
* `integration-tests`
* `unit-tests`

This can silently prevent important scripts from appearing in the final build output, making the issue difficult to diagnose.

The fix preserves the intended behavior of ignoring test directories while allowing valid filenames containing `test` to compile correctly.

---

**How** — How have these changes been implemented?

The compiler filtering logic in:

```txt
packages/core/framework/src/build-tools/compiler.ts
```

was updated from substring matching:

```ts
relativeFileName.includes(chunk)
```

to path-segment matching:

```ts
const segments = relativeFileName.split(path.sep)

return !chunksToIgnore.some((chunk) => segments.includes(chunk))
```

This ensures only actual path segments such as `test` or `integration-tests` are excluded.

---

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Verified locally using a Medusa test application linked against the modified local framework package.

### Reproduction Test

Created:

```txt
src/scripts/reset-test-vendor-password.ts
```

and ran:

```bash
npx medusa build
```

Verified that:

```txt
.medusa/server/src/scripts/reset-test-vendor-password.js
```

is now correctly generated.

### Regression Verification

Created:

```txt
src/test/foo.ts
```

and verified that:

```txt
.medusa/server/src/test/foo.js
```

is still excluded from the build output.

---

## Examples

```ts
// Previously excluded incorrectly
src/scripts/reset-test-vendor-password.ts

// Now included correctly after build
.medusa/server/src/scripts/reset-test-vendor-password.js
```

---

## Additional Context

This issue was caused by broad substring matching against the full relative path, which unintentionally matched filenames containing `test`.

The updated implementation limits exclusion behavior to actual path segments, preserving the intended semantics of ignored directories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the build compiler’s file inclusion/exclusion logic; mistakes could cause unintended files to be skipped or included in build output across platforms.
> 
> **Overview**
> Fixes `Compiler.#emitBuildOutput` filtering so ignored chunks (e.g., `test`, `integration-tests`) match **path segments/prefixes** rather than arbitrary substrings in the full relative path, preventing files like `reset-test-*.ts` from being incorrectly excluded.
> 
> Adds path normalization to `/` and differentiates single-segment ignores (segment match) vs multi-segment ignores (directory-prefix match). Includes a patch changeset for `@medusajs/framework`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead4adf2e9fdec89aa55f03fb4b02003d7763b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->