### PR TITLE
fix(dashboard): validate CSV imports by file extension instead of MIME type

### DIFF
--- a/packages/admin/dashboard/src/routes/products/product-import/components/upload-import.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-import/components/upload-import.tsx
@@ -3,8 +3,7 @@ import { FileType, FileUpload } from "../../../../components/common/file-upload"
 import { Hint } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 
-const SUPPORTED_FORMATS = ["text/csv"]
-const SUPPORTED_FORMATS_FILE_EXTENSIONS = [".csv"]
+const SUPPORTED_FORMATS = [".csv"]
 
 export const UploadImport = ({
   onUploaded,
@@ -16,14 +15,16 @@ export const UploadImport = ({
 
   const hasInvalidFiles = (fileList: FileType[]) => {
     const invalidFile = fileList.find(
-      (f) => !SUPPORTED_FORMATS.includes(f.file.type)
+      (f) => !SUPPORTED_FORMATS.some((ext) =>
+        f.file.name.toLowerCase().endsWith(ext)
+      )
     )
 
     if (invalidFile) {
       setError(
         t("products.media.invalidFileType", {
           name: invalidFile.file.name,
-          types: SUPPORTED_FORMATS_FILE_EXTENSIONS.join(", "),
+          types: SUPPORTED_FORMATS.join(", "),
         })
       )
 


### PR DESCRIPTION
This is an independent contribution and is not associated with any hackathon or competition.

## Summary

Switches CSV file validation in the product import upload component from MIME type checking to file extension checking. On Windows machines with Microsoft Excel installed, .csv files report application/vnd.ms-excel as their MIME type instead of text/csv, causing valid files to be rejected.

## Root Cause

The hasInvalidFiles function in upload-import.tsx compares file.type (browser-reported MIME type) against a hardcoded ["text/csv"] whitelist. On Windows, the CSV file type is registered to Excel with MIME type application/vnd.ms-excel in the system registry. The browser reports this OS-level MIME type, causing the whitelist check to fail for valid .csv files.

## Fix

Replaced MIME type validation with file extension validation. The SUPPORTED_FORMATS constant now uses [".csv"] (file extensions) instead of ["text/csv"] (MIME types), and hasInvalidFiles checks f.file.name.toLowerCase().endsWith(ext) instead of SUPPORTED_FORMATS.includes(f.file.type). The SUPPORTED_FORMATS_FILE_EXTENSIONS constant was removed and folded into SUPPORTED_FORMATS.

The FileUpload component's accept attribute already supports file extensions (.csv) - no change needed there.

## Testing

- On Windows with Excel: .csv files now pass validation since the check uses file extension rather than the OS-assigned MIME type
- On all platforms: .csv files continue to be accepted; non-CSV files continue to be rejected
- Drag-and-drop uploads are also covered since the validation runs for both file picker and drag-and-drop paths

Closes #15416
