### PR TITLE
fix(utils): filter snapshot file selection to .snapshot- prefix in mi…

### DIFF
--- a/.changeset/clean-pets-deny.md
+++ b/.changeset/clean-pets-deny.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+fix(utils): filter snapshot file selection to .snapshot- prefix to prevent DROP TABLE generation

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -10,7 +10,7 @@ import {
 } from "@medusajs/deps/mikro-orm/postgresql"
 import { EventEmitter } from "events"
 import { access, mkdir, rename, writeFile } from "fs/promises"
-import { dirname, join } from "path"
+import { basename, dirname, join } from "path"
 import { readDir } from "../common"
 import { CustomDBMigrator } from "../dal/mikro-orm/custom-db-migrator"
 
@@ -203,13 +203,18 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
     })
 
     /**
-     * We assume all JSON files are snapshot files in this directory
+     * Only consider files that start with ".snapshot-" but do not match
+     * the expected module snapshot name. This handles legacy snapshot
+     * file naming while avoiding full-DB snapshots written by MikroORM
+     * directly (e.g. ".snapshot-<dbname>.json").
      */
+    const expectedName = basename(snapshotPath)
     const snapshotFile = entries.find(
       (entry) =>
         entry.isFile() &&
         entry.name.endsWith(".json") &&
-        entry.name.startsWith(".snapshot-")
+        entry.name.startsWith(".snapshot-") &&
+        entry.name !== expectedName
     )
 
     if (snapshotFile) {

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -84,8 +84,7 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
     const migrator = connection.getMigrator()
 
     try {
-      await this.
-      (migrator["snapshotPath"])
+      await this.migrateSnapshotFile(migrator["snapshotPath"])
       await this.ensureSnapshot(migrator["snapshotPath"])
       const migrationResult = await migrator.createMigration()
       const code = migrationResult.code

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -212,19 +212,14 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
       ignoreMissing: true,
     })
 
-    /**
-     * Only consider files that start with ".snapshot-" but do not match
-     * the expected module snapshot name. This handles legacy snapshot
-     * file naming while avoiding full-DB snapshots written by MikroORM
-     * directly (e.g. ".snapshot-<dbname>.json").
-     */
+    // Legacy module snapshots used `.snapshot-<module>.json`;
+    // new format is `.snapshot-medusa-<module>.json`.
+    // Only match the exact legacy filename to avoid picking up
+    // full-DB snapshots written by MikroORM (.snapshot-<databaseName>.json).
     const expectedName = basename(snapshotPath)
+    const legacyName = expectedName.replace(/^\.snapshot-medusa-/, ".snapshot-")
     const snapshotFile = entries.find(
-      (entry) =>
-        entry.isFile() &&
-        entry.name.endsWith(".json") &&
-        entry.name.startsWith(".snapshot-") &&
-        entry.name !== expectedName
+      (entry) => entry.isFile() && entry.name === legacyName
     )
 
     if (snapshotFile) {

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -206,7 +206,10 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
      * We assume all JSON files are snapshot files in this directory
      */
     const snapshotFile = entries.find(
-      (entry) => entry.isFile() && entry.name.endsWith(".json")
+      (entry) =>
+        entry.isFile() &&
+        entry.name.endsWith(".json") &&
+        entry.name.startsWith(".snapshot-")
     )
 
     if (snapshotFile) {

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -84,7 +84,8 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
     const migrator = connection.getMigrator()
 
     try {
-      await this.migrateSnapshotFile(migrator["snapshotPath"])
+      await this.
+      (migrator["snapshotPath"])
       await this.ensureSnapshot(migrator["snapshotPath"])
       const migrationResult = await migrator.createMigration()
       const code = migrationResult.code

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -198,6 +198,16 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
    * the first one will be used.
    */
   protected async migrateSnapshotFile(snapshotPath: string): Promise<void> {
+    // If the expected snapshot already exists, no migration needed -
+    // running the rename would incorrectly overwrite it with a stale
+    // full-DB snapshot (e.g. .snapshot-<databaseName>.json).
+    const alreadyExists = await access(snapshotPath)
+      .then(() => true)
+      .catch(() => false)
+    if (alreadyExists) {
+      return
+    }
+
     const entries = await readDir(dirname(snapshotPath), {
       ignoreMissing: true,
     })


### PR DESCRIPTION
## Summary

**What** — Fixes `migrateSnapshotFile` to skip the snapshot rename when the expected module snapshot already exists, and tightens the file selection predicate as a secondary guard.

**Why** — Fixes #15330. `migrateSnapshotFile` was introduced to rename legacy MikroORM snapshots (`.snapshot-<databaseName>.json`) to the new module-name-based convention (`.snapshot-<moduleName>.json`). However, when `db:generate` is run more than once after `db:migrate`, both files exist simultaneously in the migrations directory. The function would find the full-DB snapshot, rename it over the correct module snapshot, and use it as the MikroORM baseline — causing MikroORM to diff the entire database schema against the module's entity metadata and generate `DROP TABLE` statements for every core Medusa table not in scope. Applying this migration without manual inspection would wipe the entire database.

How — Two changes were made to `migrateSnapshotFile` in `packages/core/utils/src/migrations/index.ts`:

1. **Early return if the expected snapshot already exists** — if the module snapshot is already present at `snapshotPath`, the function returns immediately. This prevents the full-DB snapshot from being picked up on subsequent `db:generate` runs.

2. **Exact legacy filename match** — instead of a broad predicate, the function now derives the known legacy snapshot name (`legacyName = expectedName.replace(/^\.snapshot-medusa-/, ".snapshot-")`) and only matches that exact file. This ensures only a valid legacy module snapshot is ever renamed, and MikroORM's full-DB snapshot (`.snapshot-<databaseName>.json`) is never picked up.

`basename` was also added to the existing `path` import, and the inline comment was updated to reflect the new logic.

**Testing** — The bug can be reproduced by running `medusa db:generate <moduleName>` twice on a project that has run `db:migrate` at least once. Before the fix, the second generated migration contains `DROP TABLE` statements for all core Medusa tables. After the fix, the early return prevents the full-DB snapshot from being picked up, and the migration contains only the expected `ALTER TABLE` / `CREATE TABLE` statements for the module's own entities.

---

## Checklist

- [x] I have added a **changeset** for this PR
- [ ] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue — Closes #15330