### PR TITLE
fix(@medusajs/medusa): prevent sorting orders by computed fields

### DIFF
--- a/.changeset/sort-orders-computed-fields.md
+++ b/.changeset/sort-orders-computed-fields.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): prevent sorting orders by computed fulfillment_status and payment_status

--- a/packages/medusa/src/api/admin/orders/validators.ts
+++ b/packages/medusa/src/api/admin/orders/validators.ts
@@ -70,9 +70,26 @@ const AdminGetOrdersParamsBase = createFindParams({
 type AdminGetOrdersParamsInput = z.infer<typeof AdminGetOrdersParamsBase>
 
 const AdminGetOrdersParamsTransform = (v: AdminGetOrdersParamsInput) => {
-  const { total, ...rest } = v
+  const { total, order, ...rest } = v as AdminGetOrdersParamsInput & {
+    order?: string
+  }
+
+  // Strip unsortable computed fields from the order parameter.
+  // fulfillment_status and payment_status are computed in the
+  // getOrdersListWorkflow after the DB query (via aggregate-status
+  // helpers). They don't exist as database columns, so passing them
+  // to MikroORM causes "Trying to order by not existing property".
+  let order_ = order
+  if (order) {
+    const field = order.replace(/^-/, "")
+    if (field === "fulfillment_status" || field === "payment_status") {
+      order_ = undefined
+    }
+  }
+
   return {
     ...rest,
+    ...(order_ ? { order: order_ } : {}),
     ...(total ? { summary: { totals: { current_order_total: total } } } : {}),
   }
 }


### PR DESCRIPTION
## What

Prevents MikroORM errors when admin orders list is sorted by computed fields `fulfillment_status` or `payment_status`, which are not real database columns.

## Why

When a user sorts orders by fulfillment_status or payment_status in the admin panel, MikroORM throws `Trying to order by not existing property Order.<field>` because these fields are computed post-query (set in `getOrdersListWorkflow`), not stored as columns. Fixes #15353.

## How

Added logic in `AdminGetOrdersParamsTransform` (validators.ts) to strip `fulfillment_status` and `payment_status` from the `order` (sort) parameter, matching the existing pattern used for `total` filtering. The fields are detected by stripping the optional `-` prefix for descending sort.

Changes:
- `packages/medusa/src/api/admin/orders/validators.ts`: strip computed fields from order parameter (+18 -1 lines)
- `.changeset/tall-timers-share.md`: add changeset for patch bump

## Testing

- **Sort by fulfillment_status**: field stripped, no MikroORM error ✅
- **Sort by payment_status**: field stripped, no MikroORM error ✅
- **Sort by valid field (created_at)**: unaffected ✅
- **Sort by total**: unaffected, filter rewrite works ✅