### PR TITLE
fix: make data table sort menu scrollable

### DIFF
--- a/.changeset/scrollable-sort-menu.md
+++ b/.changeset/scrollable-sort-menu.md
@@ -1,0 +1,5 @@
+---
+"@medusajs/ui": patch
+---
+
+fix(ui): make data table sort menu options scrollable

--- a/packages/design-system/ui/src/blocks/data-table/components/data-table-sorting-menu.tsx
+++ b/packages/design-system/ui/src/blocks/data-table/components/data-table-sorting-menu.tsx
@@ -82,19 +82,21 @@ const DataTableSortingMenu = (props: DataTableSortingMenuProps) => {
         </DropdownMenu.Trigger>
       </Wrapper>
       <DropdownMenu.Content side="bottom">
-        <DropdownMenu.RadioGroup value={sorting?.id} onValueChange={setKey}>
-          {sortableColumns.map((column) => {
-            return (
-              <DropdownMenu.RadioItem
-                onSelect={(e) => e.preventDefault()}
-                value={column.id}
-                key={column.id}
-              >
-                {getSortLabel(column)}
-              </DropdownMenu.RadioItem>
-            )
-          })}
-        </DropdownMenu.RadioGroup>
+        <div className="max-h-[300px] overflow-auto p-1">
+          <DropdownMenu.RadioGroup value={sorting?.id} onValueChange={setKey}>
+            {sortableColumns.map((column) => {
+              return (
+                <DropdownMenu.RadioItem
+                  onSelect={(e) => e.preventDefault()}
+                  value={column.id}
+                  key={column.id}
+                >
+                  {getSortLabel(column)}
+                </DropdownMenu.RadioItem>
+              )
+            })}
+          </DropdownMenu.RadioGroup>
+        </div>
         {sorting && (
           <React.Fragment>
             <DropdownMenu.Separator />


### PR DESCRIPTION
## What

Made the data table sort menu's sortable column list scrollable and added a patch changeset for @medusajs/ui.

## Why

When a table has many sortable columns, the sort dropdown can overflow the viewport and users cannot reach all options.

## How

Wrapped the sortable-column RadioGroup in a max-height scroll container, matching the existing filter dropdown option-list pattern. The sort direction controls remain outside the scrollable list.

Fixes #14692.

## Testing

- git diff --cached --check
- yarn workspace @medusajs/ui lint attempted, but the fresh clone does not have a completed dependency install and eslint is not available in node_modules.