### PR TITLE
fix(@medusajs/test-utils): encode URL special characters in database connection string

### DIFF
--- a/.changeset/encode-url-special-chars.md
+++ b/.changeset/encode-url-special-chars.md
@@ -2,4 +2,4 @@
 "@medusajs/test-utils": patch
 ---
 
-fix(medusa-test-utils): encode URL special characters in database connection string
+fix(test-utils): encode URL special characters in database connection string

--- a/.changeset/encode-url-special-chars.md
+++ b/.changeset/encode-url-special-chars.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/test-utils": patch
+---
+
+fix(medusa-test-utils): encode URL special characters in database connection string


### PR DESCRIPTION
## What

Adds changeset file for package @medusajs/test-utils (patch bump). This is a chore PR to supplement #15361.

## Why

medusa-os-bot required a changeset file under .changeset/ before the original PR could be merged. The code fix in #15361 is correct — this PR only adds the changeset metadata.

## How

Added .changeset/encode-url-special-chars.md with patch bump for @medusajs/test-utils.

## Testing

- Changeset file exists in .changeset/ directory ✅
- Changeset format follows Medusa conventions ✅