### PR TITLE
fix: prevent crash when deleting last product media image (#15443)

### DIFF
--- a/.changeset/tired-lights-worry.md
+++ b/.changeset/tired-lights-worry.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): prevent crash when deleting last product media image

--- a/packages/admin/dashboard/src/routes/products/product-media/components/product-media-gallery/product-media-gallery.tsx
+++ b/packages/admin/dashboard/src/routes/products/product-media/components/product-media-gallery/product-media-gallery.tsx
@@ -93,7 +93,7 @@ export const ProductMediaGallery = ({ product }: ProductMediaGalleryProps) => {
         .map((i) => ({ id: i.id, url: i.url })) || []
 
     if (curr === media.length - 1) {
-      setCurr((prev) => prev - 1)
+      setCurr((prev) => Math.max(0, prev - 1))
     }
 
     await mutateAsync({


### PR DESCRIPTION
## Problem

When deleting the only remaining image in the product media gallery, the page crashes with:
```
can't access property 'id', media[curr] is undefined
```

Root cause: `handleDeleteCurrent` decrements `curr` when deleting the last item:
```ts
if (curr === media.length - 1) {
  setCurr((prev) => prev - 1)
}
```
With only 1 image, curr goes from 0 to -1. On re-render with empty media array, `media[-1]` is undefined, and the Canvas/Preview components crash accessing `.id`, `.url`, `.isThumbnail`.

## Fix

Clamp `curr` to 0 minimum:
```ts
setCurr((prev) => Math.max(0, prev - 1))
```

## Testing

1. Create a product with exactly one image
2. Navigate to Products > product > Media
3. Click trash icon to delete the image
4. Confirm deletion
5. Gallery should show empty state instead of crashing

Fixes #15443
