### PR TITLE
fix(dashboard): preserve zero-amount shipping option prices on re-save

### DIFF
--- a/.changeset/fix-zero-shipping-price.md
+++ b/.changeset/fix-zero-shipping-price.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(@medusajs/dashboard): preserve zero-amount shipping option prices on re-save
+
+Falsy checks treated a price of `0` as unset, dropping free-shipping prices from the API payload on subsequent edits. Replaced `!value` with `value === undefined || value === ""` in the create/edit form handlers, fixed the same issue in `buildShippingOptionPriceRules`, and used `??` instead of `||` in the price cell initialisation.

--- a/.changeset/fix-zero-shipping-price.md
+++ b/.changeset/fix-zero-shipping-price.md
@@ -2,6 +2,6 @@
 "@medusajs/dashboard": patch
 ---
 
-fix(@medusajs/dashboard): preserve zero-amount shipping option prices on re-save
+fix(dashboard): preserve zero-amount shipping option prices on re-save
 
 Falsy checks treated a price of `0` as unset, dropping free-shipping prices from the API payload on subsequent edits. Replaced `!value` with `value === undefined || value === ""` in the create/edit form handlers, fixed the same issue in `buildShippingOptionPriceRules`, and used `??` instead of `||` in the price cell initialisation.

--- a/packages/admin/dashboard/src/routes/locations/common/components/shipping-option-price-cell/shipping-option-price-cell.tsx
+++ b/packages/admin/dashboard/src/routes/locations/common/components/shipping-option-price-cell/shipping-option-price-cell.tsx
@@ -197,7 +197,7 @@ const Inner = ({
     [currencyInfo]
   )
 
-  const [localValue, setLocalValue] = useState<string | number>(value || "")
+  const [localValue, setLocalValue] = useState<string | number>(value ?? "")
 
   const handleValueChange: CurrencyInputProps["onValueChange"] = (
     value,

--- a/packages/admin/dashboard/src/routes/locations/common/utils/__tests__/price-rule-helpers.spec.ts
+++ b/packages/admin/dashboard/src/routes/locations/common/utils/__tests__/price-rule-helpers.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+import { buildShippingOptionPriceRules } from "../price-rule-helpers"
+
+describe("buildShippingOptionPriceRules", () => {
+  it("should return an empty array when no conditions are provided", () => {
+    const rules = buildShippingOptionPriceRules({})
+    expect(rules).toEqual([])
+  })
+
+  it("should include a gte rule with value 0", () => {
+    const rules = buildShippingOptionPriceRules({ gte: 0 })
+    expect(rules).toHaveLength(1)
+    expect(rules[0]).toMatchObject({ operator: "gte", value: 0 })
+  })
+
+  it("should include a lte rule with value 0", () => {
+    const rules = buildShippingOptionPriceRules({ lte: 0 })
+    expect(rules).toHaveLength(1)
+    expect(rules[0]).toMatchObject({ operator: "lte", value: 0 })
+  })
+
+  it("should include all conditions when some have value 0", () => {
+    const rules = buildShippingOptionPriceRules({ gte: 0, lte: 100 })
+    expect(rules).toHaveLength(2)
+    expect(rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ operator: "gte", value: 0 }),
+        expect.objectContaining({ operator: "lte", value: 100 }),
+      ])
+    )
+  })
+
+  it("should exclude conditions with null values", () => {
+    const rules = buildShippingOptionPriceRules({ gte: 50, gt: null })
+    expect(rules).toHaveLength(1)
+    expect(rules[0]).toMatchObject({ operator: "gte", value: 50 })
+  })
+
+  it("should exclude conditions with undefined values", () => {
+    const rules = buildShippingOptionPriceRules({
+      gte: 50,
+      lt: undefined,
+      eq: undefined,
+    })
+    expect(rules).toHaveLength(1)
+    expect(rules[0]).toMatchObject({ operator: "gte", value: 50 })
+  })
+
+  it("should build rules for all supported operators", () => {
+    const rules = buildShippingOptionPriceRules({
+      gte: 10,
+      lte: 100,
+      gt: 5,
+      lt: 200,
+      eq: 50,
+    })
+    expect(rules).toHaveLength(5)
+    expect(rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ operator: "gte", value: 10 }),
+        expect.objectContaining({ operator: "lte", value: 100 }),
+        expect.objectContaining({ operator: "gt", value: 5 }),
+        expect.objectContaining({ operator: "lt", value: 200 }),
+        expect.objectContaining({ operator: "eq", value: 50 }),
+      ])
+    )
+  })
+
+  it("should accept string values and cast them to numbers", () => {
+    const rules = buildShippingOptionPriceRules({ gte: "0", lte: "100" })
+    expect(rules).toHaveLength(2)
+    expect(rules[0]).toMatchObject({ operator: "gte", value: 0 })
+    expect(rules[1]).toMatchObject({ operator: "lte", value: 100 })
+  })
+
+  it("should set the correct ITEM_TOTAL attribute on all rules", () => {
+    const rules = buildShippingOptionPriceRules({ gte: 0, lte: 50 })
+    rules.forEach((rule) => {
+      expect(rule.attribute).toBe("item_total")
+    })
+  })
+})

