### PR TITLE
fix(inventory,core-flows,medusa): add missing locking to reservation steps

### DIFF
--- a/.changeset/yummy-deserts-punch.md
+++ b/.changeset/yummy-deserts-punch.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/inventory": patch
+"@medusajs/core-flows": patch
+"@medusajs/medusa": patch
+---
+
+fix(inventory,core-flows,medusa): add missing locking to reservation steps

--- a/integration-tests/http/__tests__/reservations/admin/reservations.spec.ts
+++ b/integration-tests/http/__tests__/reservations/admin/reservations.spec.ts
@@ -579,6 +579,92 @@ medusaIntegrationTestRunner({
 
         listReservationItemsSpy.mockRestore()
       })
+
+      describe("reserved_quantity consistency after soft-delete and restore", () => {
+        let reservationId: string
+        let inventoryService: any
+
+        const getLevel = async () => {
+          const res = await api.get(
+            `/admin/inventory-items/${inventoryItem1.id}/location-levels?location_id[]=${stockLocation1.id}&fields=reserved_quantity,available_quantity,stocked_quantity`,
+            adminHeaders
+          )
+          return res.data.inventory_levels[0]
+        }
+
+        beforeEach(async () => {
+          inventoryService = appContainer.resolve(Modules.INVENTORY)
+
+          await api.post(
+            `/admin/inventory-items/${inventoryItem1.id}/location-levels`,
+            { location_id: stockLocation1.id, stocked_quantity: 10 },
+            adminHeaders
+          )
+
+          const res = await api.post(
+            `/admin/reservations`,
+            {
+              line_item_id: "line-item-id-1",
+              inventory_item_id: inventoryItem1.id,
+              location_id: stockLocation1.id,
+              quantity: 5,
+            },
+            adminHeaders
+          )
+          reservationId = res.data.reservation.id
+        })
+
+        // Scenario 1: a single soft-delete + restore cycle must leave reserved_quantity unchanged.
+        // This fails because restoreReservationItems_ calls super.listReservationItems without
+        // including soft-deleted records, so the quantity adjustment is skipped and reserved_quantity
+        // stays at 0 instead of returning to 5.
+        it("should restore reserved_quantity to its pre-deletion value after a soft-delete/restore cycle", async () => {
+          const before = await getLevel()
+          expect(before.reserved_quantity).toBe(5)
+          expect(before.available_quantity).toBe(5)
+
+          await inventoryService.softDeleteReservationItems([reservationId])
+
+          const afterDelete = await getLevel()
+          expect(afterDelete.reserved_quantity).toBe(0)
+
+          await inventoryService.restoreReservationItems([reservationId])
+
+          const afterRestore = await getLevel()
+          // This assertion currently FAILS: reserved_quantity remains 0 because
+          // restoreReservationItems_ lists reservation items before restoring them,
+          // but the soft-delete filter excludes them from the list result, so no
+          // quantity adjustment is applied on the way back up.
+          expect(afterRestore.reserved_quantity).toBe(5)
+          expect(afterRestore.available_quantity).toBe(5)
+        })
+
+        // Scenario 2: multiple delete/restore cycles compound the missing increment,
+        // eventually driving reserved_quantity below zero with no visible reservations —
+        // exactly the state the customer reported (In Stock: 4, Reserved: -32, Available: 36).
+        it("should not accumulate negative reserved_quantity across repeated soft-delete/restore cycles", async () => {
+          for (let i = 0; i < 3; i++) {
+            await inventoryService.softDeleteReservationItems([reservationId])
+            await inventoryService.restoreReservationItems([reservationId])
+          }
+
+          // Final deletion: leaves no visible reservation records.
+          await inventoryService.softDeleteReservationItems([reservationId])
+
+          const reservations = await api.get(
+            `/admin/reservations?inventory_item_id[]=${inventoryItem1.id}`,
+            adminHeaders
+          )
+          expect(reservations.data.reservations).toHaveLength(0)
+
+          const level = await getLevel()
+          // This assertion currently FAILS: each restore cycle skips the +5 increment
+          // (see Scenario 1), so each full cycle nets -5. After 3 cycles + 1 final
+          // delete the actual value is -20 (3 skipped restores × -5, plus 1 final -5).
+          expect(level.reserved_quantity).toBe(0)
+          expect(level.available_quantity).toBe(10)
+        })
+      })
     })
   },
 })

--- a/integration-tests/http/__tests__/reservations/admin/reservations.spec.ts
+++ b/integration-tests/http/__tests__/reservations/admin/reservations.spec.ts
@@ -615,9 +615,6 @@ medusaIntegrationTestRunner({
         })
 
         // Scenario 1: a single soft-delete + restore cycle must leave reserved_quantity unchanged.
-        // This fails because restoreReservationItems_ calls super.listReservationItems without
-        // including soft-deleted records, so the quantity adjustment is skipped and reserved_quantity
-        // stays at 0 instead of returning to 5.
         it("should restore reserved_quantity to its pre-deletion value after a soft-delete/restore cycle", async () => {
           const before = await getLevel()
           expect(before.reserved_quantity).toBe(5)
@@ -631,17 +628,12 @@ medusaIntegrationTestRunner({
           await inventoryService.restoreReservationItems([reservationId])
 
           const afterRestore = await getLevel()
-          // This assertion currently FAILS: reserved_quantity remains 0 because
-          // restoreReservationItems_ lists reservation items before restoring them,
-          // but the soft-delete filter excludes them from the list result, so no
-          // quantity adjustment is applied on the way back up.
+
           expect(afterRestore.reserved_quantity).toBe(5)
           expect(afterRestore.available_quantity).toBe(5)
         })
 
-        // Scenario 2: multiple delete/restore cycles compound the missing increment,
-        // eventually driving reserved_quantity below zero with no visible reservations —
-        // exactly the state the customer reported (In Stock: 4, Reserved: -32, Available: 36).
+        // Scenario 2: multiple delete/restore cycles don't cause negative reserved_quantity
         it("should not accumulate negative reserved_quantity across repeated soft-delete/restore cycles", async () => {
           for (let i = 0; i < 3; i++) {
             await inventoryService.softDeleteReservationItems([reservationId])
@@ -658,9 +650,7 @@ medusaIntegrationTestRunner({
           expect(reservations.data.reservations).toHaveLength(0)
 
           const level = await getLevel()
-          // This assertion currently FAILS: each restore cycle skips the +5 increment
-          // (see Scenario 1), so each full cycle nets -5. After 3 cycles + 1 final
-          // delete the actual value is -20 (3 skipped restores × -5, plus 1 final -5).
+
           expect(level.reserved_quantity).toBe(0)
           expect(level.available_quantity).toBe(10)
         })

--- a/packages/core/core-flows/src/reservation/steps/delete-reservations-by-line-items.ts
+++ b/packages/core/core-flows/src/reservation/steps/delete-reservations-by-line-items.ts
@@ -17,18 +17,34 @@ export const deleteReservationsByLineItemsStep = createStep(
   deleteReservationsByLineItemsStepId,
   async (ids: DeleteReservationsByLineItemsStepInput, { container }) => {
     const service = container.resolve<IInventoryService>(Modules.INVENTORY)
+    const locking = container.resolve(Modules.LOCKING)
 
-    await service.deleteReservationItemsByLineItem(ids)
+    const reservations = await service.listReservationItems(
+      { line_item_id: ids },
+      { select: ["id", "inventory_item_id"] }
+    )
 
-    return new StepResponse(void 0, ids)
+    const inventoryItemIds = reservations.map((r) => r.inventory_item_id)
+    const lockingKeys = Array.from(new Set(inventoryItemIds))
+
+    await locking.execute(lockingKeys, async () => {
+      await service.deleteReservationItemsByLineItem(ids)
+    })
+
+    return new StepResponse(void 0, { ids, inventoryItemIds })
   },
-  async (prevIds, { container }) => {
-    if (!prevIds?.length) {
+  async (data, { container }) => {
+    if (!data?.ids?.length) {
       return
     }
 
     const service = container.resolve<IInventoryService>(Modules.INVENTORY)
+    const locking = container.resolve(Modules.LOCKING)
 
-    await service.restoreReservationItemsByLineItem(prevIds)
+    const lockingKeys = Array.from(new Set(data.inventoryItemIds))
+
+    await locking.execute(lockingKeys, async () => {
+      await service.restoreReservationItemsByLineItem(data.ids)
+    })
   }
 )

--- a/packages/core/core-flows/src/reservation/steps/delete-reservations.ts
+++ b/packages/core/core-flows/src/reservation/steps/delete-reservations.ts
@@ -16,18 +16,34 @@ export const deleteReservationsStep = createStep(
   deleteReservationsStepId,
   async (ids: DeleteReservationsStepInput, { container }) => {
     const service = container.resolve<IInventoryService>(Modules.INVENTORY)
+    const locking = container.resolve(Modules.LOCKING)
 
-    await service.softDeleteReservationItems(ids)
+    const reservations = await service.listReservationItems(
+      { id: ids },
+      { select: ["id", "inventory_item_id"] }
+    )
 
-    return new StepResponse(void 0, ids)
+    const inventoryItemIds = reservations.map((r) => r.inventory_item_id)
+    const lockingKeys = Array.from(new Set(inventoryItemIds))
+
+    await locking.execute(lockingKeys, async () => {
+      await service.softDeleteReservationItems(ids)
+    })
+
+    return new StepResponse(void 0, { ids, inventoryItemIds })
   },
-  async (prevIds, { container }) => {
-    if (!prevIds?.length) {
+  async (data, { container }) => {
+    if (!data?.ids?.length) {
       return
     }
 
     const service = container.resolve<IInventoryService>(Modules.INVENTORY)
+    const locking = container.resolve(Modules.LOCKING)
 
-    await service.restoreReservationItems(prevIds)
+    const lockingKeys = Array.from(new Set(data.inventoryItemIds))
+
+    await locking.execute(lockingKeys, async () => {
+      await service.restoreReservationItems(data.ids)
+    })
   }
 )

--- a/packages/core/core-flows/src/reservation/steps/update-reservations.ts
+++ b/packages/core/core-flows/src/reservation/steps/update-reservations.ts
@@ -17,6 +17,14 @@ export type UpdateReservationsStepInput =
   InventoryTypes.UpdateReservationItemInput[]
 
 export const updateReservationsStepId = "update-reservations-step"
+
+type UpdateReservationsCompensationInput = {
+  dataBeforeUpdate: InventoryTypes.ReservationItemDTO[]
+  selects: string[]
+  relations: string[]
+  inventoryItemIds: string[]
+}
+
 /**
  * This step updates one or more reservations.
  *
@@ -34,28 +42,42 @@ export const updateReservationsStep = createStep(
     const inventoryModuleService = container.resolve<IInventoryService>(
       Modules.INVENTORY
     )
+    const locking = container.resolve(Modules.LOCKING)
 
     if (!data.length) {
-      return new StepResponse([], {
+      return new StepResponse<
+        InventoryTypes.ReservationItemDTO[],
+        UpdateReservationsCompensationInput
+      >([], {
         dataBeforeUpdate: [],
         selects: [],
         relations: [],
+        inventoryItemIds: [],
       })
     }
 
     const { selects, relations } = getSelectsAndRelationsFromObjectArray(data)
-    const dataBeforeUpdate = await inventoryModuleService.listReservationItems(
-      { id: data.map((d) => d.id) },
-      { relations, select: selects }
+    const selectsWithInventoryItem = Array.from(
+      new Set([...selects, "inventory_item_id"])
     )
 
-    const updatedReservations =
-      await inventoryModuleService.updateReservationItems(data)
+    const dataBeforeUpdate = await inventoryModuleService.listReservationItems(
+      { id: data.map((d) => d.id) },
+      { relations, select: selectsWithInventoryItem }
+    )
+
+    const inventoryItemIds = dataBeforeUpdate.map((r) => r.inventory_item_id)
+    const lockingKeys = Array.from(new Set(inventoryItemIds))
+
+    const updatedReservations = await locking.execute(lockingKeys, async () => {
+      return await inventoryModuleService.updateReservationItems(data)
+    })
 
     return new StepResponse(updatedReservations, {
       dataBeforeUpdate,
       selects,
       relations,
+      inventoryItemIds,
     })
   },
   async (revertInput, { container }) => {
@@ -63,16 +85,26 @@ export const updateReservationsStep = createStep(
       return
     }
 
-    const { dataBeforeUpdate = [], selects, relations } = revertInput
+    const {
+      dataBeforeUpdate = [],
+      selects,
+      relations,
+      inventoryItemIds = [],
+    } = revertInput
 
     const inventoryModuleService = container.resolve<IInventoryService>(
       Modules.INVENTORY
     )
+    const locking = container.resolve(Modules.LOCKING)
 
-    await inventoryModuleService.updateReservationItems(
-      dataBeforeUpdate.map((data) =>
-        convertItemResponseToUpdateRequest(data, selects, relations)
+    const lockingKeys = Array.from(new Set(inventoryItemIds))
+
+    await locking.execute(lockingKeys, async () => {
+      await inventoryModuleService.updateReservationItems(
+        dataBeforeUpdate.map((data) =>
+          convertItemResponseToUpdateRequest(data, selects, relations)
+        )
       )
-    )
+    })
   }
 )

--- a/packages/medusa/src/migration-scripts/reconcile-inventory-reserved-quantity.ts
+++ b/packages/medusa/src/migration-scripts/reconcile-inventory-reserved-quantity.ts
@@ -1,0 +1,137 @@
+import {
+  ContainerRegistrationKeys,
+  promiseAll,
+} from "@medusajs/framework/utils"
+import {
+  StepResponse,
+  WorkflowResponse,
+  createStep,
+  createWorkflow,
+} from "@medusajs/framework/workflows-sdk"
+import { ExecArgs } from "@medusajs/types"
+
+type InventoryLevelMismatch = {
+  id: string
+  inventory_item_id: string
+  location_id: string
+  current_reserved_quantity: string
+  current_raw_reserved_quantity: { value: string; precision: number } | null
+  expected_reserved_quantity: string
+}
+
+const BIG_NUMBER_PRECISION = 20
+
+const findMismatchedReservedQuantitiesStep = createStep(
+  "find-mismatched-reserved-quantities",
+  async (_, { container }) => {
+    const knex = container.resolve(ContainerRegistrationKeys.PG_CONNECTION)
+
+    const result = await knex.raw(`
+      WITH expected AS (
+        SELECT
+          il.id,
+          il.inventory_item_id,
+          il.location_id,
+          il.reserved_quantity::text AS current_reserved_quantity,
+          il.raw_reserved_quantity AS current_raw_reserved_quantity,
+          COALESCE((
+            SELECT SUM(ri.quantity)
+            FROM reservation_item ri
+            WHERE ri.inventory_item_id = il.inventory_item_id
+              AND ri.location_id = il.location_id
+              AND ri.deleted_at IS NULL
+          ), 0)::text AS expected_reserved_quantity
+        FROM inventory_level il
+        WHERE il.deleted_at IS NULL
+      )
+      SELECT *
+      FROM expected
+      WHERE current_reserved_quantity::numeric <> expected_reserved_quantity::numeric
+    `)
+
+    return new StepResponse(result.rows as InventoryLevelMismatch[])
+  }
+)
+
+const reconcileReservedQuantitiesStep = createStep(
+  "reconcile-reserved-quantities",
+  async (
+    { rows }: { rows: InventoryLevelMismatch[] },
+    { container }
+  ) => {
+    if (!rows.length) {
+      return new StepResponse(0, [])
+    }
+
+    const knex = container.resolve(ContainerRegistrationKeys.PG_CONNECTION)
+
+    await promiseAll(
+      rows.map((row) => {
+        const rawValue = {
+          value: Number(row.expected_reserved_quantity).toPrecision(
+            BIG_NUMBER_PRECISION
+          ),
+          precision: BIG_NUMBER_PRECISION,
+        }
+
+        return knex("inventory_level")
+          .where({ id: row.id })
+          .update({
+            reserved_quantity: knex.raw("?::numeric", [
+              row.expected_reserved_quantity,
+            ]),
+            raw_reserved_quantity: JSON.stringify(rawValue),
+          })
+      })
+    )
+
+    return new StepResponse(rows.length, rows)
+  },
+  async (rows, { container }) => {
+    if (!rows?.length) {
+      return
+    }
+
+    const knex = container.resolve(ContainerRegistrationKeys.PG_CONNECTION)
+
+    await promiseAll(
+      rows.map((row) =>
+        knex("inventory_level")
+          .where({ id: row.id })
+          .update({
+            reserved_quantity: knex.raw("?::numeric", [
+              row.current_reserved_quantity,
+            ]),
+            raw_reserved_quantity: row.current_raw_reserved_quantity
+              ? JSON.stringify(row.current_raw_reserved_quantity)
+              : null,
+          })
+      )
+    )
+  }
+)
+
+const reconcileInventoryReservedQuantityWorkflow = createWorkflow(
+  "reconcile-inventory-reserved-quantity",
+  () => {
+    const rows = findMismatchedReservedQuantitiesStep()
+    reconcileReservedQuantitiesStep({ rows })
+    return new WorkflowResponse({})
+  }
+)
+
+export default async function reconcileInventoryReservedQuantity({
+  container,
+}: ExecArgs) {
+  const logger = container.resolve("logger")
+
+  logger.info(
+    "Starting reconciliation of inventory_level.reserved_quantity against active reservation_item rows..."
+  )
+
+  await reconcileInventoryReservedQuantityWorkflow(container).run({})
+
+  logger.info(
+    "Finished reconciliation of inventory_level.reserved_quantity."
+  )
+}

--- a/packages/medusa/src/migration-scripts/reconcile-inventory-reserved-quantity.ts
+++ b/packages/medusa/src/migration-scripts/reconcile-inventory-reserved-quantity.ts
@@ -55,10 +55,7 @@ const findMismatchedReservedQuantitiesStep = createStep(
 
 const reconcileReservedQuantitiesStep = createStep(
   "reconcile-reserved-quantities",
-  async (
-    { rows }: { rows: InventoryLevelMismatch[] },
-    { container }
-  ) => {
+  async ({ rows }: { rows: InventoryLevelMismatch[] }, { container }) => {
     if (!rows.length) {
       return new StepResponse(0, [])
     }
@@ -131,7 +128,5 @@ export default async function reconcileInventoryReservedQuantity({
 
   await reconcileInventoryReservedQuantityWorkflow(container).run({})
 
-  logger.info(
-    "Finished reconciliation of inventory_level.reserved_quantity."
-  )
+  logger.info("Finished reconciliation of inventory_level.reserved_quantity.")
 }

--- a/packages/modules/inventory/src/models/inventory-level.ts
+++ b/packages/modules/inventory/src/models/inventory-level.ts
@@ -14,6 +14,12 @@ const InventoryLevel = model
     }),
     available_quantity: model.bigNumber().computed(),
   })
+  .checks([
+    {
+      name: "inventory_level_reserved_quantity_non_negative",
+      expression: (columns) => `${columns.reserved_quantity} >= 0`,
+    },
+  ])
   .indexes([
     {
       name: "IDX_inventory_level_inventory_item_id",

--- a/packages/modules/inventory/src/models/inventory-level.ts
+++ b/packages/modules/inventory/src/models/inventory-level.ts
@@ -14,12 +14,6 @@ const InventoryLevel = model
     }),
     available_quantity: model.bigNumber().computed(),
   })
-  .checks([
-    {
-      name: "inventory_level_reserved_quantity_non_negative",
-      expression: (columns) => `${columns.reserved_quantity} >= 0`,
-    },
-  ])
   .indexes([
     {
       name: "IDX_inventory_level_inventory_item_id",

--- a/packages/modules/inventory/src/services/inventory-module.ts
+++ b/packages/modules/inventory/src/services/inventory-module.ts
@@ -782,10 +782,10 @@ export default class InventoryModuleService
     config?: RestoreReturn<string>,
     @MedusaContext() context: Context = {}
   ): Promise<void> {
+    await super.restoreReservationItems({ id: ids }, config, context)
+
     const reservations: InventoryTypes.ReservationItemDTO[] =
       await super.listReservationItems({ id: ids }, {}, context)
-
-    await super.restoreReservationItems({ id: ids }, config, context)
 
     await this.adjustInventoryLevelsForReservationsRestore(
       reservations,
@@ -883,17 +883,17 @@ export default class InventoryModuleService
     lineItemId: string | string[],
     @MedusaContext() context: Context = {}
   ): Promise<void> {
+    await this.reservationItemService_.restore(
+      { line_item_id: lineItemId },
+      context
+    )
+
     const reservations: InventoryTypes.ReservationItemDTO[] =
       await this.reservationItemService_.list(
         { line_item_id: lineItemId },
         {},
         context
       )
-
-    await this.reservationItemService_.restore(
-      { line_item_id: lineItemId },
-      context
-    )
 
     await this.adjustInventoryLevelsForReservationsRestore(
       reservations,


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

- Fix restoreReservationItems_ and restoreReservationItemsByLineItem_ in the inventory module so the quantity adjustment is no longer skipped on restore.
 - Wrap deleteReservationsStep, deleteReservationsByLineItemsStep, and updateReservationsStep in locking.execute on both forward and compensation paths.
  - Add a migration script (reconcile-inventory-reserved-quantity) that recomputes inventory_level.reserved_quantity from the sum of active reservation_item.quantity for every drifted row.

**Why** — Why are these changes relevant or necessary?  

 1. `restoreReservationItems_` listed records before restoring them, so the standard deleted_at IS NULL filter returned an empty set and `adjustInventoryLevelsForReservationsRestore` was a no-op. Every workflow compensation that restored a deletion lost the +N increment, so repeated cancel/restore cycles drove `reserved_quantity` progressively negative. This explains the repeated reports we got for negative reserved quantities.
  2. `deleteReservationsStep, deleteReservationsByLineItemsStep, and updateReservationsStep` mutated reserved_quantity without locking, while `createReservationsStep` did. So concurrent operations against the same inventory item could lose decrements.
  3. Environments already affected by the bug need their data reconciled when upgrading.

**How** — How have these changes been implemented?

- Restore bug: swapped the order in both restoreReservationItems_ and restoreReservationItemsByLineItem_ so restore runs before list.
  - Locking parity: each affected step now fetches the relevant inventory_item_ids up front and wraps the service call in locking.execute(keys, …). Mirrors the existing createReservationsStep pattern.
  - Data reconciliation: the migration script runs a CTE that joins each non-deleted inventory_level to SUM(quantity) of its active reservation items, selects only the rows that drift, and updates both reserved_quantity and raw_reserved_quantity. It's idempotent and has a compensation that restores prior values.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Integration tests

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
