### PR TITLE
fix(admin): add GMD (Gambian Dalasi) to default currency lists

### DIFF
--- a/packages/admin/dashboard/src/lib/data/currencies.ts
+++ b/packages/admin/dashboard/src/lib/data/currencies.ts
@@ -247,6 +247,12 @@ export const currencies: Record<string, CurrencyInfo> = {
     symbol_native: "GH₵",
     decimal_digits: 2,
   },
+  GMD: {
+    code: "GMD",
+    name: "Gambian Dalasi",
+    symbol_native: "D",
+    decimal_digits: 2,
+  },
   GNF: {
     code: "GNF",
     name: "Guinean Franc",

--- a/packages/core/utils/src/defaults/currencies.ts
+++ b/packages/core/utils/src/defaults/currencies.ts
@@ -369,6 +369,15 @@ export const defaultCurrencies: Record<string, Currency> = {
     code: "GHS",
     name_plural: "Ghanaian cedis",
   },
+  GMD: {
+    symbol: "D",
+    name: "Gambian Dalasi",
+    symbol_native: "D",
+    decimal_digits: 2,
+    rounding: 0,
+    code: "GMD",
+    name_plural: "Gambian dalasis",
+  },
   GNF: {
     symbol: "FG",
     name: "Guinean Franc",


### PR DESCRIPTION
## Summary

- Add the **GMD** (Gambian Dalasi, ISO 4217) currency to both currency-lookup maps
- Fixes the admin region-create page crash when a store has GMD in \`supported_currencies\`

Closes #15265

## Files changed

- \`packages/core/utils/src/defaults/currencies.ts\` (consumed as \`@medusajs/utils/dist/defaults/currencies.js\`)
- \`packages/admin/dashboard/src/lib/data/currencies.ts\`

Both insertions are alphabetical, between **GHS** (Ghanaian Cedi) and **GNF** (Guinean Franc).

## Why this is the fix

Several admin pages iterate \`store.supported_currencies\` and look each entry up in these hardcoded maps. Any currency missing from the map yields \`undefined\`, then \`undefined.code\` throws — exactly the \`TypeError: Cannot read properties of undefined (reading 'code')\` reported in the issue.

GMD is a real ISO 4217 currency (Gambia, since 1971) and was simply omitted from these defaults.

## Currency metadata

Sourced from ISO 4217:

| Field | Value |
|---|---|
| code | \`GMD\` |
| name | \`Gambian Dalasi\` |
| symbol / symbol_native | \`D\` |
| decimal_digits | \`2\` |
| rounding | \`0\` |
| name_plural (utils only) | \`Gambian dalasis\` |

The dashboard schema (\`CurrencyInfo\`) does not have a \`name_plural\` field, so that key only appears in the utils file — matches the existing pattern for other currencies in that file.

## Test plan

- [x] Inserted alphabetically — diff is +9 lines (utils) and +6 lines (dashboard), no other changes
- [x] No imports added; only data change
- [ ] Reviewer step: insert a GMD row into the \`currency\` table, set as supported in a test store, confirm regions-create page renders without crash
- [ ] Reviewer step: confirm currency picker on a region surfaces \"D — Gambian Dalasi\"

## Notes

- Single-responsibility data fix, no behavior changes elsewhere
- If reviewers prefer the alphabetical sort to follow a different convention than what I used, happy to adjust

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-only change that adds a missing ISO currency entry; main risk is minimal and limited to potential metadata typos (symbol/decimals) affecting display.
> 
> **Overview**
> Adds **GMD (Gambian Dalasi)** to the hardcoded currency lookup tables used by the admin dashboard (`currencies.ts`) and core utils defaults (`defaultCurrencies`).
> 
> This prevents admin flows that render/iterate `supported_currencies` from failing when `GMD` is present by ensuring lookups return a defined currency object with symbol/name/decimal metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8656031853670b1d228f0aad5af4e63b49f4a49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->