### PR TITLE
fix: build should throw if medusa-config throws

### DIFF
--- a/.changeset/ten-kiwis-mate.md
+++ b/.changeset/ten-kiwis-mate.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/framework": patch
+"@medusajs/medusa": patch
+---
+
+builds should fail if medusa-config throws

--- a/packages/core/framework/src/config/__fixtures__/medusa-config-throwing.js
+++ b/packages/core/framework/src/config/__fixtures__/medusa-config-throwing.js
@@ -1,0 +1,5 @@
+import { defineConfig } from "@medusajs/utils"
+
+throw new Error("Uncaught error in medusa-config-throwing.js")
+
+export default defineConfig()

--- a/packages/core/framework/src/config/__tests__/index.spec.ts
+++ b/packages/core/framework/src/config/__tests__/index.spec.ts
@@ -1,7 +1,8 @@
-import { configLoader } from "../loader"
+import { ContainerRegistrationKeys } from "@medusajs/utils"
 import { join } from "path"
 import { container } from "../../container"
-import { ContainerRegistrationKeys } from "@medusajs/utils"
+import { logger } from "../../logger"
+import { configLoader } from "../loader"
 
 describe("configLoader", () => {
   const entryDirectory = join(__dirname, "../__fixtures__")
@@ -39,9 +40,9 @@ describe("configLoader", () => {
     expect(configModule.projectConfig.workerMode).toBe("worker")
   })
 
-  it("should load config without throwing errors when throwOnError is false", async () => {
+  it("should load config without throwing errors when throwOnValidationError is false", async () => {
     await configLoader(entryDirectory, "medusa-config", {
-      throwOnError: false,
+      throwOnValidationError: false,
     })
 
     const configModule = container.resolve(
@@ -52,10 +53,10 @@ describe("configLoader", () => {
     expect(configModule.projectConfig).toBeDefined()
   })
 
-  it("should pass throwOnError option through to buildHttpConfig", async () => {
+  it("should pass throwOnValidationError option through to buildHttpConfig", async () => {
     // When throwOnError is false, missing jwtSecret and cookieSecret should not cause errors
     await configLoader(entryDirectory, "medusa-config-2", {
-      throwOnError: false,
+      throwOnValidationError: false,
     })
 
     const configModule = container.resolve(
@@ -68,5 +69,25 @@ describe("configLoader", () => {
     expect(configModule.projectConfig.http).toBeDefined()
     expect(configModule.projectConfig.http.jwtSecret).toBe("supersecret")
     expect(configModule.projectConfig.http.cookieSecret).toBe("supersecret")
+  })
+
+  it("should fail on config file errors", async () => {
+    const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {})
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit(1)")
+    })
+
+    await expect(
+      configLoader(entryDirectory, "medusa-config-throwing")
+    ).rejects.toThrow("process.exit(1)")
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    const logged = errorSpy.mock.calls.flat().map(String).join(" ")
+    expect(logged).toContain("Error in loading config:")
+    expect(logged).toContain("Uncaught error in medusa-config-throwing.js")
+
+    errorSpy.mockRestore()
+    exitSpy.mockRestore()
   })
 })

--- a/packages/core/framework/src/config/config.ts
+++ b/packages/core/framework/src/config/config.ts
@@ -72,10 +72,10 @@ export class ConfigManager {
   protected buildHttpConfig(
     projectConfig: Partial<ConfigModule["projectConfig"]>,
     options?: {
-      throwOnError?: boolean
+      throwOnValidationError?: boolean
     }
   ): ConfigModule["projectConfig"]["http"] {
-    const { throwOnError = true } = options ?? {}
+    const { throwOnValidationError = true } = options ?? {}
     const http = (projectConfig.http ??
       {}) as ConfigModule["projectConfig"]["http"]
 
@@ -91,7 +91,7 @@ export class ConfigManager {
     http.jwtPublicKey = http?.jwtPublicKey ?? process.env.JWT_PUBLIC_KEY
 
     if (
-      throwOnError &&
+      throwOnValidationError &&
       http?.jwtPublicKey &&
       ((http.jwtVerifyOptions && !http.jwtVerifyOptions.algorithms?.length) ||
         (http.jwtOptions && !http.jwtOptions.algorithm))
@@ -102,7 +102,7 @@ export class ConfigManager {
     }
 
     if (!http.jwtSecret) {
-      if (throwOnError) {
+      if (throwOnValidationError) {
         this.rejectErrors(
           `http.jwtSecret not found.${
             this.#isProduction ? "" : "Using default 'supersecret'."
@@ -117,7 +117,7 @@ export class ConfigManager {
       process.env.COOKIE_SECRET)!
 
     if (!http.cookieSecret) {
-      if (throwOnError) {
+      if (throwOnValidationError) {
         this.rejectErrors(
           `http.cookieSecret not found.${
             this.#isProduction ? "" : " Using default 'supersecret'."
@@ -139,7 +139,7 @@ export class ConfigManager {
   protected normalizeProjectConfig(
     config: Partial<ConfigModule>,
     options?: {
-      throwOnError?: boolean
+      throwOnValidationError?: boolean
     }
   ): ConfigModule["projectConfig"] {
     const projConfig = config?.projectConfig ?? {}
@@ -153,7 +153,7 @@ export class ConfigManager {
     }
 
     outputConfig.http = this.buildHttpConfig(projConfig, {
-      throwOnError: options?.throwOnError,
+      throwOnValidationError: options?.throwOnValidationError,
     })
 
     let workerMode = outputConfig?.workerMode!
@@ -182,16 +182,16 @@ export class ConfigManager {
   loadConfig({
     projectConfig = {},
     baseDir,
-    throwOnError = true,
+    throwOnValidationError = true,
   }: {
     projectConfig: Partial<ConfigModule>
     baseDir: string
-    throwOnError?: boolean
+    throwOnValidationError?: boolean
   }): ConfigModule {
     this.#baseDir = baseDir
 
     const normalizedProjectConfig = this.normalizeProjectConfig(projectConfig, {
-      throwOnError,
+      throwOnValidationError,
     })
 
     this.#config = {

--- a/packages/core/framework/src/config/loader.ts
+++ b/packages/core/framework/src/config/loader.ts
@@ -1,6 +1,6 @@
 import { ContainerRegistrationKeys, getConfigFile } from "@medusajs/utils"
-import { asFunction } from "../deps/awilix"
 import { container } from "../container"
+import { asFunction } from "../deps/awilix"
 import { logger as defaultLogger } from "../logger"
 import { ConfigManager } from "./config"
 import { ConfigModule } from "./types"
@@ -25,29 +25,29 @@ container.register(
  *
  * @param entryDirectory The directory to find the config file from
  * @param configFileName The name of the config file to search for in the entry directory
- * @param options.throwOnError When false, missing config files and validation errors won't throw.
+ * @param options.throwOnValidationError When false, validation errors won't throw.
  * Useful for build/compile commands. Defaults to true.
  */
 export async function configLoader(
   entryDirectory: string,
   configFileName: string = "medusa-config",
   options?: {
-    throwOnError?: boolean
+    throwOnValidationError?: boolean
   }
 ): Promise<ConfigModule> {
-  const { throwOnError = true } = options ?? {}
+  const { throwOnValidationError = true } = options ?? {}
   const config = await getConfigFile<ConfigModule>(
     entryDirectory,
     configFileName
   )
 
-  if (config.error && throwOnError) {
+  if (config.error) {
     handleConfigError(config.error)
   }
 
   return configManager.loadConfig({
     projectConfig: config.configModule!,
     baseDir: entryDirectory,
-    throwOnError,
+    throwOnValidationError,
   })
 }

--- a/packages/medusa/src/commands/build.ts
+++ b/packages/medusa/src/commands/build.ts
@@ -12,7 +12,7 @@ export default async function build({
 }) {
   const container = await initializeContainer(directory, {
     skipDbConnection: true,
-    throwOnError: false,
+    throwOnValidationError: false,
   })
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
 

--- a/packages/medusa/src/loaders/index.ts
+++ b/packages/medusa/src/loaders/index.ts
@@ -134,12 +134,12 @@ export async function initializeContainer(
   rootDirectory: string,
   options?: {
     skipDbConnection?: boolean
-    throwOnError?: boolean
+    throwOnValidationError?: boolean
   }
 ): Promise<MedusaContainer> {
   await featureFlagsLoader(rootDirectory)
   const configDir = await configLoader(rootDirectory, "medusa-config", {
-    throwOnError: options?.throwOnError,
+    throwOnValidationError: options?.throwOnValidationError,
   })
   await featureFlagsLoader(join(__dirname, ".."))
 


### PR DESCRIPTION
## Summary

**What**
Currently, when an error is thrown from medusa-config, the build fails with an obscure error that hides the actual error thrown:
```
TypeError: Cannot read properties of null (reading 'admin')
    at ConfigManager.loadConfig (/Users/pedroluisguzmanhernandez/projects/bookstore/node_modules/@medusajs/framework/src/config/config.ts:199:28)
    at configLoader (/Users/pedroluisguzmanhernandez/projects/bookstore/node_modules/@medusajs/framework/src/config/loader.ts:48:24)
    at async initializeContainer (/Users/pedroluisguzmanhernandez/projects/bookstore/node_modules/@medusajs/medusa/src/loaders/index.ts:141:21)
    at async build (/Users/pedroluisguzmanhernandez/projects/bookstore/node_modules/@medusajs/medusa/src/commands/build.ts:13:21)
✨  Done in 1.30s.
```
This PR fixes that

**Why**
This conceals the actual error and makes it impossible to debug the root cause

**How**
The issue was introduced in this PR https://github.com/medusajs/medusa/pull/14540. The intention there was to prevent build failures when some expected config values were undefined, cause this is common in CI where the env variables are not the same as in production. This PR changes the `throwOnError` to `throwOnValidationError`, so we only skip the error if it's a framework validation error, not if there are errors loading the medusa-config.

**Testing**
Added a unit test for it
## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable
