### PR TITLE
feat(auth): add MFA retrieval

### DIFF
--- a/packages/core/types/src/auth/common/mfa.ts
+++ b/packages/core/types/src/auth/common/mfa.ts
@@ -16,6 +16,11 @@ export type AuthMfaDTO = {
   metadata?: Record<string, unknown> | null
 }
 
+export type AuthMfaSelector = {
+  id: string
+  auth_identity_id?: string
+}
+
 export type AuthMfaRecoveryCodeDTO = {
   id: string
   auth_identity_id?: string

--- a/packages/core/types/src/auth/service.ts
+++ b/packages/core/types/src/auth/service.ts
@@ -6,6 +6,7 @@ import {
   AuthenticationResponse,
   AuthMfaChallengeDTO,
   AuthMfaDTO,
+  AuthMfaSelector,
   AuthMfaStartResponse,
   AuthIdentityDTO,
   UseAuthMfaRecoveryCodeDTO,
@@ -198,6 +199,15 @@ export interface IAuthModuleService extends IModuleService {
    */
   disableAuthMfa(
     data: DisableAuthMfaDTO,
+    sharedContext?: Context
+  ): Promise<AuthMfaDTO>
+
+  /**
+   * This method retrieves a configured MFA method.
+   */
+  retrieveAuthMfa(
+    selector: string | AuthMfaSelector,
+    config?: FindConfig<AuthMfaDTO>,
     sharedContext?: Context
   ): Promise<AuthMfaDTO>
 

--- a/packages/modules/auth/integration-tests/__tests__/auth-module-service/mfa.spec.ts
+++ b/packages/modules/auth/integration-tests/__tests__/auth-module-service/mfa.spec.ts
@@ -151,6 +151,26 @@ moduleIntegrationTestRunner<IAuthModuleService>({
         ])
         expect(factors[0]).not.toHaveProperty("secret")
         expect(factors[0]).not.toHaveProperty("provider_metadata")
+      })
+
+      it("retrieves an MFA factor without exposing provider metadata", async () => {
+        const setup = await service.startAuthMfa({
+          auth_identity_id: "test-id",
+          provider: "totp",
+        })
+
+        const retrievedById = await service.retrieveAuthMfa(setup.mfa.id)
+
+        expect(retrievedById).toEqual(
+          expect.objectContaining({
+            id: setup.mfa.id,
+            auth_identity_id: "test-id",
+            provider: "totp",
+            status: "pending",
+          })
+        )
+        expect(retrievedById).not.toHaveProperty("secret")
+        expect(retrievedById).not.toHaveProperty("provider_metadata")
 
         const retrieved = await service.retrieveAuthMfa({
           id: setup.mfa.id,

--- a/packages/modules/auth/integration-tests/__tests__/auth-module-service/mfa.spec.ts
+++ b/packages/modules/auth/integration-tests/__tests__/auth-module-service/mfa.spec.ts
@@ -151,6 +151,29 @@ moduleIntegrationTestRunner<IAuthModuleService>({
         ])
         expect(factors[0]).not.toHaveProperty("secret")
         expect(factors[0]).not.toHaveProperty("provider_metadata")
+
+        const retrieved = await service.retrieveAuthMfa({
+          id: setup.mfa.id,
+          auth_identity_id: "test-id",
+        })
+
+        expect(retrieved).toEqual(
+          expect.objectContaining({
+            id: setup.mfa.id,
+            auth_identity_id: "test-id",
+            provider: "totp",
+            status: "pending",
+          })
+        )
+        expect(retrieved).not.toHaveProperty("secret")
+        expect(retrieved).not.toHaveProperty("provider_metadata")
+
+        await expect(
+          service.retrieveAuthMfa({
+            id: setup.mfa.id,
+            auth_identity_id: "test-id-1",
+          })
+        ).rejects.toThrow(`MFA factor with id "${setup.mfa.id}" was not found`)
       })
 
       it("enables a pending TOTP factor after a valid code", async () => {

--- a/packages/modules/auth/src/services/auth-module.ts
+++ b/packages/modules/auth/src/services/auth-module.ts
@@ -495,6 +495,38 @@ export default class AuthModuleService
   }
 
   @InjectManager()
+  async retrieveAuthMfa(
+    selector: string | AuthTypes.AuthMfaSelector,
+    config: FindConfig<AuthTypes.AuthMfaDTO> = {},
+    @MedusaContext() sharedContext: Context = {}
+  ): Promise<AuthTypes.AuthMfaDTO> {
+    const filters =
+      typeof selector === "string"
+        ? { id: [selector] }
+        : {
+            id: [selector.id],
+            auth_identity_id: selector.auth_identity_id,
+          }
+
+    const [factor] = await this.authMfaFactorService_.list(
+      filters,
+      config,
+      sharedContext
+    )
+
+    if (!factor) {
+      const id = typeof selector === "string" ? selector : selector.id
+
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `MFA factor with id "${id}" was not found`
+      )
+    }
+
+    return await this.serializeMfaFactor_(factor)
+  }
+
+  @InjectManager()
   async listAuthMfa(
     filters: AuthTypes.FilterableAuthMfaProps = {},
     config: FindConfig<AuthTypes.AuthMfaDTO> = {},


### PR DESCRIPTION

Adds `retrieveAuthMfa` to the auth module service so callers can fetch a single MFA method by id, optionally scoped to an auth identity. The returned DTO uses the existing MFA serialization path, so provider metadata and secrets stay hidden.
