### PR TITLE
docs: clarify that redisUrl must be set manually in medusa-config.ts (#14962)

### DIFF
--- a/www/apps/book/app/learn/configurations/medusa-config/page.mdx
+++ b/www/apps/book/app/learn/configurations/medusa-config/page.mdx
@@ -817,6 +817,12 @@ This configuration is not used for modules that also connect to Redis, such as t
 
 <Note>
 
+`REDIS_URL` is included in the `.env` template that the Medusa CLI scaffolds, but Redis session storage is not enabled automatically. To enable it, you must explicitly set `redisUrl: process.env.REDIS_URL` in `medusa-config.ts` (see the example below).
+
+</Note>
+
+<Note>
+
 You must first have Redis installed. You can refer to [Redis's installation guide](https://redis.io/docs/getting-started/installation/).
 
 </Note>


### PR DESCRIPTION
## Summary

**What** — Adds a note to the `redisUrl` section of the configuration docs explaining that `REDIS_URL` from the scaffolded `.env` is not picked up by `defineConfig` unless you also set `redisUrl: process.env.REDIS_URL` in `medusa-config.ts`.

**Why** — #14962 reports the gap: the CLI scaffold writes `REDIS_URL` to `.env`, so users (reasonably) assume Redis session storage will work. It doesn't, because `defineConfig()` only reads it in cloud mode. @shahednasser confirmed (2026-03-31) that the code behavior is intentional and the fix belongs in the docs. The medusa-os-bot follow-up named the exact file and section to update.

**How** — Inserts a `<Note>` admonition right after the existing intro paragraph in the `### redisUrl` section of `www/apps/book/app/learn/configurations/medusa-config/page.mdx`. The new note sits above the existing "Redis must be installed" note and points readers to the example block below. Uses the same `<Note>` component already used in this section, so styling matches.

**Testing** — Doc-only change, no code or build impact. Verified the mdx still parses by reading the rendered structure (existing two-`<Note>`-blocks pattern is used elsewhere in this same file).

---

## Examples

The new note explains the manual config step inline, then the existing example block (already in the section) shows the actual code:

```ts title="medusa-config.ts"
module.exports = defineConfig({
  projectConfig: {
    redisUrl: process.env.REDIS_URL ||
      "redis://localhost:6379",
    // ...
  },
})
```

---

## Checklist

- [x] I have linked the related issue: closes #14962
- [x] The change is docs-only; no test/changeset required (matches recent docs PRs like #15401, #15388)

---

## Additional Context

The bot's 2026-04-15 comment on #14962 already drafted the fix scope; this PR applies it verbatim against the named file/section.
