### PR TITLE
docs: add TSDocs for "respect allow_backorder when calculating pickup inventory av"

### DIFF
--- a/packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart.ts
+++ b/packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart.ts
@@ -26,6 +26,9 @@ import {
 } from "../utils/schemas"
 import { getTranslatedShippingOptionsStep } from "../../common/steps/get-translated-shipping-option"
 
+/**
+ * The ID of the workflow that lists the shipping options of a cart.
+ */
 export const listShippingOptionsForCartWorkflowId =
   "list-shipping-options-for-cart"
 /**


### PR DESCRIPTION
## Automated TSDoc Additions

This PR adds TSDoc comments to TypeScript source files changed in commit [`e6c632a`](https://github.com/medusajs/medusa/commit/e6c632ada9ced677e44198f145097422890abc63).

**Triggered by:** fix(core-flows): respect allow_backorder when calculating pickup inventory availability (#15440)

**Files updated:**
- `packages/core/core-flows/src/cart/workflows/list-shipping-options-for-cart.ts`

> Review carefully before merging. Claude may have missed context or used incorrect descriptions.