### PR TITLE
fix(dashboard): include inventory query in detail key

### DIFF
--- a/.changeset/fix-inventory-item-query-key.md
+++ b/.changeset/fix-inventory-item-query-key.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): include inventory item query params in detail cache keys

--- a/packages/admin/dashboard/src/hooks/api/inventory.tsx
+++ b/packages/admin/dashboard/src/hooks/api/inventory.tsx
@@ -59,7 +59,7 @@ export const useInventoryItem = (
 ) => {
   const { data, ...rest } = useQuery({
     queryFn: () => sdk.admin.inventoryItem.retrieve(id, query),
-    queryKey: inventoryItemsQueryKeys.detail(id),
+    queryKey: inventoryItemsQueryKeys.detail(id, query),
     ...options,
   })
 

--- a/packages/admin/dashboard/src/routes/inventory/inventory-detail/loader.ts
+++ b/packages/admin/dashboard/src/routes/inventory/inventory-detail/loader.ts
@@ -5,12 +5,14 @@ import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 import { INVENTORY_DETAIL_FIELDS } from "./constants"
 
+const inventoryDetailQueryParams = {
+  fields: INVENTORY_DETAIL_FIELDS,
+}
+
 const inventoryDetailQuery = (id: string) => ({
-  queryKey: inventoryItemsQueryKeys.detail(id),
+  queryKey: inventoryItemsQueryKeys.detail(id, inventoryDetailQueryParams),
   queryFn: async () =>
-    sdk.admin.inventoryItem.retrieve(id, {
-      fields: INVENTORY_DETAIL_FIELDS,
-    }),
+    sdk.admin.inventoryItem.retrieve(id, inventoryDetailQueryParams),
 })
 
 export const inventoryItemLoader = async ({ params }: LoaderFunctionArgs) => {


### PR DESCRIPTION
## Summary

Fixes #14782.

This updates inventory item detail caching so query parameters are part of the React Query key. `useInventoryItem` already passes the query object to `sdk.admin.inventoryItem.retrieve`; this PR makes the cache key reflect that same query object so detail fetches with different field sets do not overwrite each other.

The inventory detail route loader now uses the same query params object for both its query key and request, keeping the loader cache aligned with the detail page hook.

## Why

The inventory detail page fetches variants with `fields: "*variants,*variants.product,*variants.options"`, while the edit attributes drawer fetches the same inventory item without that expanded field query. Because both requests previously shared `inventoryItemsQueryKeys.detail(id)`, the narrower drawer response could replace the detail page cache entry and make linked variants disappear.

## Validation

- `yarn prettier --check packages/admin/dashboard/src/hooks/api/inventory.tsx packages/admin/dashboard/src/routes/inventory/inventory-detail/loader.ts .changeset/fix-inventory-item-query-key.md`
- `yarn lint:path packages/admin/dashboard/src/hooks/api/inventory.tsx packages/admin/dashboard/src/routes/inventory/inventory-detail/loader.ts`
- `git diff --check`

I also attempted `yarn workspace @medusajs/dashboard typecheck`, but this fresh checkout fails before reaching this patch because dashboard workspace dependencies such as `@medusajs/ui`, `@medusajs/icons`, and `@medusajs/types` are not resolved/built locally.
