### PR TITLE
fix(dashboard): fix RTL layout issues for Hebrew, Arabic, and Farsi

### DIFF
--- a/.changeset/hebrew-rtl-layout-fixes.md
+++ b/.changeset/hebrew-rtl-layout-fixes.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): fix RTL layout issues for Hebrew and other RTL languages

--- a/packages/admin/dashboard/src/components/common/json-view-section/json-view-section.tsx
+++ b/packages/admin/dashboard/src/components/common/json-view-section/json-view-section.tsx
@@ -83,7 +83,7 @@ export const JsonViewSection = ({ data }: JsonViewSectionProps) => {
             </div>
           </div>
           <Drawer.Body className="flex flex-1 flex-col overflow-hidden px-[5px] py-0 pb-[5px]">
-            <div className="bg-ui-contrast-bg-subtle flex-1 overflow-auto rounded-b-[4px] rounded-t-lg p-3">
+            <div className="bg-ui-contrast-bg-subtle flex-1 overflow-auto rounded-b-[4px] rounded-t-lg p-3" dir="ltr">
               <Suspense
                 fallback={<div className="flex size-full flex-col"></div>}
               >

--- a/packages/admin/dashboard/src/components/data-grid/components/data-grid-currency-cell.tsx
+++ b/packages/admin/dashboard/src/components/data-grid/components/data-grid-currency-cell.tsx
@@ -108,7 +108,7 @@ const Inner = ({
   const combinedRed = useCombinedRefs(inputRef, ref)
 
   return (
-    <div className="relative flex size-full items-center">
+    <div className="relative flex size-full items-center" dir="ltr">
       <span
         className="txt-compact-small text-ui-fg-muted pointer-events-none absolute left-0 w-fit min-w-4"
         aria-hidden

--- a/packages/admin/dashboard/src/components/data-grid/components/data-grid-root.tsx
+++ b/packages/admin/dashboard/src/components/data-grid/components/data-grid-root.tsx
@@ -728,7 +728,7 @@ export const DataGridRoot = <
                             width: header.getSize(),
                             ...getCommonPinningStyles(header.column),
                           }}
-                          className="bg-ui-bg-base txt-compact-small-plus flex items-center border-b border-r px-4 py-2.5"
+                          className="bg-ui-bg-base txt-compact-small-plus flex items-center border-b border-r rtl:border-l rtl:border-r-0 px-4 py-2.5"
                         >
                           {header.isPlaceholder
                             ? null
@@ -902,7 +902,7 @@ const DataGridHeader = ({
         </div>
       )}
       {headerContent}
-      <div className="ml-auto flex items-center gap-x-2">
+      <div className="ml-auto rtl:mr-auto rtl:ml-0 flex items-center gap-x-2">
         {errorCount > 0 && (
           <Button
             size="small"
@@ -966,7 +966,7 @@ const DataGridCell = <TData,>({
       data-row-index={rowIndex}
       data-column-index={columnIndex}
       className={clx(
-        "relative flex items-stretch border-b border-r p-0 outline-none"
+        "relative flex items-stretch border-b border-r rtl:border-l rtl:border-r-0 p-0 outline-none"
       )}
       tabIndex={-1}
     >
@@ -980,7 +980,7 @@ const DataGridCell = <TData,>({
           <div
             onMouseDown={onDragToFillStart}
             className={clx(
-              "bg-ui-fg-interactive absolute bottom-0 right-0 z-[3] size-1.5 cursor-ns-resize",
+              "bg-ui-fg-interactive absolute bottom-0 right-0 rtl:left-0 rtl:right-auto z-[3] size-1.5 cursor-ns-resize",
               {
                 "cursor-nwse-resize": multiColumnSelection,
               }
@@ -1136,7 +1136,7 @@ const DataGridRowSkeleton = ({
             key={`skeleton-cell-${vc.index}`}
             role="gridcell"
             style={{ width: vc.size }}
-            className="relative flex items-center border-b border-r p-0 outline-none"
+            className="relative flex items-center border-b border-r rtl:border-l rtl:border-r-0 p-0 outline-none"
           >
             <div className="flex h-full w-full items-center px-4">
               <div className="bg-ui-bg-component h-4 w-3/4 animate-pulse rounded" />

--- a/packages/admin/dashboard/src/components/layout/nav-item/nav-item.tsx
+++ b/packages/admin/dashboard/src/components/layout/nav-item/nav-item.tsx
@@ -32,11 +32,11 @@ export type INavItem = {
 }
 
 const BASE_NAV_LINK_CLASSES =
-  "text-ui-fg-subtle transition-fg hover:bg-ui-bg-subtle-hover flex items-center gap-x-2 rounded-md py-0.5 pl-0.5 pr-2 outline-none [&>svg]:text-ui-fg-subtle focus-visible:shadow-borders-focus"
+  "text-ui-fg-subtle transition-fg hover:bg-ui-bg-subtle-hover flex items-center gap-x-2 rounded-md py-0.5 pl-0.5 pr-2 rtl:pr-0.5 rtl:pl-2 outline-none [&>svg]:text-ui-fg-subtle focus-visible:shadow-borders-focus"
 const ACTIVE_NAV_LINK_CLASSES =
   "bg-ui-bg-base shadow-elevation-card-rest text-ui-fg-base hover:bg-ui-bg-base"
-const NESTED_NAV_LINK_CLASSES = "pl-[34px] pr-2 py-1 w-full text-ui-fg-muted"
-const SETTING_NAV_LINK_CLASSES = "pl-2 py-1"
+const NESTED_NAV_LINK_CLASSES = "pl-[34px] pr-2 rtl:pr-[34px] rtl:pl-2 py-1 w-full text-ui-fg-muted"
+const SETTING_NAV_LINK_CLASSES = "pl-2 rtl:pr-2 rtl:pl-0 py-1"
 
 const getIsOpen = (
   to: string,
@@ -165,8 +165,8 @@ export const NavItem = ({
         <RadixCollapsible.Root open={open} onOpenChange={setOpen}>
           <RadixCollapsible.Trigger
             className={clx(
-              "text-ui-fg-subtle hover:text-ui-fg-base transition-fg hover:bg-ui-bg-subtle-hover flex w-full items-center gap-x-2 rounded-md py-0.5 pl-0.5 pr-2 outline-none lg:hidden",
-              { "pl-2": isSetting }
+              "text-ui-fg-subtle hover:text-ui-fg-base transition-fg hover:bg-ui-bg-subtle-hover flex w-full items-center gap-x-2 rounded-md py-0.5 pl-0.5 pr-2 rtl:pr-0.5 rtl:pl-2 outline-none lg:hidden",
+              { "pl-2": isSetting, "rtl:pr-2 rtl:pl-0": isSetting }
             )}
           >
             <div className="flex size-6 items-center justify-center">

--- a/packages/admin/dashboard/src/components/table/table-cells/common/money-amount-cell/money-amount-cell.tsx
+++ b/packages/admin/dashboard/src/components/table/table-cells/common/money-amount-cell/money-amount-cell.tsx
@@ -32,7 +32,7 @@ export const MoneyAmountCell = ({
         className
       )}
     >
-      <span className="truncate">{formatted}</span>
+      <span className="truncate" dir="ltr">{formatted}</span>
     </div>
   )
 }

--- a/packages/admin/dashboard/src/routes/orders/order-allocate-items/components/order-create-fulfillment-form/order-allocate-items-item.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-allocate-items/components/order-create-fulfillment-form/order-allocate-items-item.tsx
@@ -109,7 +109,7 @@ export function OrderAllocateItemsItem({
                   </span>
                 )}
                 {hasInventoryKit && (
-                  <Component className="text-ui-fg-muted ml-2 overflow-visible pt-[2px]" />
+                  <Component className="text-ui-fg-muted ml-2 rtl:mr-2 rtl:ml-0 overflow-visible pt-[2px]" />
                 )}
               </div>
               <Text as="div" className="text-ui-fg-subtle txt-small">
@@ -172,7 +172,7 @@ export function OrderAllocateItemsItem({
           <div className="flex items-center gap-3">
             <div className="bg-ui-border-strong block h-[12px] w-[1px]" />
 
-            <div className="text-ui-fg-subtle txt-small mr-2 flex flex-row items-center gap-2">
+            <div className="text-ui-fg-subtle txt-small mr-2 rtl:ml-2 rtl:mr-0 flex flex-row items-center gap-2">
               <Form.Field
                 control={form.control}
                 name={
@@ -191,6 +191,7 @@ export function OrderAllocateItemsItem({
                       <Form.Control>
                         <Input
                           className="bg-ui-bg-base txt-small w-[46px] rounded-lg text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                          dir="ltr"
                           type="number"
                           {...field}
                           disabled={!locationId}
@@ -282,7 +283,7 @@ export function OrderAllocateItemsItem({
                       {location?.available_quantity || "-"}
                       {location?.available_quantity &&
                         quantityField[`${item.id}-${i.id}`] && (
-                          <span className="text-ui-fg-error txt-small ml-1">
+                          <span className="text-ui-fg-error txt-small ml-1 rtl:mr-1 rtl:ml-0">
                             -{quantityField[`${item.id}-${i.id}`]}
                           </span>
                         )}
@@ -306,7 +307,7 @@ export function OrderAllocateItemsItem({
                 <div className="flex items-center gap-3">
                   <div className="bg-ui-border-strong block h-[12px] w-[1px]" />
 
-                  <div className="text-ui-fg-subtle txt-small mr-1 flex flex-row items-center gap-2">
+                  <div className="text-ui-fg-subtle txt-small mr-1 rtl:ml-1 rtl:mr-0 flex flex-row items-center gap-2">
                     <Form.Field
                       control={form.control}
                       name={`quantity.${item.id}-${i.id}`}
@@ -321,6 +322,7 @@ export function OrderAllocateItemsItem({
                             <Form.Control>
                               <Input
                                 className="bg-ui-bg-base txt-small w-[46px] rounded-lg text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                                dir="ltr"
                                 type="number"
                                 {...field}
                                 disabled={!locationId}

--- a/packages/admin/dashboard/src/routes/orders/order-create-claim/components/add-claim-items-table/use-claim-item-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-claim/components/add-claim-items-table/use-claim-item-table-columns.tsx
@@ -71,7 +71,7 @@ export const useClaimItemTableColumns = (currencyCode: string) => {
       }),
       columnHelper.accessor("quantity", {
         header: () => (
-          <div className="flex size-full items-center overflow-hidden text-right">
+          <div className="flex size-full items-center overflow-hidden text-right" dir="ltr">
             <span className="truncate">{t("fields.quantity")}</span>
           </div>
         ),

--- a/packages/admin/dashboard/src/routes/orders/order-create-claim/components/add-claim-items-table/use-claim-item-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-claim/components/add-claim-items-table/use-claim-item-table-columns.tsx
@@ -71,7 +71,7 @@ export const useClaimItemTableColumns = (currencyCode: string) => {
       }),
       columnHelper.accessor("quantity", {
         header: () => (
-          <div className="flex size-full items-center overflow-hidden text-right" dir="ltr">
+          <div className="flex size-full items-center overflow-hidden text-right">
             <span className="truncate">{t("fields.quantity")}</span>
           </div>
         ),

--- a/packages/admin/dashboard/src/routes/orders/order-create-claim/components/claim-create-form/claim-create-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-claim/components/claim-create-form/claim-create-form.tsx
@@ -784,7 +784,7 @@ export const ClaimCreateForm = ({
                       <Text
                         size="small"
                         leading="compact"
-                        className="text-ui-fg-muted ml-1 inline"
+                        className="text-ui-fg-muted ml-1 rtl:mr-1 rtl:ml-0 inline"
                       >
                         ({t("fields.optional")})
                       </Text>
@@ -1053,7 +1053,7 @@ export const ClaimCreateForm = ({
 
             {/* CARRY OVER PROMOTION */}
             {hasPromotions && (
-              <div className="bg-ui-bg-field mt-4 rounded-lg border py-2 pl-2 pr-4">
+              <div className="bg-ui-bg-field mt-4 rounded-lg border py-2 pl-2 pr-4 rtl:pl-4 rtl:pr-2">
                 <Form.Field
                   control={form.control}
                   name="carry_over_promotions"
@@ -1061,7 +1061,7 @@ export const ClaimCreateForm = ({
                     return (
                       <Form.Item>
                         <div className="flex items-center">
-                          <Form.Control className="mr-4 self-start">
+                          <Form.Control className="mr-4 self-start rtl:ml-4 rtl:mr-0">
                             <Switch
                               dir="ltr"
                               className="mt-[2px] rtl:rotate-180"
@@ -1104,7 +1104,7 @@ export const ClaimCreateForm = ({
             )}
 
             {/* SEND NOTIFICATION*/}
-            <div className="bg-ui-bg-field mt-8 rounded-lg border py-2 pl-2 pr-4">
+            <div className="bg-ui-bg-field mt-8 rounded-lg border py-2 pl-2 pr-4 rtl:pl-4 rtl:pr-2">
               <Form.Field
                 control={form.control}
                 name="send_notification"
@@ -1112,7 +1112,7 @@ export const ClaimCreateForm = ({
                   return (
                     <Form.Item>
                       <div className="flex items-center">
-                        <Form.Control className="mr-4 self-start">
+                        <Form.Control className="mr-4 self-start rtl:ml-4 rtl:mr-0">
                           <Switch
                             dir="ltr"
                             className="mt-[2px] rtl:rotate-180"

--- a/packages/admin/dashboard/src/routes/orders/order-create-edit/components/order-edit-create-form/order-edit-create-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-edit/components/order-edit-create-form/order-edit-create-form.tsx
@@ -170,7 +170,7 @@ export const OrderEditCreateForm = ({
             />
 
             {/* SEND NOTIFICATION*/}
-            <div className="bg-ui-bg-field mt-8 rounded-lg border py-2 pl-2 pr-4">
+            <div className="bg-ui-bg-field mt-8 rounded-lg border py-2 pl-2 pr-4 rtl:pl-4 rtl:pr-2">
               <Form.Field
                 control={form.control}
                 name="send_notification"
@@ -178,7 +178,7 @@ export const OrderEditCreateForm = ({
                   return (
                     <Form.Item>
                       <div className="flex items-center">
-                        <Form.Control className="mr-4 self-start">
+                        <Form.Control className="mr-4 self-start rtl:ml-4 rtl:mr-0">
                           <Switch
                             dir="ltr"
                             className="mt-[2px] rtl:rotate-180"

--- a/packages/admin/dashboard/src/routes/orders/order-create-edit/components/order-edit-create-form/order-edit-item.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-edit/components/order-edit-create-form/order-edit-item.tsx
@@ -163,13 +163,13 @@ function OrderEditItem({ item, currencyCode, orderId }: OrderEditItemProps) {
           </div>
 
           {isAddedItem && (
-            <Badge size="2xsmall" rounded="full" color="blue" className="mr-1">
+            <Badge size="2xsmall" rounded="full" color="blue" className="mr-1 rtl:ml-1 rtl:mr-0">
               {t("general.new")}
             </Badge>
           )}
 
           {isItemRemoved ? (
-            <Badge size="2xsmall" rounded="full" color="red" className="mr-1">
+            <Badge size="2xsmall" rounded="full" color="red" className="mr-1 rtl:ml-1 rtl:mr-0">
               {t("general.removed")}
             </Badge>
           ) : (
@@ -178,7 +178,7 @@ function OrderEditItem({ item, currencyCode, orderId }: OrderEditItemProps) {
                 size="2xsmall"
                 rounded="full"
                 color="orange"
-                className="mr-1"
+                className="mr-1 rtl:ml-1 rtl:mr-0"
               >
                 {t("general.modified")}
               </Badge>
@@ -225,7 +225,7 @@ function OrderEditItem({ item, currencyCode, orderId }: OrderEditItemProps) {
             )}
           </div>
 
-          <div className="text-ui-fg-subtle txt-small mr-2 flex flex-shrink-0">
+          <div className="text-ui-fg-subtle txt-small mr-2 rtl:ml-2 rtl:mr-0 flex flex-shrink-0">
             <MoneyAmountCell currencyCode={currencyCode} amount={item.total} />
           </div>
 

--- a/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/add-exchange-inbound-items-table/use-exchange-item-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/add-exchange-inbound-items-table/use-exchange-item-table-columns.tsx
@@ -71,7 +71,7 @@ export const useExchangeItemTableColumns = (currencyCode: string) => {
       }),
       columnHelper.accessor("quantity", {
         header: () => (
-          <div className="flex size-full items-center overflow-hidden text-right" dir="ltr">
+          <div className="flex size-full items-center overflow-hidden text-right">
             <span className="truncate">{t("fields.quantity")}</span>
           </div>
         ),

--- a/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/add-exchange-inbound-items-table/use-exchange-item-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/add-exchange-inbound-items-table/use-exchange-item-table-columns.tsx
@@ -71,7 +71,7 @@ export const useExchangeItemTableColumns = (currencyCode: string) => {
       }),
       columnHelper.accessor("quantity", {
         header: () => (
-          <div className="flex size-full items-center overflow-hidden text-right">
+          <div className="flex size-full items-center overflow-hidden text-right" dir="ltr">
             <span className="truncate">{t("fields.quantity")}</span>
           </div>
         ),

--- a/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-create-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-create-form.tsx
@@ -541,7 +541,7 @@ export const ExchangeCreateForm = ({
 
             {/* CARRY OVER PROMOTION */}
             {hasPromotions && (
-              <div className="bg-ui-bg-field mt-4 rounded-lg border py-2 pl-2 pr-4">
+              <div className="bg-ui-bg-field mt-4 rounded-lg border py-2 pl-2 pr-4 rtl:pl-4 rtl:pr-2">
                 <Form.Field
                   control={form.control}
                   name="carry_over_promotions"
@@ -549,7 +549,7 @@ export const ExchangeCreateForm = ({
                     return (
                       <Form.Item>
                         <div className="flex items-center">
-                          <Form.Control className="mr-4 self-start">
+                          <Form.Control className="mr-4 self-start rtl:ml-4 rtl:mr-0">
                             <Switch
                               dir="ltr"
                               className="mt-[2px] rtl:rotate-180"
@@ -592,7 +592,7 @@ export const ExchangeCreateForm = ({
             )}
 
             {/* SEND NOTIFICATION*/}
-            <div className="bg-ui-bg-field mt-8 rounded-lg border py-2 pl-2 pr-4">
+            <div className="bg-ui-bg-field mt-8 rounded-lg border py-2 pl-2 pr-4 rtl:pl-4 rtl:pr-2">
               <Form.Field
                 control={form.control}
                 name="send_notification"
@@ -600,7 +600,7 @@ export const ExchangeCreateForm = ({
                   return (
                     <Form.Item>
                       <div className="flex items-center">
-                        <Form.Control className="mr-4 self-start">
+                        <Form.Control className="mr-4 self-start rtl:ml-4 rtl:mr-0">
                           <Switch
                             dir="ltr"
                             className="mt-[2px] rtl:rotate-180"

--- a/packages/admin/dashboard/src/routes/orders/order-create-fulfillment/components/order-create-fulfillment-form/order-create-fulfillment-item.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-fulfillment/components/order-create-fulfillment-form/order-create-fulfillment-item.tsx
@@ -133,7 +133,7 @@ export function OrderCreateFulfillmentItem({
     <div className="bg-ui-bg-subtle shadow-elevation-card-rest my-2 rounded-xl">
       <div className="flex flex-row items-center">
         {disabled && (
-          <div className="ml-4 inline-flex items-center">
+          <div className="ml-4 rtl:mr-4 rtl:ml-0 inline-flex items-center">
             <Tooltip
               content={t("orders.fulfillment.disabledItemTooltip")}
               side="top"
@@ -165,7 +165,7 @@ export function OrderCreateFulfillmentItem({
           </div>
 
           <div className="flex flex-1 items-center gap-x-1">
-            <div className="mr-2 block h-[16px] w-[2px] bg-gray-200" />
+            <div className="mr-2 rtl:ml-2 rtl:mr-0 block h-[16px] w-[2px] bg-gray-200" />
 
             <div className="text-small flex flex-1 flex-col">
               <span className="text-ui-fg-subtle font-medium">
@@ -177,7 +177,7 @@ export function OrderCreateFulfillmentItem({
             </div>
 
             <div className="flex flex-1 items-center gap-x-1">
-              <div className="mr-2 block h-[16px] w-[2px] bg-gray-200" />
+              <div className="mr-2 rtl:ml-2 rtl:mr-0 block h-[16px] w-[2px] bg-gray-200" />
 
               <div className="flex flex-col">
                 <span className="text-ui-fg-subtle font-medium">
@@ -205,6 +205,7 @@ export function OrderCreateFulfillmentItem({
                       <Form.Control>
                         <Input
                           className="bg-ui-bg-base txt-small w-[50px] rounded-lg text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                          dir="ltr"
                           type="number"
                           {...field}
                           onChange={(e) => {

--- a/packages/admin/dashboard/src/routes/orders/order-create-return/components/add-return-items-table/use-return-item-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-return/components/add-return-items-table/use-return-item-table-columns.tsx
@@ -71,7 +71,7 @@ export const useReturnItemTableColumns = (currencyCode: string) => {
       }),
       columnHelper.accessor("quantity", {
         header: () => (
-          <div className="flex size-full items-center overflow-hidden text-right" dir="ltr">
+          <div className="flex size-full items-center overflow-hidden text-right">
             <span className="truncate">{t("fields.quantity")}</span>
           </div>
         ),

--- a/packages/admin/dashboard/src/routes/orders/order-create-return/components/add-return-items-table/use-return-item-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-return/components/add-return-items-table/use-return-item-table-columns.tsx
@@ -71,7 +71,7 @@ export const useReturnItemTableColumns = (currencyCode: string) => {
       }),
       columnHelper.accessor("quantity", {
         header: () => (
-          <div className="flex size-full items-center overflow-hidden text-right">
+          <div className="flex size-full items-center overflow-hidden text-right" dir="ltr">
             <span className="truncate">{t("fields.quantity")}</span>
           </div>
         ),

--- a/packages/admin/dashboard/src/routes/orders/order-create-return/components/return-create-form/return-create-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-create-return/components/return-create-form/return-create-form.tsx
@@ -582,7 +582,7 @@ export const ReturnCreateForm = ({
                       <Text
                         size="small"
                         leading="compact"
-                        className="text-ui-fg-muted ml-1 inline"
+                        className="text-ui-fg-muted ml-1 rtl:mr-1 rtl:ml-0 inline"
                       >
                         ({t("fields.optional")})
                       </Text>
@@ -735,7 +735,7 @@ export const ReturnCreateForm = ({
             </div>
 
             {/* SEND NOTIFICATION*/}
-            <div className="bg-ui-bg-field mt-8 rounded-lg border py-2 pl-2 pr-4">
+            <div className="bg-ui-bg-field mt-8 rounded-lg border py-2 pl-2 pr-4 rtl:pl-4 rtl:pr-2">
               <Form.Field
                 control={form.control}
                 name="send_notification"
@@ -743,7 +743,7 @@ export const ReturnCreateForm = ({
                   return (
                     <Form.Item>
                       <div className="flex items-center">
-                        <Form.Control className="mr-4 self-start">
+                        <Form.Control className="mr-4 self-start rtl:ml-4 rtl:mr-0">
                           <Switch
                             dir="ltr"
                             className="mt-[2px] rtl:rotate-180"

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-activity-section/order-timeline.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-activity-section/order-timeline.tsx
@@ -706,6 +706,7 @@ const OrderActivityItem = ({
                 size="small"
                 leading="compact"
                 className="text-ui-fg-subtle text-right"
+                dir="ltr"
               >
                 {getRelativeDate(timestamp)}
               </Text>
@@ -739,7 +740,7 @@ const OrderActivityCollapsible = ({
             <div className="border-ui-border-strong w-px flex-1 bg-[linear-gradient(var(--border-strong)_33%,rgba(255,255,255,0)_0%)] bg-[length:1px_3px] bg-right bg-repeat-y" />
           </div>
           <div className="pb-4">
-            <RadixCollapsible.Trigger className="text-left">
+            <RadixCollapsible.Trigger className="text-left rtl:text-right">
               <Text
                 size="small"
                 leading="compact"

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-payment-section/order-payment-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-payment-section/order-payment-section.tsx
@@ -96,14 +96,14 @@ const Refund = ({
 
   const RefundNoteIndicator = refund.note && (
     <Tooltip content={refund.note}>
-      <DocumentText className="text-ui-tag-neutral-icon ml-1 inline" />
+      <DocumentText className="text-ui-tag-neutral-icon ml-1 inline rtl:mr-1 rtl:ml-0" />
     </Tooltip>
   )
 
   return (
     <div className="bg-ui-bg-subtle text-ui-fg-subtle grid grid-cols-[1fr_1fr_1fr_20px] items-center gap-x-4 px-6 py-4">
       <div className="flex flex-row">
-        <div className="self-center pr-3">
+        <div className="self-center pr-3 rtl:pl-3 rtl:pr-0">
           <ArrowDownRightMini className="text-ui-fg-muted" />
         </div>
         <div>

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
@@ -1028,7 +1028,7 @@ const ReturnBreakdownWithDamages = ({
 
           {item?.note && (
             <Tooltip content={item.note}>
-              <DocumentText className="text-ui-tag-neutral-icon ml-1 inline" />
+              <DocumentText className="text-ui-tag-neutral-icon ml-1 inline rtl:mr-1 rtl:ml-0" />
             </Tooltip>
           )}
 
@@ -1046,7 +1046,7 @@ const ReturnBreakdownWithDamages = ({
         <Text size="small" leading="compact" className="text-ui-fg-muted">
           {t(`orders.returns.damagedItemReceived`)}
 
-          <span className="ml-2">
+          <span className="ml-2 rtl:mr-2 rtl:ml-0">
             <ReturnInfoPopover orderReturn={orderReturn} />
           </span>
         </Text>
@@ -1106,7 +1106,7 @@ const ReturnBreakdown = ({
 
             {item?.note && (
               <Tooltip content={item.note}>
-                <DocumentText className="text-ui-tag-neutral-icon ml-1 inline" />
+                <DocumentText className="text-ui-tag-neutral-icon ml-1 inline rtl:mr-1 rtl:ml-0" />
               </Tooltip>
             )}
 
@@ -1124,7 +1124,7 @@ const ReturnBreakdown = ({
           {orderReturn && isRequested && (
             <Text size="small" leading="compact" className="text-ui-fg-muted">
               {getRelativeDate(orderReturn.created_at)}
-              <span className="ml-2">
+              <span className="ml-2 rtl:mr-2 rtl:ml-0">
                 <ReturnInfoPopover orderReturn={orderReturn} />
               </span>
             </Text>
@@ -1134,7 +1134,7 @@ const ReturnBreakdown = ({
             <Text size="small" leading="compact" className="text-ui-fg-muted">
               {t(`orders.returns.itemReceived`)}
 
-              <span className="ml-2">
+              <span className="ml-2 rtl:mr-2 rtl:ml-0">
                 <ReturnInfoPopover orderReturn={orderReturn} />
               </span>
             </Text>

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
@@ -578,12 +578,12 @@ const Cost = ({
     <Text size="small" leading="compact">
       {label} {tooltip}
     </Text>
-    <div className="text-right">
+    <div className="text-right" dir="ltr">
       <Text size="small" leading="compact">
         {secondaryValue}
       </Text>
     </div>
-    <div className="text-right">
+    <div className="text-right" dir="ltr">
       <Text size="small" leading="compact">
         {value}
       </Text>
@@ -654,7 +654,7 @@ const CostBreakdown = ({
       />
 
       {isShippingOpen && (
-        <div className="flex flex-col gap-1 pl-5">
+        <div className="flex flex-col gap-1 pl-5 rtl:pr-5 rtl:pl-0">
           {(order.shipping_methods || [])
             .sort((m1, m2) =>
               (m1.created_at as string).localeCompare(m2.created_at as string)
@@ -705,14 +705,14 @@ const CostBreakdown = ({
             )}
           </div>
 
-          <div className="text-right">
+          <div className="text-right" dir="ltr">
             <Text size="small" leading="compact">
               {getLocaleAmount(order.original_tax_total, order.currency_code)}
             </Text>
           </div>
         </div>
         {isTaxOpen && (
-          <div className="flex flex-col gap-1 pl-5">
+          <div className="flex flex-col gap-1 pl-5 rtl:pr-5 rtl:pl-0">
             {Object.entries(taxCodes).map(([code, { total, rate }]) => {
               return (
                 <div

--- a/packages/admin/dashboard/src/routes/orders/order-receive-return/components/order-receive-return-form/order-receive-return-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-receive-return/components/order-receive-return-form/order-receive-return-form.tsx
@@ -239,7 +239,7 @@ export function OrderReceiveReturnForm({
                 </div>
               )}
             </div>
-            <span className="text-ui-fg-muted txt-small text-right">
+            <span className="text-ui-fg-muted txt-small text-right" dir="ltr">
               {t("orders.returns.receive.itemsLabel")}
             </span>
           </div>
@@ -294,6 +294,7 @@ export function OrderReceiveReturnForm({
                                 type="number"
                                 value={value ?? 0}
                                 className="bg-ui-bg-field-component text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                                dir="ltr"
                                 onChange={(e) => {
                                   const value =
                                     e.target.value === ""

--- a/packages/admin/dashboard/src/routes/orders/order-receive-return/components/order-receive-return-form/order-receive-return-form.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-receive-return/components/order-receive-return-form/order-receive-return-form.tsx
@@ -239,7 +239,7 @@ export function OrderReceiveReturnForm({
                 </div>
               )}
             </div>
-            <span className="text-ui-fg-muted txt-small text-right" dir="ltr">
+            <span className="text-ui-fg-muted txt-small text-right">
               {t("orders.returns.receive.itemsLabel")}
             </span>
           </div>

--- a/packages/admin/dashboard/src/routes/product-variants/product-variant-media/components/edit-product-variant-media-form/edit-product-variant-media-form.tsx
+++ b/packages/admin/dashboard/src/routes/product-variants/product-variant-media/components/edit-product-variant-media-form/edit-product-variant-media-form.tsx
@@ -255,7 +255,7 @@ export const EditProductVariantMediaForm = ({
                 onClick={() => setIsSidebarOpen(false)}
               >
                 <div
-                  className="bg-ui-bg-base border-ui-border-base absolute right-0 top-0 h-full w-80 border-l"
+                  className="bg-ui-bg-base border-ui-border-base absolute right-0 top-0 h-full w-80 border-l rtl:left-0 rtl:right-auto rtl:border-r rtl:border-l-0"
                   onClick={(e) => e.stopPropagation()}
                 >
                   <div className="border-ui-border-base border-b p-4">
@@ -264,7 +264,7 @@ export const EditProductVariantMediaForm = ({
                         <h3 className="ui-fg-base text-sm font-medium">
                           {t("products.media.availableImages")}
                         </h3>
-                        <p className="text-ui-fg-muted mt-1 pr-2 text-xs">
+                        <p className="text-ui-fg-muted mt-1 pr-2 text-xs rtl:pl-2 rtl:pr-0">
                           {t("products.media.selectToAdd")}
                         </p>
                       </div>
@@ -372,14 +372,14 @@ const MediaGridItem = ({
       )}
     >
       {isThumbnail && (
-        <div className="absolute left-2 top-2">
+        <div className="absolute left-2 top-2 rtl:right-2 rtl:left-auto">
           <Tooltip content={t("products.media.thumbnailTooltip")}>
             <ThumbnailBadge />
           </Tooltip>
         </div>
       )}
       <div
-        className={clx("transition-fg absolute right-2 top-2 opacity-0", {
+        className={clx("transition-fg absolute right-2 top-2 opacity-0 rtl:left-2 rtl:right-auto", {
           "group-focus-within:opacity-100 group-hover:opacity-100 group-focus:opacity-100":
             !checked,
           "opacity-100": checked,

--- a/packages/admin/dashboard/src/routes/products/product-media/components/edit-product-media-form/edit-product-media-form.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-media/components/edit-product-media-form/edit-product-media-form.tsx
@@ -253,7 +253,7 @@ export const EditProductMediaForm = ({ product }: ProductMediaViewProps) => {
                 </div>
               </div>
             </DndContext>
-            <div className="bg-ui-bg-base overflow-auto border-b px-6 py-4 lg:border-b-0 lg:border-l">
+            <div className="bg-ui-bg-base overflow-auto border-b px-6 py-4 lg:border-b-0 lg:border-l rtl:lg:border-r rtl:lg:border-l-0">
               <UploadMediaFormItem form={form} append={append} />
             </div>
           </div>
@@ -388,7 +388,7 @@ const MediaGridItem = ({
       ref={setNodeRef}
     >
       {media.isThumbnail && (
-        <div className="absolute left-2 top-2">
+        <div className="absolute left-2 top-2 rtl:right-2 rtl:left-auto">
           <Tooltip content={t("products.media.thumbnailTooltip")}>
             <ThumbnailBadge />
           </Tooltip>
@@ -403,7 +403,7 @@ const MediaGridItem = ({
         {...listeners}
       />
       <div
-        className={clx("transition-fg absolute right-2 top-2 opacity-0", {
+        className={clx("transition-fg absolute right-2 top-2 opacity-0 rtl:left-2 rtl:right-auto", {
           "group-focus-within:opacity-100 group-hover:opacity-100 group-focus:opacity-100":
             !isDragging && !checked,
           "opacity-100": checked,
@@ -436,12 +436,12 @@ export const MediaGridItemOverlay = ({
   return (
     <div className="shadow-elevation-card-rest hover:shadow-elevation-card-hover focus-visible:shadow-borders-focus bg-ui-bg-subtle-hover group relative aspect-square h-auto max-w-full cursor-grabbing overflow-hidden rounded-lg outline-none">
       {media.isThumbnail && (
-        <div className="absolute left-2 top-2">
+        <div className="absolute left-2 top-2 rtl:right-2 rtl:left-auto">
           <ThumbnailBadge />
         </div>
       )}
       <div
-        className={clx("transition-fg absolute right-2 top-2 opacity-0", {
+        className={clx("transition-fg absolute right-2 top-2 opacity-0 rtl:left-2 rtl:right-auto", {
           "opacity-100": checked,
         })}
       >

--- a/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rules-form-field/rules-form-field.tsx
+++ b/packages/admin/dashboard/src/routes/promotions/common/edit-rules/components/rules-form-field/rules-form-field.tsx
@@ -399,7 +399,7 @@ export const RulesFormField = ({
 
             {index < fields.length - 1 && (
               <div className="relative px-6 py-3">
-                <div className="border-ui-border-strong absolute bottom-0 left-[40px] top-0 z-[-1] w-px bg-[linear-gradient(var(--border-strong)_33%,rgba(255,255,255,0)_0%)] bg-[length:1px_3px] bg-repeat-y"></div>
+                <div className="border-ui-border-strong absolute bottom-0 left-[40px] top-0 z-[-1] w-px bg-[linear-gradient(var(--border-strong)_33%,rgba(255,255,255,0)_0%)] bg-[length:1px_3px] bg-repeat-y rtl:right-[40px] rtl:left-auto"></div>
 
                 <Badge size="2xsmall" className=" text-xs">
                   {t("promotions.form.and")}
@@ -431,7 +431,7 @@ export const RulesFormField = ({
           <Button
             type="button"
             variant="transparent"
-            className="text-ui-fg-muted hover:text-ui-fg-subtle ml-2 inline-block"
+            className="text-ui-fg-muted hover:text-ui-fg-subtle ml-2 inline-block rtl:mr-2 rtl:ml-0"
             onClick={() => {
               const indicesToRemove = fields
                 .map((field: any, index) => {

--- a/packages/admin/dashboard/src/routes/reservations/reservation-list/components/reservation-list-table/use-reservation-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/reservations/reservation-list/components/reservation-list-table/use-reservation-table-columns.tsx
@@ -78,7 +78,7 @@ export const useReservationTableColumns = () => {
       }),
       columnHelper.accessor("quantity", {
         header: () => (
-          <div className="flex size-full items-center justify-end overflow-hidden text-right">
+          <div className="flex size-full items-center justify-end overflow-hidden text-right" dir="ltr">
             <span className="truncate">{t("fields.quantity")}</span>
           </div>
         ),
@@ -86,7 +86,7 @@ export const useReservationTableColumns = () => {
           const quantity = getValue()
 
           return (
-            <div className="flex size-full items-center justify-end overflow-hidden text-right">
+            <div className="flex size-full items-center justify-end overflow-hidden text-right" dir="ltr">
               <span className="truncate">{quantity}</span>
             </div>
           )

--- a/packages/admin/dashboard/src/routes/reservations/reservation-list/components/reservation-list-table/use-reservation-table-columns.tsx
+++ b/packages/admin/dashboard/src/routes/reservations/reservation-list/components/reservation-list-table/use-reservation-table-columns.tsx
@@ -78,7 +78,7 @@ export const useReservationTableColumns = () => {
       }),
       columnHelper.accessor("quantity", {
         header: () => (
-          <div className="flex size-full items-center justify-end overflow-hidden text-right" dir="ltr">
+          <div className="flex size-full items-center justify-end overflow-hidden text-right">
             <span className="truncate">{t("fields.quantity")}</span>
           </div>
         ),
@@ -86,7 +86,7 @@ export const useReservationTableColumns = () => {
           const quantity = getValue()
 
           return (
-            <div className="flex size-full items-center justify-end overflow-hidden text-right" dir="ltr">
+            <div className="flex size-full items-center justify-end overflow-hidden text-right">
               <span className="truncate">{quantity}</span>
             </div>
           )


### PR DESCRIPTION
Closes #15371

## Summary

**What** — Fix RTL layout issues in the admin dashboard when `dir="rtl"` is active (Hebrew, Arabic, Farsi languages).

**Why** — The dashboard sets `dir="rtl"` on `<html>` when an RTL language is selected, but many components use directional Tailwind classes (`pl-*`, `pr-*`, `ml-*`, `mr-*`, `left-*`, `right-*`, `border-l/r`) without `rtl:` counterparts, causing broken layouts — wrong padding sides, misaligned icons, absolute-positioned elements on the wrong side.

**How** — For each directional class, assessed whether it is **semantic** (conveys reading/navigation direction — should flip in RTL) or **decorative** (fixed visual, should stay). Added `rtl:` Tailwind variant counterparts for semantic cases. Added `dir="ltr"` to elements displaying monetary values and numeric data (universally LTR regardless of locale).

**Testing** — Verified by switching the dashboard to עברית (Hebrew) and spot-checking: sidebar nav, forms, modals, tables, data grid, order flows, media galleries.

---

## Changes

| Component | Fix |
|---|---|
| `nav-item` | `pl-*`/`pr-*` padding swapped with `rtl:` counterparts |
| `data-grid-root` | `border-r` cell separators flip, resize handle flips, `ml-auto` toolbar flips |
| `money-amount-cell`, `data-grid-currency-cell` | `dir="ltr"` on numeric value elements |
| `order-summary-section` | `pl-5` indents flip, icon `ml-*` margins flip |
| `order-allocate-items-item`, `order-create-fulfillment-item`, `order-edit-item` | `ml-*`/`mr-*` margins flip |
| `claim-create-form`, `exchange-create-form`, `return-create-form`, `order-edit-create-form`, `order-receive-return-form` | Form field container `pl-2 pr-4` and control `mr-4` flip |
| `order-timeline` | `text-left` trigger gets `rtl:text-right` |
| `order-payment-section` | Icon margin and padding flip |
| `edit-product-media-form`, `edit-product-variant-media-form` | Absolute overlay buttons flip sides |
| `rules-form-field` | Tree connector `left-[40px]` flips to `right-[40px]` |
| `json-view-section` | Content wrapper gets `dir="ltr"` (code is always LTR) |

---

## Checklist

- [x] I have added a **changeset** for this PR (patch)
- [ ] The changes are covered by relevant **tests** *(RTL layout correctness is verified visually)*
- [x] I have verified the code works as intended locally