### PR TITLE
fix(utils): disable generating snapshots on running migrations

### DIFF
--- a/.changeset/soft-clowns-relate.md
+++ b/.changeset/soft-clowns-relate.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/utils": patch
+---
+
+fix(utils): disable generating snapshots on running migrations

--- a/packages/core/utils/src/dal/mikro-orm/custom-db-migrator.ts
+++ b/packages/core/utils/src/dal/mikro-orm/custom-db-migrator.ts
@@ -42,11 +42,11 @@ export class CustomDBMigrator extends BaseMigrator {
         const up = instance.up
         const down = instance.down
         instance.up = async function (...args) {
-          this.driver.execute(`SET LOCAL search_path TO ${customSchema}`)
+          await this.driver.execute(`SET LOCAL search_path TO ${customSchema}`)
           return up.bind(this)(...args)
         }
         instance.down = async function (...args) {
-          this.driver.execute(`SET LOCAL search_path TO ${customSchema}`)
+          await this.driver.execute(`SET LOCAL search_path TO ${customSchema}`)
           return down.bind(this)(...args)
         }
       }

--- a/packages/core/utils/src/dal/mikro-orm/mikro-orm-create-connection.ts
+++ b/packages/core/utils/src/dal/mikro-orm/mikro-orm-create-connection.ts
@@ -74,6 +74,7 @@ export async function mikroOrmCreateConnection(
   database: ModuleServiceInitializeOptions["database"] & {
     connection?: any
     snapshotName?: string
+    snapshot?: boolean
     filters?: Record<string, Filter>
   },
   entities: any[],
@@ -131,6 +132,7 @@ export async function mikroOrmCreateConnection(
       disableForeignKeys: false,
       path: pathToMigrations,
       snapshotName: database.snapshotName,
+      snapshot: database.snapshot,
       generator: CustomTsMigrationGenerator,
       silent: !(
         database.debug ??

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -199,8 +199,8 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
    */
   protected async migrateSnapshotFile(snapshotPath: string): Promise<void> {
     // If the expected snapshot already exists, no rename needed — running the
-    // rename would incorrectly overwrite it with a stale full-DB snapshot
-    // (e.g. .snapshot-<databaseName>.json) left by db:migrate.
+    // rename would incorrectly overwrite it with an incorrect snapshot file,
+    // leading to side effects when generating migrations
     const alreadyExists = await access(snapshotPath)
       .then(() => true)
       .catch(() => false)

--- a/packages/core/utils/src/migrations/index.ts
+++ b/packages/core/utils/src/migrations/index.ts
@@ -10,7 +10,7 @@ import {
 } from "@medusajs/deps/mikro-orm/postgresql"
 import { EventEmitter } from "events"
 import { access, mkdir, rename, writeFile } from "fs/promises"
-import { dirname, join } from "path"
+import { basename, dirname, join } from "path"
 import { readDir } from "../common"
 import { CustomDBMigrator } from "../dal/mikro-orm/custom-db-migrator"
 
@@ -198,19 +198,34 @@ export class Migrations extends EventEmitter<MigrationsEvents> {
    * the first one will be used.
    */
   protected async migrateSnapshotFile(snapshotPath: string): Promise<void> {
+    // If the expected snapshot already exists, no rename needed — running the
+    // rename would incorrectly overwrite it with a stale full-DB snapshot
+    // (e.g. .snapshot-<databaseName>.json) left by db:migrate.
+    const alreadyExists = await access(snapshotPath)
+      .then(() => true)
+      .catch(() => false)
+    if (alreadyExists) {
+      return
+    }
+
     const entries = await readDir(dirname(snapshotPath), {
       ignoreMissing: true,
     })
 
-    /**
-     * We assume all JSON files are snapshot files in this directory
-     */
+    // Only rename the exact known legacy filename (`.snapshot-<module>.json`
+    // renamed to `.snapshot-medusa-<module>.json` for plugin:db:generate users).
+    // Matching any `.json` file risks picking up full-DB snapshots.
+    const expectedName = basename(snapshotPath)
+    const legacyName = expectedName.replace(/^\.snapshot-medusa-/, ".snapshot-")
     const snapshotFile = entries.find(
-      (entry) => entry.isFile() && entry.name.endsWith(".json")
+      (entry) => entry.isFile() && entry.name === legacyName
     )
 
     if (snapshotFile) {
-      const absoluteName = join(snapshotFile.parentPath || snapshotFile.path, snapshotFile.name)
+      const absoluteName = join(
+        snapshotFile.parentPath || snapshotFile.path,
+        snapshotFile.name
+      )
 
       if (absoluteName !== snapshotPath) {
         await rename(absoluteName, snapshotPath)

--- a/packages/core/utils/src/migrations/integration-tests/__tests__/migrations-generate.spec.ts
+++ b/packages/core/utils/src/migrations/integration-tests/__tests__/migrations-generate.spec.ts
@@ -3,11 +3,22 @@ import { join } from "path"
 import { setTimeout } from "timers/promises"
 
 import { FileSystem } from "../../../common"
-import { DmlEntity, mikroORMEntityBuilder, model, toMikroOrmEntities } from "../../../dml"
+import {
+  DmlEntity,
+  mikroORMEntityBuilder,
+  model,
+  toMikroOrmEntities,
+} from "../../../dml"
 import { defineMikroOrmCliConfig } from "../../../modules-sdk"
 import { BigNumber } from "../../../totals/big-number"
 import { mikroOrmCreateConnection } from "../../../dal"
 import { Migrations } from "../../index"
+
+class TestMigrations extends Migrations {
+  async callMigrateSnapshotFile(snapshotPath: string) {
+    return this.migrateSnapshotFile(snapshotPath)
+  }
+}
 
 jest.setTimeout(30000)
 
@@ -139,7 +150,7 @@ describe("Generate migrations", () => {
   })
 
   test("generate new file when entities are added", async () => {
-    function run(entities: DmlEntity<any, any>[]) {
+    async function run(entities: DmlEntity<any, any>[]) {
       const config = defineMikroOrmCliConfig(moduleName, {
         entities,
         dbName: dbName,
@@ -204,13 +215,14 @@ describe("Generate migrations", () => {
     expect(await fs.exists(`.snapshot-${dbName}.json`)).toBeFalsy()
   })
 
-  test("rename existing snapshot file to the new filename", async () => {
-    await fs.createJson(".snapshot-foo.json", {
+  test("rename existing snapshot file to the new filename (plugins)", async () => {
+    // Legacy snapshot name: no medusa- prefix, matching the module name
+    await fs.createJson(".snapshot-my-test-generate.json", {
       tables: [],
       namespaces: [],
     })
 
-    function run(entities: DmlEntity<any, any>[]) {
+    async function run(entities: DmlEntity<any, any>[]) {
       const config = defineMikroOrmCliConfig(moduleName, {
         entities,
         dbName: dbName,
@@ -232,7 +244,7 @@ describe("Generate migrations", () => {
 
     const run1 = await run([User])
     expect(await fs.exists(run1.fileName))
-    expect(await fs.exists(".snapshot-foo.json")).toBeFalsy()
+    expect(await fs.exists(".snapshot-my-test-generate.json")).toBeFalsy()
     expect(
       await fs.exists(".snapshot-medusa-my-test-generate.json")
     ).toBeTruthy()
@@ -248,5 +260,80 @@ describe("Generate migrations", () => {
     expect(await fs.exists(run2.fileName))
 
     expect(run1.fileName).not.toEqual(run2.fileName)
+  })
+})
+
+describe("migrateSnapshotFile", () => {
+  const snapshotFs = new FileSystem(join(__dirname, "./migrations-snapshot"))
+
+  beforeEach(async () => {
+    await snapshotFs.cleanup()
+  })
+
+  afterEach(async () => {
+    await snapshotFs.cleanup()
+  })
+
+  test("preserves correct module snapshot when a DB-name snapshot also exists", async () => {
+    const moduleSnapshotName = ".snapshot-my-module.json"
+    const dbSnapshotName = ".snapshot-medusa-my-module.json"
+
+    await snapshotFs.createJson(moduleSnapshotName, {
+      tables: ["user"],
+      namespaces: [],
+    })
+    await snapshotFs.createJson(dbSnapshotName, {
+      tables: ["user", "order", "cart"],
+      namespaces: [],
+    })
+
+    const migrations = new TestMigrations({})
+    await migrations.callMigrateSnapshotFile(
+      join(snapshotFs.basePath, moduleSnapshotName)
+    )
+
+    // Module snapshot must be untouched
+    const content = await snapshotFs.contentsJson(moduleSnapshotName)
+    expect(content.tables).toEqual(["user"])
+
+    // DB-name snapshot must still exist (not deleted or renamed)
+    expect(await snapshotFs.exists(dbSnapshotName)).toBeTruthy()
+  })
+
+  test("does not rename a DB-name snapshot to the module snapshot name", async () => {
+    const moduleSnapshotName = ".snapshot-my-module.json"
+    const dbSnapshotName = ".snapshot-medusa-my-module.json"
+
+    await snapshotFs.createJson(dbSnapshotName, {
+      tables: ["user", "order", "cart"],
+      namespaces: [],
+    })
+
+    const migrations = new TestMigrations({})
+    await migrations.callMigrateSnapshotFile(
+      join(snapshotFs.basePath, moduleSnapshotName)
+    )
+
+    // DB-name snapshot must NOT have been renamed to the module snapshot name
+    expect(await snapshotFs.exists(moduleSnapshotName)).toBeFalsy()
+    expect(await snapshotFs.exists(dbSnapshotName)).toBeTruthy()
+  })
+
+  test("renames legacy plugin snapshot (no medusa- prefix) to the new plugin snapshot name (with medusa- prefix)", async () => {
+    const legacySnapshotName = ".snapshot-my-module.json"
+    const newSnapshotName = ".snapshot-medusa-my-module.json"
+
+    await snapshotFs.createJson(legacySnapshotName, {
+      tables: ["user"],
+      namespaces: [],
+    })
+
+    const migrations = new TestMigrations({})
+    await migrations.callMigrateSnapshotFile(
+      join(snapshotFs.basePath, newSnapshotName)
+    )
+
+    expect(await snapshotFs.exists(newSnapshotName)).toBeTruthy()
+    expect(await snapshotFs.exists(legacySnapshotName)).toBeFalsy()
   })
 })

--- a/packages/core/utils/src/migrations/integration-tests/__tests__/migrations-generate.spec.ts
+++ b/packages/core/utils/src/migrations/integration-tests/__tests__/migrations-generate.spec.ts
@@ -3,9 +3,10 @@ import { join } from "path"
 import { setTimeout } from "timers/promises"
 
 import { FileSystem } from "../../../common"
-import { DmlEntity, mikroORMEntityBuilder, model } from "../../../dml"
+import { DmlEntity, mikroORMEntityBuilder, model, toMikroOrmEntities } from "../../../dml"
 import { defineMikroOrmCliConfig } from "../../../modules-sdk"
 import { BigNumber } from "../../../totals/big-number"
+import { mikroOrmCreateConnection } from "../../../dal"
 import { Migrations } from "../../index"
 
 jest.setTimeout(30000)
@@ -172,6 +173,35 @@ describe("Generate migrations", () => {
     expect(await fs.exists(run2.fileName))
 
     expect(run1.fileName).not.toEqual(run2.fileName)
+  })
+
+  test("snapshot file is named after the module name, not the database name", async () => {
+    const User = model.define("User", {
+      id: model.id().primaryKey(),
+      email: model.text().unique(),
+    })
+
+    /**
+     * Simulate what buildGenerateMigrationScript does: pass snapshotName
+     * derived from the module key so the snapshot is always named after
+     * the module, never after the runtime database name.
+     */
+    const moduleKey = "my-custom-module"
+    const orm = await mikroOrmCreateConnection(
+      {
+        clientUrl: `postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/${dbName}`,
+        snapshotName: `.snapshot-${moduleKey}`,
+      },
+      toMikroOrmEntities([User]),
+      fs.basePath
+    )
+
+    const migrations = new Migrations(orm)
+    await migrations.generate()
+
+    expect(await fs.exists(`.snapshot-${moduleKey}.json`)).toBeTruthy()
+    // Must not fall back to a DB-name-based snapshot
+    expect(await fs.exists(`.snapshot-${dbName}.json`)).toBeFalsy()
   })
 
   test("rename existing snapshot file to the new filename", async () => {

--- a/packages/core/utils/src/migrations/integration-tests/__tests__/migrations-run.spec.ts
+++ b/packages/core/utils/src/migrations/integration-tests/__tests__/migrations-run.spec.ts
@@ -4,10 +4,11 @@ import { MetadataStorage } from "@medusajs/deps/mikro-orm/core"
 import { createDatabase, dropDatabase } from "pg-god"
 import { TSMigrationGenerator } from "@medusajs/deps/mikro-orm/migrations"
 
-import { model } from "../../../dml"
+import { model, toMikroOrmEntities } from "../../../dml"
 import { FileSystem } from "../../../common"
 import { Migrations, MigrationsEvents } from "../../index"
 import { defineMikroOrmCliConfig } from "../../../modules-sdk"
+import { mikroOrmCreateConnection } from "../../../dal"
 
 const migrationFileNameGenerator = (_: string, name?: string) => {
   return `Migration${new Date().getTime()}${name ? `_${name}` : ""}`
@@ -131,6 +132,49 @@ describe.skip("Run migrations", () => {
       path: expect.stringContaining(__dirname),
       context: {},
     })
+  })
+
+  test("running migrations does not create a snapshot file", async () => {
+    const moduleKey = "my-test-run-module"
+
+    const User = model.define("User", {
+      id: model.id().primaryKey(),
+      email: model.text().unique(),
+    })
+
+    /**
+     * First generate a migration using the module-name snapshot convention,
+     * mirroring what buildGenerateMigrationScript does.
+     */
+    const generateOrm = await mikroOrmCreateConnection(
+      {
+        clientUrl: `postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/${dbName}`,
+        snapshotName: `.snapshot-${moduleKey}`,
+      },
+      toMikroOrmEntities([User]),
+      fs.basePath
+    )
+    await new Migrations(generateOrm).generate()
+    expect(await fs.exists(`.snapshot-${moduleKey}.json`)).toBeTruthy()
+
+    /**
+     * Now run the migration with snapshot: false, mirroring what
+     * buildMigrationScript does. No new snapshot file should appear.
+     */
+    const runOrm = await mikroOrmCreateConnection(
+      {
+        clientUrl: `postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/${dbName}`,
+        snapshot: false,
+      },
+      [],
+      fs.basePath
+    )
+    await new Migrations(runOrm).run()
+
+    // Module-name snapshot must remain untouched
+    expect(await fs.exists(`.snapshot-${moduleKey}.json`)).toBeTruthy()
+    // No DB-name-based snapshot must have been created
+    expect(await fs.exists(`.snapshot-${dbName}.json`)).toBeFalsy()
   })
 
   test("throw error when migration fails during run", async () => {

--- a/packages/core/utils/src/modules-sdk/migration-scripts/migration-down.ts
+++ b/packages/core/utils/src/modules-sdk/migration-scripts/migration-down.ts
@@ -35,7 +35,11 @@ export function buildRevertMigrationScript({ moduleName, pathToMigrations }) {
     logger.info(`MODULE: ${moduleName}`)
 
     const dbData = loadDatabaseConfig(moduleName, options)!
-    const orm = await mikroOrmCreateConnection(dbData, [], pathToMigrations)
+    const orm = await mikroOrmCreateConnection(
+      { ...dbData, snapshot: false },
+      [],
+      pathToMigrations
+    )
     const migrations = new Migrations(orm)
 
     migrations.on("reverting", (migration) => {

--- a/packages/core/utils/src/modules-sdk/migration-scripts/migration-down.ts
+++ b/packages/core/utils/src/modules-sdk/migration-scripts/migration-down.ts
@@ -36,7 +36,7 @@ export function buildRevertMigrationScript({ moduleName, pathToMigrations }) {
 
     const dbData = loadDatabaseConfig(moduleName, options)!
     const orm = await mikroOrmCreateConnection(
-      { ...dbData, snapshot: false, pool: { min: 0 } },
+      { ...dbData, snapshot: false },
       [],
       pathToMigrations
     )

--- a/packages/core/utils/src/modules-sdk/migration-scripts/migration-down.ts
+++ b/packages/core/utils/src/modules-sdk/migration-scripts/migration-down.ts
@@ -36,7 +36,7 @@ export function buildRevertMigrationScript({ moduleName, pathToMigrations }) {
 
     const dbData = loadDatabaseConfig(moduleName, options)!
     const orm = await mikroOrmCreateConnection(
-      { ...dbData, snapshot: false },
+      { ...dbData, snapshot: false, pool: { min: 0 } },
       [],
       pathToMigrations
     )

--- a/packages/core/utils/src/modules-sdk/migration-scripts/migration-up.ts
+++ b/packages/core/utils/src/modules-sdk/migration-scripts/migration-up.ts
@@ -34,7 +34,11 @@ export function buildMigrationScript({ moduleName, pathToMigrations }) {
     logger.info(`MODULE: ${moduleName}`)
 
     const dbData = loadDatabaseConfig(moduleName, options)!
-    const orm = await mikroOrmCreateConnection(dbData, [], pathToMigrations)
+    const orm = await mikroOrmCreateConnection(
+      { ...dbData, snapshot: false },
+      [],
+      pathToMigrations
+    )
     const migrations = new Migrations(orm)
 
     migrations.on("migrating", (migration) => {

--- a/packages/core/utils/src/modules-sdk/migration-scripts/migration-up.ts
+++ b/packages/core/utils/src/modules-sdk/migration-scripts/migration-up.ts
@@ -35,7 +35,7 @@ export function buildMigrationScript({ moduleName, pathToMigrations }) {
 
     const dbData = loadDatabaseConfig(moduleName, options)!
     const orm = await mikroOrmCreateConnection(
-      { ...dbData, snapshot: false, pool: { min: 0 } },
+      { ...dbData, snapshot: false },
       [],
       pathToMigrations
     )

--- a/packages/core/utils/src/modules-sdk/migration-scripts/migration-up.ts
+++ b/packages/core/utils/src/modules-sdk/migration-scripts/migration-up.ts
@@ -35,7 +35,7 @@ export function buildMigrationScript({ moduleName, pathToMigrations }) {
 
     const dbData = loadDatabaseConfig(moduleName, options)!
     const orm = await mikroOrmCreateConnection(
-      { ...dbData, snapshot: false },
+      { ...dbData, snapshot: false, pool: { min: 0 } },
       [],
       pathToMigrations
     )


### PR DESCRIPTION
Disable generating snapshots when running migrations + added tests