### PR TITLE
feat(js-sdk): add MFA auth helpers

### DIFF
--- a/.changeset/fresh-masks-sip.md
+++ b/.changeset/fresh-masks-sip.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/js-sdk": patch
+---
+
+feat(js-sdk): add MFA auth helpers

--- a/packages/admin/dashboard/src/hooks/api/auth.tsx
+++ b/packages/admin/dashboard/src/hooks/api/auth.tsx
@@ -3,6 +3,20 @@ import { HttpTypes } from "@medusajs/types"
 import { UseMutationOptions, useMutation } from "@tanstack/react-query"
 import { sdk } from "../../lib/client"
 
+const ensureAuthTokenOrRedirect = async (
+  authResponse: ReturnType<typeof sdk.auth.login>
+) => {
+  const result = await authResponse
+
+  if (typeof result === "string" || "location" in result) {
+    return result
+  }
+
+  throw new Error(
+    "Multi-factor authentication is not supported in the dashboard"
+  )
+}
+
 export const useSignInWithEmailPass = (
   options?: UseMutationOptions<
     | string
@@ -14,7 +28,8 @@ export const useSignInWithEmailPass = (
   >
 ) => {
   return useMutation({
-    mutationFn: (payload) => sdk.auth.login("user", "emailpass", payload),
+    mutationFn: (payload) =>
+      ensureAuthTokenOrRedirect(sdk.auth.login("user", "emailpass", payload)),
     onSuccess: async (data, variables, context) => {
       options?.onSuccess?.(data, variables, context)
     },

--- a/packages/admin/dashboard/src/routes/login/components/cloud-auth-login.tsx
+++ b/packages/admin/dashboard/src/routes/login/components/cloud-auth-login.tsx
@@ -90,7 +90,7 @@ const useHandleLogin = (isAutoLogin: boolean) => {
         callback_url: `${window.location.origin}${window.location.pathname}?auth_provider=${CLOUD_AUTH_PROVIDER}`,
       })
 
-      if (typeof result === "object" && result.location) {
+      if (typeof result === "object" && "location" in result) {
         // Redirect to Medusa Cloud for authentication
         window.location.href = result.location
         return
@@ -128,7 +128,17 @@ const useAuthCallback = (searchParams: URLSearchParams) => {
         const query = Object.fromEntries(searchParams)
         delete query.auth_provider // BE doesn't need this
 
-        token = await sdk.auth.callback("user", CLOUD_AUTH_PROVIDER, query)
+        const result = await sdk.auth.callback(
+          "user",
+          CLOUD_AUTH_PROVIDER,
+          query
+        )
+
+        if (typeof result !== "string") {
+          throw new Error("Unexpected authentication callback response")
+        }
+
+        token = result
       } catch (error) {
         throw new Error("Authentication callback failed")
       }

--- a/packages/core/js-sdk/src/__tests__/auth.spec.ts
+++ b/packages/core/js-sdk/src/__tests__/auth.spec.ts
@@ -1,0 +1,282 @@
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+
+import { Auth } from "../auth"
+import { Client } from "../client"
+
+const baseUrl = "https://someurl.com"
+const token = "token-123"
+const jwtTokenStorageKey = "medusa_auth_token"
+
+const mfaChallenge = {
+  id: "authmfachal_123",
+  auth_identity_id: "authid_123",
+  methods: ["totp"],
+  expires_at: "2026-05-20T10:00:00.000Z",
+  attempts: 0,
+  max_attempts: 5,
+  completed_at: null,
+  metadata: null,
+}
+
+const storage = {
+  data: new Map<string, string>(),
+  getItem: jest.fn((key: string) => storage.data.get(key) ?? null),
+  setItem: jest.fn((key: string, value: string) => {
+    storage.data.set(key, value)
+  }),
+  removeItem: jest.fn((key: string) => {
+    storage.data.delete(key)
+  }),
+}
+
+const server = setupServer(
+  http.all("*", () => {
+    return new HttpResponse(null, {
+      status: 404,
+      statusText: "Not Found",
+    })
+  })
+)
+
+const createAuth = () => {
+  const config = {
+    baseUrl,
+    auth: {
+      type: "jwt",
+      jwtTokenStorageMethod: "custom",
+      storage,
+    },
+  } as const
+
+  return new Auth(new Client(config), config)
+}
+
+describe("Auth", () => {
+  beforeAll(() => server.listen())
+
+  beforeEach(() => {
+    storage.data.clear()
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => server.resetHandlers())
+
+  afterAll(() => server.close())
+
+  it("stores a token returned from login", async () => {
+    server.use(
+      http.post(`${baseUrl}/auth/user/emailpass`, async ({ request }) => {
+        expect(await request.json()).toEqual({
+          email: "test@example.com",
+          password: "secret",
+        })
+
+        return HttpResponse.json({ token })
+      })
+    )
+
+    const auth = createAuth()
+    const result = await auth.login("user", "emailpass", {
+      email: "test@example.com",
+      password: "secret",
+    })
+
+    expect(result).toBe(token)
+    expect(storage.setItem).toHaveBeenCalledWith(jwtTokenStorageKey, token)
+  })
+
+  it("returns an MFA challenge from login without storing a token", async () => {
+    server.use(
+      http.post(`${baseUrl}/auth/user/emailpass`, () => {
+        return HttpResponse.json({
+          mfa_required: true,
+          mfa_challenge: mfaChallenge,
+        })
+      })
+    )
+
+    const auth = createAuth()
+    const result = await auth.login("user", "emailpass", {
+      email: "test@example.com",
+      password: "secret",
+    })
+
+    expect(result).toEqual({
+      mfa_required: true,
+      mfa_challenge: mfaChallenge,
+    })
+    expect(storage.setItem).not.toHaveBeenCalled()
+  })
+
+  it("returns redirect locations from login", async () => {
+    server.use(
+      http.post(`${baseUrl}/auth/user/github`, () => {
+        return HttpResponse.json({
+          location: "https://github.com/login/oauth/authorize",
+        })
+      })
+    )
+
+    const auth = createAuth()
+    const result = await auth.login("user", "github", {})
+
+    expect(result).toEqual({
+      location: "https://github.com/login/oauth/authorize",
+    })
+    expect(storage.setItem).not.toHaveBeenCalled()
+  })
+
+  it("returns an MFA challenge from auth callbacks without storing a token", async () => {
+    server.use(
+      http.get(`${baseUrl}/auth/user/github/callback`, ({ request }) => {
+        expect(new URL(request.url).searchParams.get("code")).toBe("code_123")
+
+        return HttpResponse.json({
+          mfa_required: true,
+          mfa_challenge: mfaChallenge,
+        })
+      })
+    )
+
+    const auth = createAuth()
+    const result = await auth.callback("user", "github", {
+      code: "code_123",
+    })
+
+    expect(result).toEqual({
+      mfa_required: true,
+      mfa_challenge: mfaChallenge,
+    })
+    expect(storage.setItem).not.toHaveBeenCalled()
+  })
+
+  it("manages MFA factors", async () => {
+    const mfaFactor = {
+      id: "authmfa_123",
+      auth_identity_id: "authid_123",
+      provider: "totp",
+      status: "pending",
+      metadata: null,
+    }
+
+    server.use(
+      http.get(`${baseUrl}/auth/mfa/factors`, () => {
+        return HttpResponse.json({ mfa_factors: [mfaFactor] })
+      }),
+      http.post(`${baseUrl}/auth/mfa/factors`, async ({ request }) => {
+        expect(await request.json()).toEqual({
+          provider: "totp",
+          label: "Authenticator app",
+        })
+
+        return HttpResponse.json({
+          mfa_factor: mfaFactor,
+          secret: "SECRET",
+          otpauth_url: "otpauth://totp/test",
+        })
+      }),
+      http.post(
+        `${baseUrl}/auth/mfa/factors/${mfaFactor.id}/verify`,
+        async ({ request }) => {
+          expect(await request.json()).toEqual({ code: "123456" })
+
+          return HttpResponse.json({
+            mfa_factor: {
+              ...mfaFactor,
+              status: "enabled",
+            },
+          })
+        }
+      ),
+      http.delete(
+        `${baseUrl}/auth/mfa/factors/${mfaFactor.id}`,
+        async ({ request }) => {
+          expect(await request.json()).toEqual({
+            method: "totp",
+            code: "123456",
+          })
+
+          return HttpResponse.json({
+            mfa_factor: {
+              ...mfaFactor,
+              status: "disabled",
+            },
+          })
+        }
+      ),
+      http.post(`${baseUrl}/auth/mfa/recovery-codes`, async ({ request }) => {
+        expect(await request.json()).toEqual({ count: 8 })
+
+        return HttpResponse.json({
+          recovery_codes: ["code-1", "code-2"],
+        })
+      })
+    )
+
+    const auth = createAuth()
+
+    await expect(auth.mfa.list()).resolves.toEqual({
+      mfa_factors: [mfaFactor],
+    })
+    await expect(
+      auth.mfa.start({
+        provider: "totp",
+        label: "Authenticator app",
+      })
+    ).resolves.toEqual({
+      mfa_factor: mfaFactor,
+      secret: "SECRET",
+      otpauth_url: "otpauth://totp/test",
+    })
+    await expect(
+      auth.mfa.verify(mfaFactor.id, { code: "123456" })
+    ).resolves.toEqual({
+      mfa_factor: {
+        ...mfaFactor,
+        status: "enabled",
+      },
+    })
+    await expect(
+      auth.mfa.disable(mfaFactor.id, {
+        method: "totp",
+        code: "123456",
+      })
+    ).resolves.toEqual({
+      mfa_factor: {
+        ...mfaFactor,
+        status: "disabled",
+      },
+    })
+    await expect(
+      auth.mfa.generateRecoveryCodes({ count: 8 })
+    ).resolves.toEqual({
+      recovery_codes: ["code-1", "code-2"],
+    })
+  })
+
+  it("stores the token returned from MFA challenge verification", async () => {
+    server.use(
+      http.post(
+        `${baseUrl}/auth/mfa/challenges/${mfaChallenge.id}/verify`,
+        async ({ request }) => {
+          expect(await request.json()).toEqual({
+            method: "totp",
+            code: "123456",
+          })
+
+          return HttpResponse.json({ token })
+        }
+      )
+    )
+
+    const auth = createAuth()
+    const result = await auth.mfa.verifyChallenge(mfaChallenge.id, {
+      method: "totp",
+      code: "123456",
+    })
+
+    expect(result).toBe(token)
+    expect(storage.setItem).toHaveBeenCalledWith(jwtTokenStorageKey, token)
+  })
+})

--- a/packages/core/js-sdk/src/auth/index.ts
+++ b/packages/core/js-sdk/src/auth/index.ts
@@ -2,62 +2,163 @@ import { AuthTypes, HttpTypes } from "@medusajs/types"
 import { Client } from "../client.js"
 import { ClientHeaders, Config } from "../types.js"
 
+/**
+ * Redirect response returned when an authentication provider requires the user
+ * to continue authentication on another page.
+ */
 export type AuthRedirectResponse = {
+  /**
+   * The URL to redirect the user to.
+   */
   location: string
 }
 
+/**
+ * Response returned when authentication succeeds but must be completed with
+ * a multi-factor authentication (MFA) challenge before issuing a token.
+ */
 export type AuthMfaRequiredResponse = {
+  /**
+   * Indicates that the client must complete the returned MFA challenge.
+   */
   mfa_required: true
+  /**
+   * The MFA challenge to complete.
+   */
   mfa_challenge: AuthTypes.AuthMfaChallengeDTO
 }
 
+/**
+ * Response returned from an authentication attempt.
+ */
 export type AuthLoginResponse =
   | string
   | AuthRedirectResponse
   | AuthMfaRequiredResponse
 
+/**
+ * Response returned from an authentication callback.
+ */
 export type AuthCallbackResponse = string | AuthMfaRequiredResponse
 
+/**
+ * Response containing the authenticated identity's MFA factors.
+ */
 export type AuthMfaListResponse = {
+  /**
+   * The MFA factors configured for the authenticated identity.
+   */
   mfa_factors: AuthTypes.AuthMfaDTO[]
 }
 
+/**
+ * Response returned when starting MFA setup.
+ */
 export type AuthMfaSetupResponse = {
+  /**
+   * The pending MFA factor.
+   */
   mfa_factor: AuthTypes.AuthMfaDTO
+  /**
+   * The setup secret. For TOTP, this can be entered manually in an
+   * authenticator app.
+   */
   secret?: string
+  /**
+   * The setup URI. For TOTP, this can be rendered as a QR code.
+   */
   otpauth_url?: string
 }
 
+/**
+ * Response containing a single MFA factor.
+ */
 export type AuthMfaFactorResponse = {
+  /**
+   * The MFA factor.
+   */
   mfa_factor: AuthTypes.AuthMfaDTO
 }
 
+/**
+ * Response containing newly generated MFA recovery codes.
+ */
 export type AuthMfaRecoveryCodesResponse = {
+  /**
+   * The recovery codes. These are only returned once and should be stored by
+   * the user.
+   */
   recovery_codes: string[]
 }
 
+/**
+ * Payload used to start MFA setup.
+ */
 export type AuthMfaStartPayload = {
+  /**
+   * The MFA provider to set up.
+   */
   provider: AuthTypes.AuthMfaProvider
+  /**
+   * Optional label for the MFA factor.
+   */
   label?: string | null
+  /**
+   * Optional issuer name. For TOTP, authenticator apps show this as the
+   * service name.
+   */
   issuer?: string
+  /**
+   * Optional metadata to store with the MFA factor.
+   */
   metadata?: Record<string, unknown> | null
 }
 
+/**
+ * Payload used to verify a pending MFA setup.
+ */
 export type AuthMfaVerifyPayload = {
+  /**
+   * The verification code from the MFA provider.
+   */
   code: string
 }
 
+/**
+ * Payload used to disable an MFA factor.
+ */
 export type AuthMfaDisablePayload = {
+  /**
+   * Optional challenge method used to authorize disabling MFA when configured.
+   */
   method?: AuthTypes.AuthMfaChallengeMethod
+  /**
+   * Optional verification code for the selected challenge method.
+   */
   code?: string
 }
 
+/**
+ * Payload used to generate recovery codes.
+ */
 export type AuthMfaGenerateRecoveryCodesPayload = {
+  /**
+   * Number of recovery codes to generate.
+   */
   count?: number
 }
 
+/**
+ * Payload used to verify an MFA challenge.
+ */
 export type AuthMfaVerifyChallengePayload = {
+  /**
+   * The MFA challenge method used for verification.
+   */
   method: AuthTypes.AuthMfaChallengeMethod
+  /**
+   * The verification code for the selected challenge method.
+   */
   code: string
 }
 
@@ -77,13 +178,50 @@ export class Auth {
     this.config = config
   }
 
+  /**
+   * Methods for managing and completing multi-factor authentication (MFA).
+   */
   mfa = {
+    /**
+     * This method retrieves the MFA factors configured for the authenticated
+     * identity. It sends a request to the
+     * [List MFA Factors](https://docs.medusajs.com/api/admin#auth_getmfa_factors)
+     * API route.
+     *
+     * @param headers - Headers to pass in the request.
+     * @returns The configured MFA factors.
+     *
+     * @tags auth
+     *
+     * @example
+     * const { mfa_factors } = await sdk.auth.mfa.list()
+     */
     list: async (headers?: ClientHeaders) => {
       return await this.client.fetch<AuthMfaListResponse>("/auth/mfa/factors", {
         headers,
       })
     },
 
+    /**
+     * This method starts MFA setup for the authenticated identity. It sends a
+     * request to the
+     * [Create MFA Factor](https://docs.medusajs.com/api/admin#auth_postmfa_factors)
+     * API route.
+     *
+     * @param body - The MFA setup details.
+     * @param headers - Headers to pass in the request.
+     * @returns The pending MFA factor and any setup details returned by the provider.
+     *
+     * @tags auth
+     *
+     * @example
+     * const setup = await sdk.auth.mfa.start({
+     *   provider: "totp",
+     *   label: "Authenticator app"
+     * })
+     *
+     * // Render setup.otpauth_url as a QR code or show setup.secret manually.
+     */
     start: async (body: AuthMfaStartPayload, headers?: ClientHeaders) => {
       return await this.client.fetch<AuthMfaSetupResponse>(
         "/auth/mfa/factors",
@@ -95,6 +233,23 @@ export class Auth {
       )
     },
 
+    /**
+     * This method verifies a pending MFA factor setup. It sends a request to the
+     * [Verify MFA Factor](https://docs.medusajs.com/api/admin#auth_postmfa_factorsidverify)
+     * API route.
+     *
+     * @param id - The ID of the MFA factor to verify.
+     * @param body - The verification details.
+     * @param headers - Headers to pass in the request.
+     * @returns The verified MFA factor.
+     *
+     * @tags auth
+     *
+     * @example
+     * const { mfa_factor } = await sdk.auth.mfa.verify("authmfa_123", {
+     *   code: "123456"
+     * })
+     */
     verify: async (
       id: string,
       body: AuthMfaVerifyPayload,
@@ -110,6 +265,22 @@ export class Auth {
       )
     },
 
+    /**
+     * This method disables an MFA factor for the authenticated identity. It
+     * sends a request to the
+     * [Delete MFA Factor](https://docs.medusajs.com/api/admin#auth_deletemfa_factorsid)
+     * API route.
+     *
+     * @param id - The ID of the MFA factor to disable.
+     * @param body - Optional verification details required by the server configuration.
+     * @param headers - Headers to pass in the request.
+     * @returns The disabled MFA factor.
+     *
+     * @tags auth
+     *
+     * @example
+     * const { mfa_factor } = await sdk.auth.mfa.disable("authmfa_123")
+     */
     disable: async (
       id: string,
       body?: AuthMfaDisablePayload,
@@ -125,6 +296,21 @@ export class Auth {
       )
     },
 
+    /**
+     * This method generates new recovery codes for the authenticated identity.
+     * It sends a request to the
+     * [Generate MFA Recovery Codes](https://docs.medusajs.com/api/admin#auth_postmfa_recovery-codes)
+     * API route.
+     *
+     * @param body - Optional recovery code generation details.
+     * @param headers - Headers to pass in the request.
+     * @returns The generated recovery codes.
+     *
+     * @tags auth
+     *
+     * @example
+     * const { recovery_codes } = await sdk.auth.mfa.generateRecoveryCodes()
+     */
     generateRecoveryCodes: async (
       body?: AuthMfaGenerateRecoveryCodesPayload,
       headers?: ClientHeaders
@@ -139,6 +325,35 @@ export class Auth {
       )
     },
 
+    /**
+     * This method verifies an MFA challenge returned from `sdk.auth.login` or
+     * `sdk.auth.callback`. It sends a request to the
+     * [Verify MFA Challenge](https://docs.medusajs.com/api/admin#auth_postmfa_challengesidverify)
+     * API route.
+     *
+     * If verification succeeds, the returned token is stored based on the SDK's
+     * auth configuration, matching `sdk.auth.login`.
+     *
+     * @param id - The ID of the MFA challenge to verify.
+     * @param body - The challenge verification details.
+     * @param headers - Headers to pass in the request.
+     * @returns The authentication JWT token.
+     *
+     * @tags auth
+     *
+     * @example
+     * const result = await sdk.auth.login("user", "emailpass", {
+     *   email: "user@example.com",
+     *   password: "secret"
+     * })
+     *
+     * if (typeof result === "object" && "mfa_challenge" in result) {
+     *   await sdk.auth.mfa.verifyChallenge(result.mfa_challenge.id, {
+     *     method: "totp",
+     *     code: "123456"
+     *   })
+     * }
+     */
     verifyChallenge: async (
       id: string,
       body: AuthMfaVerifyChallengePayload,

--- a/packages/core/js-sdk/src/auth/index.ts
+++ b/packages/core/js-sdk/src/auth/index.ts
@@ -1,6 +1,72 @@
-import { HttpTypes } from "@medusajs/types"
+import { AuthTypes, HttpTypes } from "@medusajs/types"
 import { Client } from "../client.js"
 import { ClientHeaders, Config } from "../types.js"
+
+export type AuthRedirectResponse = {
+  location: string
+}
+
+export type AuthMfaRequiredResponse = {
+  mfa_required: true
+  mfa_challenge: AuthTypes.AuthMfaChallengeDTO
+}
+
+export type AuthLoginResponse =
+  | string
+  | AuthRedirectResponse
+  | AuthMfaRequiredResponse
+
+export type AuthCallbackResponse = string | AuthMfaRequiredResponse
+
+export type AuthMfaListResponse = {
+  mfa_factors: AuthTypes.AuthMfaDTO[]
+}
+
+export type AuthMfaSetupResponse = {
+  mfa_factor: AuthTypes.AuthMfaDTO
+  secret?: string
+  otpauth_url?: string
+}
+
+export type AuthMfaFactorResponse = {
+  mfa_factor: AuthTypes.AuthMfaDTO
+}
+
+export type AuthMfaRecoveryCodesResponse = {
+  recovery_codes: string[]
+}
+
+export type AuthMfaStartPayload = {
+  provider: AuthTypes.AuthMfaProvider
+  label?: string | null
+  issuer?: string
+  metadata?: Record<string, unknown> | null
+}
+
+export type AuthMfaVerifyPayload = {
+  code: string
+}
+
+export type AuthMfaDisablePayload = {
+  method?: AuthTypes.AuthMfaChallengeMethod
+  code?: string
+}
+
+export type AuthMfaGenerateRecoveryCodesPayload = {
+  count?: number
+}
+
+export type AuthMfaVerifyChallengePayload = {
+  method: AuthTypes.AuthMfaChallengeMethod
+  code: string
+}
+
+type AuthProviderResponse = {
+  token?: string
+  location?: string
+  mfa_required?: true
+  mfa_challenge?: AuthTypes.AuthMfaChallengeDTO
+}
 
 export class Auth {
   private client: Client
@@ -9,6 +75,87 @@ export class Auth {
   constructor(client: Client, config: Config) {
     this.client = client
     this.config = config
+  }
+
+  mfa = {
+    list: async (headers?: ClientHeaders) => {
+      return await this.client.fetch<AuthMfaListResponse>("/auth/mfa/factors", {
+        headers,
+      })
+    },
+
+    start: async (body: AuthMfaStartPayload, headers?: ClientHeaders) => {
+      return await this.client.fetch<AuthMfaSetupResponse>(
+        "/auth/mfa/factors",
+        {
+          method: "POST",
+          body,
+          headers,
+        }
+      )
+    },
+
+    verify: async (
+      id: string,
+      body: AuthMfaVerifyPayload,
+      headers?: ClientHeaders
+    ) => {
+      return await this.client.fetch<AuthMfaFactorResponse>(
+        `/auth/mfa/factors/${id}/verify`,
+        {
+          method: "POST",
+          body,
+          headers,
+        }
+      )
+    },
+
+    disable: async (
+      id: string,
+      body?: AuthMfaDisablePayload,
+      headers?: ClientHeaders
+    ) => {
+      return await this.client.fetch<AuthMfaFactorResponse>(
+        `/auth/mfa/factors/${id}`,
+        {
+          method: "DELETE",
+          body: body ?? {},
+          headers,
+        }
+      )
+    },
+
+    generateRecoveryCodes: async (
+      body?: AuthMfaGenerateRecoveryCodesPayload,
+      headers?: ClientHeaders
+    ) => {
+      return await this.client.fetch<AuthMfaRecoveryCodesResponse>(
+        "/auth/mfa/recovery-codes",
+        {
+          method: "POST",
+          body: body ?? {},
+          headers,
+        }
+      )
+    },
+
+    verifyChallenge: async (
+      id: string,
+      body: AuthMfaVerifyChallengePayload,
+      headers?: ClientHeaders
+    ) => {
+      const { token } = await this.client.fetch<{ token: string }>(
+        `/auth/mfa/challenges/${id}/verify`,
+        {
+          method: "POST",
+          body,
+          headers,
+        }
+      )
+
+      await this.setToken_(token)
+      return token
+    },
   }
 
   /**
@@ -127,15 +274,20 @@ export class Auth {
     actor: string,
     method: string,
     payload: HttpTypes.AdminSignInWithEmailPassword | Record<string, unknown>
-  ) => {
-    // There will either be token or location returned from the backend.
-    const { token, location } = await this.client.fetch<{
-      token?: string
-      location?: string
-    }>(`/auth/${actor}/${method}`, {
-      method: "POST",
-      body: payload,
-    })
+  ): Promise<AuthLoginResponse> => {
+    // There will either be token, location, or MFA challenge returned from the backend.
+    const { token, location, mfa_challenge } =
+      await this.client.fetch<AuthProviderResponse>(`/auth/${actor}/${method}`, {
+        method: "POST",
+        body: payload,
+      })
+
+    if (mfa_challenge) {
+      return {
+        mfa_required: true,
+        mfa_challenge,
+      }
+    }
 
     // In the case of an oauth login, we return the redirect location to the caller.
     // They can decide if they do an immediate redirect or put it in an <a> tag.
@@ -143,8 +295,12 @@ export class Auth {
       return { location }
     }
 
-    await this.setToken_(token as string)
-    return token as string
+    if (!token) {
+      throw new Error("Unexpected authentication response")
+    }
+
+    await this.setToken_(token)
+    return token
   }
 
   /**
@@ -157,7 +313,7 @@ export class Auth {
    *
    * Learn more in the [JS SDK Authentication](https://docs.medusajs.com/resources/js-sdk/auth/overview) guide.
    *
-   * @param actor - The actor type. For example, `user` for admin user, or `customer` for customer.
+   * @param actor - The actor type. For example, `user` for admin user, or `customer`.
    * @param method - The authentication provider to use. For example, `google`.
    * @param query - The query parameters from the Oauth callback, which should be passed to the API route. This includes query parameters like
    * `code` and `state`.
@@ -189,14 +345,26 @@ export class Auth {
     actor: string,
     method: string,
     query?: Record<string, unknown>
-  ) => {
-    const { token } = await this.client.fetch<{ token: string }>(
-      `/auth/${actor}/${method}/callback`,
-      {
-        method: "GET",
-        query,
+  ): Promise<AuthCallbackResponse> => {
+    const { token, mfa_challenge } =
+      await this.client.fetch<AuthProviderResponse>(
+        `/auth/${actor}/${method}/callback`,
+        {
+          method: "GET",
+          query,
+        }
+      )
+
+    if (mfa_challenge) {
+      return {
+        mfa_required: true,
+        mfa_challenge,
       }
-    )
+    }
+
+    if (!token) {
+      throw new Error("Unexpected authentication callback response")
+    }
 
     await this.setToken_(token)
     return token

--- a/packages/core/js-sdk/src/index.ts
+++ b/packages/core/js-sdk/src/index.ts
@@ -32,7 +32,22 @@ export default Medusa
 
 export { FetchError, Client } from "./client.js"
 export { Admin } from "./admin/index.js"
-export { Auth } from "./auth/index.js"
+export {
+  Auth,
+  type AuthCallbackResponse,
+  type AuthLoginResponse,
+  type AuthMfaDisablePayload,
+  type AuthMfaFactorResponse,
+  type AuthMfaGenerateRecoveryCodesPayload,
+  type AuthMfaListResponse,
+  type AuthMfaRecoveryCodesResponse,
+  type AuthMfaRequiredResponse,
+  type AuthMfaSetupResponse,
+  type AuthMfaStartPayload,
+  type AuthMfaVerifyChallengePayload,
+  type AuthMfaVerifyPayload,
+  type AuthRedirectResponse,
+} from "./auth/index.js"
 export { Store } from "./store/index.js"
 export {
   Config,


### PR DESCRIPTION
## Summary
- add SDK helpers for MFA factor setup, verification, disabling, recovery codes, and challenge verification
- return MFA challenge responses from auth login and callback flows
- add SDK tests for MFA login/callback behavior and MFA management methods
