### PR TITLE
fix(http-types-generator, types): correctly generate types for OperatorMap

### DIFF
--- a/.changeset/ready-dolls-fly.md
+++ b/.changeset/ready-dolls-fly.md
@@ -1,0 +1,6 @@
+---
+"@medusajs/http-types-generator": patch
+"@medusajs/types": patch
+---
+
+fix(http-types-generator, types): correctly generate types for OperatorMap

--- a/packages/cli/http-types-generator/src/__tests__/ts-helpers.spec.ts
+++ b/packages/cli/http-types-generator/src/__tests__/ts-helpers.spec.ts
@@ -1,0 +1,90 @@
+import ts from "typescript"
+import { TsHelpers } from "../utils/ts-helpers"
+import { createSingleFileProgram } from "./utils/ts-utils"
+
+/**
+ * Resolves the type of a top-level `export const NAME` declaration.
+ */
+function getConstType(checker: ts.TypeChecker, source: ts.SourceFile, name: string): ts.Type {
+  let result: ts.Type | undefined
+  ts.forEachChild(source, (node) => {
+    if (result) return
+    if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && decl.name.text === name) {
+          const sym = checker.getSymbolAtLocation(decl.name)
+          if (sym) result = checker.getTypeOfSymbolAtLocation(sym, decl)
+        }
+      }
+    }
+  })
+  if (!result) throw new Error(`const '${name}' not found`)
+  return result
+}
+
+describe("TsHelpers.isOperatorMapZodSchema", () => {
+  // Minimal Zod-shaped declarations: only the structural shape the resolver
+  // inspects (class name + first type argument) needs to be present.
+  const ZOD_DECLS = `
+    declare class ZodString { _zod: any }
+    declare class ZodArray<T> { _zod: any }
+    declare class ZodUnion<T> { _zod: any }
+    declare class ZodOptional<T> { _zod: any }
+    declare class ZodObject<Shape> { _zod: any }
+  `
+
+  function setup(source: string) {
+    const { program, checker } = createSingleFileProgram(source)
+    return { checker, source: program.getSourceFile("input.ts")! }
+  }
+
+  it("detects createOperatorMap-style schemas wrapped in ZodOptional", () => {
+    const { checker, source } = setup(`
+      ${ZOD_DECLS}
+      type SimpleType = ZodOptional<ZodUnion<readonly [
+        ZodOptional<ZodString>,
+        ZodOptional<ZodArray<ZodString>>
+      ]>>
+      type ArrayType = ZodOptional<ZodArray<ZodString>>
+      type OperatorMapInner = ZodUnion<readonly [
+        SimpleType,
+        ZodObject<{
+          $eq: SimpleType
+          $ne: SimpleType
+          $in: ArrayType
+          $nin: ArrayType
+          $like: SimpleType
+          $ilike: SimpleType
+          $gt: SimpleType
+          $gte: SimpleType
+          $lt: SimpleType
+          $lte: SimpleType
+        }>
+      ]>
+      export declare const operatorMap: ZodOptional<OperatorMapInner>
+    `)
+    const type = getConstType(checker, source, "operatorMap")
+    expect(TsHelpers.isOperatorMapZodSchema(checker, type)).toBe(true)
+  })
+
+  it("returns false for a plain ZodOptional<ZodString>", () => {
+    const { checker, source } = setup(`
+      ${ZOD_DECLS}
+      export declare const plain: ZodOptional<ZodString>
+    `)
+    const type = getConstType(checker, source, "plain")
+    expect(TsHelpers.isOperatorMapZodSchema(checker, type)).toBe(false)
+  })
+
+  it("returns false for a ZodObject whose shape does not contain operator keys", () => {
+    const { checker, source } = setup(`
+      ${ZOD_DECLS}
+      export declare const obj: ZodOptional<ZodObject<{
+        title: ZodOptional<ZodString>
+        handle: ZodOptional<ZodString>
+      }>>
+    `)
+    const type = getConstType(checker, source, "obj")
+    expect(TsHelpers.isOperatorMapZodSchema(checker, type)).toBe(false)
+  })
+})

--- a/packages/cli/http-types-generator/src/__tests__/type-pipeline.spec.ts
+++ b/packages/cli/http-types-generator/src/__tests__/type-pipeline.spec.ts
@@ -274,6 +274,68 @@ describe("ZodPipe (transform) schemas", () => {
 })
 
 // ---------------------------------------------------------------------------
