### PR TITLE
fix: add missing GMD (Gambian Dalasi) currency

### DIFF
--- a/packages/admin/dashboard/src/lib/data/currencies.ts
+++ b/packages/admin/dashboard/src/lib/data/currencies.ts
@@ -247,6 +247,12 @@ export const currencies: Record<string, CurrencyInfo> = {
     symbol_native: "GH₵",
     decimal_digits: 2,
   },
+  GMD: {
+    code: "GMD",
+    name: "Gambian Dalasi",
+    symbol_native: "D",
+    decimal_digits: 2,
+  },
   GNF: {
     code: "GNF",
     name: "Guinean Franc",

--- a/packages/core/utils/src/defaults/currencies.ts
+++ b/packages/core/utils/src/defaults/currencies.ts
@@ -369,6 +369,15 @@ export const defaultCurrencies: Record<string, Currency> = {
     code: "GHS",
     name_plural: "Ghanaian cedis",
   },
+  GMD: {
+    symbol: "D",
+    name: "Gambian Dalasi",
+    symbol_native: "D",
+    decimal_digits: 2,
+    rounding: 0,
+    code: "GMD",
+    name_plural: "Gambian dalasis",
+  },
   GNF: {
     symbol: "FG",
     name: "Guinean Franc",


### PR DESCRIPTION
## What does this PR do?

Adds the missing GMD (Gambian Dalasi) entry to the currency maps in both:

- `packages/core/utils/src/defaults/currencies.ts`
- `packages/admin/dashboard/src/lib/data/currencies.ts`

## Why is it needed?

GMD is a valid ISO 4217 currency code but was absent from both maps. When a store has GMD configured as a supported currency, the admin region-create page crashes with:

```
Cannot read properties of undefined (reading 'code')
```

because the lookup returns `undefined` for GMD.

## How was it tested?

Manual inspection of the existing entries — the fix follows the identical pattern used by all adjacent currency entries (GHS, GNF). GMD is inserted alphabetically between GHS and GNF.

Fixes #15265