--- a/packages/admin/dashboard/src/routes/locations/common/utils/__tests__/price-rule-helpers.spec.ts
+++ b/packages/admin/dashboard/src/routes/locations/common/utils/__tests__/price-rule-helpers.spec.ts
@@ -66,6 +66,12 @@ describe("buildShippingOptionPriceRules", () => {
     )
   })
 
+  it("should exclude conditions with empty string values", () => {
+    const rules = buildShippingOptionPriceRules({ gte: "", lte: 100 })
+    expect(rules).toHaveLength(1)
+    expect(rules[0]).toMatchObject({ operator: "lte", value: 100 })
+  })
+
   it("should accept string values and cast them to numbers", () => {
     const rules = buildShippingOptionPriceRules({ gte: "0", lte: "100" })
     expect(rules).toHaveLength(2)

--- a/packages/admin/dashboard/src/routes/locations/common/utils/price-rule-helpers.ts
+++ b/packages/admin/dashboard/src/routes/locations/common/utils/price-rule-helpers.ts
@@ -30,7 +30,9 @@ export const buildShippingOptionPriceRules = (rule: {
     { value: rule.eq, operator: "eq" },
   ]
 
-  const conditionsWithValues = conditions.filter(({ value }) => value !== undefined && value !== null) as {
+  const conditionsWithValues = conditions.filter(
+    ({ value }) => value !== undefined && value !== null && value !== ""
+  ) as {
     value: string | number
     operator: string
   }[]

--- a/packages/admin/dashboard/src/routes/locations/common/utils/price-rule-helpers.ts
+++ b/packages/admin/dashboard/src/routes/locations/common/utils/price-rule-helpers.ts
@@ -30,7 +30,7 @@ export const buildShippingOptionPriceRules = (rule: {
     { value: rule.eq, operator: "eq" },
   ]
 
-  const conditionsWithValues = conditions.filter(({ value }) => value) as {
+  const conditionsWithValues = conditions.filter(({ value }) => value !== undefined && value !== null) as {
     value: string | number
     operator: string
   }[]

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
@@ -88,7 +88,7 @@ export function CreateShippingOptionsForm({
   const handleSubmit = form.handleSubmit(async (data) => {
     const currencyPrices = Object.entries(data.currency_prices)
       .map(([code, value]) => {
-        if (!value) {
+        if (value === undefined || value === "") {
           return undefined
         }
 
@@ -101,7 +101,7 @@ export function CreateShippingOptionsForm({
 
     const regionPrices = Object.entries(data.region_prices)
       .map(([region_id, value]) => {
-        if (!value) {
+        if (value === undefined || value === "") {
           return undefined
         }
 

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
@@ -303,7 +303,7 @@ const findRuleValue = (
   return (
     rules?.find(
       (r) => r.attribute === ITEM_TOTAL_ATTRIBUTE && r.operator === operator
-    )?.value || fallbackValue
+    )?.value ?? fallbackValue
   )
 }
 

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
@@ -133,7 +133,7 @@ export function EditShippingOptionsPricingForm({
     const currencyPrices = Object.entries(data.currency_prices)
       .map(([code, value]) => {
         if (
-          !value ||
+          (value === undefined || value === "") ||
           !currencies.some((c) => c.toLowerCase() === code.toLowerCase())
         ) {
           return undefined
@@ -173,7 +173,10 @@ export function EditShippingOptionsPricingForm({
      */
     const regionPrices = Object.entries(data.region_prices)
       .map(([region_id, value]) => {
-        if (!value || !regions?.some((region) => region.id === region_id)) {
+        if (
+          (value === undefined || value === "") ||
+          !regions?.some((region) => region.id === region_id)
+        ) {
           return undefined
         }
 


### PR DESCRIPTION
Fixes #15450 -  fix(dashboard): preserve zero-amount shipping option prices on re-save

## Summary

**What** — What changes are introduced in this PR?

Fixes shipping option prices set to 0 (free shipping) being dropped on subsequent edits across the create and edit shipping option pricing forms, the price rule helper utility, and the price cell component.

**Why** — Why are these changes relevant or necessary?  

JavaScript's falsy coercion treats 0 as "no value", so existing free-shipping prices were silently omitted from the API payload every time the form was re-submitted. The API interpreted the missing entries as deletions, causing the 0 to disappear after the first edit.

**How** — How have these changes been implemented?

Four targeted changes, all replacing falsy checks with explicit empty-value checks:
  - edit-shipping-options-pricing-form.tsx & create-shipping-options-form.tsx — !value → value === undefined || value === "" in the currency and region price filters inside handleSubmit
  - price-rule-helpers.ts — .filter(({ value }) => value) → .filter(({ value }) => value !== undefined && value !== null) so conditional rules with a 0 threshold (e.g. gte: 0) are no longer dropped
  - shipping-option-price-cell.tsx — value || "" → value ?? "" so the cell initialises with 0 displayed instead of blank

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

Unit tests added for buildShippingOptionPriceRules covering zero-value conditions (gte: 0, lte: 0, mixed zero/non-zero), null/undefined exclusion, string casting, and all five operators. All 9 tests pass.

---
## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable
