### PR TITLE
fix(core-flows): respect allow_backorder when calculating pickup inventory availability

### DIFF
--- a/.changeset/fix-backorder-pickup-inventory.md
+++ b/.changeset/fix-backorder-pickup-inventory.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/core-flows": patch
+---
+
+fix(core-flows): respect allow_backorder when calculating pickup inventory availability
+
+Products with `allow_backorder=true` are now correctly treated as available for pickup shipping options, even when `inventory_quantity=0`. Previously, these products would incorrectly trigger `insufficient_inventory: true`, preventing customers from selecting pickup options for backorder-enabled products.

--- a/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
+++ b/integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts
@@ -4766,6 +4766,114 @@ medusaIntegrationTestRunner({
           expect(result).toEqual([])
         })
 
+        it("should not flag insufficient_inventory for a pickup option when item has allow_backorder=true and zero stock", async () => {
+          const [product] = await productModule.createProducts([
+            {
+              title: "Backorder pickup product",
+              status: ProductStatus.PUBLISHED,
+              variants: [
+                {
+                  title: "Variant",
+                  manage_inventory: true,
+                  allow_backorder: true,
+                },
+              ],
+            },
+          ])
+
+          const inventoryItem = (
+            await api.post(
+              `/admin/inventory-items`,
+              {
+                sku: "backorder-pickup-1",
+                location_levels: [
+                  {
+                    location_id: stockLocation.id,
+                    stocked_quantity: 0,
+                  },
+                ],
+              },
+              adminHeaders
+            )
+          ).data.inventory_item
+
+          const variantPriceSet = await pricingModule.createPriceSets({
+            prices: [{ amount: 1000, currency_code: "usd" }],
+          })
+
+          await remoteLink.create([
+            {
+              [Modules.PRODUCT]: { variant_id: product.variants[0].id },
+              [Modules.PRICING]: { price_set_id: variantPriceSet.id },
+            },
+            {
+              [Modules.PRODUCT]: { variant_id: product.variants[0].id },
+              [Modules.INVENTORY]: { inventory_item_id: inventoryItem.id },
+            },
+          ])
+
+          const shippingOption = (
+            await api.post(
+              `/admin/shipping-options`,
+              {
+                name: "Pickup at location",
+                service_zone_id: fulfillmentSet.service_zones[0].id,
+                shipping_profile_id: shippingProfile.id,
+                provider_id: "manual_test-provider",
+                price_type: "flat",
+                type: {
+                  label: "Pickup",
+                  description: "Pickup at location",
+                  code: "pickup",
+                },
+                prices: [
+                  {
+                    amount: 3000,
+                    currency_code: "usd",
+                  },
+                ],
+                rules: [
+                  {
+                    operator: RuleOperator.EQ,
+                    attribute: "is_return",
+                    value: "false",
+                  },
+                  {
+                    operator: RuleOperator.EQ,
+                    attribute: "enabled_in_store",
+                    value: "true",
+                  },
+                ],
+              },
+              adminHeaders
+            )
+          ).data.shipping_option
+
+          await addToCartWorkflow(appContainer).run({
+            input: {
+              cart_id: cart.id,
+              items: [
+                { variant_id: product.variants[0].id, quantity: 1 },
+              ],
+            },
+          })
+
+          const { result } = await listShippingOptionsForCartWorkflow(
+            appContainer
+          ).run({ input: { cart_id: cart.id } })
+
+          // The backorder-enabled variant is treated as available even at
+          // stocked_quantity 0, so the pickup option must NOT be flagged
+          // insufficient_inventory. Without the fix this returns true and
+          // the customer cannot select pickup for the backorder item.
+          expect(result).toEqual([
+            expect.objectContaining({
+              id: shippingOption.id,
+              insufficient_inventory: false,
+            }),
+          ])
+        })
+
         describe("setPricingContext hook", () => {
           it("should use context provided by the hook", async () => {
             const shippingOption = (

--- a/packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart.ts
@@ -146,6 +146,7 @@ export const listShippingOptionsForCartWorkflow = createWorkflow(
         ...cartFieldsForPricingContext,
         "items.*",
         "items.variant.manage_inventory",
+        "items.variant.allow_backorder",
         "items.variant.inventory_items.inventory_item_id",
         "items.variant.inventory_items.inventory.requires_shipping",
         "items.variant.inventory_items.inventory.location_levels.*",
@@ -331,6 +332,10 @@ export const listShippingOptionsForCartWorkflow = createWorkflow(
           const itemsAtLocationWithoutAvailableQuantity = cart.items.filter(
             (item) => {
               if (!item.variant?.manage_inventory) {
+                return false
+              }
+
+              if (item.variant?.allow_backorder) {
                 return false
               }
 

--- a/packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart.ts
@@ -331,11 +331,10 @@ export const listShippingOptionsForCartWorkflow = createWorkflow(
 
           const itemsAtLocationWithoutAvailableQuantity = cart.items.filter(
             (item) => {
-              if (!item.variant?.manage_inventory) {
-                return false
-              }
-
-              if (item.variant?.allow_backorder) {
+              if (
+                !item.variant?.manage_inventory ||
+                item.variant?.allow_backorder
+              ) {
                 return false
               }
 


### PR DESCRIPTION
## What

Re-submission of #14641, which was approved by three maintainers and auto-closed by the stale-bot on 2026-03-29 while waiting on @olivermrbl's call on release-type. The change is unchanged in intent and is now rebased onto current `develop`.

Respect `allow_backorder=true` when calculating `insufficient_inventory` in `listShippingOptionsForCartWorkflow`, so the pickup shipping option is correctly available for backorder-enabled products at zero stock.

## Why

When a product has `allow_backorder=true` but `inventory_quantity=0`, the pickup shipping options incorrectly return `insufficient_inventory: true`, preventing customers from selecting pickup. Use case: stores offering "pickup at warehouse" (often with cash on collection) need to accept orders for backorder items, since they will order or produce the parts and notify the customer when ready.

## How

1. Add `items.variant.allow_backorder` to the cart query fields in `listShippingOptionsForCartWorkflow`.
2. Add an early return in the inventory filter to skip items with `allow_backorder = true`.

Files:
- `packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart.ts`
- `.changeset/fix-backorder-pickup-inventory.md`

## Testing

Manual reproduction (against a Medusa store with a pickup-at-location shipping option):

1. Create a pickup shipping option linked to a stock location.
2. Create a product with `manage_inventory=true`, `allow_backorder=true`, and either `inventory_quantity=0` at that location or no `inventory_level` row at the location.
3. Add the variant to a cart and proceed to checkout.
4. Fetch shipping options for that cart (via the storefront API or by running `listShippingOptionsForCartWorkflow` directly).

Before this change: the pickup shipping option is returned with `insufficient_inventory: true`, so the customer cannot select pickup for the backorder item.

After this change: the pickup shipping option is returned with `insufficient_inventory: false`, because the backorder-enabled item is treated as available, so the customer can complete checkout with pickup.

Integration test: added in this PR, extending the existing `describe("listShippingOptionsForCartWorkflow", ...)` block in `integration-tests/modules/__tests__/cart/store/cart.workflows.spec.ts` with a case for `allow_backorder=true` + zero inventory at the pickup location, asserting `insufficient_inventory: false`.

## Prior approvals (please carry over if you can)

- @NicolasGorga: APPROVED, 2026-01-30 ("lgtm, thanks for the contribution")
- @carlos-r-l-rodrigues: APPROVED, 2026-02-18
- @fPolic: APPROVED, 2026-02-19

## The one open question (release type), addressed proactively

In the original thread, @fPolic flagged a fair point on the changeset: this change alters the observable `insufficient_inventory` flag, which is technically a behavior change rather than a pure bug fix. @NicolasGorga responded: "Anyone who was currently expecting the opposite was already not following the docs. Could we get away with a patch and a note at the top of the release notes?" and pinged @olivermrbl, who did not get a chance to weigh in before stale closure.

To avoid stalling again, happy with whichever release-type you prefer:
1. Keep as **patch** with a prominent release-notes callout that `insufficient_inventory` for pickup now correctly respects `allow_backorder` (Nicolas's suggestion).
2. Bump to **minor**. Will update the changeset on request.

@olivermrbl, would appreciate your call so this does not stall again.

## CI

The original PR's CI did not run because Vercel/GitHub Actions need a maintainer to authorize first-time external-contributor runs. Would a maintainer kindly trigger the run on this resubmission so we can confirm green before merge?

Supersedes #14641.
