### PR TITLE
fix: preserve zero prices in shipping option edit form (#15450)

### DIFF
--- a/.changeset/plain-ghosts-know.md
+++ b/.changeset/plain-ghosts-know.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/dashboard": patch
+---
+
+fix(dashboard): preserve zero prices in shipping option edit form

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
@@ -133,7 +133,7 @@ export function EditShippingOptionsPricingForm({
     const currencyPrices = Object.entries(data.currency_prices)
       .map(([code, value]) => {
         if (
-          (value === undefined || value === null || value === '') ||
+          (value === undefined || value === null || value === "") ||
           !currencies.some((c) => c.toLowerCase() === code.toLowerCase())
         ) {
           return undefined
@@ -173,7 +173,7 @@ export function EditShippingOptionsPricingForm({
      */
     const regionPrices = Object.entries(data.region_prices)
       .map(([region_id, value]) => {
-        if ((value === undefined || value === null || value === '') || !regions?.some((region) => region.id === region_id)) {
+        if ((value === undefined || value === null || value === "") || !regions?.some((region) => region.id === region_id)) {
           return undefined
         }
 

--- a/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
+++ b/packages/admin/dashboard/src/routes/locations/location-service-zone-shipping-option-pricing/components/create-shipping-options-form/edit-shipping-options-pricing-form.tsx
@@ -133,7 +133,7 @@ export function EditShippingOptionsPricingForm({
     const currencyPrices = Object.entries(data.currency_prices)
       .map(([code, value]) => {
         if (
-          !value ||
+          (value === undefined || value === null || value === '') ||
           !currencies.some((c) => c.toLowerCase() === code.toLowerCase())
         ) {
           return undefined
@@ -173,7 +173,7 @@ export function EditShippingOptionsPricingForm({
      */
     const regionPrices = Object.entries(data.region_prices)
       .map(([region_id, value]) => {
-        if (!value || !regions?.some((region) => region.id === region_id)) {
+        if ((value === undefined || value === null || value === '') || !regions?.some((region) => region.id === region_id)) {
           return undefined
         }
 


### PR DESCRIPTION
## Problem

Setting a shipping option price to 0 (free shipping) works on initial save, but the price is dropped when editing the shipping option later. This is because `handleSubmit` uses `!value` to check for empty prices:

```ts
if (!value || !currencies.some(...)) {
  return undefined
}
```

In JavaScript, `!0 === true`, so a price of 0 is treated as "no value" and filtered out. The price data is then sent without that country's price, causing frontend exceptions.

## Fix

Changed the falsy checks to explicit empty-value checks that preserve 0:

```ts
// Before (drops 0)
if (!value || ...)

// After (preserves 0)
if ((value === undefined || value === null || value === '') || ...)
```

Applied to both currency_prices and region_prices validation in `edit-shipping-options-pricing-form.tsx`.

## Testing

1. Create a shipping option with price 0 for a country
2. Save (works correctly)
3. Edit the shipping option to modify another country's price
4. Save again — the 0 price should be preserved, not dropped

Fixes #15450
