### PR TITLE
docs: add TSDocs for "enable index when querying products via promotion attribute "

### DIFF
--- a/packages/medusa/src/api/admin/products/route.ts
+++ b/packages/medusa/src/api/admin/products/route.ts
@@ -14,6 +14,15 @@ import {
 import IndexEngineFeatureFlag from "../../../feature-flags/index-engine"
 import { remapKeysForProduct, remapProductResponse } from "./helpers"
 
+/**
+ * Retrieve a list of products for admin access. Supports both regular query 
+ * and index engine for enhanced filtering and search capabilities.
+ * 
+ * @param req - The authenticated request containing list parameters
+ * @param res - The response object
+ * 
+ * @see {@link https://docs.medusajs.com/api/admin#products_getproducts | API Reference}
+ */
 export const GET = async (
   req: AuthenticatedMedusaRequest<HttpTypes.AdminProductListParams>,
   res: MedusaResponse<HttpTypes.AdminProductListResponse>
@@ -106,6 +115,14 @@ async function getProductsWithIndexEngine(
   })
 }
 
+/**
+ * Create a new product with the provided data.
+ * 
+ * @param req - The authenticated request containing product creation data and additional data
+ * @param res - The response object containing the created product
+ * 
+ * @see {@link https://docs.medusajs.com/api/admin#products_postproducts | API Reference}
+ */
 export const POST = async (
   req: AuthenticatedMedusaRequest<
     HttpTypes.AdminCreateProduct & AdditionalData,

--- a/packages/medusa/src/api/admin/promotions/rule-value-options/[rule_type]/[rule_attribute_id]/route.ts
+++ b/packages/medusa/src/api/admin/promotions/rule-value-options/[rule_type]/[rule_attribute_id]/route.ts
@@ -28,13 +28,18 @@ import IndexEngineFeatureFlag from "../../../../../../feature-flags/index-engine
 */
 const ENTITIES_SUPPORTED_BY_INDEX_ENGINE = ["product"]
 
-/*
-  This endpoint returns all the potential values for rules (promotion rules, target rules and buy rules)
-  given an attribute of a rule. The response for different rule_attributes are returned uniformly
-  as an array of labels and values.
-  Eg. If the rule_attribute requested is "currency_code" for "rules" rule type, we return currencies
-  from the currency module.
-*/
+/**
+ * Retrieve available rule value options for promotion rules based on rule type and attribute.
+ * Returns potential values for rules (promotion rules, target rules and buy rules) given 
+ * an attribute of a rule. Supports both index engine and graph query methods.
+ * 
+ * @param req - The authenticated request containing rule type and attribute parameters
+ * @param res - The response object containing the rule value options
+ * 
+ * @example
+ * If the rule_attribute requested is "currency_code" for "rules" rule type, 
+ * returns currencies from the currency module.
+ */
 export const GET = async (
   req: AuthenticatedMedusaRequest<HttpTypes.AdminGetPromotionsRuleValueParams>,
   res: MedusaResponse<HttpTypes.AdminRuleValueOptionsListResponse>

--- a/packages/medusa/src/api/store/products/route.ts
+++ b/packages/medusa/src/api/store/products/route.ts
@@ -10,6 +10,15 @@ import IndexEngineFeatureFlag from "../../../feature-flags/index-engine"
 import { wrapVariantsWithInventoryQuantityForSalesChannel } from "../../utils/middlewares"
 import { RequestWithContext, wrapProductsWithTaxPrices } from "./helpers"
 
+/**
+ * Retrieve a list of products for store access. Supports both regular query 
+ * and index engine for enhanced filtering and search capabilities.
+ * 
+ * @param req - The store request containing list parameters and context
+ * @param res - The response object containing products with tax prices and inventory quantities
+ * 
+ * @see {@link https://docs.medusajs.com/api/store#products_getproducts | API Reference}
+ */
 export const GET = async (
   req: RequestWithContext<HttpTypes.StoreProductListParams>,
   res: MedusaResponse<HttpTypes.StoreProductListResponse>


### PR DESCRIPTION
## Automated TSDoc Additions

This PR adds TSDoc comments to TypeScript source files changed in commit [`5e8fc90`](https://github.com/medusajs/medusa/commit/5e8fc904fe00d8c89b6615cfbbdbde66531d2337).

**Triggered by:** feat(medusa): enable index when querying products via promotion attribute values and enable sku search in products entrypoint (#15386)

**Files updated:**
- `packages/medusa/src/api/admin/products/route.ts`
- `packages/medusa/src/api/admin/promotions/rule-value-options/[rule_type]/[rule_attribute_id]/route.ts`
- `packages/medusa/src/api/store/products/route.ts`

> Review carefully before merging. Claude may have missed context or used incorrect descriptions.