### PR TITLE
docs: add TSDocs for "acquire lock before fetching cart in u… (#15363)"

### DIFF
--- a/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
+++ b/packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts
@@ -56,6 +56,9 @@ export type UpdateCartPromotionsWorkflowInput = {
   force_refresh_payment_collection?: boolean
 }
 
+/**
+ * The ID of the workflow that updates a cart's promotions.
+ */
 export const updateCartPromotionsWorkflowId = "update-cart-promotions"
 /**
  * This workflow updates a cart's promotions, applying or removing promotion codes from the cart. It also computes the adjustments


### PR DESCRIPTION
## Automated TSDoc Additions

This PR adds TSDoc comments to TypeScript source files changed in commit [`de43962`](https://github.com/medusajs/medusa/commit/de43962211feb705d27b2f388384e3f3f4b6d466).

**Triggered by:** fix(core-flows): acquire lock before fetching cart in u… (#15363)

**Files updated:**
- `packages/core/core-flows/src/cart/workflows/update-cart-promotions.ts`

> Review carefully before merging. Claude may have missed context or used incorrect descriptions.