### PR TITLE
fix(currencies): add GMD to supported currencies

### DIFF
--- a/.changeset/add-gmd-currency.md
+++ b/.changeset/add-gmd-currency.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/utils": patch
+"@medusajs/dashboard": patch
+---
+
+fix(currencies): add GMD to supported currencies

--- a/.changeset/add-gmd-currency.md
+++ b/.changeset/add-gmd-currency.md
@@ -3,4 +3,4 @@
 "@medusajs/dashboard": patch
 ---
 
-fix(currencies): add GMD to supported currencies
+fix(utils, dashboard): add GMD to supported currencies

--- a/packages/admin/dashboard/src/lib/data/currencies.ts
+++ b/packages/admin/dashboard/src/lib/data/currencies.ts
@@ -247,6 +247,12 @@ export const currencies: Record<string, CurrencyInfo> = {
     symbol_native: "GH₵",
     decimal_digits: 2,
   },
+  GMD: {
+    code: "GMD",
+    name: "Gambian Dalasi",
+    symbol_native: "D",
+    decimal_digits: 2,
+  },
   GNF: {
     code: "GNF",
     name: "Guinean Franc",

--- a/packages/core/utils/src/defaults/currencies.ts
+++ b/packages/core/utils/src/defaults/currencies.ts
@@ -369,6 +369,15 @@ export const defaultCurrencies: Record<string, Currency> = {
     code: "GHS",
     name_plural: "Ghanaian cedis",
   },
+  GMD: {
+    symbol: "D",
+    name: "Gambian Dalasi",
+    symbol_native: "D",
+    decimal_digits: 2,
+    rounding: 0,
+    code: "GMD",
+    name_plural: "Gambian Dalasis",
+  },
   GNF: {
     symbol: "FG",
     name: "Guinean Franc",


### PR DESCRIPTION
## What

Added the missing `GMD` (Gambian Dalasi, ISO 4217) currency entry to the two hardcoded currency dictionaries used by the Medusa admin dashboard:

- `packages/core/utils/src/defaults/currencies.ts` (`@medusajs/utils`)
- `packages/admin/dashboard/src/lib/data/currencies.ts` (`@medusajs/dashboard`)

A patch changeset is included to release new versions of both packages.

## Why

Fixes #15265.

When a store has GMD set as a supported currency, any admin page that iterates over `store.supported_currencies` and looks each one up in the hardcoded map receives `undefined` for GMD. Accessing fields like `.code` or `.symbol_native` on `undefined` throws a `TypeError`, crashing the admin region-create page (and other pages that consume the currency map).

GMD is a valid ISO 4217 code (Gambian Dalasi, used by The Gambia) but was absent from these static lists.

## How

Inserted a `GMD` entry in alphabetical order (between `GHS` and `GNF`) in both files, matching the shape of all surrounding entries:

- `packages/core/utils/src/defaults/currencies.ts`: includes `symbol`, `name`, `symbol_native`, `decimal_digits`, `rounding`, `code`, and `name_plural`
- `packages/admin/dashboard/src/lib/data/currencies.ts`: includes `code`, `name`, `symbol_native`, and `decimal_digits`

No logic was changed — this is a purely additive data fix.

## Testing

Verified locally by:
1. Inserting a GMD row into the `currency` table (as described in the issue).
2. Setting GMD as the store's default supported currency via the admin (Settings → Store).
3. Navigating to Settings → Regions → Create — no longer crashes.
4. Confirming GMD appears correctly in currency dropdowns with name "Gambian Dalasi" and symbol "D".