### PR TITLE
fix(@medusajs/test-utils): encode URL special characters in database connection string

### DIFF
--- a/.changeset/url-encode-db-connection.md
+++ b/.changeset/url-encode-db-connection.md
@@ -2,4 +2,4 @@
 "@medusajs/test-utils": patch
 ---
 
-Encoded URL special characters in database connection string.
+fix(@medusajs/test-utils): encode URL special characters in database connection string

--- a/.changeset/url-encode-db-connection.md
+++ b/.changeset/url-encode-db-connection.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/test-utils": patch
+---
+
+Encoded URL special characters in database connection string.

--- a/packages/medusa-test-utils/src/database.ts
+++ b/packages/medusa-test-utils/src/database.ts
@@ -29,8 +29,8 @@ export function getDatabaseURL(dbName?: string): string {
   const DB_PORT = process.env.DB_PORT ?? "5432"
   const DB_NAME = dbName ?? process.env.DB_TEMP_NAME
 
-  return `postgres://${DB_USERNAME}${
-    DB_PASSWORD ? `:${DB_PASSWORD}` : ""
+  return `postgres://${encodeURIComponent(DB_USERNAME)}${
+    DB_PASSWORD ? `:${encodeURIComponent(DB_PASSWORD)}` : ""
   }@${DB_HOST}:${DB_PORT}/${DB_NAME}`
 }
 


### PR DESCRIPTION
## What

Fixes invalid Postgres connection URLs when database credentials contain URL-special characters (`#`, `@`, `:`, `/`). Fixes #15343.

## Root Cause

`getDatabaseURL` in `@medusajs/test-utils` builds the connection URL via string interpolation without percent-encoding. When a password contains `#`, Node's WHATWG URL parser treats it as a fragment separator, truncating the authority. `@`, `:`, `/` also cause URL parsing failures. Integration tests fail with `TypeError: Invalid URL`.

## Fix

Wrapped both `DB_USERNAME` and `DB_PASSWORD` in `encodeURIComponent()` (`#` → `%23`, `@` → `%40`, etc). The pg driver decodes percent-encoded characters when parsing the connection URL, so authentication works correctly.

## Changes

- `packages/medusa-test-utils/src/database.ts`: `encodeURIComponent` on `DB_USERNAME` and `DB_PASSWORD` (+2 −2 lines)

## Testing

- **Password with # (fragment)**: percent-encoded as %23, connection succeeds ✅
- **Password with @ (userinfo delimiter)**: percent-encoded as %40, connection succeeds ✅
- **Password without special characters**: behavior unchanged, no regression ✅