### PR TITLE
Fix backend build ignore path matching

### DIFF
--- a/.changeset/bright-files-build.md
+++ b/.changeset/bright-files-build.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/framework": patch
+---
+
+Fix backend build ignore matching so files with `test` in their filename are not skipped unless they are inside an ignored test directory.

--- a/.changeset/bright-files-build.md
+++ b/.changeset/bright-files-build.md
@@ -2,4 +2,4 @@
 "@medusajs/framework": patch
 ---
 
-Fix backend build ignore matching so files with `test` in their filename are not skipped unless they are inside an ignored test directory.
+fix(framework): backend build ignore matching no longer skips files containing `test` in their filename

--- a/packages/core/framework/src/build-tools/__tests__/compiler.spec.ts
+++ b/packages/core/framework/src/build-tools/__tests__/compiler.spec.ts
@@ -1,0 +1,38 @@
+import path from "path"
+
+import { shouldIgnoreBackendBuildFile } from "../ignore-files"
+
+describe("shouldIgnoreBackendBuildFile", () => {
+  const projectRoot = path.join("tmp", "medusa-app")
+  const ignoredChunks = ["integration-tests", "test", "unit-tests", "src/admin"]
+
+  it("does not ignore script filenames that contain test", () => {
+    expect(
+      shouldIgnoreBackendBuildFile(
+        projectRoot,
+        path.join(
+          projectRoot,
+          "src",
+          "scripts",
+          "reset-test-vendor-password.ts"
+        ),
+        ignoredChunks
+      )
+    ).toBe(false)
+  })
+
+  it.each([
+    ["test directory", path.join("test", "helpers.ts")],
+    ["unit-tests directory", path.join("unit-tests", "orders.ts")],
+    ["integration-tests directory", path.join("integration-tests", "api.ts")],
+    ["admin source directory", path.join("src", "admin", "widgets.tsx")],
+  ])("ignores files inside the %s", (_label, relativePath) => {
+    expect(
+      shouldIgnoreBackendBuildFile(
+        projectRoot,
+        path.join(projectRoot, relativePath),
+        ignoredChunks
+      )
+    ).toBe(true)
+  })
+})

--- a/packages/core/framework/src/build-tools/compiler.ts
+++ b/packages/core/framework/src/build-tools/compiler.ts
@@ -5,6 +5,8 @@ import { access, constants, copyFile, mkdir, rm } from "fs/promises"
 import path from "path"
 import type tsStatic from "typescript"
 
+import { shouldIgnoreBackendBuildFile } from "./ignore-files"
+
 /**
  * The compiler exposes the opinionated APIs for compiling Medusa
  * applications and plugins. You can perform the following
@@ -190,9 +192,10 @@ export class Compiler {
   }> {
     const ts = await this.#loadTSCompiler()
     const filesToCompile = tsConfig.fileNames.filter((fileName) => {
-      const relativeFileName = path.relative(this.#projectRoot, fileName)
-      return !chunksToIgnore.some((chunk) =>
-        relativeFileName.includes(`${chunk}`)
+      return !shouldIgnoreBackendBuildFile(
+        this.#projectRoot,
+        fileName,
+        chunksToIgnore
       )
     })
 

--- a/packages/core/framework/src/build-tools/ignore-files.ts
+++ b/packages/core/framework/src/build-tools/ignore-files.ts
@@ -1,0 +1,21 @@
+import path from "path"
+
+export function shouldIgnoreBackendBuildFile(
+  projectRoot: string,
+  fileName: string,
+  chunksToIgnore: string[]
+): boolean {
+  const relativeFileName = path.relative(projectRoot, fileName)
+  const fileSegments = relativeFileName.split(path.sep)
+
+  return chunksToIgnore.some((chunk) => {
+    const chunkSegments = chunk.split(/[\\/]+/)
+
+    return fileSegments.some((_segment, index) =>
+      chunkSegments.every(
+        (chunkSegment, chunkIndex) =>
+          fileSegments[index + chunkIndex] === chunkSegment
+      )
+    )
+  })
+}


### PR DESCRIPTION
Fixes #15341.

The backend build ignore list was matching substrings in the full relative path, so a script like `src/scripts/reset-test-vendor-password.ts` was filtered out just because the filename contains `test`.

This changes the check to compare path segments instead. Directories like `test`, `unit-tests`, `integration-tests`, and `src/admin` are still ignored, but normal files with `test` in the name are kept.

I added a focused regression test for the filename case and the existing ignored directory cases.

Checked locally:
- node_modules\.bin\jest.cmd --config packages/core/framework/jest.config.js packages/core/framework/src/build-tools/__tests__/compiler.spec.ts --runInBand --no-cache
- node_modules\.bin\prettier.cmd --check packages/core/framework/src/build-tools/compiler.ts packages/core/framework/src/build-tools/ignore-files.ts packages/core/framework/src/build-tools/__tests__/compiler.spec.ts

I also tried `yarn workspace @medusajs/framework build`, but this checkout is sparse to avoid Windows long-path failures in generated docs, and the immutable install cannot resolve the partial workspace without wanting to rewrite the lockfile. So the full workspace build is not included here.