### PR TITLE
Fixes #14880 fix(dashboard): use useCancelReturnRequest in order activity cancel button

### DIFF
--- a/.changeset/fix-cancel-return-request-activity.md
+++ b/.changeset/fix-cancel-return-request-activity.md
@@ -1,0 +1,7 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): use correct cancel hook for return requests in order activity section
+
+The Cancel button in the order Activity timeline was calling `useCancelReturn` (`POST /admin/returns/:id/cancel`), which requires all linked return fulfillments to be canceled first. For storefront-created returns this fails with a 400 if an active return fulfillment exists. The correct hook for canceling a return that is still in the request stage is `useCancelReturnRequest` (`DELETE /admin/returns/:id/request`), which is already used by the active return panel. Both Admin entry points now call the same cancel path.

--- a/packages/admin/dashboard/src/routes/orders/order-detail/components/order-activity-section/order-timeline.tsx
+++ b/packages/admin/dashboard/src/routes/orders/order-detail/components/order-activity-section/order-timeline.tsx
@@ -28,7 +28,10 @@ import {
   useCancelExchange,
   useExchanges,
 } from "../../../../../hooks/api/exchanges"
-import { useCancelReturn, useReturns } from "../../../../../hooks/api/returns"
+import {
+  useCancelReturnRequest,
+  useReturns,
+} from "../../../../../hooks/api/returns"
 import { useDate } from "../../../../../hooks/use-date"
 import { getFormattedAddress } from "../../../../../lib/addresses"
 import { getStylizedAmount } from "../../../../../lib/money-amount-helpers"
@@ -872,7 +875,7 @@ const ReturnBody = ({
   const prompt = usePrompt()
   const { t } = useTranslation()
 
-  const { mutateAsync: cancelReturnRequest } = useCancelReturn(
+  const { mutateAsync: cancelReturnRequest } = useCancelReturnRequest(
     orderReturn.id,
     orderReturn.order_id
   )

--- a/packages/core/js-sdk/src/__tests__/admin-return.spec.ts
+++ b/packages/core/js-sdk/src/__tests__/admin-return.spec.ts
@@ -1,0 +1,71 @@
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+import { Return } from "../admin/return"
+import { Client } from "../client"
+
+const baseUrl = "https://someurl.com"
+const returnId = "return_123"
+const mockReturn = { id: returnId }
+
+const server = setupServer(
+  http.post(`${baseUrl}/admin/returns/${returnId}/cancel`, () => {
+    return HttpResponse.json({ return: mockReturn })
+  }),
+  http.delete(`${baseUrl}/admin/returns/${returnId}/request`, () => {
+    return HttpResponse.json({ return: mockReturn })
+  }),
+  http.all("*", ({ request }) => {
+    return new HttpResponse(
+      JSON.stringify({ message: `Unexpected request: ${request.method} ${request.url}` }),
+      { status: 404 }
+    )
+  })
+)
+
+describe("Admin Return SDK", () => {
+  let returnSdk: Return
+
+  beforeAll(() => {
+    const client = new Client({ baseUrl })
+    returnSdk = new Return(client)
+    server.listen()
+  })
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  describe("cancel", () => {
+    it("should call POST /admin/returns/:id/cancel", async () => {
+      const result = await returnSdk.cancel(returnId)
+      expect(result).toEqual({ return: mockReturn })
+    })
+  })
+
+  describe("cancelRequest", () => {
+    it("should call DELETE /admin/returns/:id/request", async () => {
+      const result = await returnSdk.cancelRequest(returnId)
+      expect(result).toEqual({ return: mockReturn })
+    })
+  })
+
+  describe("cancel vs cancelRequest", () => {
+    it("should call different endpoints and HTTP methods", async () => {
+      const calls: string[] = []
+
+      server.use(
+        http.post(`${baseUrl}/admin/returns/${returnId}/cancel`, () => {
+          calls.push("POST /cancel")
+          return HttpResponse.json({ return: mockReturn })
+        }),
+        http.delete(`${baseUrl}/admin/returns/${returnId}/request`, () => {
+          calls.push("DELETE /request")
+          return HttpResponse.json({ return: mockReturn })
+        })
+      )
+
+      await returnSdk.cancel(returnId)
+      await returnSdk.cancelRequest(returnId)
+
+      expect(calls).toEqual(["POST /cancel", "DELETE /request"])
+    })
+  })
+})


### PR DESCRIPTION
Fixes #14880 fix(dashboard): use useCancelReturnRequest in order activity cancel button

## Summary

**What** — What changes are introduced in this PR?

The Cancel button in the order Activity timeline now calls the correct API when canceling a storefront-created return request. A changeset is included for @medusajs/dashboard.

**Why** — Why are these changes relevant or necessary?  

The ReturnBody component in order-timeline.tsx was using useCancelReturn, which hits POST /admin/returns/:id/cancel. That endpoint requires all linked return fulfillments to be canceled first — so any storefront-initiated return with an active return fulfillment failed with 400: All fulfillments must be canceled before canceling a return. The active return panel (active-order-return-section.tsx) already used the correct hook, useCancelReturnRequest (DELETE /admin/returns/:id/request), creating an inconsistency between two Admin UI entry points for the same action.

**How** — How have these changes been implemented?

Single import swap in order-timeline.tsx: useCancelReturn → useCancelReturnRequest.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

  Unit tests added in packages/core/js-sdk/src/__tests__/admin-return.spec.ts using msw to intercept HTTP calls, verifying:
  - sdk.admin.return.cancel() calls POST /admin/returns/:id/cancel
  - sdk.admin.return.cancelRequest() calls DELETE /admin/returns/:id/request
  - Both methods route to distinct endpoints 
Note: the dashboard has no React Testing Library or hook-level test infrastructure, so a direct call-site test is not feasible in this PR. The SDK tests cover the underlying endpoint invariant, and the manual steps above verify the full Admin UI flow. A regression to the wrong hook would not cause a TypeScript error (both hooks have identical signatures) the manual storefront flow is the intended regression check for the dashboard side.

---


## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [x] I have linked the related issue(s) if applicable

