### PR TITLE
feat(medusa): enable index when querying products via promotion attribute values and enable sku search in products entrypoint

### DIFF
--- a/.changeset/vast-facts-dream.md
+++ b/.changeset/vast-facts-dream.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+feat(medusa): enable index when querying products via promotion attribute values and enable sku search in products entrypoint

--- a/packages/medusa/src/api/admin/products/route.ts
+++ b/packages/medusa/src/api/admin/products/route.ts
@@ -84,6 +84,11 @@ async function getProductsWithIndexEngine(
     delete filters.price_list_id
   }
 
+  // TODO: Remove once we implement search by relations in a similar way to query.graph
+  if (isPresent(filters.q)) {
+    filters["variants"] ??= {}
+  }
+
   const { data: products, metadata } = await query.index({
     entity: "product",
     fields: req.queryConfig.fields ?? [],

--- a/packages/medusa/src/api/admin/promotions/rule-value-options/[rule_type]/[rule_attribute_id]/route.ts
+++ b/packages/medusa/src/api/admin/promotions/rule-value-options/[rule_type]/[rule_attribute_id]/route.ts
@@ -73,10 +73,16 @@ export const GET = async (
     ENTITIES_SUPPORTED_BY_INDEX_ENGINE.includes(queryConfig.entryPoint)
 
   if (useIndexEngine) {
+    // TODO: Remove once we implement search by relations in a similar way to query.graph
+    const filters = { ...filterableFields }
+    if (!!filters.q) {
+      filters.variants = filters.variants ?? {}
+    }
+
     const { data, metadata } = await query.index({
       entity: queryConfig.entryPoint,
       fields,
-      filters: filterableFields,
+      filters,
       pagination: req.queryConfig.pagination,
     })
 
@@ -85,13 +91,14 @@ export const GET = async (
       value: r[queryConfig.valueAttr],
     }))
 
-    return res.json({
+    res.json({
       values,
       count: metadata!.estimate_count,
       estimate_count: metadata!.estimate_count,
       offset: metadata!.skip,
       limit: metadata!.take,
     })
+    return
   }
 
   const { data, metadata } = await query.graph({

--- a/packages/medusa/src/api/admin/promotions/rule-value-options/[rule_type]/[rule_attribute_id]/route.ts
+++ b/packages/medusa/src/api/admin/promotions/rule-value-options/[rule_type]/[rule_attribute_id]/route.ts
@@ -5,7 +5,7 @@ import {
 import { HttpTypes } from "@medusajs/framework/types"
 import {
   ContainerRegistrationKeys,
-  remoteQueryObjectFromString,
+  FeatureFlag,
 } from "@medusajs/framework/utils"
 import {
   ruleQueryConfigurations,
@@ -16,6 +16,17 @@ import {
   ApplicationMethodTargetTypeValues,
   RuleTypeValues,
 } from "@medusajs/types"
+import IndexEngineFeatureFlag from "../../../../../../feature-flags/index-engine"
+
+/*
+  Entry points that exist as top-level types in the Index module's default schema
+  (packages/modules/index/src/utils/default-schema.ts). Only `product` qualifies
+  today; the other entry points this endpoint may receive (product_category,
+  product_collection, product_type, product_tag, region, currency, customer_group,
+  country, sales_channel, shipping_option_type) are not top-level types in the
+  index, so they keep using query.graph.
+*/
+const ENTITIES_SUPPORTED_BY_INDEX_ENGINE = ["product"]
 
 /*
   This endpoint returns all the potential values for rules (promotion rules, target rules and buy rules)
@@ -30,7 +41,6 @@ export const GET = async (
 ) => {
   const { rule_type: ruleType, rule_attribute_id: ruleAttributeId } = req.params
   const queryConfig = ruleQueryConfigurations[ruleAttributeId]
-  const remoteQuery = req.scope.resolve(ContainerRegistrationKeys.REMOTE_QUERY)
   const filterableFields = req.filterableFields
 
   if (filterableFields.value) {
@@ -55,26 +65,51 @@ export const GET = async (
     delete filterableFields.application_method_target_type
   }
 
-  const { rows, metadata } = await remoteQuery(
-    remoteQueryObjectFromString({
-      entryPoint: queryConfig.entryPoint,
-      variables: {
-        filters: filterableFields,
-        ...req.queryConfig.pagination,
-      },
-      fields: [queryConfig.labelAttr, queryConfig.valueAttr],
-    })
-  )
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const fields = [queryConfig.labelAttr, queryConfig.valueAttr]
 
-  const values = rows.map((r) => ({
+  const useIndexEngine =
+    FeatureFlag.isFeatureEnabled(IndexEngineFeatureFlag.key) &&
+    ENTITIES_SUPPORTED_BY_INDEX_ENGINE.includes(queryConfig.entryPoint)
+
+  if (useIndexEngine) {
+    const { data, metadata } = await query.index({
+      entity: queryConfig.entryPoint,
+      fields,
+      filters: filterableFields,
+      pagination: req.queryConfig.pagination,
+    })
+
+    const values = data.map((r) => ({
+      label: r[queryConfig.labelAttr],
+      value: r[queryConfig.valueAttr],
+    }))
+
+    return res.json({
+      values,
+      count: metadata!.estimate_count,
+      estimate_count: metadata!.estimate_count,
+      offset: metadata!.skip,
+      limit: metadata!.take,
+    })
+  }
+
+  const { data, metadata } = await query.graph({
+    entity: queryConfig.entryPoint,
+    fields,
+    filters: filterableFields,
+    pagination: req.queryConfig.pagination,
+  })
+
+  const values = data.map((r) => ({
     label: r[queryConfig.labelAttr],
     value: r[queryConfig.valueAttr],
   }))
 
   res.json({
     values,
-    count: metadata.count,
-    offset: metadata.skip,
-    limit: metadata.take,
+    count: metadata!.count,
+    offset: metadata!.skip,
+    limit: metadata!.take,
   })
 }

--- a/packages/medusa/src/api/store/products/route.ts
+++ b/packages/medusa/src/api/store/products/route.ts
@@ -66,6 +66,11 @@ async function getProductsWithIndexEngine(
     delete filters.sales_channel_id
   }
 
+  // TODO: Remove once we implement search by relations in a similar way to query.graph
+  if (isPresent(filters.q)) {
+    filters["variants"] ??= {}
+  }
+
   const { data: products = [], metadata } = await query.index(
     {
       entity: "product",


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Enable the use of the Index module in the promotions rule value options endpoint for `product` attribute. Also, enable product entrypoint when using Index module to search by variant SKU, by including a `variants` filter noop, that triggers the Index build query logic to consider the variant vector column when performing the search.

For the SKU search, this is a quick `hack` but we should probably decide on what search behavior we want in Index and make it cohesive with what we do with query.graph, since right now, both are disconnected and define the searchable fields differently as well as the keyword matching when performing search.

**Why** — Why are these changes relevant or necessary?  

Searching for products in the promotions rule value form takes a long time in large catalogs, even when the Index module is enabled. Performing search queries passing a variant SKU has no effect when using the Index module, when the opposite is true when not using it.

**How** — How have these changes been implemented?

*Please provide answer here*

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

*Please provide answer here*

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
