### PR TITLE
fix: rename duplicate column id to fix React key warning (#15485)

### DIFF
--- a/.changeset/fifty-trains-cry.md
+++ b/.changeset/fifty-trains-cry.md
@@ -2,4 +2,4 @@
 "@medusajs/dashboard": patch
 ---
 
-fix: rename duplicate column id to fix React key warning
+fix(dashboard): rename duplicate column id to fix React key warning

--- a/packages/admin/dashboard/src/hooks/table/columns/use-order-table-columns.tsx
+++ b/packages/admin/dashboard/src/hooks/table/columns/use-order-table-columns.tsx
@@ -118,7 +118,7 @@ export const useOrderTableColumns = (props: UseOrderTableColumnsProps) => {
         },
       }),
       columnHelper.display({
-        id: "actions",
+        id: "country",
         cell: ({ row }) => {
           const countryCode = row.original.shipping_address?.country_code
           const country = countries.find((c) => c.iso_2 === countryCode)


### PR DESCRIPTION
## What

Renames the CountryCell display column id from `"actions"` to `"country"` in `use-order-table-columns.tsx` to fix a duplicate React key warning.

## Why

In the customer detail orders table, TanStack Table generates duplicate internal keys because two display columns share the same `id: "actions"`:

1. `useOrderTableColumns` defines a display column with `id: "actions"` that renders a `CountryCell`
2. `CustomerOrderSection` appends another display column with `id: "actions"` for the action menu

This produces keys like `0_actions`, triggering React's duplicate key warning.

## How

Renamed the CountryCell display column id from `"actions"` to `"country"` in `use-order-table-columns.tsx`. The only other caller (`order-list-table.tsx`) does not filter by this id, so the rename has no side effects.

## Testing

- Navigate to Customers > customer > Orders tab
- Verify no React key warning in console
- Verify country column still renders correctly

Fixes #15485