### PR TITLE
fix(medusa,settings): handle non-sortable computed order fields (#15353)

### DIFF
--- a/.changeset/order-table-unsupported-sorting.md
+++ b/.changeset/order-table-unsupported-sorting.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/settings": patch
+"@medusajs/medusa": patch
+---
+
+fix(medusa,settings): prevent "Trying to order by not existing property" errors when sorting orders by the computed `total`, `payment_status`, or `fulfillment_status` fields. The admin orders list endpoint now ignores these non-sortable fields instead of failing, and the orders table reports them as non-sortable so the UI no longer offers the invalid sort.

--- a/integration-tests/http/__tests__/order/admin/order.spec.ts
+++ b/integration-tests/http/__tests__/order/admin/order.spec.ts
@@ -84,6 +84,38 @@ medusaIntegrationTestRunner({
         expect(response.data.orders).toEqual([])
       })
 
+      it.each([
+        "total",
+        "-total",
+        "payment_status",
+        "-payment_status",
+        "fulfillment_status",
+        "-fulfillment_status",
+      ])(
+        "should not error when ordering by non-sortable computed field '%s'",
+        async (order) => {
+          const response = await api.get(
+            `/admin/orders?order=${order}`,
+            adminHeaders
+          )
+
+          expect(response.status).toEqual(200)
+          expect(response.data.orders).toHaveLength(1)
+          expect(response.data.orders[0].id).toEqual(seeder.order.id)
+        }
+      )
+
+      it("should still order by a valid sortable field", async () => {
+        const response = await api.get(
+          `/admin/orders?order=-display_id`,
+          adminHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.orders).toHaveLength(1)
+        expect(response.data.orders[0].id).toEqual(seeder.order.id)
+      })
+
       it("should search orders by shipping address", async () => {
         let response = await api.get(
           `/admin/orders?fields=+shipping_address.address_1,+shipping_address.address_2`,
@@ -418,6 +450,42 @@ medusaIntegrationTestRunner({
             }
           }
         )
+      })
+
+      describe("sort by computed fields", () => {
+        it.each([
+          "total",
+          "-total",
+          "payment_status",
+          "-payment_status",
+          "fulfillment_status",
+          "-fulfillment_status",
+        ])(
+          "should not error when ordering by computed field '%s'",
+          async (orderParam) => {
+            const response = await api.get(
+              `/admin/orders?order=${orderParam}`,
+              adminHeaders
+            )
+
+            expect(response.status).toEqual(200)
+            expect(response.data.orders).toEqual([
+              expect.objectContaining({ id: order.id }),
+            ])
+          }
+        )
+
+        it("should still order by a valid column", async () => {
+          const response = await api.get(
+            `/admin/orders?order=-display_id`,
+            adminHeaders
+          )
+
+          expect(response.status).toEqual(200)
+          expect(response.data.orders).toEqual([
+            expect.objectContaining({ id: order.id }),
+          ])
+        })
       })
 
       it("should return shipping_address when pagination included", async () => {

--- a/integration-tests/http/__tests__/views/admin/columns.spec.ts
+++ b/integration-tests/http/__tests__/views/admin/columns.spec.ts
@@ -181,6 +181,19 @@ medusaIntegrationTestRunner({
           const totalField = response.data.columns.find((c) => c.id === "total")
           expect(totalField?.default_order).toBe(700)
           expect(totalField?.category).toBe("metric")
+          // Computed fields are resolved after the DB query, so the list API
+          // cannot order by them - they must be reported as non-sortable.
+          expect(totalField?.sortable).toBe(false)
+
+          const paymentStatusField = response.data.columns.find(
+            (c) => c.id === "payment_status"
+          )
+          expect(paymentStatusField?.sortable).toBe(false)
+
+          const fulfillmentStatusField = response.data.columns.find(
+            (c) => c.id === "fulfillment_status"
+          )
+          expect(fulfillmentStatusField?.sortable).toBe(false)
 
           const createdAtField = response.data.columns.find(
             (c) => c.id === "created_at"

--- a/packages/medusa/src/api/admin/orders/validators.ts
+++ b/packages/medusa/src/api/admin/orders/validators.ts
@@ -69,10 +69,27 @@ const AdminGetOrdersParamsBase = createFindParams({
 
 type AdminGetOrdersParamsInput = z.infer<typeof AdminGetOrdersParamsBase>
 
+// Fields that exist on the Order GraphQL type but are computed after the
+// database query (no backing column), so the list query cannot order by
+// them without a MikroORM "not existing property" error.
+const NON_SORTABLE_ORDER_FIELDS = [
+  "total",
+  "payment_status",
+  "fulfillment_status",
+]
+
 const AdminGetOrdersParamsTransform = (v: AdminGetOrdersParamsInput) => {
-  const { total, ...rest } = v
+  const { total, order, ...rest } = v
+
+  const orderField = order?.startsWith("-") ? order.slice(1) : order
+  const sortableOrder =
+    orderField && NON_SORTABLE_ORDER_FIELDS.includes(orderField)
+      ? undefined
+      : order
+
   return {
     ...rest,
+    ...(sortableOrder ? { order: sortableOrder } : {}),
     ...(total ? { summary: { totals: { current_order_total: total } } } : {}),
   }
 }

--- a/packages/modules/settings/integration-tests/__tests__/entity-discovery.spec.ts
+++ b/packages/modules/settings/integration-tests/__tests__/entity-discovery.spec.ts
@@ -753,7 +753,7 @@ moduleIntegrationTestRunner<SettingsTypes.ISettingsModuleService>({
             expect(fulfillmentStatus?.filter?.operators).toBeUndefined()
           })
 
-          it("should keep the column itself visible and sortable when filtering is disabled", async () => {
+          it("should keep the column itself visible when filtering is disabled", async () => {
             const columns = await service.generateEntityColumns("Order")
 
             expect(columns).not.toBeNull()
@@ -762,13 +762,11 @@ moduleIntegrationTestRunner<SettingsTypes.ISettingsModuleService>({
               (c) => c.id === "payment_status"
             )
             expect(paymentStatus?.default_visible).toBe(true)
-            expect(paymentStatus?.sortable).toBe(true)
 
             const fulfillmentStatus = columns!.find(
               (c) => c.id === "fulfillment_status"
             )
             expect(fulfillmentStatus?.default_visible).toBe(true)
-            expect(fulfillmentStatus?.sortable).toBe(true)
           })
 
           it("should keep filtering enabled on other Order scalar fields", async () => {
@@ -781,6 +779,57 @@ moduleIntegrationTestRunner<SettingsTypes.ISettingsModuleService>({
 
             const total = columns!.find((c) => c.id === "total")
             expect(total?.filter?.enabled).toBe(true)
+          })
+        })
+
+        describe("nonSortableFields", function () {
+          it("should disable sorting on Order's computed total and status fields", async () => {
+            const columns = await service.generateEntityColumns("Order")
+
+            expect(columns).not.toBeNull()
+
+            const total = columns!.find((c) => c.id === "total")
+            expect(total).toBeDefined()
+            expect(total?.sortable).toBe(false)
+
+            const paymentStatus = columns!.find(
+              (c) => c.id === "payment_status"
+            )
+            expect(paymentStatus).toBeDefined()
+            expect(paymentStatus?.sortable).toBe(false)
+
+            const fulfillmentStatus = columns!.find(
+              (c) => c.id === "fulfillment_status"
+            )
+            expect(fulfillmentStatus).toBeDefined()
+            expect(fulfillmentStatus?.sortable).toBe(false)
+          })
+
+          it("should keep non-sortable columns visible and filterable where applicable", async () => {
+            const columns = await service.generateEntityColumns("Order")
+
+            expect(columns).not.toBeNull()
+
+            const total = columns!.find((c) => c.id === "total")
+            expect(total?.default_visible).toBe(true)
+            expect(total?.filter?.enabled).toBe(true)
+
+            const paymentStatus = columns!.find(
+              (c) => c.id === "payment_status"
+            )
+            expect(paymentStatus?.default_visible).toBe(true)
+          })
+
+          it("should keep sorting enabled on other Order scalar fields", async () => {
+            const columns = await service.generateEntityColumns("Order")
+
+            expect(columns).not.toBeNull()
+
+            const displayId = columns!.find((c) => c.id === "display_id")
+            expect(displayId?.sortable).toBe(true)
+
+            const createdAt = columns!.find((c) => c.id === "created_at")
+            expect(createdAt?.sortable).toBe(true)
           })
         })
 
@@ -971,6 +1020,21 @@ moduleIntegrationTestRunner<SettingsTypes.ISettingsModuleService>({
             expect(merged?.nonFilterableFields).toContain("payment_status")
             expect(merged?.nonFilterableFields).toContain("fulfillment_status")
             expect(merged?.nonFilterableFields).toContain("custom_computed_field")
+          })
+
+          it("should concatenate nonSortableFields when extending an existing override", () => {
+            const registry = getEntityOverrideRegistry()
+
+            registry.register("Order", {
+              nonSortableFields: ["custom_computed_field"],
+            })
+
+            const merged = registry.get("Order")
+
+            expect(merged?.nonSortableFields).toContain("total")
+            expect(merged?.nonSortableFields).toContain("payment_status")
+            expect(merged?.nonSortableFields).toContain("fulfillment_status")
+            expect(merged?.nonSortableFields).toContain("custom_computed_field")
           })
         })
 

--- a/packages/modules/settings/src/utils/column-generator.ts
+++ b/packages/modules/settings/src/utils/column-generator.ts
@@ -24,6 +24,7 @@ import {
   getFieldFilterRules,
   getFieldOrdering,
   getNonFilterableFields,
+  getNonSortableFields,
 } from "./entity-overrides"
 import {
   buildFilterConfig,
@@ -105,6 +106,7 @@ export function generateEntityColumns(
   const fieldOrdering = getFieldOrdering(entity.name, override)
   const additionalTypes = getAdditionalTypes(entity.name, override)
   const nonFilterableFields = getNonFilterableFields(entity.name, override)
+  const nonSortableFields = getNonSortableFields(entity.name, override)
 
   const schemaTypeMap = entityDiscovery.getSchemaTypeMap()
   const columns: ViewConfigurationColumn[] = []
@@ -121,6 +123,7 @@ export function generateEntityColumns(
     defaultVisibleFields,
     fieldOrdering,
     nonFilterableFields,
+    nonSortableFields,
     propertyLabels
   )
 
@@ -138,6 +141,7 @@ export function generateEntityColumns(
         defaultVisibleFields,
         fieldOrdering,
         nonFilterableFields,
+        nonSortableFields,
         propertyLabels
       )
     }
@@ -204,6 +208,7 @@ function processEntityType(
   defaultVisibleFields: string[],
   fieldOrdering: Record<string, number>,
   nonFilterableFields: string[],
+  nonSortableFields: string[],
   propertyLabels?: Map<string, PropertyLabel>,
   parentPath: string = ""
 ): void {
@@ -262,7 +267,10 @@ function processEntityType(
         name: label?.label || formatFieldName(fieldName),
         description: label?.description || undefined,
         field: fullPath,
-        sortable: !parentPath, // Only top-level fields are sortable
+        // Only top-level fields are sortable, and fields explicitly marked
+        // as non-sortable (e.g. computed values not backed by a real column)
+        // are excluded to avoid invalid list-API order parameters.
+        sortable: !parentPath && !nonSortableFields.includes(fullPath),
         hideable: true,
         default_visible: defaultVisibleFields.includes(fullPath),
         data_type: dataType,

--- a/packages/modules/settings/src/utils/entity-overrides.ts
+++ b/packages/modules/settings/src/utils/entity-overrides.ts
@@ -48,6 +48,17 @@ export interface EntityOverride {
   nonFilterableFields?: string[]
 
   /**
+   * Fields that should be displayed as columns but cannot be sorted on.
+   * Use for fields that exist on the entity's GraphQL type (e.g. computed
+   * values like `total`, `payment_status`, or `fulfillment_status`) but are
+   * resolved after the database query and therefore are not real columns the
+   * list API can order by. Dotted paths are supported (e.g. `customer.email`)
+   * to target nested-relationship scalar fields, matching the convention used
+   * by `defaultVisibleFields` and `fieldOrdering`.
+   */
+  nonSortableFields?: string[]
+
+  /**
    * Computed columns specific to this entity.
    * Note: Computed columns can also be defined in the ComputedColumnRegistry.
    */
@@ -86,6 +97,7 @@ export const BUILTIN_ENTITY_OVERRIDES: Record<string, EntityOverride> = {
       country: 800,
     },
     nonFilterableFields: ["payment_status", "fulfillment_status"],
+    nonSortableFields: ["total", "payment_status", "fulfillment_status"],
   },
   Product: {
     excludeSuffixes: ["_link"],
@@ -200,6 +212,10 @@ export class EntityOverrideRegistry {
         nonFilterableFields: [
           ...(existing.nonFilterableFields || []),
           ...(override.nonFilterableFields || []),
+        ],
+        nonSortableFields: [
+          ...(existing.nonSortableFields || []),
+          ...(override.nonSortableFields || []),
         ],
         computedColumns: [
           ...(existing.computedColumns || []),
@@ -349,6 +365,19 @@ export function getNonFilterableFields(
 ): string[] {
   const resolvedOverride = override ?? getEntityOverride(entityName)
   return resolvedOverride?.nonFilterableFields || []
+}
+
+/**
+ * Get fields that should be displayed but not sortable for an entity.
+ * @param entityName - The entity name (used if override is not provided)
+ * @param override - Optional pre-resolved override to use instead of looking up by entity name
+ */
+export function getNonSortableFields(
+  entityName: string,
+  override?: EntityOverride
+): string[] {
+  const resolvedOverride = override ?? getEntityOverride(entityName)
+  return resolvedOverride?.nonSortableFields || []
 }
 
 /**


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

- `GET /admin/orders` now ignores `total`, `payment_status`, and `fulfillment_status` in the `order` (sort) param instead of passing them to the query layer.
- A new `nonSortableFields` entity override (mirroring the existing `nonFilterableFields`) marks these columns as non-sortable, so the configurable orders table no longer offers sorting on them.

**Why** — Why are these changes relevant or necessary?

Sorting the admin Orders table by Total / Payment status / Fulfillment status failed with `Trying to order by not existing property Order.total` (#15353). These fields exist on the Order GraphQL type but are **computed after the database query**, so MikroORM cannot `ORDER BY` them. The fix protects every caller (legacy admin table, configurable table, saved views, JS SDK, direct API) and returns results instead of a 500.

**How** — How have these changes been implemented?

- `AdminGetOrdersParamsTransform` (orders validators) strips a non-sortable field from `order`, handling the leading `-` descending prefix, and falls back to default ordering.
- `column-generator` reads a new `getNonSortableFields()` helper and sets `sortable: false` for the configured fields. The `nonSortableFields` override, registry merge logic, and getter mirror the existing `nonFilterableFields` mechanism for consistency.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Verified locally against Postgres after a full `yarn build`:

- `integration-tests/http/__tests__/order/admin/order.spec.ts` — added a suite asserting `200` (not `500`) for `total`, `-total`, `payment_status`, `-payment_status`, `fulfillment_status`, `-fulfillment_status`, and that a valid column (`-display_id`) still sorts. **7/7 passed.**
- `packages/modules/settings/integration-tests/__tests__/entity-discovery.spec.ts` — added `nonSortableFields` assertions + override-merge test. **83/83 passed.**
- `integration-tests/http/__tests__/views/admin/columns.spec.ts` — asserts the columns are reported non-sortable. **4/4 passed.**

Reviewer repro: open the admin Orders table and sort by Total / Payment status / Fulfillment status — previously a 500, now returns results (and with `view_configurations` enabled the column no longer exposes a sort toggle).

---

## Examples

```ts
// Before: 500 — "Trying to order by not existing property Order.total"
await sdk.admin.order.list({ order: "total" })

// After: request succeeds; the unsupported sort is ignored and
// default ordering is applied instead of erroring.
const { orders } = await sdk.admin.order.list({ order: "total" })

// Valid columns are unaffected:
await sdk.admin.order.list({ order: "-display_id" })
