### PR TITLE
fix(create-medusa-app): fix incorrect command replacement when using yarn and npm

### DIFF
--- a/.changeset/flat-jars-attack.md
+++ b/.changeset/flat-jars-attack.md
@@ -1,0 +1,5 @@
+---
+"create-medusa-app": patch
+---
+
+fix(create-medusa-app): fix incorrect command replacement when using yarn and npm

--- a/packages/cli/create-medusa-app/src/utils/__tests__/package-manager.test.ts
+++ b/packages/cli/create-medusa-app/src/utils/__tests__/package-manager.test.ts
@@ -316,7 +316,7 @@ describe("PackageManager", () => {
     const makePackageJson = (extra: Record<string, unknown> = {}) =>
       JSON.stringify({
         name: "test",
-        scripts: { dev: "pnpm dev", build: "pnpm build" },
+        scripts: { dev: "pnpm -r dev", build: "pnpm -r build", start: "pnpm start" },
         ...extra,
       })
 
@@ -368,26 +368,66 @@ describe("PackageManager", () => {
       expect(written.workspaces).toEqual(["apps/*", "apps/storefront"])
     })
 
-    it("should replace pnpm references in scripts", async () => {
+    it("should replace pnpm -r scripts with turbo", async () => {
       const pm = new PackageManager(processManager)
       pm["packageManager"] = "yarn"
 
       await pm.transformWorkspaceConfig("/test/path")
 
       const written = getWrittenPackageJson()
-      expect(written.scripts.dev).toBe("yarn dev")
-      expect(written.scripts.build).toBe("yarn build")
+      expect(written.scripts.dev).toBe("turbo dev")
+      expect(written.scripts.build).toBe("turbo build")
     })
 
-    it("should replace pnpm references in scripts with npm when using npm", async () => {
+    it("should replace non-recursive pnpm scripts with the package manager", async () => {
+      const pm = new PackageManager(processManager)
+      pm["packageManager"] = "yarn"
+
+      await pm.transformWorkspaceConfig("/test/path")
+
+      const written = getWrittenPackageJson()
+      expect(written.scripts.start).toBe("yarn start")
+    })
+
+    it("should replace pnpm -r scripts with turbo when using npm", async () => {
       const pm = new PackageManager(processManager)
       pm["packageManager"] = "npm"
 
       await pm.transformWorkspaceConfig("/test/path")
 
       const written = getWrittenPackageJson()
-      expect(written.scripts.dev).toBe("npm dev")
-      expect(written.scripts.build).toBe("npm build")
+      expect(written.scripts.dev).toBe("turbo dev")
+      expect(written.scripts.build).toBe("turbo build")
+    })
+
+    it("should replace non-recursive pnpm scripts with npm when using npm", async () => {
+      const pm = new PackageManager(processManager)
+      pm["packageManager"] = "npm"
+
+      await pm.transformWorkspaceConfig("/test/path")
+
+      const written = getWrittenPackageJson()
+      expect(written.scripts.start).toBe("npm start")
+    })
+
+    it("should handle mixed pnpm -r and plain pnpm in the same script", async () => {
+      mockReadFileSync
+        .mockReset()
+        .mockReturnValueOnce(YAML_CONTENT)
+        .mockReturnValueOnce(
+          JSON.stringify({
+            name: "test",
+            scripts: { all: "pnpm -r build && pnpm start" },
+          })
+        )
+
+      const pm = new PackageManager(processManager)
+      pm["packageManager"] = "yarn"
+
+      await pm.transformWorkspaceConfig("/test/path")
+
+      const written = getWrittenPackageJson()
+      expect(written.scripts.all).toBe("turbo build && yarn start")
     })
 
     it("should delete pnpm-workspace.yaml", async () => {

--- a/packages/cli/create-medusa-app/src/utils/package-manager.ts
+++ b/packages/cli/create-medusa-app/src/utils/package-manager.ts
@@ -210,7 +210,12 @@ export default class PackageManager {
       const pm = this.packageManager!
       packageJson.scripts = Object.fromEntries(
         Object.entries(packageJson.scripts as Record<string, string>).map(
-          ([key, value]) => [key, value.replace(/\bpnpm\b/g, pm)]
+          ([key, value]) => [
+            key,
+            value
+              .replace(/\bpnpm\s+-r\s+(\S+)/g, "turbo $1")
+              .replace(/\bpnpm\b/g, pm),
+          ]
         )
       )
     }


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Correctly replace `pnpm -r` commands with `turbo` for other package managers

**Why** — Why are these changes relevant or necessary?  

Currently if you're using `yarn` or `npm` with `create-medusa-app`, the created project's `dev` and `build` commands change from `pnpm -r dev` to `yarn -r dev`. However, yarn and npm don't support the `-r` flag. This causes an error when running the command.

**How** — How have these changes been implemented?

Replace `pnpm -r` with `turbo`, since it's already set up in the starter, and keep other `pnpm` replacements as-is.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Run `yarn dev --use-yarn` in the `packages/cli/create-medusa-app` directory and observe the created project's package.json.

---

## Examples

Provide examples or code snippets that demonstrate how this feature works, or how it can be used in practice.  
This helps with documentation and ensures maintainers can quickly understand and verify the change.

```ts
// Example usage
```

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