+// createOperatorMap fields routed through the shape-arg fallback
+// (regression: applyAndAndOrOperators' `z.lazy()` makes `_output` unresolvable)
+// ---------------------------------------------------------------------------
+
+describe("createOperatorMap shape-arg fallback", () => {
+  // Mimic the runtime situation where the outer schema's `_output` leaks the
+  // raw ZodObject type (because `applyAndAndOrOperators` introduces a
+  // self-referential `z.lazy()`). Inner Zod nodes intentionally omit `_output`
+  // so that `getZodOutputType` returns undefined and `propType` remains a Zod
+  // schema type — the path that previously emitted `any`.
+  const ZOD_DECLS = `
+    declare class ZodString { _zod: any }
+    declare class ZodArray<T> { _zod: any }
+    declare class ZodUnion<T> { _zod: any }
+    declare class ZodOptional<T> { _zod: any }
+    declare class ZodObject<Shape> {
+      _input: ZodObject<Shape>
+      _output: ZodObject<Shape>
+      _zod: any
+      parse: any
+      safeParse: any
+    }
+    type SimpleType = ZodOptional<ZodUnion<readonly [
+      ZodOptional<ZodString>,
+      ZodOptional<ZodArray<ZodString>>
+    ]>>
+    type ArrayType = ZodOptional<ZodArray<ZodString>>
+    type OperatorMap = ZodOptional<ZodUnion<readonly [
+      SimpleType,
+      ZodObject<{
+        $eq: SimpleType
+        $ne: SimpleType
+        $in: ArrayType
+        $nin: ArrayType
+        $like: SimpleType
+        $ilike: SimpleType
+        $gt: SimpleType
+        $gte: SimpleType
+        $lt: SimpleType
+        $lte: SimpleType
+      }>
+    ]>>
+  `
+
+  it("emits OperatorMap<string> instead of any for createOperatorMap fields", () => {
+    const [result] = runPipeline(`
+      ${ZOD_DECLS}
+      export declare const AdminGetShippingOptionTypesParams: ZodObject<{
+        created_at: OperatorMap
+        updated_at: OperatorMap
+        deleted_at: OperatorMap
+      }>
+    `)
+    expect(result.code).toMatch(/created_at\??: OperatorMap<string>/)
+    expect(result.code).toMatch(/updated_at\??: OperatorMap<string>/)
+    expect(result.code).toMatch(/deleted_at\??: OperatorMap<string>/)
+    expect(result.code).not.toMatch(/created_at\??:\s*any/)
+    expect(result.tracker.needsOperatorMap).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Pipeline runner that mirrors the generate command's name-resolution logic
 // (used to test the registry skip + domain-scoped override fixes)
 // ---------------------------------------------------------------------------

--- a/packages/cli/http-types-generator/src/core/type-emitter.ts
+++ b/packages/cli/http-types-generator/src/core/type-emitter.ts
@@ -31,7 +31,13 @@ export class TypeEmitter {
     resolved: ResolvedSchemaType,
     importTracker: ImportTracker
   ): string {
-    const { type, hasFindParams, hasSelectParams, hasBaseFilterable } = resolved
+    const {
+      type,
+      hasFindParams,
+      hasSelectParams,
+      hasBaseFilterable,
+      zodShapeType,
+    } = resolved
 
     if (hasFindParams) {
       importTracker.needsFindParams = true
@@ -47,7 +53,8 @@ export class TypeEmitter {
     const properties = resolver.resolveProperties(
       type,
       hasFindParams,
-      hasSelectParams
+      hasSelectParams,
+      zodShapeType
     )
 
     const hasOperatorMapProp = properties.some((p) => p.isOperatorMap)

--- a/packages/cli/http-types-generator/src/core/type-resolver.ts
+++ b/packages/cli/http-types-generator/src/core/type-resolver.ts
@@ -13,6 +13,13 @@ export interface ResolvedSchemaType {
   hasBaseFilterable: boolean
   /** The schema name for diagnostic reporting */
   schemaName: string
+  /**
+   * The raw Zod-shape type (the first type argument of `ZodObject<Shape>`),
+   * used as a fallback source of per-property Zod schema info when the
+   * inferred output for a property is degraded to `any` by complex types
+   * (e.g. `createOperatorMap()` returning `any` through `_output`).
+   */
+  zodShapeType?: ts.Type
 }
 
 /** Property names that belong to `FindParams` (superset of SelectParams) */
@@ -101,6 +108,9 @@ export class TypeResolver {
 
     let hasBaseFilterable = initialPropNames.has("$and")
 
+    let zodShapeType: ts.Type | undefined =
+      this.resolveFromZodObjectShapeArg(zodType)
+
     if (hasCircularLazyIssue && baseFieldsType) {
       const baseFieldsOutput = TsHelpers.getZodOutputType(
         this.checker,
@@ -110,6 +120,10 @@ export class TypeResolver {
         resolvedType = baseFieldsOutput
         properties = resolvedType.getProperties()
         hasBaseFilterable = true
+      }
+      const baseFieldsShape = this.resolveFromZodObjectShapeArg(baseFieldsType)
+      if (baseFieldsShape) {
+        zodShapeType = baseFieldsShape
       }
     } else if (hasCircularLazyIssue) {
       const shapeResolved = this.resolveFromZodObjectShapeArg(zodType)
@@ -136,6 +150,7 @@ export class TypeResolver {
       hasSelectParams,
       hasBaseFilterable,
       schemaName: httpTypeName,
+      zodShapeType,
     }
   }
 
@@ -149,10 +164,17 @@ export class TypeResolver {
   resolveProperties(
     resolvedType: ts.Type,
     hasFindParams: boolean,
-    hasSelectParams = false
+    hasSelectParams = false,
+    zodShapeType?: ts.Type
   ): PropertyInfo[] {
     const properties = resolvedType.getProperties()
     const result: PropertyInfo[] = []
+    const shapeProps = new Map<string, ts.Symbol>()
+    if (zodShapeType) {
+      for (const p of zodShapeType.getProperties()) {
+        shapeProps.set(p.name, p)
+      }
+    }
 
     for (const prop of properties) {
       const propName = prop.name
@@ -177,7 +199,44 @@ export class TypeResolver {
       }
 
       const nonNullableType = this.checker.getNonNullableType(propType)
-      const isOperatorMap = TsHelpers.isOperatorMapType(nonNullableType)
+      let isOperatorMap = TsHelpers.isOperatorMapType(nonNullableType)
+
+      // Fallback for the shape-arg path: when `_output` couldn't be fully
+      // resolved by TypeScript (typically due to `z.lazy()` circular
+      // references introduced by `applyAndAndOrOperators`), the resolved
+      // `propType` may be `any` or a degraded type that doesn't expose the
+      // OperatorMap members. Inspect the raw Zod schema's structure directly
+      // to detect `createOperatorMap()`.
+      if (!isOperatorMap && TsHelpers.isZodType(rawPropType)) {
+        isOperatorMap = TsHelpers.isOperatorMapZodSchema(
+          this.checker,
+          rawPropType
+        )
+      }
+      if (!isOperatorMap) {
+        const shapeProp = shapeProps.get(propName)
+        if (shapeProp) {
+          const shapePropType = this.checker.getTypeOfSymbol(shapeProp)
+          if (TsHelpers.isZodType(shapePropType)) {
+            isOperatorMap = TsHelpers.isOperatorMapZodSchema(
+              this.checker,
+              shapePropType
+            )
+            if (isOperatorMap && !isOptional) {
+              const shapeSymbolName =
+                shapePropType.getSymbol()?.getName() ?? ""
+              if (
+                shapeSymbolName === "ZodOptional" ||
+                shapeSymbolName === "ZodNullable" ||
+                shapeSymbolName === "ZodDefault" ||
+                shapeSymbolName === "ZodPipe"
+              ) {
+                isOptional = true
+              }
+            }
+          }
+        }
+      }
 
       const isFindParamsField =
         (hasFindParams && FIND_PARAMS_FIELDS.has(propName)) ||

--- a/packages/cli/http-types-generator/src/utils/ts-helpers.ts
+++ b/packages/cli/http-types-generator/src/utils/ts-helpers.ts
@@ -93,6 +93,95 @@ export class TsHelpers {
     return TsHelpers.isOperatorMapMember(type)
   }
 
+  /** Zod wrapper class names whose first type argument is the wrapped schema. */
+  private static readonly ZOD_WRAPPER_NAMES = new Set([
+    "ZodOptional",
+    "ZodNullable",
+    "ZodDefault",
+    "ZodPipe",
+    "ZodEffects",
+    "ZodReadonly",
+    "ZodLazy",
+    "ZodCatch",
+    "ZodBranded",
+  ])
+
+  /**
+   * Structurally inspects a Zod schema's TypeScript type to determine whether
+   * it represents an `OperatorMap` (the union produced by `createOperatorMap()`).
+   *
+   * This is used as a fallback when the schema's `_output` cannot be fully
+   * resolved by the TypeScript compiler (e.g. because `applyAndAndOrOperators`
+   * introduces a `z.lazy()` circular reference). Instead of relying on
+   * `_output`, walk the Zod type-argument tree: unwrap `ZodOptional`/
+   * `ZodNullable`/`ZodDefault`/`ZodPipe`/..., descend into `ZodUnion` options,
+   * and look for a `ZodObject` whose shape contains the operator keys
+   * (`$eq`, `$ne`, `$in`, ...).
+   */
+  static isOperatorMapZodSchema(
+    checker: ts.TypeChecker,
+    zodType: ts.Type
+  ): boolean {
+    return TsHelpers.checkOperatorMapZod(checker, zodType, new Set())
+  }
+
+  private static checkOperatorMapZod(
+    checker: ts.TypeChecker,
+    type: ts.Type,
+    seen: Set<ts.Type>
+  ): boolean {
+    if (seen.has(type)) {
+      return false
+    }
+    seen.add(type)
+
+    const name = type.getSymbol()?.getName() ?? ""
+
+    if (TsHelpers.ZOD_WRAPPER_NAMES.has(name)) {
+      const args = checker.getTypeArguments(type as ts.TypeReference) ?? []
+      for (const arg of args) {
+        if (TsHelpers.checkOperatorMapZod(checker, arg, seen)) {
+          return true
+        }
+      }
+      return false
+    }
+
+    if (name === "ZodUnion" || name === "ZodDiscriminatedUnion") {
+      const args = checker.getTypeArguments(type as ts.TypeReference) ?? []
+      for (const arg of args) {
+        // The first type argument is typically the tuple of options.
+        // Iterate the tuple's own type arguments to reach each option.
+        const tupleArgs =
+          checker.getTypeArguments(arg as ts.TypeReference) ?? []
+        if (tupleArgs.length > 0) {
+          for (const t of tupleArgs) {
+            if (TsHelpers.checkOperatorMapZod(checker, t, seen)) {
+              return true
+            }
+          }
+        } else if (TsHelpers.checkOperatorMapZod(checker, arg, seen)) {
+          return true
+        }
+      }
+      return false
+    }
+
+    if (name === "ZodObject") {
+      const args = checker.getTypeArguments(type as ts.TypeReference) ?? []
+      if (args.length === 0) {
+        return false
+      }
+      const shapeProps = args[0].getProperties().map((p) => p.name)
+      const matchCount = TsHelpers.OPERATOR_MAP_PROPS.filter((op) =>
+        shapeProps.includes(op)
+      ).length
+      return matchCount >= 4
+    }
+
+    return false
+  }
+
   /**
    * Returns a simplified display string for a TypeScript type, suitable for
    * use in error messages and diagnostics.

--- a/packages/core/types/src/http/shipping-option-type/admin/queries.ts
+++ b/packages/core/types/src/http/shipping-option-type/admin/queries.ts
@@ -1,17 +1,17 @@
 import { FindParams, SelectParams } from "../../common"
-import { BaseFilterable } from "../../../dal"
+import { BaseFilterable, OperatorMap } from "../../../dal"
 
 export interface AdminGetShippingOptionTypeParams extends SelectParams {}
 
 export interface AdminShippingOptionTypeListParams
   extends FindParams,
     BaseFilterable<AdminShippingOptionTypeListParams> {
-  code?: string | string[] | undefined
   q?: string | undefined
-  created_at?: any
   id?: string | string[] | undefined
-  updated_at?: any
-  deleted_at?: any
   label?: string | string[] | undefined
+  code?: string | string[] | undefined
   description?: string | string[] | undefined
+  created_at?: OperatorMap<string>
+  updated_at?: OperatorMap<string>
+  deleted_at?: OperatorMap<string>
 }


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

Correctly generate HTTP types for Zod schemas / properties that use applyAndAndOrOperators

**Why** — Why are these changes relevant or necessary?  

When applyAndAndOrOperators wraps a Zod schema with `z.lazy`, TypeScript can't properly resolve the type of the output of the operator map. This leads to properties having `any` type instead of the actual type in the generated type.

**How** — How have these changes been implemented?

Add utilities to walk through an `applyAndAndOrOperators` and its arguments, looking for a shape that contains some of the common operator map properties like `$eq`, `$ne`, etc... and, if found, use the `OperatorMap` type for the property.

Also fix a property type in the `types` package that used `any` incorrectly due to this issue.

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

-

---

## Checklist

Please ensure the following before requesting a review:

- [x] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Add any additional context, related issues, or references that might help the reviewer understand this PR.
