### PR TITLE
fix(dashboard): order list status badges show correct colors when view_configurations is enabled

### DIFF
--- a/.changeset/fix-order-list-status-badges.md
+++ b/.changeset/fix-order-list-status-badges.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): order list fulfillment and payment status badges render with the correct status colors when view_configurations is enabled

--- a/packages/admin/dashboard/src/lib/table/cell-renderers.tsx
+++ b/packages/admin/dashboard/src/lib/table/cell-renderers.tsx
@@ -59,12 +59,12 @@ const StatusRenderer: CellRenderer = (value, row, column, t) => {
     return <ProductStatusCell status={row.status} />
   }
 
-  if (column.context === "payment" && t) {
+  if (column.field === "payment_status" && t) {
     const { label, color } = getOrderPaymentStatus(t, value)
     return <StatusBadge color={color}>{label}</StatusBadge>
   }
 
-  if (column.context === "fulfillment" && t) {
+  if (column.field === "fulfillment_status" && t) {
     const { label, color } = getOrderFulfillmentStatus(t, value)
     return <StatusBadge color={color}>{label}</StatusBadge>
   }


### PR DESCRIPTION
## Summary

**What** — Fix the order list fulfillment/payment status badges rendering as grey when the `view_configurations` feature flag is enabled.

**Why** — The generic `StatusRenderer` in `cell-renderers.tsx` only delegated to the order-specific helpers (`getOrderFulfillmentStatus` / `getOrderPaymentStatus`) when `column.context === "fulfillment"` / `"payment"`. The column generator in `packages/modules/settings/src/utils/column-generator.ts` never assigns those `context` values — it only emits `"display"`, `"filter"`, or `"both"` (those describe display/filter scope, not the semantic domain). So the check never matched and execution fell through to the generic `getStatusColor()` switch, which doesn't know about `not_fulfilled`, `partially_fulfilled`, `shipped`, or `delivered` and returns `"grey"` for all of them.

**How** — Detect by `column.field === "fulfillment_status"` / `"payment_status"` instead of `column.context`. This matches the existing pattern a few lines above (`column.field === "status"` for product columns) and the column definitions in `routes/orders/order-list/components/order-list-table/hooks/use-order-data-table-columns.tsx` (which already key off `apiColumn.field === "fulfillment_status"` / `"payment_status"`).

**Testing** — Manual verification on a Medusa 2.15.x admin:
1. Enable the \`view_configurations\` feature flag.
2. Open the Orders list.
3. Verify fulfillment status badges render with their semantic colors:
   - \`not_fulfilled\` → red
   - \`partially_fulfilled\` / \`partially_shipped\` / \`partially_delivered\` / \`partially_returned\` → orange
   - \`fulfilled\` / \`shipped\` / \`delivered\` / \`returned\` → green
   - \`canceled\` → red
4. Verify payment status badges similarly map to the colors defined in \`getOrderPaymentStatus\` (\`captured\` green, \`not_paid\`/\`refunded\`/\`canceled\` red, \`awaiting\`/\`authorized\`/\`partially_*\` orange).
5. Confirm non-order status columns (e.g. product \`status\`) still render through the existing \`column.field === "status"\` branch.

## Examples

Before — \`view_configurations\` enabled, all fulfillment badges grey:
\`\`\`
[grey] not_fulfilled
[grey] partially_fulfilled
[grey] shipped
\`\`\`

After:
\`\`\`
[red]    not_fulfilled
[orange] partially_fulfilled
[green]  shipped
\`\`\`

## Checklist

- [x] I have added a **changeset** for this PR (patch on \`@medusajs/dashboard\`)
- [ ] The changes are covered by relevant **tests** — the \`packages/admin/dashboard\` package currently only has tests for pure utilities; adding a unit test for this renderer requires importing \`@medusajs/ui\` which the test harness doesn't resolve without a prior \`yarn build\` across the design-system. Happy to add a test if maintainers prefer a specific approach (e.g. extract a pure \`getStatusBadgeProps(field, value, t)\` helper, or set up workspace test deps).
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue

Closes #15415