### PR TITLE
Allow cancelling pending MFA setup

### DIFF
--- a/.changeset/pending-mfa-cancel.md
+++ b/.changeset/pending-mfa-cancel.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/auth": patch
+---
+
+fix(auth): allow cancelling pending MFA setup without a challenge

--- a/packages/modules/auth/integration-tests/__tests__/auth-module-service/mfa.spec.ts
+++ b/packages/modules/auth/integration-tests/__tests__/auth-module-service/mfa.spec.ts
@@ -571,6 +571,30 @@ moduleIntegrationTestRunner<IAuthModuleService>({
           })
         ).rejects.toThrow("MFA verification code is required to disable MFA")
       })
+
+      it("allows cancelling pending MFA setup without a challenge", async () => {
+        const setup = await service.startAuthMfa({
+          auth_identity_id: "test-id",
+          provider: "totp",
+        })
+
+        await expect(service.retrieveAuthMfa(setup.mfa.id)).resolves.toEqual(
+          expect.objectContaining({
+            status: "pending",
+          })
+        )
+
+        const factor = await service.disableAuthMfa({
+          id: setup.mfa.id,
+        })
+
+        expect(factor).toEqual(
+          expect.objectContaining({
+            id: setup.mfa.id,
+            status: "disabled",
+          })
+        )
+      })
     })
   },
 })

--- a/packages/modules/auth/src/services/auth-module.ts
+++ b/packages/modules/auth/src/services/auth-module.ts
@@ -468,7 +468,10 @@ export default class AuthModuleService
       sharedContext
     )
 
-    if (this.getMfaDisablePolicy_() === "challenge") {
+    if (
+      factor.status === "enabled" &&
+      this.getMfaDisablePolicy_() === "challenge"
+    ) {
       if (!data.method || !data.code) {
         throw new MedusaError(
           MedusaError.Types.INVALID_DATA,


### PR DESCRIPTION
Allows pending MFA setup to be cancelled without a challenge.