### PR TITLE
fix(@medusajs/medusa): prevent sorting orders by computed fields

### DIFF
--- a/.changeset/sort-orders-computed-fields.md
+++ b/.changeset/sort-orders-computed-fields.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): prevent sorting orders by computed fulfillment_status, payment_status, and total fields

--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -478,6 +478,47 @@ medusaIntegrationTestRunner({
           order.billing_address.city
         )
       })
+
+      it("should not error when sorting by fulfillment_status (computed field)", async () => {
+        const response = await api.get(
+          `/admin/orders?order=fulfillment_status`,
+          adminHeaders
+        )
+
+        expect(response.status).toBe(200)
+        expect(response.data.orders).toBeDefined()
+      })
+
+      it("should not error when sorting by payment_status (computed field)", async () => {
+        const response = await api.get(
+          `/admin/orders?order=-payment_status`,
+          adminHeaders
+        )
+
+        expect(response.status).toBe(200)
+        expect(response.data.orders).toBeDefined()
+      })
+
+      it("should not error when sorting by total (computed field)", async () => {
+        const response = await api.get(
+          `/admin/orders?order=total`,
+          adminHeaders
+        )
+
+        expect(response.status).toBe(200)
+        expect(response.data.orders).toBeDefined()
+      })
+
+      it("should not error when sorting by a valid database column", async () => {
+        const response = await api.get(
+          `/admin/orders?order=created_at`,
+          adminHeaders
+        )
+
+        expect(response.status).toBe(200)
+        expect(response.data.orders).toBeDefined()
+        expect(response.data.orders).toHaveLength(1)
+      })
     })
 
     describe("POST /orders/:id", () => {

--- a/packages/medusa/src/api/admin/orders/validators.ts
+++ b/packages/medusa/src/api/admin/orders/validators.ts
@@ -70,9 +70,33 @@ const AdminGetOrdersParamsBase = createFindParams({
 type AdminGetOrdersParamsInput = z.infer<typeof AdminGetOrdersParamsBase>
 
 const AdminGetOrdersParamsTransform = (v: AdminGetOrdersParamsInput) => {
-  const { total, ...rest } = v
+  const { total, order, ...rest } = v as AdminGetOrdersParamsInput & {
+    order?: string
+  }
+
+  // Strip unsortable computed fields from the order parameter.
+  // fulfillment_status and payment_status are computed in the
+  // getOrdersListWorkflow after the DB query (via aggregate-status
+  // helpers). total is not a database column either — it is
+  // calculated post-query. Passing any of these to MikroORM
+  // causes "Trying to order by not existing property".
+  const UNORDERABLE_FIELDS = [
+    "fulfillment_status",
+    "payment_status",
+    "total",
+  ]
+
+  let order_ = order
+  if (order) {
+    const field = order.replace(/^-/, "")
+    if (UNORDERABLE_FIELDS.includes(field)) {
+      order_ = undefined
+    }
+  }
+
   return {
     ...rest,
+    ...(order_ ? { order: order_ } : {}),
     ...(total ? { summary: { totals: { current_order_total: total } } } : {}),
   }
 }


### PR DESCRIPTION
## What

Prevents MikroORM errors when admin orders list is sorted by computed fields `fulfillment_status`, `payment_status`, or `total`, which are not real database columns.

## Why

When a user sorts orders by any of these computed fields in the admin panel, MikroORM throws `Trying to order by not existing property Order.<field>` because these fields are computed post-query (set in `getOrdersListWorkflow`), not stored as columns. Fixes #15353.

## How

Added logic in `AdminGetOrdersParamsTransform` (validators.ts) to strip `fulfillment_status`, `payment_status`, and `total` from the `order` (sort) parameter. The fields are detected by stripping the optional `-` prefix for descending sort. Uses an `UNORDERABLE_FIELDS` constant array for clarity.

## Changes

- `packages/medusa/src/api/admin/orders/validators.ts`: strip computed fields from order parameter (+25 -1 lines)
- `integration-tests/http/__tests__/order/admin/order.spec.ts`: add tests for all three computed fields and a valid field regression check (+41 lines)
- `.changeset/sort-orders-computed-fields.md`: add changeset for patch bump

## Testing

- Sort by `fulfillment_status`: field stripped, no MikroORM error ✅
- Sort by `-payment_status`: field stripped, no MikroORM error ✅
- Sort by `total`: field stripped, no MikroORM error ✅
- Sort by `created_at` (valid column): normal behavior preserved ✅