### PR TITLE
Fixes #15442 fix(framework): load workflows from index.[js|ts] files in worker mode

### DIFF
--- a/.changeset/fix-workflow-index-file-loading.md
+++ b/.changeset/fix-workflow-index-file-loading.md
@@ -6,4 +6,4 @@ fix(framework): load workflows from index.[js|ts] files in worker mode
 
 The workflow loader skipped any file named `index.[js|ts]` due to the default `discoverResources` filter inherited from `ResourceLoader`. In `WORKER_MODE=server` or `shared` this went unnoticed because HTTP route imports registered the workflows as a side effect, but a `worker`-only instance never loads routes, so index-file workflows were silently unregistered.
 
-Added an `allowIndex` option to `discoverResources` and set it in `WorkflowLoader.load()`. The loader call also had a stale reference to an undeclared `customFiltering` variable which is now corrected.
+Added an `allowIndex` option to `discoverResources` and set it in `WorkflowLoader.load()`.

--- a/.changeset/fix-workflow-index-file-loading.md
+++ b/.changeset/fix-workflow-index-file-loading.md
@@ -1,0 +1,9 @@
+---
+"@medusajs/framework": patch
+---
+
+fix(framework): load workflows from index.[js|ts] files in worker mode
+
+The workflow loader skipped any file named `index.[js|ts]` due to the default `discoverResources` filter inherited from `ResourceLoader`. In `WORKER_MODE=server` or `shared` this went unnoticed because HTTP route imports registered the workflows as a side effect, but a `worker`-only instance never loads routes, so index-file workflows were silently unregistered.
+
+Added an `allowIndex` option to `discoverResources` and set it in `WorkflowLoader.load()`. The loader call also had a stale reference to an undeclared `customFiltering` variable which is now corrected.

--- a/packages/core/framework/src/utils/resource-loader.ts
+++ b/packages/core/framework/src/utils/resource-loader.ts
@@ -43,14 +43,17 @@ export abstract class ResourceLoader {
    * Discover resources from the source directory
    * @param exclude - custom exclusion regexes
    * @param customFiltering - custom filtering function
+   * @param allowIndex - when true, index.[js|ts] files are not excluded
    * @returns The resources discovered
    */
   protected async discoverResources({
     exclude,
     customFiltering,
+    allowIndex,
   }: {
     exclude?: RegExp[]
     customFiltering?: (entry: Dirent) => boolean
+    allowIndex?: boolean
   } = {}): Promise<Record<string, unknown>[]> {
     exclude ??= []
     customFiltering ??= (entry: Dirent) => {
@@ -58,7 +61,7 @@ export abstract class ResourceLoader {
 
       return (
         !entry.isDirectory() &&
-        parsedName.name !== "index" &&
+        (allowIndex || parsedName.name !== "index") &&
         !parsedName.base.endsWith(".d.ts") &&
         !entry.path.includes("__tests__") &&
         [".js", ".ts"].includes(parsedName.ext) &&

--- a/packages/core/framework/src/workflows/__fixtures__/workflows-with-index/index.ts
+++ b/packages/core/framework/src/workflows/__fixtures__/workflows-with-index/index.ts
@@ -1,0 +1,16 @@
+import {
+  createStep,
+  createWorkflow,
+  WorkflowResponse,
+} from "@medusajs/workflows-sdk"
+
+export const indexFileWorkflowId = "index-file-workflow"
+
+const step = createStep("index-file-step", () => {
+  return {} as any
+})
+
+export const indexFileWorkflow = createWorkflow(indexFileWorkflowId, () => {
+  step()
+  return new WorkflowResponse(void 0)
+})

--- a/packages/core/framework/src/workflows/__tests__/index.spec.ts
+++ b/packages/core/framework/src/workflows/__tests__/index.spec.ts
@@ -28,3 +28,20 @@ describe("WorkflowLoader", () => {
     expect(registeredWorkflows.has(productWorkflowId)).toBe(true)
   })
 })
+
+describe("WorkflowLoader - index file support", () => {
+  const rootDir = join(__dirname, "../__fixtures__", "workflows-with-index")
+
+  beforeAll(async () => {
+    const container = createMedusaContainer()
+    container.register(ContainerRegistrationKeys.LOGGER, asValue(logger))
+
+    await new WorkflowLoader(rootDir, container).load()
+  })
+
+  it("should register workflows exported from index.[js|ts] files", async () => {
+    const registeredWorkflows = WorkflowManager.getWorkflows()
+
+    expect(registeredWorkflows.has("index-file-workflow")).toBe(true)
+  })
+})

--- a/packages/core/framework/src/workflows/workflow-loader.ts
+++ b/packages/core/framework/src/workflows/workflow-loader.ts
@@ -34,7 +34,7 @@ export class WorkflowLoader extends ResourceLoader {
    * therefore we only need to import them
    */
   async load() {
-    await super.discoverResources()
+    await super.discoverResources({ allowIndex: true })
 
     this.logger.debug(`Workflows registered.`)
   }


### PR DESCRIPTION
Fixes #15442 fix(framework): load workflows from index.[js|ts] files in worker mode

## Summary

**What** — What changes are introduced in this PR?
Workflows exported from index.[js|ts] files are now picked up by the workflow loader, including in WORKER_MODE=worker instances.

**Why** — Why are these changes relevant or necessary?  

ResourceLoader.discoverResources() excludes any file named index by default (to skip barrel exports). WorkflowLoader never overrode this filter, so a workflow living in src/workflows/<name>/index.ts was silently skipped at boot. In WORKER_MODE=server/shared this went unnoticed because HTTP route imports registered the workflow as a side effect but a worker-only instance never loads routes, so the workflow stayed unregistered.

**How** — How have these changes been implemented?

The allowIndex flag approach was chosen over a full customFiltering override to avoid duplicating exclusion logic ResourceLoader.#excludes is hard-private and inaccessible to subclasses. Note: allowIndex is only honored when the default customFiltering is used; a caller providing its own filter takes full responsibility for index-file handling.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

- Added a new fixture src/workflows/__fixtures__/workflows-with-index/index.ts exporting a workflow from an index file.
- Added a describe block in src/workflows/__tests__/index.spec.ts that loads the fixture directory via WorkflowLoader and asserts the workflow is registered in WorkflowManager.
- Existing test (non-index workflows) continues to pass unchanged.



---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable
