### PR TITLE
fix(medusa): fix filtering by categories and tags in /store/products with the index module

### DIFF
--- a/.changeset/new-flowers-float.md
+++ b/.changeset/new-flowers-float.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/medusa": patch
+---
+
+fix(medusa): fix filtering by categories and tags in /store/products with the index module

--- a/packages/medusa/src/api/admin/products/utils/maybe-apply-price-lists-filter.ts
+++ b/packages/medusa/src/api/admin/products/utils/maybe-apply-price-lists-filter.ts
@@ -14,8 +14,11 @@ export function maybeApplyPriceListsFilter() {
     _,
     next: NextFunction
   ) {
-    const filterableFields: HttpTypes.AdminProductListParams =
-      req.filterableFields
+    const filterableFields: HttpTypes.AdminProductListParams & {
+      // these are available through the Zod transformation
+      tags?: string | string[]
+      categories?: string | string[]
+    } = req.filterableFields
 
     if (!filterableFields.price_list_id) {
       return next()
@@ -28,8 +31,8 @@ export function maybeApplyPriceListsFilter() {
     // variant id expansion in that case.
     if (
       FeatureFlag.isFeatureEnabled(IndexEngineFeatureFlag.key) &&
-      !filterableFields.tag_id &&
-      !filterableFields.category_id
+      !filterableFields.tags &&
+      !filterableFields.categories
     ) {
       return next()
     }

--- a/packages/medusa/src/api/store/products/route.ts
+++ b/packages/medusa/src/api/store/products/route.ts
@@ -14,14 +14,18 @@ export const GET = async (
   req: RequestWithContext<HttpTypes.StoreProductListParams>,
   res: MedusaResponse<HttpTypes.StoreProductListResponse>
 ) => {
-  const filterableFields: HttpTypes.StoreProductListParams =
+  const filterableFields: HttpTypes.StoreProductListParams & {
+    // these are available through the Zod transformation
+    tags?: string | string[]
+    categories?: string | string[]
+  } =
     req.filterableFields
 
   if (FeatureFlag.isFeatureEnabled(IndexEngineFeatureFlag.key)) {
     // TODO: These filters are not supported by the index engine yet
     if (
-      isPresent(filterableFields.tag_id) ||
-      isPresent(filterableFields.category_id)
+      isPresent(filterableFields.tags) ||
+      isPresent(filterableFields.categories)
     ) {
       return await getProducts(req, res)
     }


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Fixes the check for `category_id` and `tag_id` to `categories` and `tags` in the `/store/products` and `/admin/product` API route for the index module.

Closes #15399

**Why** — Why are these changes relevant or necessary?  

This API route applied Zod transformation for `category_id` and `tag_id` filters. So while the API route accepted those as filters, the Zod transformation deleted those properties and replaced them with `categories` and `tags`.

This leads to the check when the index module is enabled failing.

**How** — How have these changes been implemented?

- Extend the type in the filterable fields in the API routes to also include `tags` and `categories`, with a comment of where they come from.
- Change the condition to check for `tags` and `categories`.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

-

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [ ] The changes are covered by relevant **tests**
- [ ] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
